### PR TITLE
Cap worker count based on test count

### DIFF
--- a/crates/karva_collector/src/models.rs
+++ b/crates/karva_collector/src/models.rs
@@ -204,6 +204,17 @@ impl CollectedPackage {
         }
     }
 
+    /// Returns the total number of tests in this package and all subpackages.
+    pub fn test_count(&self) -> usize {
+        let module_tests: usize = self
+            .modules
+            .values()
+            .map(|m| m.test_function_defs.len())
+            .sum();
+        let package_tests: usize = self.packages.values().map(Self::test_count).sum();
+        module_tests + package_tests
+    }
+
     pub(crate) fn is_empty(&self) -> bool {
         self.modules.is_empty() && self.packages.is_empty()
     }


### PR DESCRIPTION
## Summary

- Cap effective worker count after test collection so no worker is assigned fewer than 5 tests, reducing process spawn overhead for small test suites
- Add `test_count()` method to `CollectedPackage` for recursive test counting
- Log capped worker count at INFO level when capping occurs

Closes #417

## Test plan

- [x] Unit tests verify capping formula (small, medium, high test counts, zero tests, exact multiples)
- [x] Integration test with `-v --num-workers 8` on 3 tests confirms capping log and correct results
- [x] `just test` — 441 tests pass
- [x] `prek run -a` — all pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)