### PR TITLE
Only show labels we want

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -34,10 +34,11 @@ exclude-contributors:
   - dependabot
   - dependabot[bot]
 
-exclude-labels:
-  - dependencies
-  - testing
-  - rust
-  - question
-  - performance
-  - contributor-friendly
+include-labels:
+  - bug
+  - reporting
+  - extensions/fixtures
+  - extensions/tags
+  - discovery
+  - cli
+  - documentation


### PR DESCRIPTION
## Summary

Previously we would show other labels so we have swapped this to only show the labels that we specify in the categories section.