### PR TITLE
Delete old wheels before building in `just test`

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,6 +1,7 @@
 # https://just.systems
 
 test *args:
+    rm -rf target/wheels
     maturin build
     @if command -v cargo-nextest > /dev/null 2>&1; then \
         cargo nextest run {{args}}; \


### PR DESCRIPTION
## Summary

- Adds `rm -rf target/wheels` before `maturin build` in the `just test` recipe to prevent stale wheels from being picked up non-deterministically by `find_karva_wheel()`

Closes #434

## Test plan

- [x] Verified `prek run -a` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)