### PR TITLE
Show fixture diagnostics

### DIFF
--- a/crates/karva_cli/tests/cli.rs
+++ b/crates/karva_cli/tests/cli.rs
@@ -64,11 +64,11 @@ fn test_one_test_fails() {
 
     test test_fail::test_fail ... FAILED
 
-    failures:
+    test failures:
 
     test `test_fail::test_fail` at <temp_dir>/test_fail.py:2 failed at <temp_dir>/test_fail.py:3
 
-    failures:
+    test failures:
         test_fail::test_fail at <temp_dir>/test_fail.py:2
 
     test result: FAILED. 0 passed; 1 failed; 0 skipped; finished in [TIME]
@@ -100,14 +100,14 @@ fn test_two_test_fails() {
     test tests.test_fail::test_fail ... FAILED
     test tests.test_fail::test_fail2 ... FAILED
 
-    failures:
+    test failures:
 
     test `tests.test_fail::test_fail` at <temp_dir>/tests/test_fail.py:2 failed at <temp_dir>/tests/test_fail.py:3
 
     test `tests.test_fail::test_fail2` at <temp_dir>/tests/test_fail.py:5 failed at <temp_dir>/tests/test_fail.py:6
     Test failed
 
-    failures:
+    test failures:
         tests.test_fail::test_fail at <temp_dir>/tests/test_fail.py:2
         tests.test_fail::test_fail2 at <temp_dir>/tests/test_fail.py:5
 
@@ -149,12 +149,12 @@ fn test_file_importing_another_file() {
 
     test test_cross_file::test_with_helper ... FAILED
 
-    failures:
+    test failures:
 
     test `test_cross_file::test_with_helper` at <temp_dir>/test_cross_file.py:4 failed at <temp_dir>/helper.py:4
     Data validation failed
 
-    failures:
+    test failures:
         test_cross_file::test_with_helper at <temp_dir>/test_cross_file.py:4
 
     test result: FAILED. 0 passed; 1 failed; 0 skipped; finished in [TIME]
@@ -281,11 +281,11 @@ fn test_multiple_fixtures_not_found() {
 
     test test_multiple_fixtures_not_found::test_multiple_fixtures_not_found ... FAILED
 
-    failures:
+    test failures:
 
     test `test_multiple_fixtures_not_found::test_multiple_fixtures_not_found` has missing fixtures: ["a", "b", "c"] at <temp_dir>/test_multiple_fixtures_not_found.py:1
 
-    failures:
+    test failures:
         test_multiple_fixtures_not_found::test_multiple_fixtures_not_found at <temp_dir>/test_multiple_fixtures_not_found.py:1
 
     test result: FAILED. 0 passed; 1 failed; 0 skipped; finished in [TIME]
@@ -479,7 +479,7 @@ fn test_fixture_generator_two_yields_failing_test() {
 
     test test::test_fixture_generator [fixture_generator=1] ... FAILED
 
-    failures:
+    test failures:
 
     test `test::test_fixture_generator` at <temp_dir>/test.py:9 failed at <temp_dir>/test.py:10
 
@@ -487,7 +487,7 @@ fn test_fixture_generator_two_yields_failing_test() {
 
     warning: Fixture test::fixture_generator had more than one yield statement
 
-    failures:
+    test failures:
         test::test_fixture_generator at <temp_dir>/test.py:9
 
     test result: FAILED. 0 passed; 1 failed; 0 skipped; finished in [TIME]
@@ -561,11 +561,11 @@ fn test_invalid_fixture() {
 
     invalid fixture `fixture_generator`: Invalid fixture scope: ssession at <temp_dir>/test.py:4
 
-    failures:
+    test failures:
 
     test `test::test_fixture_generator` has missing fixtures: ["fixture_generator"] at <temp_dir>/test.py:8
 
-    failures:
+    test failures:
         test::test_fixture_generator at <temp_dir>/test.py:8
 
     test result: FAILED. 0 passed; 1 failed; 0 skipped; finished in [TIME]

--- a/crates/karva_core/src/collection/collector.rs
+++ b/crates/karva_core/src/collection/collector.rs
@@ -35,6 +35,8 @@ impl TestCaseCollector {
 
         session_collected.add_finalizers(fixture_manager.reset_fixtures());
 
+        session_collected.add_fixture_diagnostics(fixture_manager.clear_diagnostics());
+
         session_collected.add_package(package_collected);
 
         session_collected
@@ -146,6 +148,8 @@ impl TestCaseCollector {
 
         module_collected.add_finalizers(module_fixture_manager.reset_fixtures());
 
+        module_collected.add_fixture_diagnostics(module_fixture_manager.clear_diagnostics());
+
         module_collected
     }
 
@@ -200,6 +204,8 @@ impl TestCaseCollector {
         }
 
         package_collected.add_finalizers(package_fixture_manager.reset_fixtures());
+
+        package_collected.add_fixture_diagnostics(package_fixture_manager.clear_diagnostics());
 
         package_collected
     }

--- a/crates/karva_core/src/collection/models/case.rs
+++ b/crates/karva_core/src/collection/models/case.rs
@@ -32,8 +32,14 @@ pub(crate) struct TestCase<'proj> {
     /// Finalizers to run after the test case is executed.
     finalizers: Finalizers,
 
-    /// The diagnostic from collecting the test case.
+    /// The missing fixtures diagnostic.
     diagnostic: Option<Diagnostic>,
+
+    /// The diagnostic from collecting the test case.
+    ///
+    /// These fixture diagnostics come from the collection process and are most likely
+    /// diagnostics of failed fixtures.
+    fixture_diagnostics: Vec<Diagnostic>,
 }
 
 impl<'proj> TestCase<'proj> {
@@ -49,105 +55,125 @@ impl<'proj> TestCase<'proj> {
             module,
             finalizers: Finalizers::default(),
             diagnostic,
+            fixture_diagnostics: Vec::new(),
         }
-    }
-
-    pub(crate) const fn function(&self) -> &TestFunction {
-        self.function
     }
 
     pub(crate) fn add_finalizers(&mut self, finalizers: Finalizers) {
         self.finalizers.update(finalizers);
     }
 
-    pub(crate) const fn finalizers(&self) -> &Finalizers {
-        &self.finalizers
+    pub(crate) fn add_fixture_diagnostics(&mut self, diagnostics: Vec<Diagnostic>) {
+        self.fixture_diagnostics.extend(diagnostics);
     }
 
-    pub(crate) fn run(&self, py: Python<'_>, reporter: &dyn Reporter) -> TestRunResult {
-        let mut run_result = TestRunResult::default();
+    pub(crate) fn run(self, py: Python<'_>, reporter: &dyn Reporter) -> TestRunResult {
+        let Self {
+            function,
+            kwargs,
+            module,
+            finalizers,
+            diagnostic,
+            fixture_diagnostics,
+        } = self;
 
-        let test_name = full_test_name(py, &self.function.name().to_string(), &self.kwargs);
+        let mut run_result = (|| {
+            let mut run_result = TestRunResult::default();
 
-        if let Some(skip_tag) = &self.function.tags().skip_tag() {
-            run_result.register_test_case_result(
-                &test_name,
-                IndividualTestResultKind::Skipped {
-                    reason: skip_tag.reason(),
-                },
-                Some(reporter),
-            );
+            let test_name = full_test_name(py, &function.name().to_string(), &kwargs);
 
-            return run_result;
-        }
-
-        if let Some(skip_if_tag) = &self.function.tags().skip_if_tag() {
-            if skip_if_tag.should_skip() {
+            if let Some(skip_tag) = &function.tags().skip_tag() {
                 run_result.register_test_case_result(
                     &test_name,
                     IndividualTestResultKind::Skipped {
-                        reason: skip_if_tag.reason(),
+                        reason: skip_tag.reason(),
                     },
                     Some(reporter),
                 );
+
                 return run_result;
             }
-        }
 
-        let case_call_result = if self.kwargs.is_empty() {
-            self.function.py_function().call0(py)
-        } else {
-            let kwargs = PyDict::new(py);
-
-            for key in self.function.definition().dependant_fixtures(py) {
-                if let Some(value) = self.kwargs.get(&key) {
-                    let _ = kwargs.set_item(key, value);
+            if let Some(skip_if_tag) = &function.tags().skip_if_tag() {
+                if skip_if_tag.should_skip() {
+                    run_result.register_test_case_result(
+                        &test_name,
+                        IndividualTestResultKind::Skipped {
+                            reason: skip_if_tag.reason(),
+                        },
+                        Some(reporter),
+                    );
+                    return run_result;
                 }
             }
 
-            self.function.py_function().call(py, (), Some(&kwargs))
-        };
+            let case_call_result = if kwargs.is_empty() {
+                function.py_function().call0(py)
+            } else {
+                let py_dict = PyDict::new(py);
 
-        let Err(err) = case_call_result else {
+                for key in function.definition().dependant_fixtures(py) {
+                    if let Some(value) = kwargs.get(&key) {
+                        let _ = py_dict.set_item(key, value);
+                    }
+                }
+
+                function.py_function().call(py, (), Some(&py_dict))
+            };
+
+            let Err(err) = case_call_result else {
+                run_result.register_test_case_result(
+                    &test_name,
+                    IndividualTestResultKind::Passed,
+                    Some(reporter),
+                );
+
+                return run_result;
+            };
+
+            // Check if the exception is a skip exception (karva.SkipError or pytest.Skipped)
+            if is_skip_exception(py, &err) {
+                let reason = extract_skip_reason(py, &err);
+                run_result.register_test_case_result(
+                    &test_name,
+                    IndividualTestResultKind::Skipped { reason },
+                    Some(reporter),
+                );
+
+                return run_result;
+            }
+
+            let default_diagnostic = || {
+                Diagnostic::from_test_fail(
+                    py,
+                    &err,
+                    FunctionDefinitionLocation::new(
+                        function.name().to_string(),
+                        function.display_with_line(module),
+                    ),
+                )
+            };
+
+            let diagnostic = diagnostic.map_or_else(default_diagnostic, |input_diagnostic| {
+                let missing_args = missing_arguments_from_error(&err.to_string());
+                handle_missing_fixtures(&missing_args, input_diagnostic)
+                    .unwrap_or_else(default_diagnostic)
+            });
+
             run_result.register_test_case_result(
                 &test_name,
-                IndividualTestResultKind::Passed,
+                IndividualTestResultKind::Failed,
                 Some(reporter),
             );
 
-            return run_result;
-        };
+            run_result.add_test_diagnostic(diagnostic);
 
-        // Check if the exception is a skip exception (karva.SkipError or pytest.Skipped)
-        if is_skip_exception(py, &err) {
-            let reason = extract_skip_reason(py, &err);
-            run_result.register_test_case_result(
-                &test_name,
-                IndividualTestResultKind::Skipped { reason },
-                Some(reporter),
-            );
+            run_result
+        })();
 
-            return run_result;
-        }
+        run_result.add_test_diagnostics(fixture_diagnostics);
 
-        let default_diagnostic = || Diagnostic::from_test_fail(py, &err, self, self.module);
-
-        let diagnostic =
-            self.diagnostic
-                .clone()
-                .map_or_else(default_diagnostic, |input_diagnostic| {
-                    let missing_args = missing_arguments_from_error(&err.to_string());
-                    handle_missing_fixtures(&missing_args, input_diagnostic)
-                        .unwrap_or_else(default_diagnostic)
-                });
-
-        run_result.register_test_case_result(
-            &test_name,
-            IndividualTestResultKind::Failed,
-            Some(reporter),
-        );
-
-        run_result.add_test_diagnostic(diagnostic);
+        run_result.add_test_diagnostics(finalizers.run(py));
 
         run_result
     }

--- a/crates/karva_core/src/diagnostic/render.rs
+++ b/crates/karva_core/src/diagnostic/render.rs
@@ -1,7 +1,7 @@
 use crate::diagnostic::{
     Diagnostic, DiscoveryDiagnostic, InvalidFixtureDiagnostic, MissingFixturesDiagnostic,
     TestFailureDiagnostic, WarningDiagnostic,
-    diagnostic::{FunctionDefinitionLocation, TestRunFailureDiagnostic},
+    diagnostic::{FixtureFailureDiagnostic, FunctionDefinitionLocation, TestRunFailureDiagnostic},
 };
 
 pub struct DisplayDiagnostic<'a> {
@@ -55,9 +55,31 @@ impl std::fmt::Display for DisplayDiagnostic<'_> {
                     )?;
                 }
             },
-
             Diagnostic::Warning(WarningDiagnostic { message }) => {
                 writeln!(f, "warning: {message}")?;
+            }
+            Diagnostic::FixtureFailure(FixtureFailureDiagnostic {
+                location:
+                    FunctionDefinitionLocation {
+                        function_name,
+                        location: function_location,
+                    },
+                traceback,
+                message,
+            }) => {
+                let location_fail_string = traceback
+                    .location
+                    .as_ref()
+                    .map(|location| format!("at {location}"))
+                    .unwrap_or_default();
+
+                writeln!(
+                    f,
+                    "fixture function `{function_name}` at {function_location} failed {location_fail_string}"
+                )?;
+                if let Some(message) = message {
+                    writeln!(f, "{message}")?;
+                }
             }
         }
 

--- a/crates/karva_core/src/discovery/models/function.rs
+++ b/crates/karva_core/src/discovery/models/function.rs
@@ -153,6 +153,8 @@ impl TestFunction {
 
             if let Some(first_test) = test_cases.first_mut() {
                 first_test.add_finalizers(fixture_manager.reset_fixtures());
+
+                first_test.add_fixture_diagnostics(fixture_manager.clear_diagnostics());
             }
         }
 

--- a/crates/karva_core/src/discovery/models/module.rs
+++ b/crates/karva_core/src/discovery/models/module.rs
@@ -21,8 +21,7 @@ pub(crate) struct DiscoveredModule {
 
 impl DiscoveredModule {
     pub(crate) fn new(path: ModulePath, module_type: ModuleType) -> Self {
-        let source_text =
-            std::fs::read_to_string(path.module_path()).expect("Failed to read source file");
+        let source_text = std::fs::read_to_string(path.path()).expect("Failed to read source file");
 
         let line_index = LineIndex::from_source_text(&source_text);
 
@@ -41,7 +40,7 @@ impl DiscoveredModule {
     }
 
     pub(crate) const fn path(&self) -> &Utf8PathBuf {
-        self.path.module_path()
+        self.path.path()
     }
 
     pub(crate) fn name(&self) -> &str {
@@ -165,6 +164,10 @@ impl<'proj> HasFixtures<'proj> for DiscoveredModule {
             .collect();
 
         all_fixtures
+    }
+
+    fn fixture_module<'a: 'proj>(&'a self) -> Option<&'a DiscoveredModule> {
+        Some(self)
     }
 }
 

--- a/crates/karva_core/src/extensions/fixtures/mod.rs
+++ b/crates/karva_core/src/extensions/fixtures/mod.rs
@@ -13,6 +13,7 @@ pub(crate) use finalizer::{Finalizer, Finalizers};
 pub(crate) use manager::FixtureManager;
 
 use crate::{
+    discovery::DiscoveredModule,
     extensions::fixtures::python::FixtureRequest,
     name::{ModulePath, QualifiedFunctionName},
     utils::cartesian_insert,
@@ -128,6 +129,10 @@ impl Fixture {
 
     pub(crate) const fn name(&self) -> &QualifiedFunctionName {
         &self.name
+    }
+
+    pub(crate) const fn function_statement(&self) -> &StmtFunctionDef {
+        &self.function_def
     }
 
     pub(crate) const fn scope(&self) -> &FixtureScope {
@@ -452,6 +457,8 @@ pub(crate) trait HasFixtures<'proj>: std::fmt::Debug {
         py: Python<'_>,
         test_cases: &[&dyn UsesFixtures],
     ) -> Vec<&'proj Fixture>;
+
+    fn fixture_module<'a: 'proj>(&'a self) -> Option<&'a DiscoveredModule>;
 }
 
 #[cfg(test)]

--- a/crates/karva_core/src/name.rs
+++ b/crates/karva_core/src/name.rs
@@ -49,7 +49,7 @@ impl ModulePath {
         self.module_name.as_str()
     }
 
-    pub(crate) const fn module_path(&self) -> &Utf8PathBuf {
+    pub(crate) const fn path(&self) -> &Utf8PathBuf {
         &self.path
     }
 }

--- a/crates/karva_core/src/runner/mod.rs
+++ b/crates/karva_core/src/runner/mod.rs
@@ -42,7 +42,7 @@ impl<'proj> StandardTestRunner<'proj> {
 
             reporter.log_test_count(total_test_cases);
 
-            diagnostics.update(&collected_session.run_with_reporter(py, reporter));
+            diagnostics.update(collected_session.run_with_reporter(py, reporter));
 
             diagnostics
         })

--- a/crates/karva_core/tests/integration/extensions/fixtures/basic.rs
+++ b/crates/karva_core/tests/integration/extensions/fixtures/basic.rs
@@ -7,7 +7,7 @@ use crate::common::{TestRunnerExt, get_auto_use_kw};
 #[test]
 fn test_fixture_manager_add_fixtures_impl_three_dependencies_different_scopes_with_fixture_in_function()
  {
-    let test_context = TestContext::with_files([
+    let context = TestContext::with_files([
         (
             "<test>/conftest.py",
             r"
@@ -28,14 +28,14 @@ def z(x, y):
         ("<test>/inner/test_file.py", "def test_1(z): pass"),
     ]);
 
-    let result = test_context.test();
+    let result = context.test();
 
     assert_snapshot!(result.display(), @"test result: ok. 1 passed; 0 failed; 0 skipped; finished in [TIME]");
 }
 
 #[test]
 fn test_runner_given_nested_path() {
-    let test_context = TestContext::with_files([
+    let context = TestContext::with_files([
         (
             "<test>/conftest.py",
             r"
@@ -48,14 +48,14 @@ def x():
         ("<test>/test_file.py", "def test_1(x): pass"),
     ]);
 
-    let result = test_context.test();
+    let result = context.test();
 
     assert_snapshot!(result.display(), @"test result: ok. 1 passed; 0 failed; 0 skipped; finished in [TIME]");
 }
 
 #[test]
 fn test_fixture_with_name_parameter() {
-    let test_context = TestContext::with_file(
+    let context = TestContext::with_file(
         "<test>/test_file.py",
         r#"import karva
 
@@ -68,24 +68,24 @@ def test_fixture_with_name_parameter(fixture_name):
 "#,
     );
 
-    let result = test_context.test();
+    let result = context.test();
 
     assert_snapshot!(result.display(), @"test result: ok. 1 passed; 0 failed; 0 skipped; finished in [TIME]");
 }
 
 #[test]
 fn test_fixture_is_different_in_different_functions() {
-    let test_context = TestContext::with_file(
+    let context = TestContext::with_file(
         "<test>/test_file.py",
         r"import karva
 
-class Testtest_context:
+class Testcontext:
     def __init__(self):
         self.x = 1
 
 @karva.fixture
 def fixture():
-    return Testtest_context()
+    return Testcontext()
 
 def test_fixture(fixture):
     assert fixture.x == 1
@@ -97,14 +97,14 @@ def test_fixture_2(fixture):
 ",
     );
 
-    let result = test_context.test();
+    let result = context.test();
 
     assert_snapshot!(result.display(), @"test result: ok. 2 passed; 0 failed; 0 skipped; finished in [TIME]");
 }
 
 #[test]
 fn test_fixture_from_current_package_session_scope() {
-    let test_context = TestContext::with_files([
+    let context = TestContext::with_files([
         (
             "<test>/tests/conftest.py",
             r"
@@ -118,14 +118,14 @@ def x():
         ("<test>/tests/test_file.py", "def test_1(x): pass"),
     ]);
 
-    let result = test_context.test();
+    let result = context.test();
 
     assert_snapshot!(result.display(), @"test result: ok. 1 passed; 0 failed; 0 skipped; finished in [TIME]");
 }
 
 #[test]
 fn test_fixture_from_current_package_function_scope() {
-    let test_context = TestContext::with_files([
+    let context = TestContext::with_files([
         (
             "<test>/tests/conftest.py",
             r"
@@ -138,14 +138,14 @@ def x():
         ("<test>/tests/test_file.py", "def test_1(x): pass"),
     ]);
 
-    let result = test_context.test();
+    let result = context.test();
 
     assert_snapshot!(result.display(), @"test result: ok. 1 passed; 0 failed; 0 skipped; finished in [TIME]");
 }
 
 #[test]
 fn test_finalizer_from_current_package_session_scope() {
-    let test_context = TestContext::with_files([
+    let context = TestContext::with_files([
         (
             "<test>/tests/conftest.py",
             r"
@@ -173,14 +173,14 @@ def test_2(x):
         ),
     ]);
 
-    let result = test_context.test();
+    let result = context.test();
 
     assert_snapshot!(result.display(), @"test result: ok. 2 passed; 0 failed; 0 skipped; finished in [TIME]");
 }
 
 #[test]
 fn test_finalizer_from_current_package_function_scope() {
-    let test_context = TestContext::with_files([
+    let context = TestContext::with_files([
         (
             "<test>/tests/conftest.py",
             r"
@@ -208,14 +208,14 @@ def test_2(x):
         ),
     ]);
 
-    let result = test_context.test();
+    let result = context.test();
 
     assert_snapshot!(result.display(), @"test result: ok. 2 passed; 0 failed; 0 skipped; finished in [TIME]");
 }
 
 #[test]
 fn test_discover_pytest_fixture() {
-    let test_context = TestContext::with_files([
+    let context = TestContext::with_files([
         (
             "<test>/tests/conftest.py",
             r"
@@ -229,14 +229,14 @@ def x():
         ("<test>/tests/test_1.py", "def test_1(x): pass"),
     ]);
 
-    let result = test_context.test();
+    let result = context.test();
 
     assert_snapshot!(result.display(), @"test result: ok. 1 passed; 0 failed; 0 skipped; finished in [TIME]");
 }
 
 #[rstest]
 fn test_dynamic_fixture_scope_session_scope(#[values("pytest", "karva")] framework: &str) {
-    let test_context = TestContext::with_file(
+    let context = TestContext::with_file(
         "<test>/test_dynamic_scope.py",
         &format!(
             r#"
@@ -262,7 +262,7 @@ def test_2(x_session):
         ),
     );
 
-    let result = test_context.test();
+    let result = context.test();
 
     allow_duplicates!(
         assert_snapshot!(result.display(), @"test result: ok. 2 passed; 0 failed; 0 skipped; finished in [TIME]")
@@ -271,7 +271,7 @@ def test_2(x_session):
 
 #[rstest]
 fn test_dynamic_fixture_scope_function_scope(#[values("pytest", "karva")] framework: &str) {
-    let test_context = TestContext::with_file(
+    let context = TestContext::with_file(
         "<test>/test_dynamic_scope.py",
         &format!(
             r#"
@@ -297,7 +297,7 @@ def test_2(x_function):
         ),
     );
 
-    let result = test_context.test();
+    let result = context.test();
 
     allow_duplicates! {
         assert_snapshot!(result.display(), @"test result: ok. 2 passed; 0 failed; 0 skipped; finished in [TIME]");
@@ -306,7 +306,7 @@ def test_2(x_function):
 
 #[test]
 fn test_fixture_override_in_test_modules() {
-    let test_context = TestContext::with_files([
+    let context = TestContext::with_files([
         (
             "<test>/tests/conftest.py",
             r"
@@ -345,14 +345,14 @@ def test_username(username):
         ),
     ]);
 
-    let result = test_context.test();
+    let result = context.test();
 
     assert_snapshot!(result.display(), @"test result: ok. 2 passed; 0 failed; 0 skipped; finished in [TIME]");
 }
 
 #[rstest]
 fn test_fixture_initialization_order(#[values("pytest", "karva")] framework: &str) {
-    let test_context = TestContext::with_file(
+    let context = TestContext::with_file(
         "<test>/test.py",
         &format!(
             r#"
@@ -397,7 +397,7 @@ fn test_fixture_initialization_order(#[values("pytest", "karva")] framework: &st
                     "#,
         ),
     );
-    let result = test_context.test();
+    let result = context.test();
 
     allow_duplicates! {
         assert_snapshot!(result.display(), @"test result: ok. 1 passed; 0 failed; 0 skipped; finished in [TIME]");
@@ -406,7 +406,7 @@ fn test_fixture_initialization_order(#[values("pytest", "karva")] framework: &st
 
 #[test]
 fn test_invalid_pytest_fixture_scope() {
-    let test_context = TestContext::with_file(
+    let context = TestContext::with_file(
         "<test>/test.py",
         r#"
                 import pytest
@@ -422,18 +422,18 @@ fn test_invalid_pytest_fixture_scope() {
                 "#,
     );
 
-    let result = test_context.test();
+    let result = context.test();
 
     assert_snapshot!(result.display(), @r#"
     discovery failures:
 
     invalid fixture `some_fixture`: Invalid fixture scope: sessionss at <temp_dir>/<test>/test.py:4
 
-    failures:
+    test failures:
 
     test `<test>.test::test_all_scopes` has missing fixtures: ["some_fixture"] at <temp_dir>/<test>/test.py:8
 
-    failures:
+    test failures:
         <test>.test::test_all_scopes at <temp_dir>/<test>/test.py:8
 
     test result: FAILED. 0 passed; 1 failed; 0 skipped; finished in [TIME]
@@ -444,7 +444,7 @@ fn test_invalid_pytest_fixture_scope() {
 
 #[test]
 fn test_missing_fixture() {
-    let test_context = TestContext::with_file(
+    let context = TestContext::with_file(
         "<test>/test.py",
         r"
                 def test_all_scopes(
@@ -454,14 +454,14 @@ fn test_missing_fixture() {
                 ",
     );
 
-    let result = test_context.test();
+    let result = context.test();
 
     assert_snapshot!(result.display(), @r#"
-    failures:
+    test failures:
 
     test `<test>.test::test_all_scopes` has missing fixtures: ["missing_fixture"] at <temp_dir>/<test>/test.py:2
 
-    failures:
+    test failures:
         <test>.test::test_all_scopes at <temp_dir>/<test>/test.py:2
 
     test result: FAILED. 0 passed; 1 failed; 0 skipped; finished in [TIME]
@@ -472,7 +472,7 @@ fn test_missing_fixture() {
 
 #[rstest]
 fn test_nested_generator_fixture(#[values("pytest", "karva")] framework: &str) {
-    let test_context = TestContext::with_file(
+    let context = TestContext::with_file(
         "<test>/test_nested_generator_fixture.py",
         &format!(
             r"
@@ -495,7 +495,7 @@ fn test_nested_generator_fixture(#[values("pytest", "karva")] framework: &str) {
         ),
     );
 
-    let result = test_context.test();
+    let result = context.test();
 
     allow_duplicates! {
         assert_snapshot!(result.display(), @"test result: ok. 1 passed; 0 failed; 0 skipped; finished in [TIME]");
@@ -504,7 +504,7 @@ fn test_nested_generator_fixture(#[values("pytest", "karva")] framework: &str) {
 
 #[rstest]
 fn test_fixture_order_respects_scope(#[values("pytest", "karva")] framework: &str) {
-    let test_context = TestContext::with_file(
+    let context = TestContext::with_file(
         "<test>/test_nested_generator_fixture.py",
         &format!(
             r"
@@ -527,9 +527,44 @@ fn test_fixture_order_respects_scope(#[values("pytest", "karva")] framework: &st
         ),
     );
 
-    let result = test_context.test();
+    let result = context.test();
 
     allow_duplicates! {
         assert_snapshot!(result.display(), @"test result: ok. 1 passed; 0 failed; 0 skipped; finished in [TIME]");
     }
+}
+
+#[test]
+fn test_fixture_fails_to_run() {
+    let context = TestContext::with_file(
+        "<test>/test_fixture_fails_to_run.py",
+        r"
+                from karva import fixture
+
+                @fixture
+                def failing_fixture():
+                    raise Exception('Fixture failed')
+
+                def test_failing_fixture(failing_fixture):
+                    pass
+                ",
+    );
+
+    let result = context.test();
+
+    assert_snapshot!(result.display(), @r#"
+    fixture failures:
+
+    fixture function `failing_fixture` at <temp_dir>/<test>/test_fixture_fails_to_run.py:4 failed at <temp_dir>/<test>/test_fixture_fails_to_run.py:6
+    Fixture failed
+
+    test failures:
+
+    test `<test>.test_fixture_fails_to_run::test_failing_fixture` has missing fixtures: ["failing_fixture"] at <temp_dir>/<test>/test_fixture_fails_to_run.py:8
+
+    test failures:
+        <test>.test_fixture_fails_to_run::test_failing_fixture at <temp_dir>/<test>/test_fixture_fails_to_run.py:8
+
+    test result: FAILED. 0 passed; 1 failed; 0 skipped; finished in [TIME]
+    "#);
 }

--- a/crates/karva_core/tests/integration/extensions/fixtures/decorators.rs
+++ b/crates/karva_core/tests/integration/extensions/fixtures/decorators.rs
@@ -149,11 +149,11 @@ def test_fixtures_given_by_decorator(a, b):
     let result = test_context.test();
 
     assert_snapshot!(result.display(), @r#"
-    failures:
+    test failures:
 
     test `<test>.test_fixtures_given_by_decorator_one_missing::test_fixtures_given_by_decorator` has missing fixtures: ["b"] at <temp_dir>/<test>/test_fixtures_given_by_decorator_one_missing.py:12
 
-    failures:
+    test failures:
         <test>.test_fixtures_given_by_decorator_one_missing::test_fixtures_given_by_decorator at <temp_dir>/<test>/test_fixtures_given_by_decorator_one_missing.py:12
 
     test result: FAILED. 0 passed; 1 failed; 0 skipped; finished in [TIME]


### PR DESCRIPTION
## Summary

We now show explicit fixture failures.

Before we just error logged them, but this isn't very useful.

In the future we should show "missing fixtures" diagnostic for a fixture with missing fixtures.

## Test Plan

Added test that shows fixture failing.


