### PR TITLE
Add `name=` parameter to `assert_snapshot` for named snapshots

### DIFF
--- a/crates/karva/tests/it/extensions/snapshot.rs
+++ b/crates/karva/tests/it/extensions/snapshot.rs
@@ -2505,3 +2505,353 @@ def test_empty_filters():
     unchanged
     ");
 }
+
+#[test]
+fn test_snapshot_named_creates_correct_file() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+def test_hello():
+    karva.assert_snapshot('hello world', name='greeting')
+        ",
+    );
+
+    let mut cmd = context.command_no_parallel();
+    cmd.arg("--snapshot-update");
+
+    assert_cmd_snapshot!(cmd, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    test test::test_hello ... ok
+
+    test result: ok. 1 passed; 0 failed; 0 skipped; finished in [TIME]
+
+    ----- stderr -----
+    ");
+
+    let content = context.read_file("snapshots/test__test_hello--greeting.snap");
+    insta::assert_snapshot!(content, @r"
+    ---
+    source: test.py:5::test_hello
+    ---
+    hello world
+    ");
+}
+
+#[test]
+fn test_snapshot_named_matches() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+def test_hello():
+    karva.assert_snapshot('hello world', name='greeting')
+        ",
+    );
+
+    let mut cmd = context.command_no_parallel();
+    cmd.arg("--snapshot-update");
+    let _ = cmd.output();
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    test test::test_hello ... ok
+
+    test result: ok. 1 passed; 0 failed; 0 skipped; finished in [TIME]
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_snapshot_named_mismatch() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+def test_hello():
+    karva.assert_snapshot('hello world', name='greeting')
+        ",
+    );
+
+    let mut cmd = context.command_no_parallel();
+    cmd.arg("--snapshot-update");
+    let _ = cmd.output();
+
+    context.write_file(
+        "test.py",
+        r"
+import karva
+
+def test_hello():
+    karva.assert_snapshot('goodbye world', name='greeting')
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    test test::test_hello ... FAILED
+
+    diagnostics:
+
+    error[test-failure]: Test `test_hello` failed
+     --> test.py:4:5
+      |
+    2 | import karva
+    3 |
+    4 | def test_hello():
+      |     ^^^^^^^^^^
+    5 |     karva.assert_snapshot('goodbye world', name='greeting')
+      |
+    info: Test failed here
+     --> test.py:5:5
+      |
+    4 | def test_hello():
+    5 |     karva.assert_snapshot('goodbye world', name='greeting')
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: Snapshot mismatch for 'test_hello--greeting'.
+          Snapshot file: <temp_dir>/snapshots/test__test_hello--greeting.snap
+          [LONG-LINE]┬[LONG-LINE]
+              1       | -hello world
+                    1 | +goodbye world
+          [LONG-LINE]┴[LONG-LINE]
+
+    test result: FAILED. 0 passed; 1 failed; 0 skipped; finished in [TIME]
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_snapshot_named_multiple() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+def test_page():
+    karva.assert_snapshot('Welcome', name='header')
+    karva.assert_snapshot('Goodbye', name='footer')
+        ",
+    );
+
+    let mut cmd = context.command_no_parallel();
+    cmd.arg("--snapshot-update");
+
+    assert_cmd_snapshot!(cmd, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    test test::test_page ... ok
+
+    test result: ok. 1 passed; 0 failed; 0 skipped; finished in [TIME]
+
+    ----- stderr -----
+    ");
+
+    let header = context.read_file("snapshots/test__test_page--header.snap");
+    insta::assert_snapshot!(header, @r"
+    ---
+    source: test.py:5::test_page
+    ---
+    Welcome
+    ");
+
+    let footer = context.read_file("snapshots/test__test_page--footer.snap");
+    insta::assert_snapshot!(footer, @r"
+    ---
+    source: test.py:6::test_page
+    ---
+    Goodbye
+    ");
+}
+
+#[test]
+fn test_snapshot_named_and_unnamed_mixed() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+def test_mixed():
+    karva.assert_snapshot('unnamed value')
+    karva.assert_snapshot('named value', name='special')
+        ",
+    );
+
+    let mut cmd = context.command_no_parallel();
+    cmd.arg("--snapshot-update");
+
+    assert_cmd_snapshot!(cmd, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    test test::test_mixed ... ok
+
+    test result: ok. 1 passed; 0 failed; 0 skipped; finished in [TIME]
+
+    ----- stderr -----
+    ");
+
+    let unnamed = context.read_file("snapshots/test__test_mixed.snap");
+    insta::assert_snapshot!(unnamed, @r"
+    ---
+    source: test.py:5::test_mixed
+    ---
+    unnamed value
+    ");
+
+    let named = context.read_file("snapshots/test__test_mixed--special.snap");
+    insta::assert_snapshot!(named, @r"
+    ---
+    source: test.py:6::test_mixed
+    ---
+    named value
+    ");
+}
+
+#[test]
+fn test_snapshot_name_and_inline_error() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+def test_both():
+    karva.assert_snapshot('value', name='foo', inline='bar')
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    test test::test_both ... FAILED
+
+    diagnostics:
+
+    error[test-failure]: Test `test_both` failed
+     --> test.py:4:5
+      |
+    2 | import karva
+    3 |
+    4 | def test_both():
+      |     ^^^^^^^^^
+    5 |     karva.assert_snapshot('value', name='foo', inline='bar')
+      |
+    info: Test failed here
+     --> test.py:5:5
+      |
+    4 | def test_both():
+    5 |     karva.assert_snapshot('value', name='foo', inline='bar')
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: assert_snapshot() cannot use both 'inline' and 'name' arguments
+
+    test result: FAILED. 0 passed; 1 failed; 0 skipped; finished in [TIME]
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_snapshot_named_parametrized() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+@karva.tags.parametrize('lang', ['en', 'fr'])
+def test_translate(lang):
+    karva.assert_snapshot(f'hello_{lang}', name='greeting')
+        ",
+    );
+
+    let mut cmd = context.command_no_parallel();
+    cmd.arg("--snapshot-update");
+
+    assert_cmd_snapshot!(cmd, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    test test::test_translate(lang=en) ... ok
+    test test::test_translate(lang=fr) ... ok
+
+    test result: ok. 2 passed; 0 failed; 0 skipped; finished in [TIME]
+
+    ----- stderr -----
+    ");
+
+    let en = context.read_file("snapshots/test__test_translate--greeting(lang=en).snap");
+    insta::assert_snapshot!(en, @r"
+    ---
+    source: test.py:6::test_translate(lang=en)
+    ---
+    hello_en
+    ");
+
+    let fr = context.read_file("snapshots/test__test_translate--greeting(lang=fr).snap");
+    insta::assert_snapshot!(fr, @r"
+    ---
+    source: test.py:6::test_translate(lang=fr)
+    ---
+    hello_fr
+    ");
+}
+
+#[test]
+fn test_snapshot_named_prune() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+def test_hello():
+    karva.assert_snapshot('hello world', name='greeting')
+        ",
+    );
+
+    let mut cmd = context.command_no_parallel();
+    cmd.arg("--snapshot-update");
+    let _ = cmd.output();
+
+    context.write_file(
+        "test.py",
+        r"
+import karva
+
+def test_other():
+    pass
+        ",
+    );
+
+    assert_cmd_snapshot!(context.snapshot("prune"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Removed: <temp_dir>/snapshots/test__test_hello--greeting.snap (function `test_hello` not found in test.py)
+
+    1 snapshot(s) pruned.
+
+    ----- stderr -----
+    warning: Prune uses static analysis and may not detect all unreferenced snapshots.
+    ");
+
+    assert!(
+        !context
+            .root()
+            .join("snapshots/test__test_hello--greeting.snap")
+            .exists(),
+        "Expected named snapshot to be removed"
+    );
+}

--- a/crates/karva_snapshot/src/storage.rs
+++ b/crates/karva_snapshot/src/storage.rs
@@ -178,6 +178,7 @@ pub fn parse_source(source: &str) -> Option<(&str, &str)> {
 /// and class prefix `TestClass::test_method` → `test_method`.
 pub fn base_function_name(name: &str) -> &str {
     let name = name.rsplit_once("::").map_or(name, |(_, method)| method);
+    let name = name.split_once("--").map_or(name, |(base, _)| base);
     let name = name.split_once('(').map_or(name, |(base, _)| base);
     let name = name.rsplit_once('-').map_or(name, |(base, suffix)| {
         if suffix.chars().all(|c| c.is_ascii_digit()) {
@@ -484,6 +485,12 @@ mod tests {
     #[test]
     fn test_base_function_name_class_prefix() {
         assert_eq!(base_function_name("TestClass::test_method"), "test_method");
+    }
+
+    #[test]
+    fn test_base_function_name_named() {
+        assert_eq!(base_function_name("test_foo--header"), "test_foo");
+        assert_eq!(base_function_name("test_foo--header(x=1)"), "test_foo");
     }
 
     #[test]

--- a/python/karva/_karva/__init__.pyi
+++ b/python/karva/_karva/__init__.pyi
@@ -111,10 +111,17 @@ def raises(
             representation of the exception.
     """
 
+@overload
 def assert_snapshot(
     value: object,
     *,
     inline: str | None = None,
+) -> None: ...
+@overload
+def assert_snapshot(
+    value: object,
+    *,
+    name: str,
 ) -> None: ...
 
 class SnapshotSettings:


### PR DESCRIPTION
## Summary

- Add `name=` keyword argument to `karva.assert_snapshot()` for user-defined snapshot names
- Named snapshots produce files like `test__test_page--header.snap` using the `--` convention
- `name=` and `inline=` are mutually exclusive (enforced via typing overloads and runtime check)
- Update `base_function_name()` to strip `--name` suffixes so `karva snapshot prune` works correctly with named snapshots
- Parametrized named snapshots produce `test__test_func--name(param=value).snap`

## Test plan

- [x] Unit tests for `compute_named_snapshot` (plain and parametrized)
- [x] Unit tests for `base_function_name` with `--` suffixes
- [x] Integration test: named snapshot creates correct file
- [x] Integration test: named snapshot matches on second run
- [x] Integration test: named snapshot mismatch shows correct diff
- [x] Integration test: multiple named snapshots in same test
- [x] Integration test: mixed named + unnamed in same test
- [x] Integration test: `name=` + `inline=` raises TypeError
- [x] Integration test: named parametrized snapshots
- [x] Integration test: named snapshot prune
- [x] All 574 tests pass, `prek run -a` clean