### PR TITLE
Fix run hash timestamp

### DIFF
--- a/crates/karva_cache/src/hash.rs
+++ b/crates/karva_cache/src/hash.rs
@@ -12,9 +12,9 @@ impl RunHash {
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("System time is before UNIX epoch")
-            .as_secs();
+            .as_millis();
 
-        Self(format!("run-{timestamp:x}"))
+        Self(format!("run-{timestamp}"))
     }
 
     pub fn from_existing(hash: &str) -> Self {


### PR DESCRIPTION
## Summary

Previously we could see a panic if the user ran tests twice within the same second, now we do not.