### PR TITLE
Add `karva.raises` context manager for asserting exceptions

### DIFF
--- a/crates/karva_core/src/extensions/functions/mod.rs
+++ b/crates/karva_core/src/extensions/functions/mod.rs
@@ -1,7 +1,9 @@
+pub use self::raises::{ExceptionInfo, RaisesContext};
 use pyo3::prelude::*;
 pub use python::Param;
 
 pub mod python;
+pub mod raises;
 
 // SkipError exception that can be raised to skip tests at runtime with an optional reason
 pyo3::create_exception!(karva, SkipError, pyo3::exceptions::PyException);

--- a/crates/karva_core/src/extensions/functions/raises.rs
+++ b/crates/karva_core/src/extensions/functions/raises.rs
@@ -1,0 +1,105 @@
+use pyo3::prelude::*;
+use pyo3::types::PyType;
+
+use super::FailError;
+
+#[pyclass]
+pub struct ExceptionInfo {
+    #[pyo3(get, name = "type")]
+    pub exc_type: Option<Py<PyAny>>,
+
+    #[pyo3(get)]
+    pub value: Option<Py<PyAny>>,
+
+    #[pyo3(get)]
+    pub tb: Option<Py<PyAny>>,
+}
+
+#[pymethods]
+impl ExceptionInfo {
+    #[new]
+    fn new() -> Self {
+        Self {
+            exc_type: None,
+            value: None,
+            tb: None,
+        }
+    }
+}
+
+#[pyclass]
+pub struct RaisesContext {
+    expected_exception: Py<PyAny>,
+    match_pattern: Option<String>,
+    exc_info: Py<ExceptionInfo>,
+}
+
+#[pymethods]
+impl RaisesContext {
+    fn __enter__(&self, py: Python<'_>) -> Py<ExceptionInfo> {
+        self.exc_info.clone_ref(py)
+    }
+
+    fn __exit__(
+        &self,
+        py: Python<'_>,
+        exc_type: Option<Py<PyAny>>,
+        exc_val: Option<Py<PyAny>>,
+        exc_tb: Option<Py<PyAny>>,
+    ) -> PyResult<bool> {
+        let Some(exc_type_obj) = exc_type else {
+            let repr = self.expected_exception.bind(py).repr()?.to_string();
+            return Err(FailError::new_err(format!("DID NOT RAISE {repr}")));
+        };
+
+        let exc_type_bound = exc_type_obj.bind(py);
+        let expected_bound = self.expected_exception.bind(py);
+
+        let exc_py_type = exc_type_bound.cast::<PyType>()?;
+        let expected_py_type = expected_bound.cast::<PyType>()?;
+
+        if !exc_py_type.is_subclass(expected_py_type)? {
+            return Ok(false);
+        }
+
+        if let Some(ref pattern) = self.match_pattern {
+            let exc_str = if let Some(ref val) = exc_val {
+                val.bind(py).str()?.to_string()
+            } else {
+                String::new()
+            };
+
+            let re_module = py.import("re")?;
+            let result = re_module.call_method1("search", (pattern.as_str(), exc_str.as_str()))?;
+
+            if result.is_none() {
+                return Err(FailError::new_err(format!(
+                    "Raised exception did not match pattern '{pattern}'"
+                )));
+            }
+        }
+
+        let mut info = self.exc_info.borrow_mut(py);
+        info.exc_type = Some(exc_type_obj);
+        info.value = exc_val;
+        info.tb = exc_tb;
+
+        Ok(true)
+    }
+}
+
+/// Assert that a block of code raises a specific exception.
+#[pyfunction]
+#[pyo3(signature = (expected_exception, *, r#match = None))]
+pub fn raises(
+    py: Python<'_>,
+    expected_exception: Py<PyAny>,
+    r#match: Option<String>,
+) -> PyResult<RaisesContext> {
+    let exc_info = Py::new(py, ExceptionInfo::new())?;
+    Ok(RaisesContext {
+        expected_exception,
+        match_pattern: r#match,
+        exc_info,
+    })
+}

--- a/crates/karva_core/src/python.rs
+++ b/crates/karva_core/src/python.rs
@@ -5,7 +5,10 @@ use crate::extensions::fixtures::MockEnv;
 use crate::extensions::fixtures::python::{
     FixtureFunctionDefinition, FixtureFunctionMarker, InvalidFixtureError, fixture_decorator,
 };
-use crate::extensions::functions::{FailError, SkipError, fail, param, skip};
+use crate::extensions::functions::raises::raises;
+use crate::extensions::functions::{
+    ExceptionInfo, FailError, RaisesContext, SkipError, fail, param, skip,
+};
 use crate::extensions::tags::python::{PyTags, PyTestFunction, tags};
 
 pub fn init_module(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -13,12 +16,15 @@ pub fn init_module(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(skip, m)?)?;
     m.add_function(wrap_pyfunction!(fail, m)?)?;
     m.add_function(wrap_pyfunction!(param, m)?)?;
+    m.add_function(wrap_pyfunction!(raises, m)?)?;
 
     m.add_class::<FixtureFunctionMarker>()?;
     m.add_class::<FixtureFunctionDefinition>()?;
     m.add_class::<PyTags>()?;
     m.add_class::<PyTestFunction>()?;
     m.add_class::<MockEnv>()?;
+    m.add_class::<ExceptionInfo>()?;
+    m.add_class::<RaisesContext>()?;
 
     m.add_wrapped(wrap_pymodule!(tags))?;
 

--- a/python/karva/__init__.py
+++ b/python/karva/__init__.py
@@ -1,13 +1,16 @@
 """Karva is a Python test runner, written in Rust."""
 
 from karva._karva import (
+    ExceptionInfo,
     FailError,
     MockEnv,
+    RaisesContext,
     SkipError,
     fail,
     fixture,
     karva_run,
     param,
+    raises,
     skip,
     tags,
 )
@@ -15,13 +18,16 @@ from karva._karva import (
 __version__ = "0.0.1-alpha.2"
 
 __all__: list[str] = [
+    "ExceptionInfo",
     "FailError",
     "MockEnv",
+    "RaisesContext",
     "SkipError",
     "fail",
     "fixture",
     "karva_run",
     "param",
+    "raises",
     "skip",
     "tags",
 ]

--- a/python/karva/_karva/__init__.pyi
+++ b/python/karva/_karva/__init__.pyi
@@ -1,3 +1,4 @@
+import types
 from collections.abc import Callable, Sequence
 from typing import Generic, Literal, NoReturn, Self, TypeAlias, TypeVar, overload
 
@@ -69,6 +70,45 @@ def param(
     ])
     def test_square(input, expected):
         assert input ** 2 == expected
+    """
+
+class ExceptionInfo:
+    """Stores information about a caught exception from `karva.raises`."""
+
+    @property
+    def type(self) -> type[BaseException] | None:
+        """The exception type."""
+
+    @property
+    def value(self) -> BaseException | None:
+        """The exception instance."""
+
+    @property
+    def tb(self) -> object | None:
+        """The traceback object."""
+
+class RaisesContext:
+    """Context manager returned by `karva.raises`."""
+
+    def __enter__(self) -> ExceptionInfo: ...
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: types.TracebackType | None,
+    ) -> bool: ...
+
+def raises(
+    expected_exception: type[BaseException],
+    *,
+    match: str | None = None,
+) -> RaisesContext:
+    """Assert that a block of code raises a specific exception.
+
+    Args:
+        expected_exception: The expected exception type.
+        match: An optional regex pattern to match against the string
+            representation of the exception.
     """
 
 class SkipError(Exception):


### PR DESCRIPTION
## Summary

- Add `karva.raises(expected_exception, *, match=None)` context manager as a native `pytest.raises`-equivalent
- Supports exception type matching (including subclasses), optional regex `match` parameter, and `ExceptionInfo` access (`type`, `value`, `tb`)
- Raises `FailError` for "DID NOT RAISE" and pattern mismatch failures; propagates non-matching exception types

## Test plan

- [x] Matching exception passes test
- [x] No exception raised fails with "DID NOT RAISE" message
- [x] `match` parameter that matches passes
- [x] `match` parameter that doesn't match fails
- [x] Wrong exception type propagates (test fails with traceback)
- [x] `ExceptionInfo` fields accessible after block
- [x] Exception subclass matching works
- [x] All 406 tests pass (`just test`)
- [x] Pre-commit checks pass (`prek run -a`)

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)