### PR TITLE
Move models to discovery and collection modules

### DIFF
--- a/crates/karva_core/src/collection/collector.rs
+++ b/crates/karva_core/src/collection/collector.rs
@@ -1,12 +1,10 @@
 use pyo3::prelude::*;
 
 use crate::{
+    collection::{CollectedModule, CollectedPackage, TestCase},
     diagnostic::Diagnostic,
+    discovery::{DiscoveredModule, DiscoveredPackage, TestFunction},
     fixture::{FixtureManager, FixtureScope, RequiresFixtures},
-    models::{
-        DiscoveredModule, DiscoveredPackage, TestCase, TestFunction, module::CollectedModule,
-        package::CollectedPackage,
-    },
     utils::{Upcast, partition_iter},
 };
 

--- a/crates/karva_core/src/collection/mod.rs
+++ b/crates/karva_core/src/collection/mod.rs
@@ -1,0 +1,5 @@
+pub mod collector;
+pub mod models;
+
+pub use collector::TestCaseCollector;
+pub use models::{case::TestCase, module::CollectedModule, package::CollectedPackage};

--- a/crates/karva_core/src/collection/models/case.rs
+++ b/crates/karva_core/src/collection/models/case.rs
@@ -2,8 +2,8 @@ use pyo3::{prelude::*, types::PyTuple};
 
 use crate::{
     diagnostic::Diagnostic,
+    discovery::{TestFunction, TestFunctionDisplay},
     fixture::Finalizers,
-    models::{TestFunction, test_function::TestFunctionDisplay},
     runner::RunDiagnostics,
 };
 

--- a/crates/karva_core/src/collection/models/mod.rs
+++ b/crates/karva_core/src/collection/models/mod.rs
@@ -1,0 +1,3 @@
+pub mod case;
+pub mod module;
+pub mod package;

--- a/crates/karva_core/src/collection/models/module.rs
+++ b/crates/karva_core/src/collection/models/module.rs
@@ -1,0 +1,47 @@
+use pyo3::prelude::*;
+
+use crate::{
+    collection::TestCase, diagnostic::reporter::Reporter, fixture::Finalizers,
+    runner::RunDiagnostics,
+};
+
+#[derive(Default)]
+pub struct CollectedModule<'proj> {
+    test_cases: Vec<TestCase<'proj>>,
+    finalizers: Finalizers,
+}
+
+impl<'proj> CollectedModule<'proj> {
+    #[must_use]
+    pub fn test_cases(&self) -> &[TestCase<'proj>] {
+        &self.test_cases
+    }
+
+    pub fn add_test_cases(&mut self, test_cases: Vec<TestCase<'proj>>) {
+        self.test_cases.extend(test_cases);
+    }
+
+    #[must_use]
+    pub const fn finalizers(&self) -> &Finalizers {
+        &self.finalizers
+    }
+
+    pub fn add_finalizers(&mut self, finalizers: Finalizers) {
+        self.finalizers.update(finalizers);
+    }
+
+    pub fn run_with_reporter(&self, py: Python<'_>, reporter: &mut dyn Reporter) -> RunDiagnostics {
+        let mut diagnostics = RunDiagnostics::default();
+
+        for test_case in &self.test_cases {
+            let result = test_case.run(py);
+            reporter.report();
+            diagnostics.update(&result);
+            diagnostics.add_diagnostics(test_case.finalizers().run(py));
+        }
+
+        diagnostics.add_diagnostics(self.finalizers().run(py));
+
+        diagnostics
+    }
+}

--- a/crates/karva_core/src/collection/models/package.rs
+++ b/crates/karva_core/src/collection/models/package.rs
@@ -1,0 +1,55 @@
+use pyo3::prelude::*;
+
+use crate::{
+    collection::CollectedModule, diagnostic::reporter::Reporter, fixture::Finalizers,
+    runner::RunDiagnostics,
+};
+
+#[derive(Default)]
+pub struct CollectedPackage<'proj> {
+    finalizers: Finalizers,
+    modules: Vec<CollectedModule<'proj>>,
+    packages: Vec<CollectedPackage<'proj>>,
+}
+
+impl<'proj> CollectedPackage<'proj> {
+    pub fn add_collected_module(&mut self, collected_module: CollectedModule<'proj>) {
+        self.modules.push(collected_module);
+    }
+
+    pub fn add_collected_package(&mut self, collected_package: Self) {
+        self.packages.push(collected_package);
+    }
+
+    pub fn add_finalizers(&mut self, finalizers: Finalizers) {
+        self.finalizers.update(finalizers);
+    }
+
+    #[must_use]
+    pub fn total_test_cases(&self) -> usize {
+        let mut total = 0;
+        for module in &self.modules {
+            total += module.test_cases().len();
+        }
+        for package in &self.packages {
+            total += package.total_test_cases();
+        }
+        total
+    }
+
+    pub fn run_with_reporter(&self, py: Python<'_>, reporter: &mut dyn Reporter) -> RunDiagnostics {
+        let mut diagnostics = RunDiagnostics::default();
+
+        for module in &self.modules {
+            diagnostics.update(&module.run_with_reporter(py, reporter));
+        }
+
+        for package in &self.packages {
+            diagnostics.update(&package.run_with_reporter(py, reporter));
+        }
+
+        diagnostics.add_diagnostics(self.finalizers.run(py));
+
+        diagnostics
+    }
+}

--- a/crates/karva_core/src/diagnostic/mod.rs
+++ b/crates/karva_core/src/diagnostic/mod.rs
@@ -2,8 +2,8 @@ use karva_project::path::TestPathError;
 use pyo3::prelude::*;
 
 use crate::{
+    collection::TestCase,
     diagnostic::render::{DisplayDiagnostic, SubDiagnosticDisplay},
-    models::TestCase,
 };
 
 pub mod render;

--- a/crates/karva_core/src/discovery/discoverer.rs
+++ b/crates/karva_core/src/discovery/discoverer.rs
@@ -8,8 +8,7 @@ use pyo3::prelude::*;
 
 use crate::{
     diagnostic::Diagnostic,
-    discovery::discover,
-    models::{DiscoveredModule, DiscoveredPackage, ModuleType},
+    discovery::{DiscoveredModule, DiscoveredPackage, ModuleType, discover},
     utils::add_to_sys_path,
 };
 
@@ -245,7 +244,7 @@ mod tests {
     use karva_project::{project::ProjectOptions, tests::TestEnv, verbosity::VerbosityLevel};
 
     use super::*;
-    use crate::models::{StringModule, StringPackage};
+    use crate::discovery::{StringModule, StringPackage};
 
     #[test]
     fn test_discover_files() {

--- a/crates/karva_core/src/discovery/mod.rs
+++ b/crates/karva_core/src/discovery/mod.rs
@@ -1,5 +1,11 @@
 pub mod discoverer;
+pub mod models;
 pub mod visitor;
 
 pub use discoverer::Discoverer;
+pub use models::{
+    function::{TestFunction, TestFunctionDisplay},
+    module::{DiscoveredModule, ModuleType, StringModule},
+    package::{DiscoveredPackage, StringPackage},
+};
 pub use visitor::{FunctionDefinitionVisitor, discover};

--- a/crates/karva_core/src/discovery/models/function.rs
+++ b/crates/karva_core/src/discovery/models/function.rs
@@ -8,9 +8,9 @@ use pyo3::prelude::*;
 use ruff_python_ast::StmtFunctionDef;
 
 use crate::{
+    collection::TestCase,
     diagnostic::Diagnostic,
     fixture::{FixtureManager, HasFunctionDefinition, RequiresFixtures},
-    models::TestCase,
     tag::Tags,
     utils::Upcast,
 };

--- a/crates/karva_core/src/discovery/models/mod.rs
+++ b/crates/karva_core/src/discovery/models/mod.rs
@@ -1,0 +1,3 @@
+pub mod function;
+pub mod module;
+pub mod package;

--- a/crates/karva_core/src/discovery/models/package.rs
+++ b/crates/karva_core/src/discovery/models/package.rs
@@ -1,13 +1,10 @@
 use std::collections::{HashMap, HashSet};
 
 use karva_project::{path::SystemPathBuf, project::Project, utils::module_name};
-use pyo3::prelude::*;
 
 use crate::{
-    diagnostic::reporter::Reporter,
-    fixture::{Finalizers, Fixture, HasFixtures, RequiresFixtures},
-    models::{DiscoveredModule, ModuleType, StringModule, TestFunction, module::CollectedModule},
-    runner::RunDiagnostics,
+    discovery::{DiscoveredModule, ModuleType, StringModule, TestFunction},
+    fixture::{Fixture, HasFixtures, RequiresFixtures},
     utils::Upcast,
 };
 
@@ -313,55 +310,6 @@ impl PartialEq for StringPackage {
 }
 
 impl Eq for StringPackage {}
-
-#[derive(Default)]
-pub struct CollectedPackage<'proj> {
-    finalizers: Finalizers,
-    modules: Vec<CollectedModule<'proj>>,
-    packages: Vec<CollectedPackage<'proj>>,
-}
-
-impl<'proj> CollectedPackage<'proj> {
-    pub fn add_collected_module(&mut self, collected_module: CollectedModule<'proj>) {
-        self.modules.push(collected_module);
-    }
-
-    pub fn add_collected_package(&mut self, collected_package: Self) {
-        self.packages.push(collected_package);
-    }
-
-    pub fn add_finalizers(&mut self, finalizers: Finalizers) {
-        self.finalizers.update(finalizers);
-    }
-
-    #[must_use]
-    pub fn total_test_cases(&self) -> usize {
-        let mut total = 0;
-        for module in &self.modules {
-            total += module.test_cases().len();
-        }
-        for package in &self.packages {
-            total += package.total_test_cases();
-        }
-        total
-    }
-
-    pub fn run_with_reporter(&self, py: Python<'_>, reporter: &mut dyn Reporter) -> RunDiagnostics {
-        let mut diagnostics = RunDiagnostics::default();
-
-        for module in &self.modules {
-            diagnostics.update(&module.run_with_reporter(py, reporter));
-        }
-
-        for package in &self.packages {
-            diagnostics.update(&package.run_with_reporter(py, reporter));
-        }
-
-        diagnostics.add_diagnostics(self.finalizers.run(py));
-
-        diagnostics
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/karva_core/src/discovery/visitor.rs
+++ b/crates/karva_core/src/discovery/visitor.rs
@@ -8,8 +8,8 @@ use ruff_python_parser::{Mode, ParseOptions, Parsed, parse_unchecked};
 
 use crate::{
     diagnostic::{Diagnostic, ErrorType, Severity},
+    discovery::TestFunction,
     fixture::{Fixture, FixtureExtractor, is_fixture_function},
-    models::TestFunction,
 };
 
 pub struct FunctionDefinitionVisitor<'proj, 'b> {

--- a/crates/karva_core/src/fixture/manager.rs
+++ b/crates/karva_core/src/fixture/manager.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use pyo3::{prelude::*, types::PyAny};
 
 use crate::{
+    discovery::DiscoveredPackage,
     fixture::{Finalizer, Finalizers, Fixture, FixtureScope, HasFixtures, RequiresFixtures},
-    models::DiscoveredPackage,
     utils::partition_iter,
 };
 

--- a/crates/karva_core/src/lib.rs
+++ b/crates/karva_core/src/lib.rs
@@ -1,8 +1,7 @@
-pub mod collector;
+pub mod collection;
 pub mod diagnostic;
 pub mod discovery;
 pub mod fixture;
-pub mod models;
 pub mod runner;
 pub mod tag;
 pub mod utils;

--- a/crates/karva_core/src/models/mod.rs
+++ b/crates/karva_core/src/models/mod.rs
@@ -1,9 +1,0 @@
-pub mod module;
-pub mod package;
-pub mod test_case;
-pub mod test_function;
-
-pub use module::{DiscoveredModule, ModuleType, StringModule};
-pub use package::{DiscoveredPackage, StringPackage};
-pub use test_case::TestCase;
-pub use test_function::TestFunction;

--- a/crates/karva_core/src/runner/mod.rs
+++ b/crates/karva_core/src/runner/mod.rs
@@ -1,7 +1,7 @@
 use karva_project::project::Project;
 
 use crate::{
-    collector::TestCaseCollector,
+    collection::TestCaseCollector,
     diagnostic::reporter::{DummyReporter, Reporter},
     discovery::Discoverer,
     utils::with_gil,


### PR DESCRIPTION
## Summary

`CollectedModule` and `DiscoveredModule`, for example, don't make much sense in the same module. So we have moved them respectively to `collection` and `discovery.

