### PR TITLE
Only run build workflow when affected files change

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,14 @@ name: Build / Release PyPI
 
 on:
   pull_request:
+    paths:
+      - "crates/**/*"
+      - "scripts/**/*"
+      - "python/**/*"
+      - ".github/workflows/build.yml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "pyproject.toml"
   push:
     tags:
       - v[0-9]*.[0-9]*.[0-9]*


### PR DESCRIPTION
## Summary

We currently build even on small docs changes, this is just useless as it takes ages

