### PR TITLE
Use a HashMap so we only import modules once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,11 @@ ITERATIONS ?= 1
 NUM_TESTS ?= 10000
 
 benchmark: build
-	cd scripts/benchmark && uv sync --all-extras && uv run main.py --iterations $(ITERATIONS) --num-tests $(NUM_TESTS)
+	cd scripts/benchmark && uv sync --all-extras && uv run main.py --iterations $(ITERATIONS) --num-tests $(NUM_TESTS) --run-test
+
+flame:
+	cd scripts/benchmark && uv sync --all-extras && uv run main.py --keep-test-file --num-tests 10000 && cd ../..
+	sudo sysctl kernel.perf_event_paranoid=-1
+	cargo flamegraph -- test scripts/benchmark/test_many_assertions.py
 
 .PHONY: dev pre-commit build clean docs benchmark build

--- a/assets/benchmark_results.svg
+++ b/assets/benchmark_results.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2025-05-28T20:26:19.455287</dc:date>
+    <dc:date>2025-05-29T13:58:41.333921</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -45,26 +45,26 @@ L 489.695357 113.04
 L 489.695357 79.44
 L 64.5525 79.44
 z
-" clip-path="url(#p6b1d51c5bf)" style="fill: #4ecdc4"/>
+" clip-path="url(#p6641658ea2)" style="fill: #4ecdc4"/>
    </g>
    <g id="patch_4">
     <path d="M 64.5525 45.84
-L 83.942472 45.84
-L 83.942472 12.24
+L 80.591575 45.84
+L 80.591575 12.24
 L 64.5525 12.24
 z
-" clip-path="url(#p6b1d51c5bf)" style="fill: #4ecdc4"/>
+" clip-path="url(#p6641658ea2)" style="fill: #4ecdc4"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="md616342667" d="M 0 0
+       <path id="m1a63b978b9" d="M 0 0
 L 0 3.5
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md616342667" x="64.5525" y="118.08" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m1a63b978b9" x="64.5525" y="118.08" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -142,12 +142,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#md616342667" x="179.354693" y="118.08" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m1a63b978b9" x="195.131291" y="118.08" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
-      <!-- 1.25s -->
-      <g style="fill: #ffffff" transform="translate(165.617193 132.678437) scale(0.1 -0.1)">
+      <!-- 1.00s -->
+      <g style="fill: #ffffff" transform="translate(181.393791 132.678437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531
 L 1825 531
@@ -163,6 +163,25 @@ L 794 0
 L 794 531
 z
 " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m1a63b978b9" x="325.710083" y="118.08" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 2.00s -->
+      <g style="fill: #ffffff" transform="translate(311.972583 132.678437) scale(0.1 -0.1)">
+       <defs>
         <path id="DejaVuSans-32" d="M 1228 531
 L 3431 531
 L 3431 0
@@ -187,52 +206,10 @@ Q 2828 2175 2409 1742
 Q 1991 1309 1228 531
 z
 " transform="scale(0.015625)"/>
-        <path id="DejaVuSans-35" d="M 691 4666
-L 3169 4666
-L 3169 4134
-L 1269 4134
-L 1269 2991
-Q 1406 3038 1543 3061
-Q 1681 3084 1819 3084
-Q 2600 3084 3056 2656
-Q 3513 2228 3513 1497
-Q 3513 744 3044 326
-Q 2575 -91 1722 -91
-Q 1428 -91 1123 -41
-Q 819 9 494 109
-L 494 744
-Q 775 591 1075 516
-Q 1375 441 1709 441
-Q 2250 441 2565 725
-Q 2881 1009 2881 1497
-Q 2881 1984 2565 2268
-Q 2250 2553 1709 2553
-Q 1456 2553 1204 2497
-Q 953 2441 691 2322
-L 691 4666
-z
-" transform="scale(0.015625)"/>
        </defs>
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
-       <use xlink:href="#DejaVuSans-73" transform="translate(222.65625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_3">
-     <g id="line2d_3">
-      <g>
-       <use xlink:href="#md616342667" x="294.156887" y="118.08" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_3">
-      <!-- 2.50s -->
-      <g style="fill: #ffffff" transform="translate(280.419387 132.678437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
        <use xlink:href="#DejaVuSans-73" transform="translate(222.65625 0)"/>
       </g>
@@ -241,12 +218,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#md616342667" x="408.95908" y="118.08" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m1a63b978b9" x="456.288874" y="118.08" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
-      <!-- 3.75s -->
-      <g style="fill: #ffffff" transform="translate(395.22158 132.678437) scale(0.1 -0.1)">
+      <!-- 3.00s -->
+      <g style="fill: #ffffff" transform="translate(442.551374 132.678437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516
 Q 3050 2419 3304 2112
@@ -280,21 +257,11 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
-        <path id="DejaVuSans-37" d="M 525 4666
-L 3525 4666
-L 3525 4397
-L 1831 0
-L 1172 0
-L 2766 4134
-L 525 4134
-L 525 4666
-z
-" transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#DejaVuSans-33"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-37" transform="translate(95.410156 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
        <use xlink:href="#DejaVuSans-73" transform="translate(222.65625 0)"/>
       </g>
      </g>
@@ -304,12 +271,12 @@ z
     <g id="ytick_1">
      <g id="line2d_5">
       <defs>
-       <path id="m2d670a461b" d="M 0 0
+       <path id="mba057aafbe" d="M 0 0
 L -3.5 0
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2d670a461b" x="64.5525" y="96.24" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mba057aafbe" x="64.5525" y="96.24" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -418,7 +385,7 @@ z
     <g id="ytick_2">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m2d670a461b" x="64.5525" y="29.04" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#mba057aafbe" x="64.5525" y="29.04" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -515,28 +482,9 @@ L 510.9525 118.08
 " style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_7">
-    <!-- 4.63s -->
+    <!-- 3.26s -->
     <g style="fill: #ffffff" transform="translate(493.946786 98.999375) scale(0.1 -0.1)">
      <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116
-L 825 1625
-L 2419 1625
-L 2419 4116
-z
-M 2253 4666
-L 3047 4666
-L 3047 1625
-L 3713 1625
-L 3713 1100
-L 3047 1100
-L 3047 0
-L 2419 0
-L 2419 1100
-L 313 1100
-L 313 1709
-L 2253 4666
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-36" d="M 2113 2584
 Q 1688 2584 1439 2293
 Q 1191 2003 1191 1497
@@ -568,20 +516,20 @@ Q 3103 4656 3366 4563
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(159.033203 0)"/>
      <use xlink:href="#DejaVuSans-73" transform="translate(222.65625 0)"/>
     </g>
    </g>
    <g id="text_8">
-    <!-- 0.21s -->
-    <g style="fill: #ffffff" transform="translate(88.1939 31.799375) scale(0.1 -0.1)">
+    <!-- 0.12s -->
+    <g style="fill: #ffffff" transform="translate(84.843004 31.799375) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
      <use xlink:href="#DejaVuSans-73" transform="translate(222.65625 0)"/>
     </g>
    </g>
@@ -840,7 +788,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p6b1d51c5bf">
+  <clipPath id="p6641658ea2">
    <rect x="64.5525" y="7.2" width="446.4" height="110.88"/>
   </clipPath>
  </defs>

--- a/crates/karva_core/src/diagnostics.rs
+++ b/crates/karva_core/src/diagnostics.rs
@@ -74,6 +74,12 @@ impl DiagnosticWriter {
         self.flush_stdout(&mut stdout);
     }
 
+    pub fn error(&self, error: &str) {
+        let mut stdout = self.acquire_stdout();
+        let _ = writeln!(stdout, "{}", error.red());
+        self.flush_stdout(&mut stdout);
+    }
+
     pub fn discovery_started(&self) {
         tracing::info!("{}", "Discovering tests...".blue());
     }

--- a/crates/karva_core/src/discovery/case.rs
+++ b/crates/karva_core/src/discovery/case.rs
@@ -32,15 +32,8 @@ impl TestCase {
         &self.function_definition
     }
 
-    pub fn run_test(&self, py: &Python) -> TestResult {
+    pub fn run_test(&self, py: &Python, imported_module: &Bound<'_, PyModule>) -> TestResult {
         let start_time = Instant::now();
-
-        let imported_module = match PyModule::import(*py, self.module()) {
-            Ok(module) => module,
-            Err(e) => {
-                return TestResult::new_error(self.clone(), e.to_string(), start_time.elapsed());
-            }
-        };
 
         let function = match imported_module.getattr(self.function_definition().name.to_string()) {
             Ok(function) => function,

--- a/crates/karva_core/src/discovery/discoverer.rs
+++ b/crates/karva_core/src/discovery/discoverer.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use ignore::WalkBuilder;
 use ruff_python_ast::StmtFunctionDef;
@@ -19,41 +19,45 @@ impl<'a> Discoverer<'a> {
         Self { project }
     }
 
-    pub fn discover(&self) -> Vec<TestCase> {
+    pub fn discover(&self) -> HashMap<String, HashSet<TestCase>> {
         #[allow(clippy::mutable_key_type)]
-        let mut discovered_tests = HashSet::new();
+        let mut discovered_tests: HashMap<String, HashSet<TestCase>> = HashMap::new();
 
         for path in self.project.paths() {
             discovered_tests.extend(self.discover_files(path));
         }
 
-        discovered_tests.into_iter().collect()
+        discovered_tests
     }
 
-    fn discover_files(&self, path: &PythonTestPath) -> Vec<TestCase> {
+    fn discover_files(&self, path: &PythonTestPath) -> HashMap<String, HashSet<TestCase>> {
         match path {
             PythonTestPath::File(path) => self.discover_file(path),
             PythonTestPath::Directory(dir_path) => self.discover_directory(dir_path),
             PythonTestPath::Function(path, function_name) => {
                 if let Some(test_case) = self.discover_function(path, function_name) {
-                    vec![test_case]
+                    HashMap::from([(function_name.to_string(), HashSet::from([test_case]))])
                 } else {
-                    vec![]
+                    HashMap::new() // TODO: should this be an error?
                 }
             }
         }
     }
 
-    fn discover_file(&self, path: &SystemPathBuf) -> Vec<TestCase> {
-        self.test_functions_in_file(path)
-            .into_iter()
-            .map(|function_name| {
-                TestCase::new(module_name(self.project.cwd(), path), function_name)
-            })
-            .collect()
+    fn discover_file(&self, path: &SystemPathBuf) -> HashMap<String, HashSet<TestCase>> {
+        let mut discovered_tests: HashMap<String, HashSet<TestCase>> = HashMap::new();
+        let module_name = module_name(self.project.cwd(), path);
+        for function_name in self.test_functions_in_file(path) {
+            let test_case = TestCase::new(module_name.clone(), function_name);
+            discovered_tests
+                .entry(module_name.clone())
+                .or_default()
+                .insert(test_case);
+        }
+        discovered_tests
     }
 
-    fn discover_directory(&self, path: &SystemPathBuf) -> Vec<TestCase> {
+    fn discover_directory(&self, path: &SystemPathBuf) -> HashMap<String, HashSet<TestCase>> {
         let dir_path = path.as_std_path().to_path_buf();
         let walker = WalkBuilder::new(self.project.cwd().as_std_path())
             .standard_filters(true)
@@ -62,18 +66,23 @@ impl<'a> Discoverer<'a> {
             .filter_entry(move |entry| entry.path().starts_with(&dir_path))
             .build();
 
-        walker
-            .flatten()
-            .filter_map(|entry| {
-                let entry_path = entry.path();
-                let path = SystemPathBuf::from(entry_path);
-                if !is_python_file(&path) {
-                    return None;
-                }
-                Some(self.discover_file(&path))
-            })
-            .flatten()
-            .collect()
+        let mut discovered_tests: HashMap<String, HashSet<TestCase>> = HashMap::new();
+        for entry in walker.flatten() {
+            let entry_path = entry.path();
+            let path = SystemPathBuf::from(entry_path);
+            if !is_python_file(&path) {
+                continue;
+            }
+            let discovered_tests_for_file = self.discover_file(&path);
+            for (module_name, test_cases) in discovered_tests_for_file {
+                discovered_tests
+                    .entry(module_name)
+                    .or_default()
+                    .extend(test_cases);
+            }
+        }
+
+        discovered_tests
     }
 
     fn discover_function(&self, path: &SystemPathBuf, function_name: &str) -> Option<TestCase> {
@@ -148,9 +157,9 @@ mod tests {
         let discovered_tests = discoverer.discover();
         assert_eq!(discovered_tests.len(), 1);
         assert!(
-            discovered_tests[0]
-                .to_string()
-                .ends_with("test::test_function")
+            discovered_tests["test"]
+                .iter()
+                .any(|t| t.function_definition().name.to_string() == "test_function")
         );
     }
 
@@ -174,9 +183,9 @@ mod tests {
 
         assert_eq!(discovered_tests.len(), 1);
         assert!(
-            discovered_tests[0]
-                .to_string()
-                .ends_with("test_dir.test_file1::test_function1")
+            discovered_tests["test"]
+                .iter()
+                .any(|t| t.function_definition().name.to_string() == "test_function1")
         );
     }
 
@@ -203,9 +212,9 @@ mod tests {
 
         assert_eq!(discovered_tests.len(), 1);
         assert!(
-            discovered_tests[0]
-                .to_string()
-                .ends_with("tests.test_file1::test_function1")
+            discovered_tests["test"]
+                .iter()
+                .any(|t| t.function_definition().name.to_string() == "test_function1")
         );
     }
 
@@ -235,7 +244,10 @@ mod tests {
         let discovered_tests = discoverer.discover();
 
         assert_eq!(discovered_tests.len(), 3);
-        let test_strings: Vec<String> = discovered_tests.iter().map(|t| t.to_string()).collect();
+        let test_strings: Vec<String> = discovered_tests
+            .values()
+            .map(|t| t.iter().map(|t| t.to_string()).collect())
+            .collect();
         assert!(
             test_strings
                 .iter()
@@ -277,7 +289,10 @@ def not_a_test(): pass
         let discovered_tests = discoverer.discover();
 
         assert_eq!(discovered_tests.len(), 3);
-        let test_strings: Vec<String> = discovered_tests.iter().map(|t| t.to_string()).collect();
+        let test_strings: Vec<String> = discovered_tests
+            .values()
+            .map(|t| t.iter().map(|t| t.to_string()).collect())
+            .collect();
         assert!(test_strings.iter().any(|s| s.ends_with("test_function1")));
         assert!(test_strings.iter().any(|s| s.ends_with("test_function2")));
         assert!(test_strings.iter().any(|s| s.ends_with("test_function3")));
@@ -308,7 +323,11 @@ def test_function2(): pass
         let discovered_tests = discoverer.discover();
 
         assert_eq!(discovered_tests.len(), 1);
-        assert!(discovered_tests[0].to_string().ends_with("test_function1"));
+        assert!(
+            discovered_tests["test"]
+                .iter()
+                .any(|t| t.function_definition().name.to_string() == "test_function1")
+        );
     }
 
     #[test]
@@ -373,7 +392,10 @@ def test_function(): pass
         let discovered_tests = discoverer.discover();
 
         assert_eq!(discovered_tests.len(), 2);
-        let test_strings: Vec<String> = discovered_tests.iter().map(|t| t.to_string()).collect();
+        let test_strings: Vec<String> = discovered_tests
+            .values()
+            .map(|t| t.iter().map(|t| t.to_string()).collect())
+            .collect();
         assert!(test_strings.iter().any(|s| s.ends_with("check_function1")));
         assert!(test_strings.iter().any(|s| s.ends_with("check_function2")));
     }
@@ -404,7 +426,10 @@ def test_function(): pass
         let discovered_tests = discoverer.discover();
 
         assert_eq!(discovered_tests.len(), 3);
-        let test_strings: Vec<String> = discovered_tests.iter().map(|t| t.to_string()).collect();
+        let test_strings: Vec<String> = discovered_tests
+            .values()
+            .map(|t| t.iter().map(|t| t.to_string()).collect())
+            .collect();
         assert!(test_strings.iter().any(|s| s.ends_with("test_function1")));
         assert!(test_strings.iter().any(|s| s.ends_with("test_function2")));
         assert!(test_strings.iter().any(|s| s.ends_with("test_function3")));

--- a/docs/assets/benchmark_results.svg
+++ b/docs/assets/benchmark_results.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2025-05-28T20:26:19.479934</dc:date>
+    <dc:date>2025-05-29T13:58:41.355318</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -45,26 +45,26 @@ L 489.695357 113.04
 L 489.695357 79.44
 L 64.5525 79.44
 z
-" clip-path="url(#pc340b8ad7e)" style="fill: #4ecdc4"/>
+" clip-path="url(#p0cd5403cde)" style="fill: #4ecdc4"/>
    </g>
    <g id="patch_4">
     <path d="M 64.5525 45.84
-L 83.942472 45.84
-L 83.942472 12.24
+L 80.591575 45.84
+L 80.591575 12.24
 L 64.5525 12.24
 z
-" clip-path="url(#pc340b8ad7e)" style="fill: #4ecdc4"/>
+" clip-path="url(#p0cd5403cde)" style="fill: #4ecdc4"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m3e588a76b7" d="M 0 0
+       <path id="m291e5ab3ee" d="M 0 0
 L 0 3.5
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3e588a76b7" x="64.5525" y="118.08" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m291e5ab3ee" x="64.5525" y="118.08" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -142,12 +142,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m3e588a76b7" x="179.354693" y="118.08" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m291e5ab3ee" x="195.131291" y="118.08" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
-      <!-- 1.25s -->
-      <g style="fill: #ffffff" transform="translate(165.617193 132.678437) scale(0.1 -0.1)">
+      <!-- 1.00s -->
+      <g style="fill: #ffffff" transform="translate(181.393791 132.678437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531
 L 1825 531
@@ -163,6 +163,25 @@ L 794 0
 L 794 531
 z
 " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m291e5ab3ee" x="325.710083" y="118.08" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 2.00s -->
+      <g style="fill: #ffffff" transform="translate(311.972583 132.678437) scale(0.1 -0.1)">
+       <defs>
         <path id="DejaVuSans-32" d="M 1228 531
 L 3431 531
 L 3431 0
@@ -187,52 +206,10 @@ Q 2828 2175 2409 1742
 Q 1991 1309 1228 531
 z
 " transform="scale(0.015625)"/>
-        <path id="DejaVuSans-35" d="M 691 4666
-L 3169 4666
-L 3169 4134
-L 1269 4134
-L 1269 2991
-Q 1406 3038 1543 3061
-Q 1681 3084 1819 3084
-Q 2600 3084 3056 2656
-Q 3513 2228 3513 1497
-Q 3513 744 3044 326
-Q 2575 -91 1722 -91
-Q 1428 -91 1123 -41
-Q 819 9 494 109
-L 494 744
-Q 775 591 1075 516
-Q 1375 441 1709 441
-Q 2250 441 2565 725
-Q 2881 1009 2881 1497
-Q 2881 1984 2565 2268
-Q 2250 2553 1709 2553
-Q 1456 2553 1204 2497
-Q 953 2441 691 2322
-L 691 4666
-z
-" transform="scale(0.015625)"/>
        </defs>
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
-       <use xlink:href="#DejaVuSans-73" transform="translate(222.65625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_3">
-     <g id="line2d_3">
-      <g>
-       <use xlink:href="#m3e588a76b7" x="294.156887" y="118.08" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_3">
-      <!-- 2.50s -->
-      <g style="fill: #ffffff" transform="translate(280.419387 132.678437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
        <use xlink:href="#DejaVuSans-73" transform="translate(222.65625 0)"/>
       </g>
@@ -241,12 +218,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m3e588a76b7" x="408.95908" y="118.08" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m291e5ab3ee" x="456.288874" y="118.08" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
-      <!-- 3.75s -->
-      <g style="fill: #ffffff" transform="translate(395.22158 132.678437) scale(0.1 -0.1)">
+      <!-- 3.00s -->
+      <g style="fill: #ffffff" transform="translate(442.551374 132.678437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516
 Q 3050 2419 3304 2112
@@ -280,21 +257,11 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
-        <path id="DejaVuSans-37" d="M 525 4666
-L 3525 4666
-L 3525 4397
-L 1831 0
-L 1172 0
-L 2766 4134
-L 525 4134
-L 525 4666
-z
-" transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#DejaVuSans-33"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-37" transform="translate(95.410156 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
        <use xlink:href="#DejaVuSans-73" transform="translate(222.65625 0)"/>
       </g>
      </g>
@@ -304,12 +271,12 @@ z
     <g id="ytick_1">
      <g id="line2d_5">
       <defs>
-       <path id="m9e5e2562e0" d="M 0 0
+       <path id="m74b2587daf" d="M 0 0
 L -3.5 0
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9e5e2562e0" x="64.5525" y="96.24" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m74b2587daf" x="64.5525" y="96.24" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -418,7 +385,7 @@ z
     <g id="ytick_2">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m9e5e2562e0" x="64.5525" y="29.04" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m74b2587daf" x="64.5525" y="29.04" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -515,28 +482,9 @@ L 510.9525 118.08
 " style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_7">
-    <!-- 4.63s -->
+    <!-- 3.26s -->
     <g style="fill: #ffffff" transform="translate(493.946786 98.999375) scale(0.1 -0.1)">
      <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116
-L 825 1625
-L 2419 1625
-L 2419 4116
-z
-M 2253 4666
-L 3047 4666
-L 3047 1625
-L 3713 1625
-L 3713 1100
-L 3047 1100
-L 3047 0
-L 2419 0
-L 2419 1100
-L 313 1100
-L 313 1709
-L 2253 4666
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-36" d="M 2113 2584
 Q 1688 2584 1439 2293
 Q 1191 2003 1191 1497
@@ -568,20 +516,20 @@ Q 3103 4656 3366 4563
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(159.033203 0)"/>
      <use xlink:href="#DejaVuSans-73" transform="translate(222.65625 0)"/>
     </g>
    </g>
    <g id="text_8">
-    <!-- 0.21s -->
-    <g style="fill: #ffffff" transform="translate(88.1939 31.799375) scale(0.1 -0.1)">
+    <!-- 0.12s -->
+    <g style="fill: #ffffff" transform="translate(84.843004 31.799375) scale(0.1 -0.1)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
      <use xlink:href="#DejaVuSans-73" transform="translate(222.65625 0)"/>
     </g>
    </g>
@@ -840,7 +788,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pc340b8ad7e">
+  <clipPath id="p0cd5403cde">
    <rect x="64.5525" y="7.2" width="446.4" height="110.88"/>
   </clipPath>
  </defs>


### PR DESCRIPTION
## Summary

Before, we imported the module of each test case once, meaning we would import multiple modules multiple times.

In this PR i refactor how the discoverer returns the discovered test cases, meaning each module only gets imported once. This gives us around a 2x speed up.


