### PR TITLE
Support pytest param in fixtures

### DIFF
--- a/crates/karva_core/src/extensions/fixtures/mod.rs
+++ b/crates/karva_core/src/extensions/fixtures/mod.rs
@@ -21,7 +21,7 @@ pub(crate) use utils::{handle_missing_fixtures, missing_arguments_from_error};
 use crate::{
     diagnostic::{Diagnostic, FunctionDefinitionLocation, FunctionKind},
     discovery::DiscoveredModule,
-    extensions::fixtures::python::FixtureRequest,
+    extensions::fixtures::{python::FixtureRequest, utils::handle_custom_fixture_params},
     name::{ModulePath, QualifiedFunctionName},
     utils::{cartesian_insert, function_definition_location},
 };
@@ -127,7 +127,9 @@ pub(crate) struct Fixture {
 }
 
 impl Fixture {
-    pub(crate) const fn new(
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        py: Python,
         name: QualifiedFunctionName,
         function_definition: StmtFunctionDef,
         scope: FixtureScope,
@@ -143,7 +145,7 @@ impl Fixture {
             auto_use,
             function,
             is_generator,
-            params,
+            params: params.map(|params| handle_custom_fixture_params(py, params)),
         }
     }
 
@@ -350,6 +352,7 @@ impl Fixture {
         let fixture_scope = fixture_scope(py, &scope, &name)?;
 
         Ok(Some(Self::new(
+            py,
             QualifiedFunctionName::new(name, module_name),
             function_definition.clone(),
             fixture_scope,
@@ -386,6 +389,7 @@ impl Fixture {
         let fixture_scope = fixture_scope(py, scope_obj.bind(py), &name)?;
 
         Ok(Some(Self::new(
+            py,
             QualifiedFunctionName::new(name, module_path),
             function_def.clone(),
             fixture_scope,

--- a/crates/karva_core/tests/integration/extensions/fixtures/parametrized.rs
+++ b/crates/karva_core/tests/integration/extensions/fixtures/parametrized.rs
@@ -385,3 +385,24 @@ fn test_parametrized_fixture_finalizer_with_state(#[values("pytest", "karva")] f
         assert_snapshot!(result.display(), @"test result: ok. 4 passed; 0 failed; 0 skipped; finished in [TIME]");
     }
 }
+
+#[test]
+fn test_pytest_param() {
+    let test_context = TestContext::with_file(
+        "<test>/test_file.py",
+        r"
+            import pytest
+
+            @pytest.fixture(params=['resource_1', pytest.param('resource_2'), pytest.param('resource_3')])
+            def resource(request):
+               return request.param
+
+            def test_resource(resource):
+                assert resource in ['resource_1', 'resource_2', 'resource_3']
+   ",
+    );
+
+    let result = test_context.test();
+
+    assert_snapshot!(result.display(), @"test result: ok. 3 passed; 0 failed; 0 skipped; finished in [TIME]");
+}


### PR DESCRIPTION
## Summary

Support `pytest.param` in fixtures.
