### PR TITLE
Update Rust version to 1.93

### DIFF
--- a/.claude/commands/commit-push-pr.md
+++ b/.claude/commands/commit-push-pr.md
@@ -1,6 +1,7 @@
-______________________________________________________________________
-
-## allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr create:*) description: Commit, push, and open a PR
+---
+allowed-tools: Bash(git checkout --branch:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr create:*)
+description: Commit, push, and open a PR
+---
 
 ## Context
 
@@ -11,9 +12,8 @@ ______________________________________________________________________
 ## Your task
 
 Based on the above changes:
-
 1. Create a new branch if on main
-1. Create a single commit with an appropriate message
-1. Push the branch to origin
-1. Create a pull request using `gh pr create`
-1. You have the capability to call multiple tools in a single response. You MUST do all of the above in a single message. Do not use any other tools or do anything else. Do not send any other text or messages besides these tool calls.
+2. Create a single commit with an appropriate message
+3. Push the branch to origin
+4. Create a pull request using `gh pr create`
+5. You have the capability to call multiple tools in a single response. You MUST do all of the above in a single message. Do not use any other tools or do anything else. Do not send any other text or messages besides these tool calls.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
-exclude: |
-  (?x)^(
-    .*.svg|
-    docs/cli.md|
-    docs/configuration.md
-  )$
+exclude:
+  glob:
+    - "*.svg"
+    - docs/cli.md
+    - docs/configuration.md
+    - .claude/commands/**
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.93"
 homepage = "https://github.com/karva-dev/karva"
 documentation = "https://github.com/karva-dev/karva"
 repository = "https://github.com/karva-dev/karva"

--- a/crates/karva_dev/src/generate_cli_reference.rs
+++ b/crates/karva_dev/src/generate_cli_reference.rs
@@ -226,14 +226,13 @@ fn generate_command<'a>(output: &mut String, command: &'a Command, parents: &mut
                     .get_num_args()
                     .unwrap_or_else(|| 1.into())
                     .takes_values()
+                    && let Some(values) = opt.get_value_names()
                 {
-                    if let Some(values) = opt.get_value_names() {
-                        for value in values {
-                            output.push_str(&format!(
-                                " <i>{}</i>",
-                                value.to_lowercase().replace('_', "-")
-                            ));
-                        }
+                    for value in values {
+                        output.push_str(&format!(
+                            " <i>{}</i>",
+                            value.to_lowercase().replace('_', "-")
+                        ));
                     }
                 }
                 output.push_str("</dt>");


### PR DESCRIPTION
## Summary
- Bump rust-version from 1.85 to 1.93 in workspace Cargo.toml
- Fix collapsible if statement in generate_cli_reference.rs using let chains to satisfy new clippy lint
- Convert pre-commit exclude from regex to glob format and add .claude/commands/** exclusion

## Test plan
- [x] All pre-commit checks pass (`prek run -a`)
- [x] All 311 tests pass (`just test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)