### PR TITLE
Update pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,25 +31,25 @@ repos:
         priority: 0
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.24.1
+    rev: v0.25
     hooks:
       - id: validate-pyproject
         priority: 0
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.40.0
+    rev: v1.43.1
     hooks:
       - id: typos
         priority: 0
 
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.9
+    rev: v1.7.10
     hooks:
       - id: actionlint
         priority: 0
 
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.18.0
+    rev: v1.22.0
     hooks:
       - id: zizmor
         priority: 0
@@ -71,7 +71,7 @@ repos:
         priority: 1
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.7
+    rev: v0.15.0
     hooks:
       - id: ruff-check
         args: [--fix]
@@ -87,7 +87,7 @@ repos:
         priority: 1
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.46.0
+    rev: v0.47.0
     hooks:
       - id: markdownlint-fix
         priority: 2


### PR DESCRIPTION
## Summary
- Update validate-pyproject from v0.24.1 to v0.25
- Update typos from v1.40.0 to v1.43.1
- Update actionlint from v1.7.9 to v1.7.10
- Update zizmor from v1.18.0 to v1.22.0
- Update ruff from v0.14.7 to v0.15.0
- Update markdownlint-cli from v0.46.0 to v0.47.0

## Test plan
- [x] Verify pre-commit hooks run successfully with `pre-commit run --all-files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)