### PR TITLE
Improve tag filter error messages with structured error variants

### DIFF
--- a/crates/karva_core/src/cli.rs
+++ b/crates/karva_core/src/cli.rs
@@ -143,7 +143,8 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
         .map(|p| TestPath::new(p.as_str()))
         .collect();
 
-    let tag_filter = TagFilterSet::new(&args.sub_command.tag_expressions)?;
+    let tag_filter =
+        TagFilterSet::new(&args.sub_command.tag_expressions).expect("Failed to create tag filter");
 
     let mut settings = args.sub_command.into_options().to_settings();
     settings.set_tag_filter(tag_filter);


### PR DESCRIPTION
## Summary
- Replace generic `TagFilterError { message: String }` struct with a proper enum containing specific variants: `UnexpectedCharacter`, `EmptyExpression`, `UnclosedParenthesis`, `UnexpectedToken`, and `UnexpectedEndOfExpression`
- Include the original expression in all error messages for better debugging context
- Add integration tests covering all tag expression parse error cases

## Test plan
- [x] Existing unit tests updated to assert specific error variants via `matches!`
- [x] New integration tests verify CLI error output for each parse error case
- [x] All existing tag filter tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)