### PR TITLE
Add `--dry-run` flag to `karva test`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,6 +1138,7 @@ dependencies = [
  "insta-cmd",
  "karva_cache",
  "karva_cli",
+ "karva_collector",
  "karva_logging",
  "karva_metadata",
  "karva_project",

--- a/crates/karva/Cargo.toml
+++ b/crates/karva/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 [dependencies]
 karva_cache = { workspace = true }
 karva_cli = { workspace = true }
+karva_collector = { workspace = true }
 karva_logging = { workspace = true }
 karva_metadata = { workspace = true }
 karva_project = { workspace = true }

--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -1118,3 +1118,80 @@ def test_3(): pass",
     INFO All workers completed
     ");
 }
+
+#[test]
+fn test_dry_run() {
+    let context = TestContext::with_files([
+        (
+            "test_file1.py",
+            r"
+def test_alpha(): pass
+def test_beta(): pass
+",
+        ),
+        (
+            "test_file2.py",
+            r"
+def test_gamma(): pass
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command().arg("--dry-run"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    <test> test_file1::test_alpha
+    <test> test_file1::test_beta
+    <test> test_file2::test_gamma
+
+    3 tests collected
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_dry_run_empty() {
+    let context = TestContext::new();
+
+    assert_cmd_snapshot!(context.command().arg("--dry-run"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    0 tests collected
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_dry_run_with_path_filter() {
+    let context = TestContext::with_files([
+        (
+            "test_file1.py",
+            r"
+def test_alpha(): pass
+def test_beta(): pass
+",
+        ),
+        (
+            "test_file2.py",
+            r"
+def test_gamma(): pass
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command().args(["--dry-run", "test_file1.py"]), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    <test> test_file1::test_alpha
+    <test> test_file1::test_beta
+
+    2 tests collected
+
+    ----- stderr -----
+    ");
+}

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -248,6 +248,10 @@ pub struct TestCommand {
     /// Disable reading the karva cache for test duration history
     #[clap(long, default_missing_value = "true", num_args=0..1)]
     pub no_cache: Option<bool>,
+
+    /// Print discovered tests without executing them.
+    #[clap(long)]
+    pub dry_run: bool,
 }
 
 impl TestCommand {

--- a/crates/karva_runner/src/lib.rs
+++ b/crates/karva_runner/src/lib.rs
@@ -3,4 +3,4 @@ mod orchestration;
 mod partition;
 mod shutdown;
 
-pub use orchestration::{ParallelTestConfig, run_parallel_tests};
+pub use orchestration::{ParallelTestConfig, collect_tests, run_parallel_tests};

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -45,7 +45,8 @@ karva test [OPTIONS] [PATH]...
 <li><code>never</code>:  Never display colors</li>
 </ul></dd><dt id="karva-test--config-file"><a href="#karva-test--config-file"><code>--config-file</code></a> <i>path</i></dt><dd><p>The path to a <code>karva.toml</code> file to use for configuration.</p>
 <p>While karva configuration can be included in a <code>pyproject.toml</code> file, it is not allowed in this context.</p>
-<p>May also be set with the <code>KARVA_CONFIG_FILE</code> environment variable.</p></dd><dt id="karva-test--fail-fast"><a href="#karva-test--fail-fast"><code>--fail-fast</code></a></dt><dd><p>When set, the test will fail immediately if any test fails.</p>
+<p>May also be set with the <code>KARVA_CONFIG_FILE</code> environment variable.</p></dd><dt id="karva-test--dry-run"><a href="#karva-test--dry-run"><code>--dry-run</code></a></dt><dd><p>Print discovered tests without executing them</p>
+</dd><dt id="karva-test--fail-fast"><a href="#karva-test--fail-fast"><code>--fail-fast</code></a></dt><dd><p>When set, the test will fail immediately if any test fails.</p>
 <p>This only works when running tests in parallel.</p>
 </dd><dt id="karva-test--help"><a href="#karva-test--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Print help (see a summary with '-h')</p>
 </dd><dt id="karva-test--match"><a href="#karva-test--match"><code>--match</code></a>, <code>-m</code> <i>name-patterns</i></dt><dd><p>Filter tests by name using a regular expression.</p>


### PR DESCRIPTION
## Summary

- Add `--dry-run` flag to `karva test` that prints discovered tests without executing them
- Extract `collect_tests()` from `run_parallel_tests()` in `karva_runner` for reuse
- Output sorted test names as `<test> module::function` with a summary count (`N tests collected`)

Closes #465

## Test plan

- [x] `test_dry_run` — multiple files, verifies sorted output and count
- [x] `test_dry_run_empty` — empty project, verifies `0 tests collected`
- [x] `test_dry_run_with_path_filter` — verifies `--dry-run` respects path arguments
- [x] Full test suite passes (`just test` — 631 tests)
- [x] Pre-commit checks pass (`uvx prek run -a`)