### PR TITLE
Add more ruff deps to dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,5 +22,6 @@ updates:
       - dependency-name: ruff_source_file
       - dependency-name: ruff_macros
       - dependency-name: ruff_options_metadata
+      - dependency-name: ruff_db
     cooldown:
       default-days: 7


### PR DESCRIPTION
## Summary

We continue to get dependabot PRs on these. We don't want that