### PR TITLE
Add fallback to ubuntu-latest for CodSpeed walltime benchmarks

### DIFF
--- a/.github/workflows/benchmarks-walltime.yml
+++ b/.github/workflows/benchmarks-walltime.yml
@@ -1,0 +1,70 @@
+name: Walltime Benchmarks
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        required: true
+        type: string
+      projects:
+        required: true
+        type: string
+
+permissions: {}
+
+env:
+  BENCHMARK_PYTHON_VERSION: "3.13"
+
+jobs:
+  run:
+    name: "${{ matrix.project }}"
+
+    runs-on: ${{ inputs.runner }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        project: ${{ fromJson(inputs.projects) }}
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: "Install Rust toolchain"
+        run: rustup update && rustup show
+
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+
+      - name: "Install cargo codspeed"
+        uses: taiki-e/install-action@a416ddeedbd372e614cc1386e8b642692f66865e # v2.57.1
+        with:
+          tool: cargo-codspeed
+
+      - name: Setup Python
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
+        id: setup-python
+        with:
+          python-version: ${{ env.BENCHMARK_PYTHON_VERSION }}
+
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        with:
+          python-version: ${{ env.BENCHMARK_PYTHON_VERSION }}
+
+      - name: Build wheels
+        run: |
+          uv run --no-project --with maturin maturin build
+
+      - name: Build benchmarks
+        env:
+          PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
+        run: cargo codspeed build -m walltime
+
+      - name: Run benchmarks
+        uses: CodSpeedHQ/action@972e3437949c89e1357ebd1a2dbc852fcbc57245 # v4.5.1
+        env:
+          PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
+        with:
+          token: ${{ secrets.CODSPEED_TOKEN }}
+          run: cargo codspeed run --bench ${{ matrix.project }}
+          mode: walltime

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,57 +170,25 @@ jobs:
           echo "projects=${projects}" >> "$GITHUB_OUTPUT"
 
   benchmarks-walltime:
-    name: "walltime benchmarks (${{ matrix.project }})"
-
-    runs-on: codspeed-macro
+    name: "walltime benchmarks"
 
     needs: [determine_changes, generate-walltime-benchmarks-matrix]
     if: ${{ (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
 
-    strategy:
-      fail-fast: false
-      matrix:
-        project: ${{ fromJson(needs.generate-walltime-benchmarks-matrix.outputs.projects) }}
+    uses: ./.github/workflows/benchmarks-walltime.yml
+    with:
+      runner: codspeed-macro
+      projects: ${{ needs.generate-walltime-benchmarks-matrix.outputs.projects }}
+    secrets: inherit
 
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-        with:
-          persist-credentials: false
+  benchmarks-walltime-fallback:
+    name: "walltime benchmarks (fallback)"
 
-      - name: "Install Rust toolchain"
-        run: rustup update && rustup show
+    needs: [determine_changes, generate-walltime-benchmarks-matrix, benchmarks-walltime]
+    if: ${{ !cancelled() && needs.benchmarks-walltime.result == 'failure' }}
 
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
-
-      - name: "Install cargo codspeed"
-        uses: taiki-e/install-action@a416ddeedbd372e614cc1386e8b642692f66865e # v2.57.1
-        with:
-          tool: cargo-codspeed
-
-      - name: Setup Python
-        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
-        id: setup-python
-        with:
-          python-version: ${{ env.BENCHMARK_PYTHON_VERSION }}
-
-      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
-        with:
-          python-version: ${{ env.BENCHMARK_PYTHON_VERSION }}
-
-      - name: Build wheels
-        run: |
-          uv run --no-project --with maturin maturin build
-
-      - name: Build benchmarks
-        env:
-          PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
-        run: cargo codspeed build -m walltime
-
-      - name: Run benchmarks
-        uses: CodSpeedHQ/action@972e3437949c89e1357ebd1a2dbc852fcbc57245 # v4.5.1
-        env:
-          PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
-        with:
-          token: ${{ secrets.CODSPEED_TOKEN }}
-          run: cargo codspeed run --bench ${{ matrix.project }}
-          mode: walltime
+    uses: ./.github/workflows/benchmarks-walltime.yml
+    with:
+      runner: ubuntu-latest
+      projects: ${{ needs.generate-walltime-benchmarks-matrix.outputs.projects }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Extract walltime benchmark steps into a reusable workflow (`.github/workflows/benchmarks-walltime.yml`) to eliminate duplication
- Primary job runs on `codspeed-macro` runner as before
- New fallback job runs on `ubuntu-latest` only if the primary job fails (e.g., runner unavailable)

## Test plan
- [ ] Verify CI runs walltime benchmarks on `codspeed-macro` when the runner is available
- [ ] Verify fallback to `ubuntu-latest` triggers when `codspeed-macro` is unavailable