### PR TITLE
Add skip page to docs

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -21,10 +21,13 @@ cov:
 
 # Build documentation
 docs:
+    uv venv --clear -p 3.13
+    uv sync --group docs --no-install-project
     uv run --no-project mkdocs build
 
 # Serve documentation locally
 docs-serve:
+    uv venv --clear -p 3.13
     uv sync --group docs --no-install-project
     uv run --no-project mkdocs serve
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ nav:
   - Fixtures: fixtures.md
   - Tags:
       - Parametrize: tags/parametrize.md
+      - Skip: tags/skip.md
   - CLI: cli.md
 
 theme:


### PR DESCRIPTION
## Summary

The skip tag page was not added to the mkdocs.yml file, now we have.

I also update the Justfile docs build and server commands
