### PR TITLE
Add `--watch` flag to `karva test`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,12 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
@@ -661,7 +667,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "block2",
  "libc",
  "objc2",
@@ -770,6 +776,15 @@ checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
 dependencies = [
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1011,6 +1026,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "insta"
 version = "1.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1068,15 @@ dependencies = [
  "insta",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1131,6 +1175,7 @@ dependencies = [
  "camino",
  "clap",
  "colored 3.1.1",
+ "crossbeam-channel",
  "directories",
  "dunce",
  "fs4",
@@ -1146,6 +1191,7 @@ dependencies = [
  "karva_runner",
  "karva_snapshot",
  "karva_static",
+ "notify-debouncer-mini",
  "regex",
  "rstest",
  "ruff_python_trivia",
@@ -1402,6 +1448,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,7 +1485,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "libc",
  "redox_syscall 0.7.0",
 ]
@@ -1508,15 +1574,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.10.0",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify-debouncer-mini"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaa5a66d07ed97dce782be94dcf5ab4d1b457f4243f7566c7557f15cabc8c799"
+dependencies = [
+ "log",
+ "notify",
+ "notify-types",
+ "tempfile",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -1896,7 +2014,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -1905,7 +2023,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -2095,7 +2213,7 @@ version = "0.0.0"
 source = "git+https://github.com/astral-sh/ruff/?branch=main#2b9fed3bbdbf5c1681458f9a17017ad431825f8d"
 dependencies = [
  "aho-corasick",
- "bitflags",
+ "bitflags 2.10.0",
  "compact_str",
  "get-size2",
  "is-macro",
@@ -2112,7 +2230,7 @@ name = "ruff_python_parser"
 version = "0.0.0"
 source = "git+https://github.com/astral-sh/ruff/?branch=main#2b9fed3bbdbf5c1681458f9a17017ad431825f8d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "bstr",
  "compact_str",
  "get-size2",
@@ -2179,7 +2297,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2909,6 +3027,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ insta = { version = "1.46.2" }
 insta-cmd = { version = "0.6.0" }
 itertools = { version = "0.14.0" }
 markdown = { version = "1.0.0" }
+notify-debouncer-mini = { version = "0.5" }
 pretty_assertions = { version = "1.4.1" }
 proc-macro2 = { version = "1.0.106" }
 pyo3 = { version = "0.27.2", features = ["abi3-py310"] }

--- a/crates/karva/Cargo.toml
+++ b/crates/karva/Cargo.toml
@@ -32,6 +32,8 @@ argfile = { workspace = true }
 camino = { workspace = true }
 clap = { workspace = true, features = ["wrap_help", "string", "env"] }
 colored = { workspace = true }
+crossbeam-channel = { workspace = true }
+notify-debouncer-mini = { workspace = true }
 tracing = { workspace = true, features = ["release_max_level_debug"] }
 wild = { workspace = true }
 

--- a/crates/karva/src/watch.rs
+++ b/crates/karva/src/watch.rs
@@ -1,0 +1,131 @@
+use std::fmt::Write;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use colored::Colorize;
+use crossbeam_channel::unbounded;
+use notify_debouncer_mini::new_debouncer;
+use notify_debouncer_mini::notify::RecursiveMode;
+
+use karva_cli::SubTestCommand;
+use karva_logging::Printer;
+use karva_project::Project;
+use karva_runner::ParallelTestConfig;
+
+use crate::print_test_output;
+
+fn run_and_print(
+    project: &Project,
+    config: &ParallelTestConfig,
+    sub_command: &SubTestCommand,
+    printer: Printer,
+) {
+    let start_time = Instant::now();
+    match karva_runner::run_parallel_tests(project, config, sub_command) {
+        Ok(result) => {
+            if let Err(err) = print_test_output(
+                printer,
+                start_time,
+                &result,
+                sub_command.output_format.as_ref(),
+            ) {
+                tracing::error!("Failed to print test output: {err}");
+            }
+        }
+        Err(err) => {
+            use std::io::Write as _;
+            let mut stderr = std::io::stderr().lock();
+            let _ = writeln!(stderr, "{} {err}", "error:".red().bold());
+        }
+    }
+}
+
+fn print_watching_message(printer: Printer) -> Result<()> {
+    let mut stdout = printer.stream_for_requested_summary().lock();
+    writeln!(stdout)?;
+    writeln!(
+        stdout,
+        "{}",
+        "Watching for file changes... (Ctrl+C to stop)".dimmed()
+    )?;
+    Ok(())
+}
+
+pub(crate) fn run_watch_loop(
+    project: &Project,
+    config: &ParallelTestConfig,
+    sub_command: &SubTestCommand,
+    printer: Printer,
+) -> Result<()> {
+    run_and_print(project, config, sub_command, printer);
+
+    let (tx, file_rx) = unbounded::<Vec<PathBuf>>();
+    let mut debouncer = new_debouncer(
+        Duration::from_millis(200),
+        move |res: notify_debouncer_mini::DebounceEventResult| {
+            if let Ok(events) = res {
+                let py_paths: Vec<_> = events
+                    .into_iter()
+                    .filter(|e| e.path.extension().is_some_and(|ext| ext == "py"))
+                    .map(|e| e.path)
+                    .collect();
+                if !py_paths.is_empty() {
+                    let _ = tx.send(py_paths);
+                }
+            }
+        },
+    )?;
+
+    debouncer
+        .watcher()
+        .watch(project.cwd().as_std_path(), RecursiveMode::Recursive)?;
+
+    let shutdown_rx = karva_runner::shutdown_receiver();
+
+    print_watching_message(printer)?;
+
+    loop {
+        crossbeam_channel::select! {
+            recv(shutdown_rx) -> _ => {
+                break;
+            }
+            recv(file_rx) -> result => {
+                let Ok(changed_paths) = result else {
+                    break;
+                };
+
+                // Drain any additional queued events
+                let mut all_paths = changed_paths;
+                while let Ok(more_paths) = file_rx.try_recv() {
+                    all_paths.extend(more_paths);
+                }
+                all_paths.sort();
+                all_paths.dedup();
+
+                // Clear screen
+                {
+                    use std::io::Write as _;
+                    let _ = std::io::stdout().write_all(b"\x1B[2J\x1B[1;1H");
+                }
+
+                {
+                    let mut stdout = printer.stream_for_requested_summary().lock();
+                    writeln!(stdout, "{}", "File changes detected:".bold())?;
+                    let cwd = project.cwd().as_std_path();
+                    for path in &all_paths {
+                        let display = path.strip_prefix(cwd).unwrap_or(path);
+                        writeln!(stdout, "  {}", display.display().to_string().dimmed())?;
+                    }
+                    writeln!(stdout)?;
+                }
+
+                run_and_print(project, config, sub_command, printer);
+
+                print_watching_message(printer)?;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/karva/tests/it/main.rs
+++ b/crates/karva/tests/it/main.rs
@@ -6,3 +6,4 @@ mod configuration;
 mod discovery;
 mod extensions;
 mod name_filter;
+mod watch;

--- a/crates/karva/tests/it/watch.rs
+++ b/crates/karva/tests/it/watch.rs
@@ -1,0 +1,50 @@
+use insta_cmd::assert_cmd_snapshot;
+
+use crate::common::TestContext;
+
+#[test]
+fn test_watch_and_dry_run_conflict() {
+    let context = TestContext::with_file("test.py", "def test_1(): pass");
+
+    assert_cmd_snapshot!(context.command().args(["--watch", "--dry-run"]), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Karva failed
+      Cause: `--watch` and `--dry-run` cannot be used together
+    ");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_watch_runs_and_can_be_killed() {
+    use std::time::Duration;
+
+    let context = TestContext::with_file("test.py", "def test_1(): pass");
+
+    let mut child = context
+        .command()
+        .args(["--watch", "--no-parallel"])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn karva with --watch");
+
+    // Wait for the first test run to complete
+    std::thread::sleep(Duration::from_secs(5));
+
+    child.kill().expect("Failed to kill watch process");
+
+    let output = child
+        .wait_with_output()
+        .expect("Failed to wait on child process");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        stdout.contains("test test::test_1 ... ok"),
+        "Expected test output, got: {stdout}"
+    );
+}

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -252,6 +252,10 @@ pub struct TestCommand {
     /// Print discovered tests without executing them.
     #[clap(long)]
     pub dry_run: bool,
+
+    /// Re-run tests when Python source files change.
+    #[clap(long)]
+    pub watch: bool,
 }
 
 impl TestCommand {

--- a/crates/karva_runner/src/lib.rs
+++ b/crates/karva_runner/src/lib.rs
@@ -4,3 +4,4 @@ mod partition;
 mod shutdown;
 
 pub use orchestration::{ParallelTestConfig, collect_tests, run_parallel_tests};
+pub use shutdown::shutdown_receiver;

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -73,6 +73,7 @@ karva test [OPTIONS] [PATH]...
 </dd><dt id="karva-test--try-import-fixtures"><a href="#karva-test--try-import-fixtures"><code>--try-import-fixtures</code></a></dt><dd><p>When set, we will try to import functions in each test file as well as parsing the ast to find them.</p>
 <p>This is often slower, so it is not recommended for most projects.</p>
 </dd><dt id="karva-test--verbose"><a href="#karva-test--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output (or <code>-vv</code> and <code>-vvv</code> for more verbose output)</p>
+</dd><dt id="karva-test--watch"><a href="#karva-test--watch"><code>--watch</code></a></dt><dd><p>Re-run tests when Python source files change</p>
 </dd></dl>
 
 ## karva snapshot


### PR DESCRIPTION
## Summary

- Add `--watch` flag to `karva test` that re-runs tests automatically when `.py` files change
- Uses `notify-debouncer-mini` crate for file watching with 200ms debounce
- Uses `crossbeam_channel::select!` to wait on both file change events and Ctrl+C shutdown signal
- On file change: clears screen, prints changed files, re-runs all tests
- Errors with a clear message when combined with `--dry-run`

## Test plan

- [x] `test_watch_and_dry_run_conflict` — verifies error when both flags used
- [x] `test_watch_runs_and_can_be_killed` (unix) — spawns watch mode, waits, kills, verifies tests ran
- [x] `just test` — all 640 tests pass
- [x] `uvx prek run -a` — all pre-commit checks pass

Closes #477