### PR TITLE
Fix `help` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.39"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
+checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.39"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
+checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
 dependencies = [
  "anstream",
  "anstyle",

--- a/crates/karva_cli/src/args.rs
+++ b/crates/karva_cli/src/args.rs
@@ -20,10 +20,10 @@ pub(crate) enum Command {
 
 #[derive(Debug, Parser)]
 pub(crate) struct TestCommand {
-    /// List of files or directories to check.
+    /// List of files or directories to test.
     #[clap(
-        help = "List of files, directories, or test functions to check [default: the project root]",
-        value_name = "PATHS"
+        help = "List of files, directories, or test functions to test [default: the project root]",
+        value_name = "PATH"
     )]
     pub paths: Vec<String>,
 

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -1,6 +1,5 @@
 use std::ffi::OsString;
 use std::io::{self, BufWriter, Write};
-use std::path::PathBuf;
 use std::process::{ExitCode, Termination};
 
 use anyhow::Result;

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -56,11 +56,13 @@ fn run() -> anyhow::Result<ExitStatus> {
 // Sometimes random args are passed at the start of the args list, so we try to parse args by removing the first arg until we can parse them.
 fn try_parse_args(mut args: Vec<OsString>) -> Args {
     loop {
-        match Args::try_parse_from(args.clone()) {
-            Ok(args) => break args,
-            Err(e) => {
+        match std::panic::catch_unwind(|| Args::parse_from(args.clone())) {
+            Ok(args) => {
+                break args;
+            }
+            Err(_) => {
                 if args.is_empty() {
-                    e.exit()
+                    std::process::exit(1);
                 }
                 args.remove(0);
             }

--- a/crates/karva_core/src/test_result.rs
+++ b/crates/karva_core/src/test_result.rs
@@ -2,20 +2,20 @@ use super::discoverer::DiscoveredTest;
 
 #[derive(Debug, Clone)]
 pub struct TestResultPass {
-    test: DiscoveredTest,
+    pub test: DiscoveredTest,
 }
 
 #[derive(Debug, Clone)]
 pub struct TestResultFail {
-    test: DiscoveredTest,
-    message: String,
+    pub test: DiscoveredTest,
+    pub message: String,
 }
 
 #[derive(Debug, Clone)]
 pub struct TestResultError {
-    test: DiscoveredTest,
-    message: String,
-    traceback: String,
+    pub test: DiscoveredTest,
+    pub message: String,
+    pub traceback: String,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary

Sometimes `Args::try_parse_from` would error on invalid args, here we catch panics instead

