### PR TITLE
Only test on Python 3.10 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: j178/prek-action@91fd7d7cf70ae1dee9f4f44e7dfa5d1073fe6623 # v1.0.11
 
   cargo-test:
-    name: "cargo test (${{ matrix.os }} ${{ matrix.python-version }})"
+    name: "cargo test (${{ matrix.os }})"
 
     runs-on: ${{ matrix.os }}
 
@@ -84,14 +84,9 @@ jobs:
     if: ${{ (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
 
     strategy:
-      max-parallel: 18
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.10", "3.14"]
-
-    env:
-      PYTHON_VERSION: ${{ matrix.python-version }}
 
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -110,13 +105,13 @@ jobs:
 
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.10"
 
       - name: Setup Python
         uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         id: setup-python
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.10"
 
       - name: Build wheels
         uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4


### PR DESCRIPTION
## Summary
- Remove the `python-version` matrix from the `cargo-test` job, hardcoding to Python 3.10
- Remove `python-version` from the job name
- Halves the CI matrix from 6 jobs (3 OS × 2 Python) to 3 jobs (3 OS × 1 Python)

Closes #407

## Test plan
- [ ] Verify CI runs successfully with only Python 3.10
- [ ] Confirm cargo-test jobs show as `cargo test (ubuntu-latest)`, `cargo test (windows-latest)`, `cargo test (macos-latest)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)