### PR TITLE
Add disclaimer to docs that we won't support request

### DIFF
--- a/docs/usage/fixtures/fixtures.md
+++ b/docs/usage/fixtures/fixtures.md
@@ -257,3 +257,7 @@ def username(username):
 def test_admin_user(username):
     assert username == "admin_default_user"
 ```
+
+## Limitations
+
+Karva does not support the `request` fixture. This is an intentional design decision and there are no plans to add support for it.


### PR DESCRIPTION
## Summary

I think it's good to let user's know we won't support this.