### PR TITLE
Fix leftover references and code quality violations

### DIFF
--- a/crates/karva/src/lib.rs
+++ b/crates/karva/src/lib.rs
@@ -169,7 +169,7 @@ pub(crate) fn test(args: TestCommand) -> Result<ExitStatus> {
         Utf8PathBuf::from_path_buf(cwd)
                 .map_err(|path| {
                     anyhow::anyhow!(
-                        "The current working directory `{}` contains non-Unicode characters. ty only supports Unicode paths.",
+                        "The current working directory `{}` contains non-Unicode characters. karva only supports Unicode paths.",
                         path.display()
                     )
                 })?

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -205,7 +205,7 @@ pub struct TestCommand {
 
     /// The path to a `karva.toml` file to use for configuration.
     ///
-    /// While ty configuration can be included in a `pyproject.toml` file, it is not allowed in this context.
+    /// While karva configuration can be included in a `pyproject.toml` file, it is not allowed in this context.
     #[arg(long, env = "KARVA_CONFIG_FILE", value_name = "PATH")]
     pub config_file: Option<Utf8PathBuf>,
 

--- a/crates/karva_project/src/path/utils.rs
+++ b/crates/karva_project/src/path/utils.rs
@@ -16,7 +16,8 @@ pub fn absolute(path: impl AsRef<Utf8Path>, cwd: impl AsRef<Utf8Path>) -> Utf8Pa
 
     for component in components {
         match component {
-            Utf8Component::Prefix(..) => unreachable!(),
+            Utf8Component::Prefix(..) => {}
+
             Utf8Component::RootDir => {
                 ret.push(component.as_str());
             }

--- a/crates/karva_test_semantic/src/extensions/fixtures/builtins/mock_env.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/builtins/mock_env.rs
@@ -28,7 +28,7 @@ struct NotSetType;
 
 #[pymethods]
 impl NotSetType {
-    #[allow(clippy::unused_self)]
+    #[expect(clippy::unused_self)]
     const fn __repr__(&self) -> &'static str {
         "NOTSET"
     }
@@ -59,7 +59,7 @@ impl MockEnv {
     }
 
     /// Return a string representation of the Mock object.
-    #[allow(clippy::unused_self)]
+    #[expect(clippy::unused_self)]
     pub fn __repr__(&self) -> String {
         "<MockEnv object>".to_string()
     }
@@ -225,7 +225,7 @@ impl MockEnv {
     }
 
     /// Set dictionary entry name to value.
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     fn setitem(
         &mut self,
         py: Python<'_>,
@@ -254,7 +254,7 @@ impl MockEnv {
     }
 
     /// Delete name from dict.
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     #[pyo3(signature = (dic, name, raising = true))]
     fn delitem(
         &mut self,
@@ -286,7 +286,7 @@ impl MockEnv {
 
     /// Set environment variable name to value.
     #[pyo3(signature = (name, value, prepend = None))]
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     fn setenv(
         &mut self,
         py: Python<'_>,
@@ -330,7 +330,7 @@ impl MockEnv {
 
     /// Delete name from the environment.
     #[pyo3(signature = (name, raising = true))]
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     fn delenv(&mut self, py: Python<'_>, name: String, raising: bool) -> PyResult<()> {
         let os_module = py.import("os")?;
         let environ = os_module.getattr("environ")?;
@@ -378,7 +378,7 @@ impl MockEnv {
     }
 
     /// Change the current working directory to the specified path.
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     fn chdir(&mut self, py: Python<'_>, path: Py<PyAny>) -> PyResult<()> {
         let os_module = py.import("os")?;
         let path_string = path.to_string();
@@ -480,7 +480,7 @@ struct MockEnvContext {
 
 #[pymethods]
 impl MockEnvContext {
-    #[allow(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value)]
     fn __enter__(slf: PyRef<'_, Self>) -> PyResult<Py<MockEnv>> {
         let py = slf.py();
         Py::new(py, MockEnv::new())

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -547,7 +547,9 @@ fn get_value_and_finalizer(
                 Ok((value.unbind(), Some(finalizer)))
             }
             Some(Err(err)) => Err(err),
-            None => unreachable!(),
+            None => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                "Generator fixture yielded no value",
+            )),
         }
     } else if let Some(builtin_fixture) = fixture.as_builtin()
         && let Some(finalizer_fn) = &builtin_fixture.finalizer

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -123,7 +123,7 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
         Utf8PathBuf::from_path_buf(cwd)
             .map_err(|path| {
                 anyhow::anyhow!(
-                    "The current working directory `{}` contains non-Unicode characters. ty only supports Unicode paths.",
+                    "The current working directory `{}` contains non-Unicode characters. karva only supports Unicode paths.",
                     path.display()
                 )
             })?

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -44,7 +44,7 @@ karva test [OPTIONS] [PATH]...
 <li><code>always</code>:  Always display colors</li>
 <li><code>never</code>:  Never display colors</li>
 </ul></dd><dt id="karva-test--config-file"><a href="#karva-test--config-file"><code>--config-file</code></a> <i>path</i></dt><dd><p>The path to a <code>karva.toml</code> file to use for configuration.</p>
-<p>While ty configuration can be included in a <code>pyproject.toml</code> file, it is not allowed in this context.</p>
+<p>While karva configuration can be included in a <code>pyproject.toml</code> file, it is not allowed in this context.</p>
 <p>May also be set with the <code>KARVA_CONFIG_FILE</code> environment variable.</p></dd><dt id="karva-test--fail-fast"><a href="#karva-test--fail-fast"><code>--fail-fast</code></a></dt><dd><p>When set, the test will fail immediately if any test fails.</p>
 <p>This only works when running tests in parallel.</p>
 </dd><dt id="karva-test--help"><a href="#karva-test--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Print help (see a summary with '-h')</p>


### PR DESCRIPTION
## Summary
- Fixed incorrect project name in Unicode path error messages and CLI doc comments
- Replaced `#[allow()]` with `#[expect()]` for 8 clippy lint suppressions in `mock_env.rs`
- Replaced `unreachable!()` with safe alternatives in `path/utils.rs` and `package_runner.rs`
- Regenerated CLI reference docs

## Test plan
- [x] `cargo clippy --all-targets` passes with no warnings
- [x] `just test` — all 498 tests pass
- [x] `prek run -a` — all pre-commit checks pass