### PR TITLE
Reduce benchmark iterations to speed up PR workflow

### DIFF
--- a/crates/karva_benchmark/benches/karva_benchmark_walltime.rs
+++ b/crates/karva_benchmark/benches/karva_benchmark_walltime.rs
@@ -2,7 +2,7 @@ use divan::{Bencher, bench};
 use karva_benchmark::walltime::{ProjectBenchmark, bench_project, warmup_project};
 use karva_projects::real_world_projects::KARVA_BENCHMARK_PROJECT;
 
-#[bench(sample_size = 3, sample_count = 3)]
+#[bench(sample_size = 2, sample_count = 2)]
 fn karva_benchmark(bencher: Bencher) {
     let benchmark = ProjectBenchmark::new(KARVA_BENCHMARK_PROJECT.clone());
 


### PR DESCRIPTION
## Summary
- Reduce benchmark `sample_size` and `sample_count` from 3 to 2, cutting total runs from 9 to 4
- Speeds up benchmark execution during PR iteration

Closes #435