### PR TITLE
Add `karva snapshot delete` command and fix snapshot path filtering

### DIFF
--- a/crates/karva/tests/it/extensions/snapshot.rs
+++ b/crates/karva/tests/it/extensions/snapshot.rs
@@ -1917,9 +1917,9 @@ def test_from_two():
     context.write_file("test_one.py", "def test_other():\n    pass\n");
     context.write_file("test_two.py", "def test_other():\n    pass\n");
 
-    // Only prune snapshots matching "test_one"
+    // Only prune snapshots matching "snapshots/test_one"
     let mut prune_cmd = context.snapshot("prune");
-    prune_cmd.arg("test_one");
+    prune_cmd.arg("snapshots/test_one");
     assert_cmd_snapshot!(prune_cmd, @r"
     success: true
     exit_code: 0
@@ -1961,4 +1961,236 @@ def test_hello():
     ----- stderr -----
     warning: Prune uses static analysis and may not detect all unreferenced snapshots.
     ");
+}
+
+#[test]
+fn test_snapshot_delete_all() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+def test_hello():
+    karva.assert_snapshot('hello world')
+        ",
+    );
+
+    // Create .snap via --snapshot-update
+    let mut cmd = context.command_no_parallel();
+    cmd.arg("--snapshot-update");
+    let _ = cmd.output();
+
+    // Change test to create a .snap.new as well
+    context.write_file(
+        "test.py",
+        r"
+import karva
+
+def test_hello():
+    karva.assert_snapshot('changed')
+        ",
+    );
+    let _ = context.command_no_parallel().output();
+
+    // Both .snap and .snap.new should exist
+    assert!(
+        context
+            .root()
+            .join("snapshots/test__test_hello.snap")
+            .exists()
+    );
+    assert!(
+        context
+            .root()
+            .join("snapshots/test__test_hello.snap.new")
+            .exists()
+    );
+
+    assert_cmd_snapshot!(context.snapshot("delete"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Deleted: <temp_dir>/snapshots/test__test_hello.snap
+    Deleted: <temp_dir>/snapshots/test__test_hello.snap.new
+
+    2 snapshot file(s) deleted.
+
+    ----- stderr -----
+    ");
+
+    assert!(
+        !context
+            .root()
+            .join("snapshots/test__test_hello.snap")
+            .exists()
+    );
+    assert!(
+        !context
+            .root()
+            .join("snapshots/test__test_hello.snap.new")
+            .exists()
+    );
+    assert!(!context.root().join("snapshots").exists());
+}
+
+#[test]
+fn test_snapshot_delete_dry_run() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+def test_hello():
+    karva.assert_snapshot('hello world')
+        ",
+    );
+
+    let mut cmd = context.command_no_parallel();
+    cmd.arg("--snapshot-update");
+    let _ = cmd.output();
+
+    let mut delete_cmd = context.snapshot("delete");
+    delete_cmd.arg("--dry-run");
+    assert_cmd_snapshot!(delete_cmd, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Would delete: <temp_dir>/snapshots/test__test_hello.snap
+
+    1 snapshot file(s) would be deleted.
+
+    ----- stderr -----
+    ");
+
+    assert!(
+        context
+            .root()
+            .join("snapshots/test__test_hello.snap")
+            .exists(),
+        "Expected snapshot to still exist after dry run"
+    );
+}
+
+#[test]
+fn test_snapshot_delete_no_snapshots() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+def test_hello():
+    pass
+        ",
+    );
+
+    assert_cmd_snapshot!(context.snapshot("delete"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    No snapshot files found.
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_snapshot_delete_with_path_filter() {
+    let context = TestContext::default();
+    context.write_file(
+        "test_one.py",
+        r"
+import karva
+
+def test_from_one():
+    karva.assert_snapshot('from file one')
+        ",
+    );
+    context.write_file(
+        "test_two.py",
+        r"
+import karva
+
+def test_from_two():
+    karva.assert_snapshot('from file two')
+        ",
+    );
+
+    let mut cmd = context.command_no_parallel();
+    cmd.arg("--snapshot-update");
+    let _ = cmd.output();
+
+    // Delete only snapshots matching "snapshots/test_one"
+    let mut delete_cmd = context.snapshot("delete");
+    delete_cmd.arg("snapshots/test_one");
+    assert_cmd_snapshot!(delete_cmd, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Deleted: <temp_dir>/snapshots/test_one__test_from_one.snap
+
+    1 snapshot file(s) deleted.
+
+    ----- stderr -----
+    ");
+
+    assert!(
+        !context
+            .root()
+            .join("snapshots/test_one__test_from_one.snap")
+            .exists(),
+        "Expected test_one snapshot to be deleted"
+    );
+    assert!(
+        context
+            .root()
+            .join("snapshots/test_two__test_from_two.snap")
+            .exists(),
+        "Expected test_two snapshot to still exist"
+    );
+}
+
+#[test]
+fn test_snapshot_delete_only_pending() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+def test_hello():
+    karva.assert_snapshot('hello world')
+        ",
+    );
+
+    // Run without --snapshot-update to create only .snap.new
+    let _ = context.command_no_parallel().output();
+
+    assert!(
+        context
+            .root()
+            .join("snapshots/test__test_hello.snap.new")
+            .exists()
+    );
+    assert!(
+        !context
+            .root()
+            .join("snapshots/test__test_hello.snap")
+            .exists()
+    );
+
+    assert_cmd_snapshot!(context.snapshot("delete"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Deleted: <temp_dir>/snapshots/test__test_hello.snap.new
+
+    1 snapshot file(s) deleted.
+
+    ----- stderr -----
+    ");
+
+    assert!(
+        !context
+            .root()
+            .join("snapshots/test__test_hello.snap.new")
+            .exists()
+    );
+    assert!(!context.root().join("snapshots").exists());
 }

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -111,6 +111,9 @@ pub enum SnapshotAction {
 
     /// Remove snapshot files whose source test no longer exists.
     Prune(SnapshotPruneArgs),
+
+    /// Delete all (or filtered) snapshot files (.snap and .snap.new).
+    Delete(SnapshotDeleteArgs),
 }
 
 #[derive(Debug, Parser, Default)]
@@ -127,6 +130,17 @@ pub struct SnapshotPruneArgs {
     pub paths: Vec<String>,
 
     /// Show which snapshots would be removed without deleting them.
+    #[clap(long)]
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Parser, Default)]
+pub struct SnapshotDeleteArgs {
+    /// Optional paths to filter which snapshot files are deleted.
+    #[clap(value_name = "PATH")]
+    pub paths: Vec<String>,
+
+    /// Show which snapshot files would be deleted without removing them.
     #[clap(long)]
     pub dry_run: bool,
 }

--- a/crates/karva_snapshot/src/review.rs
+++ b/crates/karva_snapshot/src/review.rs
@@ -1,6 +1,6 @@
 use std::io::{self, BufRead, Write};
 
-use camino::Utf8Path;
+use camino::{Utf8Path, Utf8PathBuf};
 use colored::Colorize;
 use console::{Key, Term};
 
@@ -101,18 +101,18 @@ fn read_review_action(out: &mut impl Write) -> io::Result<ReviewAction> {
 /// Run an interactive review session for all pending snapshots under the given root.
 ///
 /// For each pending snapshot, displays the diff and prompts the user for an action.
-pub fn run_review(root: &Utf8Path, filter_paths: &[String]) -> io::Result<ReviewSummary> {
+pub fn run_review(root: &Utf8Path, resolved_filters: &[Utf8PathBuf]) -> io::Result<ReviewSummary> {
     let pending = find_pending_snapshots(root);
 
-    let filtered: Vec<_> = if filter_paths.is_empty() {
+    let filtered: Vec<_> = if resolved_filters.is_empty() {
         pending
     } else {
         pending
             .into_iter()
             .filter(|info| {
-                filter_paths
+                resolved_filters
                     .iter()
-                    .any(|f| info.pending_path.as_str().contains(f.as_str()))
+                    .any(|f| info.pending_path.as_str().starts_with(f.as_str()))
             })
             .collect()
     };

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -91,6 +91,7 @@ karva snapshot <COMMAND>
 <dt><a href="#karva-snapshot-pending"><code>karva snapshot pending</code></a></dt><dd><p>List pending snapshots</p></dd>
 <dt><a href="#karva-snapshot-review"><code>karva snapshot review</code></a></dt><dd><p>Interactively review pending snapshots</p></dd>
 <dt><a href="#karva-snapshot-prune"><code>karva snapshot prune</code></a></dt><dd><p>Remove snapshot files whose source test no longer exists</p></dd>
+<dt><a href="#karva-snapshot-delete"><code>karva snapshot delete</code></a></dt><dd><p>Delete all (or filtered) snapshot files (.snap and .snap.new)</p></dd>
 <dt><a href="#karva-snapshot-help"><code>karva snapshot help</code></a></dt><dd><p>Print this message or the help of the given subcommand(s)</p></dd>
 </dl>
 
@@ -193,6 +194,27 @@ karva snapshot prune [OPTIONS] [PATH]...
 
 <dl class="cli-reference"><dt id="karva-snapshot-prune--dry-run"><a href="#karva-snapshot-prune--dry-run"><code>--dry-run</code></a></dt><dd><p>Show which snapshots would be removed without deleting them</p>
 </dd><dt id="karva-snapshot-prune--help"><a href="#karva-snapshot-prune--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Print help</p>
+</dd></dl>
+
+### karva snapshot delete
+
+Delete all (or filtered) snapshot files (.snap and .snap.new)
+
+<h3 class="cli-reference">Usage</h3>
+
+```
+karva snapshot delete [OPTIONS] [PATH]...
+```
+
+<h3 class="cli-reference">Arguments</h3>
+
+<dl class="cli-reference"><dt id="karva-snapshot-delete--paths"><a href="#karva-snapshot-delete--paths"><code>PATHS</code></a></dt><dd><p>Optional paths to filter which snapshot files are deleted</p>
+</dd></dl>
+
+<h3 class="cli-reference">Options</h3>
+
+<dl class="cli-reference"><dt id="karva-snapshot-delete--dry-run"><a href="#karva-snapshot-delete--dry-run"><code>--dry-run</code></a></dt><dd><p>Show which snapshot files would be deleted without removing them</p>
+</dd><dt id="karva-snapshot-delete--help"><a href="#karva-snapshot-delete--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Print help</p>
 </dd></dl>
 
 ### karva snapshot help


### PR DESCRIPTION
## Summary

- Add new `karva snapshot delete` subcommand that deletes all snapshot files (`.snap` and `.snap.new`) with optional path filtering and `--dry-run` support
- Fix path filtering across all snapshot commands by replacing unreliable `string.contains()` substring matching with absolute-path prefix matching using `resolve_filter_paths()` + `str::starts_with()`
- Add `find_all_snapshots()` to `karva_snapshot::storage` for discovering both `.snap` and `.snap.new` files
- Update `run_review` to accept resolved `&[Utf8PathBuf]` filters instead of raw `&[String]`

## Test plan

- [x] 5 new integration tests for delete: all, dry-run, no-snapshots, path-filter, only-pending
- [x] Updated `test_snapshot_prune_with_path_filter` to use correct path prefix filter
- [x] All 550 tests pass (`just test`)
- [x] `prek run -a` passes (clippy, fmt, etc.)
- [x] CLI docs regenerated via `cargo run -p karva_dev generate-all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)