### PR TITLE
Speed up tests using virtual envs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1164,6 +1164,7 @@ dependencies = [
  "camino",
  "clap",
  "colored 3.0.0",
+ "ctor",
  "ctrlc",
  "directories",
  "dunce",

--- a/crates/karva/Cargo.toml
+++ b/crates/karva/Cargo.toml
@@ -34,6 +34,7 @@ tracing = { workspace = true, features = ["release_max_level_debug"] }
 wild = { workspace = true }
 
 [dev-dependencies]
+ctor = { workspace = true }
 directories = { workspace = true }
 dunce = { workspace = true }
 insta = { workspace = true, features = ["filters"] }

--- a/crates/karva/tests/it/common/mod.rs
+++ b/crates/karva/tests/it/common/mod.rs
@@ -1,4 +1,5 @@
 use std::process::Command;
+use std::sync::Once;
 
 use anyhow::Context;
 use camino::{Utf8Path, Utf8PathBuf};
@@ -7,6 +8,8 @@ use insta::Settings;
 use insta::internals::SettingsBindDropGuard;
 use tempfile::TempDir;
 
+static VENV_INIT: Once = Once::new();
+
 pub struct TestContext {
     _temp_dir: TempDir,
     project_dir_path: Utf8PathBuf,
@@ -14,33 +17,24 @@ pub struct TestContext {
 }
 
 // Use user cache directory so we can use `uv` caching.
-fn get_test_venv_cache() -> Utf8PathBuf {
+pub fn get_test_venv_cache() -> Utf8PathBuf {
     let proj_dirs = ProjectDirs::from("", "", "karva").expect("Failed to get project directories");
     let cache_dir = proj_dirs.cache_dir();
     let venv_path = cache_dir.join("test-venv");
     Utf8PathBuf::from_path_buf(venv_path).expect("Path is not valid UTF-8")
 }
 
-impl TestContext {
-    pub fn new() -> Self {
+pub fn create_venv() {
+    VENV_INIT.call_once(|| {
         let cache_dir = get_test_venv_cache();
+        let venv_path = cache_dir.join(".venv");
+
+        // Skip if venv already exists
+        if venv_path.join("bin").exists() || venv_path.join("Scripts").exists() {
+            return;
+        }
 
         std::fs::create_dir_all(&cache_dir).expect("Failed to create cache directory");
-
-        let temp_dir =
-            TempDir::new_in(&cache_dir).expect("Failed to create temp directory in cache");
-
-        let project_path = Utf8PathBuf::from_path_buf(
-            dunce::simplified(
-                &temp_dir
-                    .path()
-                    .canonicalize()
-                    .context("Failed to canonicalize project path")
-                    .unwrap(),
-            )
-            .to_path_buf(),
-        )
-        .expect("Path is not valid UTF-8");
 
         let karva_wheel = karva_system::find_karva_wheel()
             .expect(
@@ -49,8 +43,6 @@ impl TestContext {
                 Run `maturin build` before running tests.",
             )
             .to_string();
-
-        let venv_path = project_path.join(".venv");
 
         let mut venv_args = vec!["venv", venv_path.as_str()];
 
@@ -78,11 +70,45 @@ impl TestContext {
         for arguments in &command_arguments {
             Command::new("uv")
                 .args(arguments)
-                .current_dir(&project_path)
                 .output()
                 .with_context(|| format!("Failed to run command: {arguments:?}"))
                 .unwrap();
         }
+    });
+}
+
+impl TestContext {
+    pub fn new() -> Self {
+        let cache_dir = get_test_venv_cache();
+
+        std::fs::create_dir_all(&cache_dir).expect("Failed to create cache directory");
+
+        let temp_dir =
+            TempDir::new_in(&cache_dir).expect("Failed to create temp directory in cache");
+
+        let project_path = Utf8PathBuf::from_path_buf(
+            dunce::simplified(
+                &temp_dir
+                    .path()
+                    .canonicalize()
+                    .context("Failed to canonicalize project path")
+                    .unwrap(),
+            )
+            .to_path_buf(),
+        )
+        .expect("Path is not valid UTF-8");
+
+        // Create symlink to global venv
+        let global_venv = cache_dir.join(".venv");
+        let project_venv = project_path.join(".venv");
+
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&global_venv, &project_venv)
+            .expect("Failed to create venv symlink");
+
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_dir(&global_venv, &project_venv)
+            .expect("Failed to create venv symlink");
 
         let mut settings = Settings::clone_current();
 
@@ -141,6 +167,7 @@ impl TestContext {
     pub fn command(&self) -> Command {
         let mut command = Command::new(get_bin());
         command.current_dir(self.root()).arg("test");
+        // command.env("VIRTUAL_ENV", get_test_venv_cache().join(".venv"));
         command
     }
 

--- a/crates/karva/tests/it/main.rs
+++ b/crates/karva/tests/it/main.rs
@@ -4,3 +4,9 @@ mod basic;
 mod configuration;
 mod discovery;
 mod extensions;
+
+#[cfg(test)]
+#[ctor::ctor]
+pub(crate) fn setup() {
+    common::create_venv();
+}


### PR DESCRIPTION
## Summary

Previously we created a venv for each test, this was very slow.

Here we create one global venv and symlink it.

## Test Plan

`cargo test`
