### PR TITLE
Use uv to publish pypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,9 @@ jobs:
     needs: [generate-release, build-wheels, create-release]
     if: github.event_name == 'workflow_dispatch'
 
+    permissions:
+      id-token: write
+
     steps:
       - name: "Install uv"
         uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0


### PR DESCRIPTION
## Summary

Using the maturin action is deprecated.