### PR TITLE
Update benchmark graph with new test results

### DIFF
--- a/docs/assets/benchmark_results.svg
+++ b/docs/assets/benchmark_results.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="665.436786pt" height="175.551437pt" viewBox="0 0 665.436786 175.551437" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.074286pt" height="175.551437pt" viewBox="0 0 573.074286 175.551437" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2025-12-28T20:15:25.486680</dc:date>
+    <dc:date>2026-02-04T18:00:01.267810</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -22,8 +22,8 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 175.551437 
-L 665.436786 175.551437 
-L 665.436786 0 
+L 573.074286 175.551437 
+L 573.074286 0 
 L 0 0 
 L 0 175.551437 
 z
@@ -31,53 +31,53 @@ z
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 195.005 118.08 
-L 641.405 118.08 
-L 641.405 7.2 
-L 195.005 7.2 
-L 195.005 118.08 
+    <path d="M 109.005 118.08 
+L 555.405 118.08 
+L 555.405 7.2 
+L 109.005 7.2 
+L 109.005 118.08 
 z
 " style="fill: none"/>
    </g>
    <g id="patch_3">
-    <path d="M 195.005 113.04 
-L 620.147857 113.04 
-L 620.147857 92.88 
-L 195.005 92.88 
+    <path d="M 109.005 113.04 
+L 534.147857 113.04 
+L 534.147857 92.88 
+L 109.005 92.88 
 z
-" clip-path="url(#pfb73ade6a6)" style="fill: #45744a"/>
+" clip-path="url(#pf5145cd546)" style="fill: #45744a"/>
    </g>
    <g id="patch_4">
-    <path d="M 195.005 72.72 
-L 369.611401 72.72 
-L 369.611401 52.56 
-L 195.005 52.56 
+    <path d="M 109.005 72.72 
+L 315.324328 72.72 
+L 315.324328 52.56 
+L 109.005 52.56 
 z
-" clip-path="url(#pfb73ade6a6)" style="fill: #45744a"/>
+" clip-path="url(#pf5145cd546)" style="fill: #45744a"/>
    </g>
    <g id="patch_5">
-    <path d="M 195.005 32.4 
-L 215.869401 32.4 
-L 215.869401 12.24 
-L 195.005 12.24 
+    <path d="M 109.005 32.4 
+L 177.778109 32.4 
+L 177.778109 12.24 
+L 109.005 12.24 
 z
-" clip-path="url(#pfb73ade6a6)" style="fill: #45744a"/>
+" clip-path="url(#pf5145cd546)" style="fill: #45744a"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="md4c3dacaef" d="M 0 0 
+       <path id="m39ae7757c9" d="M 0 0 
 L 0 3.5 
 " style="stroke: #808080; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md4c3dacaef" x="195.005" y="118.08" style="fill: #808080; stroke: #808080; stroke-width: 0.8"/>
+       <use xlink:href="#m39ae7757c9" x="109.005" y="118.08" style="fill: #808080; stroke: #808080; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- 0.00s -->
-      <g style="fill: #808080" transform="translate(181.2675 132.678437) scale(0.1 -0.1)">
+      <g style="fill: #808080" transform="translate(95.2675 132.678437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -150,12 +150,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#md4c3dacaef" x="301.372535" y="118.08" style="fill: #808080; stroke: #808080; stroke-width: 0.8"/>
+       <use xlink:href="#m39ae7757c9" x="218.416765" y="118.08" style="fill: #808080; stroke: #808080; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
-      <!-- 13.00s -->
-      <g style="fill: #808080" transform="translate(284.453785 132.678437) scale(0.1 -0.1)">
+      <!-- 1.75s -->
+      <g style="fill: #808080" transform="translate(204.679265 132.678437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -171,6 +171,60 @@ L 794 0
 L 794 531 
 z
 " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m39ae7757c9" x="327.828529" y="118.08" style="fill: #808080; stroke: #808080; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 3.50s -->
+      <g style="fill: #808080" transform="translate(314.091029 132.678437) scale(0.1 -0.1)">
+       <defs>
         <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
 Q 3559 1806 3559 1356 
@@ -204,24 +258,23 @@ Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
        </defs>
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
-       <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(222.65625 0)"/>
       </g>
      </g>
     </g>
-    <g id="xtick_3">
-     <g id="line2d_3">
+    <g id="xtick_4">
+     <g id="line2d_4">
       <g>
-       <use xlink:href="#md4c3dacaef" x="407.740071" y="118.08" style="fill: #808080; stroke: #808080; stroke-width: 0.8"/>
+       <use xlink:href="#m39ae7757c9" x="437.240294" y="118.08" style="fill: #808080; stroke: #808080; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_3">
-      <!-- 26.00s -->
-      <g style="fill: #808080" transform="translate(390.821321 132.678437) scale(0.1 -0.1)">
+     <g id="text_4">
+      <!-- 5.25s -->
+      <g style="fill: #808080" transform="translate(423.502794 132.678437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -247,138 +300,29 @@ Q 2828 2175 2409 1742
 Q 1991 1309 1228 531 
 z
 " transform="scale(0.015625)"/>
-        <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
        </defs>
-       <use xlink:href="#DejaVuSans-32"/>
-       <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
-       <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_4">
-     <g id="line2d_4">
-      <g>
-       <use xlink:href="#md4c3dacaef" x="514.107606" y="118.08" style="fill: #808080; stroke: #808080; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_4">
-      <!-- 39.00s -->
-      <g style="fill: #808080" transform="translate(497.188856 132.678437) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-33"/>
-       <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
-       <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(222.65625 0)"/>
       </g>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#md4c3dacaef" x="620.475142" y="118.08" style="fill: #808080; stroke: #808080; stroke-width: 0.8"/>
+       <use xlink:href="#m39ae7757c9" x="546.652059" y="118.08" style="fill: #808080; stroke: #808080; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
-      <!-- 52.00s -->
-      <g style="fill: #808080" transform="translate(603.556392 132.678437) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-35"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
+      <!-- 7.00s -->
+      <g style="fill: #808080" transform="translate(532.914559 132.678437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-37"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
-       <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(222.65625 0)"/>
       </g>
      </g>
     </g>
@@ -387,17 +331,17 @@ z
     <g id="ytick_1">
      <g id="line2d_6">
       <defs>
-       <path id="m5f9d4960f5" d="M 0 0 
+       <path id="m55cdf19a54" d="M 0 0 
 L -3.5 0 
 " style="stroke: #808080; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5f9d4960f5" x="195.005" y="102.96" style="fill: #808080; stroke: #808080; stroke-width: 0.8"/>
+       <use xlink:href="#m55cdf19a54" x="109.005" y="102.96" style="fill: #808080; stroke: #808080; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- pytest -->
-      <g style="fill: #808080" transform="translate(137.6525 109.03875) scale(0.16 -0.16)">
+      <g style="fill: #808080" transform="translate(51.6525 109.03875) scale(0.16 -0.16)">
        <defs>
         <path id="DejaVuSans-70" d="M 1159 525 
 L 1159 -1331 
@@ -501,11 +445,11 @@ z
     <g id="ytick_2">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m5f9d4960f5" x="195.005" y="62.64" style="fill: #808080; stroke: #808080; stroke-width: 0.8"/>
+       <use xlink:href="#m55cdf19a54" x="109.005" y="62.64" style="fill: #808080; stroke: #808080; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
-      <!-- pytest-xdist (20 cores) -->
+      <!-- pytest-xdist -->
       <g style="fill: #808080" transform="translate(7.2 68.71875) scale(0.16 -0.16)">
        <defs>
         <path id="DejaVuSans-2d" d="M 313 2009 
@@ -569,92 +513,6 @@ L 603 4134
 L 603 4863 
 z
 " transform="scale(0.015625)"/>
-        <path id="DejaVuSans-20" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-28" d="M 1984 4856 
-Q 1566 4138 1362 3434 
-Q 1159 2731 1159 2009 
-Q 1159 1288 1364 580 
-Q 1569 -128 1984 -844 
-L 1484 -844 
-Q 1016 -109 783 600 
-Q 550 1309 550 2009 
-Q 550 2706 781 3412 
-Q 1013 4119 1484 4856 
-L 1984 4856 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-63" d="M 3122 3366 
-L 3122 2828 
-Q 2878 2963 2633 3030 
-Q 2388 3097 2138 3097 
-Q 1578 3097 1268 2742 
-Q 959 2388 959 1747 
-Q 959 1106 1268 751 
-Q 1578 397 2138 397 
-Q 2388 397 2633 464 
-Q 2878 531 3122 666 
-L 3122 134 
-Q 2881 22 2623 -34 
-Q 2366 -91 2075 -91 
-Q 1284 -91 818 406 
-Q 353 903 353 1747 
-Q 353 2603 823 3093 
-Q 1294 3584 2113 3584 
-Q 2378 3584 2631 3529 
-Q 2884 3475 3122 3366 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-6f" d="M 1959 3097 
-Q 1497 3097 1228 2736 
-Q 959 2375 959 1747 
-Q 959 1119 1226 758 
-Q 1494 397 1959 397 
-Q 2419 397 2687 759 
-Q 2956 1122 2956 1747 
-Q 2956 2369 2687 2733 
-Q 2419 3097 1959 3097 
-z
-M 1959 3584 
-Q 2709 3584 3137 3096 
-Q 3566 2609 3566 1747 
-Q 3566 888 3137 398 
-Q 2709 -91 1959 -91 
-Q 1206 -91 779 398 
-Q 353 888 353 1747 
-Q 353 2609 779 3096 
-Q 1206 3584 1959 3584 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-72" d="M 2631 2963 
-Q 2534 3019 2420 3045 
-Q 2306 3072 2169 3072 
-Q 1681 3072 1420 2755 
-Q 1159 2438 1159 1844 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1341 3275 1631 3429 
-Q 1922 3584 2338 3584 
-Q 2397 3584 2469 3576 
-Q 2541 3569 2628 3553 
-L 2631 2963 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-29" d="M 513 4856 
-L 1013 4856 
-Q 1481 4119 1714 3412 
-Q 1947 2706 1947 2009 
-Q 1947 1309 1714 600 
-Q 1481 -109 1013 -844 
-L 513 -844 
-Q 928 -128 1133 580 
-Q 1338 1288 1338 2009 
-Q 1338 2731 1133 3434 
-Q 928 4138 513 4856 
-z
-" transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#DejaVuSans-70"/>
        <use xlink:href="#DejaVuSans-79" transform="translate(63.476562 0)"/>
@@ -668,28 +526,17 @@ z
        <use xlink:href="#DejaVuSans-69" transform="translate(473.4375 0)"/>
        <use xlink:href="#DejaVuSans-73" transform="translate(501.220703 0)"/>
        <use xlink:href="#DejaVuSans-74" transform="translate(553.320312 0)"/>
-       <use xlink:href="#DejaVuSans-20" transform="translate(592.529297 0)"/>
-       <use xlink:href="#DejaVuSans-28" transform="translate(624.316406 0)"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(663.330078 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(726.953125 0)"/>
-       <use xlink:href="#DejaVuSans-20" transform="translate(790.576172 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(822.363281 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(877.34375 0)"/>
-       <use xlink:href="#DejaVuSans-72" transform="translate(938.525391 0)"/>
-       <use xlink:href="#DejaVuSans-65" transform="translate(977.388672 0)"/>
-       <use xlink:href="#DejaVuSans-73" transform="translate(1038.912109 0)"/>
-       <use xlink:href="#DejaVuSans-29" transform="translate(1091.011719 0)"/>
       </g>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m5f9d4960f5" x="195.005" y="22.32" style="fill: #808080; stroke: #808080; stroke-width: 0.8"/>
+       <use xlink:href="#m55cdf19a54" x="109.005" y="22.32" style="fill: #808080; stroke: #808080; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
-      <!-- karva (20 cores) -->
+      <!-- karva -->
       <g style="fill: #808080" transform="translate(57.3625 28.39875) scale(0.16 -0.16)">
        <defs>
         <path id="DejaVuSans-6b" d="M 581 4863 
@@ -739,6 +586,23 @@ Q 2591 3584 2966 3190
 Q 3341 2797 3341 1997 
 z
 " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
         <path id="DejaVuSans-76" d="M 191 3500 
 L 800 3500 
 L 1894 563 
@@ -755,82 +619,119 @@ z
        <use xlink:href="#DejaVuSans-72" transform="translate(117.439453 0)"/>
        <use xlink:href="#DejaVuSans-76" transform="translate(158.552734 0)"/>
        <use xlink:href="#DejaVuSans-61" transform="translate(217.732422 0)"/>
-       <use xlink:href="#DejaVuSans-20" transform="translate(279.011719 0)"/>
-       <use xlink:href="#DejaVuSans-28" transform="translate(310.798828 0)"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(349.8125 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(413.435547 0)"/>
-       <use xlink:href="#DejaVuSans-20" transform="translate(477.058594 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(508.845703 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(563.826172 0)"/>
-       <use xlink:href="#DejaVuSans-72" transform="translate(625.007812 0)"/>
-       <use xlink:href="#DejaVuSans-65" transform="translate(663.871094 0)"/>
-       <use xlink:href="#DejaVuSans-73" transform="translate(725.394531 0)"/>
-       <use xlink:href="#DejaVuSans-29" transform="translate(777.494141 0)"/>
       </g>
      </g>
     </g>
    </g>
    <g id="patch_6">
-    <path d="M 195.005 118.08 
-L 641.405 118.08 
+    <path d="M 109.005 118.08 
+L 555.405 118.08 
 " style="fill: none; stroke: #808080; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_9">
-    <!-- 51.96s -->
-    <g style="fill: #808080" transform="translate(624.399286 105.719375) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(222.65625 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
-    </g>
-   </g>
-   <g id="text_10">
-    <!-- 21.34s -->
-    <g style="fill: #808080" transform="translate(373.862829 65.399375) scale(0.1 -0.1)">
+    <!-- 6.80s -->
+    <g style="fill: #808080" transform="translate(538.399286 105.719375) scale(0.1 -0.1)">
      <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
 z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(127.246094 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(222.65625 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(286.279297 0)"/>
+     <use xlink:href="#DejaVuSans-36"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(222.65625 0)"/>
+    </g>
+   </g>
+   <g id="text_10">
+    <!-- 3.30s -->
+    <g style="fill: #808080" transform="translate(319.575756 65.399375) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(222.65625 0)"/>
     </g>
    </g>
    <g id="text_11">
-    <!-- 2.55s -->
-    <g style="fill: #808080" transform="translate(220.12083 25.079375) scale(0.1 -0.1)">
-     <use xlink:href="#DejaVuSans-32"/>
+    <!-- 1.10s -->
+    <g style="fill: #808080" transform="translate(182.029538 25.079375) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
      <use xlink:href="#DejaVuSans-73" transform="translate(222.65625 0)"/>
     </g>
    </g>
    <g id="text_12">
-    <!-- Running pydantic tests -->
-    <g style="fill: #808080" transform="translate(314.685313 164.608) scale(0.18 -0.18)">
+    <!-- Running benchmark tests (14 cores) -->
+    <g style="fill: #808080" transform="translate(168.459844 164.608) scale(0.18 -0.18)">
      <defs>
       <path id="DejaVuSans-52" d="M 2841 2188 
 Q 3044 2119 3236 1894 
@@ -935,6 +836,169 @@ L 3481 3500
 L 3481 434 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-52"/>
      <use xlink:href="#DejaVuSans-75" transform="translate(64.982422 0)"/>
@@ -944,27 +1008,39 @@ z
      <use xlink:href="#DejaVuSans-6e" transform="translate(282.902344 0)"/>
      <use xlink:href="#DejaVuSans-67" transform="translate(346.28125 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(409.757812 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(441.544922 0)"/>
-     <use xlink:href="#DejaVuSans-79" transform="translate(505.021484 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(564.201172 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(627.677734 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(688.957031 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(752.335938 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(791.544922 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(819.328125 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(874.308594 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(906.095703 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(945.304688 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(1006.828125 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1058.927734 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(1098.136719 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(441.544922 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(505.021484 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(566.544922 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(629.923828 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(684.904297 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(748.283203 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(845.695312 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(906.974609 0)"/>
+     <use xlink:href="#DejaVuSans-6b" transform="translate(948.087891 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1005.998047 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1037.785156 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1076.994141 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1138.517578 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1190.617188 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1229.826172 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1281.925781 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(1313.712891 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(1352.726562 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(1416.349609 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1479.972656 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1511.759766 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1566.740234 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1627.921875 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1666.785156 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1728.308594 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(1780.408203 0)"/>
     </g>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pfb73ade6a6">
-   <rect x="195.005" y="7.2" width="446.4" height="110.88"/>
+  <clipPath id="pf5145cd546">
+   <rect x="109.005" y="7.2" width="446.4" height="110.88"/>
   </clipPath>
  </defs>
 </svg>

--- a/scripts/benchmark_graph.py
+++ b/scripts/benchmark_graph.py
@@ -20,8 +20,8 @@ def main() -> None:
     """Create and save a benchmark comparison graph."""
     plt.style.use("dark_background")
 
-    labels = ["pytest", "pytest-xdist (20 cores)", "karva (20 cores)"]
-    means = [51.96, 21.34, 2.55]
+    labels = ["pytest", "pytest-xdist", "karva"]
+    means = [6.8, 3.3, 1.1]
 
     y_pos = np.arange(len(labels))
 
@@ -72,7 +72,7 @@ def main() -> None:
         )
 
     plt.title(
-        "Running pydantic tests",
+        "Running benchmark tests (14 cores)",
         fontsize=18,
         pad=20,
         color="grey",


### PR DESCRIPTION
## Summary
- Updates benchmark data to use the new custom benchmark project instead of pydantic
- Reflects faster test times: pytest (6.8s), pytest-xdist (3.3s), karva (1.1s)
- Removes core count from labels since the benchmark now runs on 14 cores

## Test plan
- [x] Verify SVG renders correctly
- [x] Confirm benchmark values match the script

🤖 Generated with [Claude Code](https://claude.com/claude-code)