### PR TITLE
Rename package and module

### DIFF
--- a/crates/karva_core/src/collector/mod.rs
+++ b/crates/karva_core/src/collector/mod.rs
@@ -4,7 +4,8 @@ use crate::{
     diagnostic::Diagnostic,
     fixture::{FixtureManager, FixtureScope, RequiresFixtures},
     models::{
-        Module, Package, TestCase, TestFunction, module::CollectedModule, package::CollectedPackage,
+        DiscoveredModule, DiscoveredPackage, TestCase, TestFunction, module::CollectedModule,
+        package::CollectedPackage,
     },
     utils::{Upcast, partition_iter},
 };
@@ -16,7 +17,7 @@ impl TestCaseCollector {
     #[must_use]
     pub fn collect<'a>(
         py: Python<'_>,
-        session: &'a Package<'a>,
+        session: &'a DiscoveredPackage<'a>,
     ) -> (CollectedPackage<'a>, Vec<Diagnostic>) {
         tracing::info!("Collecting test cases");
 
@@ -52,8 +53,8 @@ impl TestCaseCollector {
         py: Python<'_>,
         test_function: &'a TestFunction<'a>,
         py_module: &Bound<'_, PyModule>,
-        module: &'a Module<'a>,
-        parents: &[&Package<'_>],
+        module: &'a DiscoveredModule<'a>,
+        parents: &[&DiscoveredPackage<'_>],
         fixture_manager: &mut FixtureManager,
     ) -> (Vec<TestCase<'a>>, Vec<Diagnostic>) {
         let mut diagnostics = Vec::new();
@@ -112,8 +113,8 @@ impl TestCaseCollector {
     #[allow(clippy::unused_self)]
     fn collect_module<'a>(
         py: Python<'_>,
-        module: &'a Module<'a>,
-        parents: &[&Package<'_>],
+        module: &'a DiscoveredModule<'a>,
+        parents: &[&DiscoveredPackage<'_>],
         fixture_manager: &mut FixtureManager,
     ) -> (CollectedModule<'a>, Vec<Diagnostic>) {
         let mut diagnostics = Vec::new();
@@ -177,8 +178,8 @@ impl TestCaseCollector {
 
     fn collect_package<'a>(
         py: Python<'_>,
-        package: &'a Package<'a>,
-        parents: &[&Package<'_>],
+        package: &'a DiscoveredPackage<'a>,
+        parents: &[&DiscoveredPackage<'_>],
         fixture_manager: &mut FixtureManager,
     ) -> (CollectedPackage<'a>, Vec<Diagnostic>) {
         let mut diagnostics = Vec::new();

--- a/crates/karva_core/src/fixture/manager.rs
+++ b/crates/karva_core/src/fixture/manager.rs
@@ -4,7 +4,7 @@ use pyo3::{prelude::*, types::PyAny};
 
 use crate::{
     fixture::{Finalizer, Finalizers, Fixture, FixtureScope, HasFixtures, RequiresFixtures},
-    models::Package,
+    models::DiscoveredPackage,
     utils::partition_iter,
 };
 
@@ -115,7 +115,7 @@ impl FixtureManager {
     fn ensure_fixture_dependencies<'proj>(
         &mut self,
         py: Python<'_>,
-        parents: &[&'proj Package<'proj>],
+        parents: &[&'proj DiscoveredPackage<'proj>],
         current: &'proj dyn HasFixtures<'proj>,
         fixture: &Fixture,
     ) {
@@ -175,7 +175,7 @@ impl FixtureManager {
     pub fn add_fixtures<'proj>(
         &mut self,
         py: Python<'_>,
-        parents: &[&'proj Package<'proj>],
+        parents: &[&'proj DiscoveredPackage<'proj>],
         current: &'proj dyn HasFixtures<'proj>,
         scopes: &[FixtureScope],
         dependencies: &[&dyn RequiresFixtures],

--- a/crates/karva_core/src/models/mod.rs
+++ b/crates/karva_core/src/models/mod.rs
@@ -3,7 +3,7 @@ pub mod package;
 pub mod test_case;
 pub mod test_function;
 
-pub use module::{Module, ModuleType, StringModule};
-pub use package::{Package, StringPackage};
+pub use module::{DiscoveredModule, ModuleType, StringModule};
+pub use package::{DiscoveredPackage, StringPackage};
 pub use test_case::TestCase;
 pub use test_function::TestFunction;

--- a/crates/karva_core/src/models/module.rs
+++ b/crates/karva_core/src/models/module.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 /// A module represents a single python file.
-pub struct Module<'proj> {
+pub struct DiscoveredModule<'proj> {
     path: SystemPathBuf,
     project: &'proj Project,
     test_functions: Vec<TestFunction<'proj>>,
@@ -22,7 +22,7 @@ pub struct Module<'proj> {
     r#type: ModuleType,
 }
 
-impl<'proj> Module<'proj> {
+impl<'proj> DiscoveredModule<'proj> {
     #[must_use]
     pub fn new(project: &'proj Project, path: &SystemPathBuf, module_type: ModuleType) -> Self {
         Self {
@@ -119,7 +119,7 @@ impl<'proj> Module<'proj> {
     }
 }
 
-impl<'proj> HasFixtures<'proj> for Module<'proj> {
+impl<'proj> HasFixtures<'proj> for DiscoveredModule<'proj> {
     fn all_fixtures<'a: 'proj>(
         &'a self,
         test_cases: &[&dyn RequiresFixtures],
@@ -144,13 +144,13 @@ impl<'proj> HasFixtures<'proj> for Module<'proj> {
     }
 }
 
-impl Display for Module<'_> {
+impl Display for DiscoveredModule<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.name())
     }
 }
 
-impl std::fmt::Debug for Module<'_> {
+impl std::fmt::Debug for DiscoveredModule<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let string_module: StringModule = self.into();
         write!(f, "{string_module:?}")
@@ -185,8 +185,8 @@ pub struct StringModule {
     pub fixtures: HashSet<(String, String)>,
 }
 
-impl From<&'_ Module<'_>> for StringModule {
-    fn from(module: &'_ Module<'_>) -> Self {
+impl From<&'_ DiscoveredModule<'_>> for StringModule {
+    fn from(module: &'_ DiscoveredModule<'_>) -> Self {
         Self {
             test_cases: module.test_functions().iter().map(|tc| tc.name()).collect(),
             fixtures: module


### PR DESCRIPTION
## Summary

`Module` and `Package` may seem unclear. And these only represent the state of a module or package after discovery

We also have `CollectedModule` and `CollectedPackage`, so it makes sense to rename these
