### PR TITLE
Add --no-cache flag to disable reading cache

### DIFF
--- a/crates/karva/src/lib.rs
+++ b/crates/karva/src/lib.rs
@@ -103,6 +103,7 @@ pub(crate) fn test(args: TestCommand) -> Result<ExitStatus> {
     let sub_command = args.sub_command.clone();
 
     let no_parallel = args.no_parallel.unwrap_or(false);
+    let no_cache = args.no_cache.unwrap_or(false);
     let num_workers = args.num_workers;
 
     let project_options_overrides = ProjectOptionsOverrides::new(config_file, args.into_options());
@@ -116,7 +117,10 @@ pub(crate) fn test(args: TestCommand) -> Result<ExitStatus> {
         num_workers.unwrap_or_else(|| karva_system::max_parallelism().get())
     };
 
-    let config = karva_runner::ParallelTestConfig { num_workers };
+    let config = karva_runner::ParallelTestConfig {
+        num_workers,
+        no_cache,
+    };
 
     let (shutdown_tx, shutdown_rx) = crossbeam_channel::unbounded();
 

--- a/crates/karva_benchmark/src/walltime.rs
+++ b/crates/karva_benchmark/src/walltime.rs
@@ -59,7 +59,10 @@ impl<'a> ProjectBenchmark<'a> {
 fn test_project(project: &ProjectDatabase) {
     let num_workers = karva_system::max_parallelism().get();
 
-    let config = karva_runner::ParallelTestConfig { num_workers };
+    let config = karva_runner::ParallelTestConfig {
+        num_workers,
+        no_cache: false,
+    };
 
     let args = SubTestCommand {
         no_ignore: Some(true),

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -160,6 +160,10 @@ pub struct TestCommand {
     /// Disable parallel execution
     #[clap(long, default_missing_value = "true", num_args=0..1)]
     pub no_parallel: Option<bool>,
+
+    /// Disable reading the karva cache for test duration history
+    #[clap(long, default_missing_value = "true", num_args=0..1)]
+    pub no_cache: Option<bool>,
 }
 
 impl TestCommand {

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -117,6 +117,7 @@ impl WorkerManager {
 
 pub struct ParallelTestConfig {
     pub num_workers: usize,
+    pub no_cache: bool,
 }
 
 /// Spawn worker processes for each partition
@@ -216,7 +217,11 @@ pub fn run_parallel_tests(
     let cache_dir = db.system().current_directory().join(CACHE_DIR);
 
     // Read durations from the most recent run to optimize partitioning
-    let previous_durations = read_recent_durations(&cache_dir).unwrap_or_default();
+    let previous_durations = if config.no_cache {
+        std::collections::HashMap::new()
+    } else {
+        read_recent_durations(&cache_dir).unwrap_or_default()
+    };
 
     if !previous_durations.is_empty() {
         tracing::debug!(

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -47,6 +47,7 @@ karva test [OPTIONS] [PATH]...
 <p>May also be set with the <code>KARVA_CONFIG_FILE</code> environment variable.</p></dd><dt id="karva-test--fail-fast"><a href="#karva-test--fail-fast"><code>--fail-fast</code></a></dt><dd><p>When set, the test will fail immediately if any test fails.</p>
 <p>This only works when running tests in parallel.</p>
 </dd><dt id="karva-test--help"><a href="#karva-test--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Print help (see a summary with '-h')</p>
+</dd><dt id="karva-test--no-cache"><a href="#karva-test--no-cache"><code>--no-cache</code></a></dt><dd><p>Disable reading the karva cache for test duration history</p>
 </dd><dt id="karva-test--no-ignore"><a href="#karva-test--no-ignore"><code>--no-ignore</code></a></dt><dd><p>When set, .gitignore files will not be respected</p>
 </dd><dt id="karva-test--no-parallel"><a href="#karva-test--no-parallel"><code>--no-parallel</code></a></dt><dd><p>Disable parallel execution</p>
 </dd><dt id="karva-test--no-progress"><a href="#karva-test--no-progress"><code>--no-progress</code></a></dt><dd><p>When set, we will not show individual test case results during execution</p>


### PR DESCRIPTION
## Summary

Resolves #394 

Add a new --no-cache flag that skips reading historical test durations from the karva cache when partitioning tests. This is useful when you want fresh partitioning without being influenced by previous run times.