### PR TITLE
Add `karva snapshot prune` command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,3 +11,4 @@
 - AVOID adding redundant comments throughout the codebase.
 - AVOID adding section separator comments (e.g., `// --- Section ---`) in test files.
 - PREFER function comments over inline comments.
+- PREFER short imports over fully-qualified paths for readability.

--- a/crates/karva/tests/it/extensions/snapshot.rs
+++ b/crates/karva/tests/it/extensions/snapshot.rs
@@ -1688,3 +1688,277 @@ def test_hello():
     ----- stderr -----
     ");
 }
+
+#[test]
+fn test_snapshot_prune_removes_unreferenced() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+def test_hello():
+    karva.assert_snapshot('hello world')
+        ",
+    );
+
+    let mut cmd = context.command_no_parallel();
+    cmd.arg("--snapshot-update");
+    let _ = cmd.output();
+
+    // Remove the test function
+    context.write_file(
+        "test.py",
+        r"
+import karva
+
+def test_other():
+    pass
+        ",
+    );
+
+    assert_cmd_snapshot!(context.snapshot("prune"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Removed: <temp_dir>/snapshots/test__test_hello.snap (function `test_hello` not found in test.py)
+
+    1 snapshot(s) pruned.
+
+    ----- stderr -----
+    warning: Prune uses static analysis and may not detect all unreferenced snapshots.
+    ");
+
+    assert!(
+        !context
+            .root()
+            .join("snapshots/test__test_hello.snap")
+            .exists(),
+        "Expected snapshot to be removed"
+    );
+}
+
+#[test]
+fn test_snapshot_prune_dry_run() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+def test_hello():
+    karva.assert_snapshot('hello world')
+        ",
+    );
+
+    let mut cmd = context.command_no_parallel();
+    cmd.arg("--snapshot-update");
+    let _ = cmd.output();
+
+    // Remove the test function
+    context.write_file(
+        "test.py",
+        r"
+import karva
+
+def test_other():
+    pass
+        ",
+    );
+
+    let mut prune_cmd = context.snapshot("prune");
+    prune_cmd.arg("--dry-run");
+    assert_cmd_snapshot!(prune_cmd, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Would remove: <temp_dir>/snapshots/test__test_hello.snap (function `test_hello` not found in test.py)
+
+    1 unreferenced snapshot(s) would be removed.
+
+    ----- stderr -----
+    warning: Prune uses static analysis and may not detect all unreferenced snapshots.
+    ");
+
+    assert!(
+        context
+            .root()
+            .join("snapshots/test__test_hello.snap")
+            .exists(),
+        "Expected snapshot to still exist after dry run"
+    );
+}
+
+#[test]
+fn test_snapshot_prune_nothing_to_prune() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+def test_hello():
+    karva.assert_snapshot('hello world')
+        ",
+    );
+
+    let mut cmd = context.command_no_parallel();
+    cmd.arg("--snapshot-update");
+    let _ = cmd.output();
+
+    assert_cmd_snapshot!(context.snapshot("prune"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    No unreferenced snapshots found.
+
+    ----- stderr -----
+    warning: Prune uses static analysis and may not detect all unreferenced snapshots.
+    ");
+}
+
+#[test]
+fn test_snapshot_prune_test_file_deleted() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+def test_hello():
+    karva.assert_snapshot('hello world')
+        ",
+    );
+
+    let mut cmd = context.command_no_parallel();
+    cmd.arg("--snapshot-update");
+    let _ = cmd.output();
+
+    std::fs::remove_file(context.root().join("test.py")).expect("remove test file");
+
+    assert_cmd_snapshot!(context.snapshot("prune"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Removed: <temp_dir>/snapshots/test__test_hello.snap (test file not found: test.py)
+
+    1 snapshot(s) pruned.
+
+    ----- stderr -----
+    warning: Prune uses static analysis and may not detect all unreferenced snapshots.
+    ");
+}
+
+#[test]
+fn test_snapshot_prune_parametrized() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+@karva.tags.parametrize('x', [1, 2])
+def test_param(x):
+    karva.assert_snapshot(str(x))
+        ",
+    );
+
+    let mut cmd = context.command_no_parallel();
+    cmd.arg("--snapshot-update");
+    let _ = cmd.output();
+
+    // Remove the parametrized test function
+    context.write_file(
+        "test.py",
+        r"
+import karva
+
+def test_other():
+    pass
+        ",
+    );
+
+    assert_cmd_snapshot!(context.snapshot("prune"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Removed: <temp_dir>/snapshots/test__test_param(x=1).snap (function `test_param` not found in test.py)
+    Removed: <temp_dir>/snapshots/test__test_param(x=2).snap (function `test_param` not found in test.py)
+
+    2 snapshot(s) pruned.
+
+    ----- stderr -----
+    warning: Prune uses static analysis and may not detect all unreferenced snapshots.
+    ");
+}
+
+#[test]
+fn test_snapshot_prune_with_path_filter() {
+    let context = TestContext::default();
+    context.write_file(
+        "test_one.py",
+        r"
+import karva
+
+def test_from_one():
+    karva.assert_snapshot('from file one')
+        ",
+    );
+    context.write_file(
+        "test_two.py",
+        r"
+import karva
+
+def test_from_two():
+    karva.assert_snapshot('from file two')
+        ",
+    );
+
+    let mut cmd = context.command_no_parallel();
+    cmd.arg("--snapshot-update");
+    let _ = cmd.output();
+
+    // Remove both test functions
+    context.write_file("test_one.py", "def test_other():\n    pass\n");
+    context.write_file("test_two.py", "def test_other():\n    pass\n");
+
+    // Only prune snapshots matching "test_one"
+    let mut prune_cmd = context.snapshot("prune");
+    prune_cmd.arg("test_one");
+    assert_cmd_snapshot!(prune_cmd, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Removed: <temp_dir>/snapshots/test_one__test_from_one.snap (function `test_from_one` not found in test_one.py)
+
+    1 snapshot(s) pruned.
+
+    ----- stderr -----
+    warning: Prune uses static analysis and may not detect all unreferenced snapshots.
+    ");
+
+    // test_two snapshot should still exist
+    assert!(
+        context
+            .root()
+            .join("snapshots/test_two__test_from_two.snap")
+            .exists(),
+        "Expected test_two snapshot to still exist"
+    );
+}
+
+#[test]
+fn test_snapshot_prune_no_snapshots() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+def test_hello():
+    pass
+        ",
+    );
+
+    assert_cmd_snapshot!(context.snapshot("prune"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    No unreferenced snapshots found.
+
+    ----- stderr -----
+    warning: Prune uses static analysis and may not detect all unreferenced snapshots.
+    ");
+}

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -108,6 +108,9 @@ pub enum SnapshotAction {
 
     /// Interactively review pending snapshots.
     Review(SnapshotFilterArgs),
+
+    /// Remove snapshot files whose source test no longer exists.
+    Prune(SnapshotPruneArgs),
 }
 
 #[derive(Debug, Parser, Default)]
@@ -115,6 +118,17 @@ pub struct SnapshotFilterArgs {
     /// Optional paths to filter snapshots by directory or file.
     #[clap(value_name = "PATH")]
     pub paths: Vec<String>,
+}
+
+#[derive(Debug, Parser, Default)]
+pub struct SnapshotPruneArgs {
+    /// Optional paths to filter snapshots by directory or file.
+    #[clap(value_name = "PATH")]
+    pub paths: Vec<String>,
+
+    /// Show which snapshots would be removed without deleting them.
+    #[clap(long)]
+    pub dry_run: bool,
 }
 
 /// Shared test execution options that can be used by both main CLI and worker processes

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -90,6 +90,7 @@ karva snapshot <COMMAND>
 <dt><a href="#karva-snapshot-reject"><code>karva snapshot reject</code></a></dt><dd><p>Reject all (or filtered) pending snapshots</p></dd>
 <dt><a href="#karva-snapshot-pending"><code>karva snapshot pending</code></a></dt><dd><p>List pending snapshots</p></dd>
 <dt><a href="#karva-snapshot-review"><code>karva snapshot review</code></a></dt><dd><p>Interactively review pending snapshots</p></dd>
+<dt><a href="#karva-snapshot-prune"><code>karva snapshot prune</code></a></dt><dd><p>Remove snapshot files whose source test no longer exists</p></dd>
 <dt><a href="#karva-snapshot-help"><code>karva snapshot help</code></a></dt><dd><p>Print this message or the help of the given subcommand(s)</p></dd>
 </dl>
 
@@ -171,6 +172,27 @@ karva snapshot review [PATH]...
 <h3 class="cli-reference">Options</h3>
 
 <dl class="cli-reference"><dt id="karva-snapshot-review--help"><a href="#karva-snapshot-review--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Print help</p>
+</dd></dl>
+
+### karva snapshot prune
+
+Remove snapshot files whose source test no longer exists
+
+<h3 class="cli-reference">Usage</h3>
+
+```
+karva snapshot prune [OPTIONS] [PATH]...
+```
+
+<h3 class="cli-reference">Arguments</h3>
+
+<dl class="cli-reference"><dt id="karva-snapshot-prune--paths"><a href="#karva-snapshot-prune--paths"><code>PATHS</code></a></dt><dd><p>Optional paths to filter snapshots by directory or file</p>
+</dd></dl>
+
+<h3 class="cli-reference">Options</h3>
+
+<dl class="cli-reference"><dt id="karva-snapshot-prune--dry-run"><a href="#karva-snapshot-prune--dry-run"><code>--dry-run</code></a></dt><dd><p>Show which snapshots would be removed without deleting them</p>
+</dd><dt id="karva-snapshot-prune--help"><a href="#karva-snapshot-prune--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Print help</p>
 </dd></dl>
 
 ### karva snapshot help


### PR DESCRIPTION
## Summary

- Add `karva snapshot prune` subcommand that detects and removes `.snap` files whose source test function no longer exists
- Uses static analysis (no Python/PyO3 needed): parses each snapshot's `source` metadata field to extract the test file and function name, then checks if they still exist on disk
- Supports `--dry-run` flag to preview which snapshots would be removed without deleting them
- Supports optional path filtering to scope pruning to specific directories or files
- Handles parametrized snapshots, numbered snapshots, inline snapshots, and class-prefixed test methods

## Test plan

- [x] 12 unit tests in `karva_snapshot` covering `parse_source`, `base_function_name`, `find_snapshots`, `find_unreferenced_snapshots`, and `remove_snapshot`
- [x] 7 integration tests covering: basic prune, dry-run, nothing to prune, test file deleted, parametrized snapshots, path filtering, no snapshots directory
- [x] `just test` — all 545 tests pass
- [x] `prek run -a` — all pre-commit checks pass