### PR TITLE
Clean up, use Arc more

### DIFF
--- a/crates/karva_core/src/extensions/functions/python.rs
+++ b/crates/karva_core/src/extensions/functions/python.rs
@@ -21,7 +21,8 @@ impl Param {
 
         for tag in tags {
             new_tags.push(
-                Tag::from_py_any(py, &tag).ok_or_else(|| PyTypeError::new_err("Invalid tag"))?,
+                Tag::try_from_py_any(py, &tag)
+                    .ok_or_else(|| PyTypeError::new_err("Invalid tag"))?,
             );
         }
 

--- a/crates/karva_core/src/extensions/tags/parametrize.rs
+++ b/crates/karva_core/src/extensions/tags/parametrize.rs
@@ -45,7 +45,7 @@ impl ParametrizationArgs {
 
     pub(crate) fn extend(&mut self, other: Self) {
         self.values.extend(other.values);
-        self.tags.extend(other.tags);
+        self.tags.extend(&other.tags);
     }
 }
 

--- a/crates/karva_core/src/normalize/models/function.rs
+++ b/crates/karva_core/src/normalize/models/function.rs
@@ -23,13 +23,13 @@ pub struct NormalizedTestFunction {
     /// Normalized fixture dependencies (already expanded)
     /// Each fixture dependency is a specific variant
     /// These are the regular fixtures that should be passed as arguments to the test function
-    pub(crate) fixture_dependencies: Vec<NormalizedFixture>,
+    pub(crate) fixture_dependencies: Arc<Vec<NormalizedFixture>>,
 
     /// Fixtures from `use_fixtures` tag that should only be executed for side effects
     /// These should NOT be passed as arguments to the test function
-    pub(crate) use_fixture_dependencies: Vec<NormalizedFixture>,
+    pub(crate) use_fixture_dependencies: Arc<Vec<NormalizedFixture>>,
 
-    pub(crate) auto_use_fixtures: Vec<NormalizedFixture>,
+    pub(crate) auto_use_fixtures: Arc<Vec<NormalizedFixture>>,
 
     /// Imported Python function
     pub(crate) function: Py<PyAny>,
@@ -49,16 +49,16 @@ impl NormalizedTestFunction {
     pub(crate) fn resolved_tags(&self) -> Tags {
         let mut tags = self.tags.clone();
 
-        for dependency in &self.fixture_dependencies {
-            tags.extend(dependency.resolved_tags());
+        for dependency in self.fixture_dependencies.iter() {
+            tags.extend(&dependency.resolved_tags());
         }
 
-        for dependency in &self.use_fixture_dependencies {
-            tags.extend(dependency.resolved_tags());
+        for dependency in self.use_fixture_dependencies.iter() {
+            tags.extend(&dependency.resolved_tags());
         }
 
-        for dependency in &self.auto_use_fixtures {
-            tags.extend(dependency.resolved_tags());
+        for dependency in self.auto_use_fixtures.iter() {
+            tags.extend(&dependency.resolved_tags());
         }
         tags
     }

--- a/crates/karva_core/src/normalize/models/module.rs
+++ b/crates/karva_core/src/normalize/models/module.rs
@@ -1,8 +1,10 @@
+use std::sync::Arc;
+
 use crate::{extensions::fixtures::NormalizedFixture, normalize::models::NormalizedTestFunction};
 
 #[derive(Debug)]
 pub struct NormalizedModule {
     pub(crate) test_functions: Vec<NormalizedTestFunction>,
 
-    pub(crate) auto_use_fixtures: Vec<NormalizedFixture>,
+    pub(crate) auto_use_fixtures: Arc<Vec<NormalizedFixture>>,
 }

--- a/crates/karva_core/src/normalize/models/package.rs
+++ b/crates/karva_core/src/normalize/models/package.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use camino::Utf8PathBuf;
 
@@ -10,11 +10,13 @@ pub struct NormalizedPackage {
 
     pub(crate) packages: HashMap<Utf8PathBuf, NormalizedPackage>,
 
-    pub(crate) auto_use_fixtures: Vec<NormalizedFixture>,
+    pub(crate) auto_use_fixtures: Arc<Vec<NormalizedFixture>>,
 }
 
 impl NormalizedPackage {
     pub(crate) fn extend_auto_use_fixtures(&mut self, fixtures: Vec<NormalizedFixture>) {
-        self.auto_use_fixtures.extend(fixtures);
+        let mut combined = (*self.auto_use_fixtures).clone();
+        combined.extend(fixtures);
+        self.auto_use_fixtures = Arc::new(combined);
     }
 }

--- a/crates/karva_core/src/runner/package_runner.rs
+++ b/crates/karva_core/src/runner/package_runner.rs
@@ -140,7 +140,7 @@ impl<'ctx, 'proj, 'rep> NormalizedPackageRunner<'ctx, 'proj, 'rep> {
 
         // Execute regular fixture dependencies and add them to kwargs
         let mut kwargs = HashMap::new();
-        for fixture in &test_function.fixture_dependencies {
+        for fixture in test_function.fixture_dependencies.iter() {
             if let Some((value, finalizer)) = self.execute_normalized_fixture(py, fixture) {
                 kwargs.insert(fixture.function_name(), value);
                 if let Some(finalizer) = finalizer {


### PR DESCRIPTION
## Summary

We do lots of cloning, we should try to reduce that, but we can use `Arc` more instead.
