### PR TITLE
Merge duplicate sections in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,14 +1,15 @@
 - ALWAYS read CONTRIBUTING.md for guidelines on how to run tools
-- ALWAYS attempt to add a test case for changed behavior
+- ALWAYS attempt to add a test case for changed behavior. Get your tests to pass — if you didn't run the tests, your code does not work.
 - PREFER integration tests, e.g., at `it/...` over unit tests
 - PREFER running specific tests over running the entire test suite
-- AVOID using `panic!`, `unreachable!`, `.unwrap()`, unsafe code, and clippy rule ignores
+- ALWAYS run `just test` to run all tests.
+- ALWAYS run `uvx prek run -a` at the end of a task.
+- FOLLOW existing code style. Check neighboring files for patterns.
+- AVOID writing significant amounts of new code. Look for existing methods and utilities first.
+- AVOID using `panic!`, `unreachable!`, `.unwrap()`, unsafe code, and clippy rule ignores. Encode constraints in the type system instead.
 - PREFER patterns like `if let` to handle fallibility
 - PREFER `#[expect()]` over `[allow()]` if clippy must be disabled
 - PREFER let chains (`if let` combined with `&&`) over nested `if let` statements
-- ALWAYS run `prek run -a` at the end of a task
-- ALWAYS run `just test` to run all tests.
-- AVOID adding redundant comments throughout the codebase.
-- AVOID adding section separator comments (e.g., `// --- Section ---`) in test files.
-- PREFER function comments over inline comments.
 - PREFER short imports over fully-qualified paths for readability.
+- AVOID redundant comments and section separators (e.g., `// --- Section ---`) in test files. Use comments to explain invariants and why something unusual was done, not to narrate code.
+- PREFER function comments over inline comments.


### PR DESCRIPTION
## Summary
- Merged two overlapping sections (lines 1-14 and 16-24) into a single clean list of 15 items
- Eliminated 6 duplicate pairs while preserving the richer phrasing from each
- Key improvements: added "encode constraints in the type system", "get your tests to pass" reinforcement, explicit `uvx prek run -a`, and merged comment guidance

## Test plan
- [x] Read resulting file and confirm no duplicates remain
- [x] Confirm all unique guidance from both sections is preserved