### PR TITLE
Show span annotations for each fixture in dependency chain

### DIFF
--- a/crates/karva/tests/it/extensions/fixtures/invalid.rs
+++ b/crates/karva/tests/it/extensions/fixtures/invalid.rs
@@ -410,7 +410,23 @@ fn test_fixture_dependency_chain_failure() {
     17 |     pass
        |
     info: Missing fixtures: `db`
-    info: Fixture `config` failed here (required by `db` -> `connection`)
+    info: Fixture `db` requires `connection`
+      --> test.py:13:5
+       |
+    12 | @fixture
+    13 | def db(connection):
+       |     ^^
+    14 |     return connection
+       |
+    info: Fixture `connection` requires `config`
+      --> test.py:9:5
+       |
+     8 | @fixture
+     9 | def connection(config):
+       |     ^^^^^^^^^^
+    10 |     return config
+       |
+    info: Fixture `config` failed here
      --> test.py:6:5
       |
     4 | @fixture

--- a/crates/karva_test_semantic/src/runner/mod.rs
+++ b/crates/karva_test_semantic/src/runner/mod.rs
@@ -6,4 +6,4 @@ mod test_iterator;
 
 use finalizer_cache::FinalizerCache;
 use fixture_cache::FixtureCache;
-pub(crate) use package_runner::{FixtureCallError, PackageRunner};
+pub(crate) use package_runner::{FixtureCallError, FixtureChainEntry, PackageRunner};


### PR DESCRIPTION
## Summary

- Each intermediate fixture in a dependency chain now gets its own sub-diagnostic with a span annotation pointing to its definition
- Replaces the previous `(required by `db` -> `connection`)` suffix with individual annotated spans
- Makes it easy to visually trace the full path from test to failing fixture

Before:
```
info: Fixture `config` failed here (required by `db` -> `connection`)
```

After:
```
info: Fixture `db` requires `connection`
  --> test.py:13:5
   |
12 | @fixture
13 | def db(connection):
   |     ^^

info: Fixture `connection` requires `config`
  --> test.py:9:5
   |
 8 | @fixture
 9 | def connection(config):
   |     ^^^^^^^^^^

info: Fixture `config` failed here
 --> test.py:6:5
```

## Test plan

- [x] Updated snapshot for `test_fixture_dependency_chain_failure` with new span-annotated output
- [x] All 641 tests pass
- [x] Pre-commit checks pass