### PR TITLE
Replace body_length heuristic with random ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,6 +1414,7 @@ dependencies = [
  "camino",
  "crossbeam-channel",
  "ctrlc",
+ "fastrand",
  "ignore",
  "karva_cache",
  "karva_cli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ directories = "6.0.0"
 divan = { package = "codspeed-divan-compat", version = "4.2.1" }
 dunce = { version = "1.0.5" }
 etcetera = { version = "0.11.0" }
+fastrand = { version = "2.3" }
 filetime = { version = "0.2.27" }
 fs4 = { version = "0.13" }
 ignore = { version = "0.4.25" }

--- a/crates/karva_runner/Cargo.toml
+++ b/crates/karva_runner/Cargo.toml
@@ -22,6 +22,7 @@ anyhow = { workspace = true }
 camino = { workspace = true }
 crossbeam-channel = { workspace = true }
 ctrlc = { workspace = true }
+fastrand = { workspace = true }
 ignore = { workspace = true }
 tracing = { workspace = true }
 which = { workspace = true }


### PR DESCRIPTION
## Summary
- Removed `body_length` (AST node count) from `TestInfo` and all weight calculations in the partitioning algorithm
- Tests without historical durations are now shuffled randomly via `fastrand` and assigned equal weight (1), replacing the body length heuristic
- Simplified `compare_test_weights` to treat tests without durations as equal

## Test plan
- [x] `just test` — all 391 tests pass
- [x] `prek run -a` — all pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)