### PR TITLE
Temporarily use ubuntu-latest for walltime benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
   benchmarks-walltime:
     name: "walltime benchmarks (${{ matrix.project }})"
 
-    runs-on: codspeed-macro
+    runs-on: ubuntu-latest # should be codspeed-macro
 
     needs: [determine_changes, generate-walltime-benchmarks-matrix]
     if: ${{ (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}


### PR DESCRIPTION
## Summary
- Temporarily switches the walltime benchmarks runner from `codspeed-macro` to `ubuntu-latest`
- Leaves a comment noting it should be switched back to `codspeed-macro`
