### PR TITLE
Disable co-author in commit-push-pr command

### DIFF
--- a/.claude/commands/commit-push-pr.md
+++ b/.claude/commands/commit-push-pr.md
@@ -11,11 +11,9 @@ description: Commit, push, and open a PR
 
 ## Your task
 
-Don't add yourself as a collaborator.
-
 Based on the above changes:
 1. Create a new branch if on main
-2. Create a single commit with an appropriate message
+2. Create a single commit with an appropriate message, don't add claude as a collaborator
 3. Push the branch to origin
 4. Create a pull request using `gh pr create`
 5. You have the capability to call multiple tools in a single response. You MUST do all of the above in a single message. Do not use any other tools or do anything else. Do not send any other text or messages besides these tool calls.


### PR DESCRIPTION
## Summary
- Add instruction to the commit-push-pr slash command to not add itself as a collaborator

## Test plan
- [x] Verify the command file is updated correctly