### PR TITLE
Add `karva cache prune` and `karva cache clean` commands

### DIFF
--- a/crates/karva/src/lib.rs
+++ b/crates/karva/src/lib.rs
@@ -9,7 +9,10 @@ use camino::{Utf8Path, Utf8PathBuf};
 use clap::Parser;
 use colored::Colorize;
 use karva_cache::AggregatedResults;
-use karva_cli::{Args, Command, OutputFormat, SnapshotAction, SnapshotCommand, TestCommand};
+use karva_cli::{
+    Args, CacheAction, CacheCommand, Command, OutputFormat, SnapshotAction, SnapshotCommand,
+    TestCommand,
+};
 use karva_collector::CollectedPackage;
 use karva_logging::{Printer, set_colored_override, setup_tracing};
 use karva_metadata::filter::{NameFilterSet, TagFilterSet};
@@ -55,6 +58,7 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
     match args.command {
         Command::Test(test_args) => test(test_args),
         Command::Snapshot(snapshot_args) => snapshot(snapshot_args),
+        Command::Cache(cache_args) => cache(&cache_args),
         Command::Version => version().map(|()| ExitStatus::Success),
     }
 }
@@ -214,6 +218,46 @@ pub(crate) fn snapshot(args: SnapshotCommand) -> Result<ExitStatus> {
                     deleted += 1;
                 }
                 writeln!(stdout, "\n{deleted} snapshot file(s) deleted.")?;
+            }
+            Ok(ExitStatus::Success)
+        }
+    }
+}
+
+pub(crate) fn cache(args: &CacheCommand) -> Result<ExitStatus> {
+    let cwd = {
+        let cwd = std::env::current_dir().context("Failed to get the current working directory")?;
+        Utf8PathBuf::from_path_buf(cwd).map_err(|path| {
+            anyhow::anyhow!(
+                "The current working directory `{}` contains non-Unicode characters.",
+                path.display()
+            )
+        })?
+    };
+
+    let printer = Printer::default();
+    let mut stdout = printer.stream_for_requested_summary().lock();
+
+    match args.action {
+        CacheAction::Prune => {
+            let cache_dir = cwd.join(karva_cache::CACHE_DIR);
+            let result = karva_cache::prune_cache(&cache_dir)?;
+            for dir_name in &result.removed {
+                writeln!(stdout, "Removed: {dir_name}")?;
+            }
+            if result.removed.is_empty() {
+                writeln!(stdout, "No cache runs to prune.")?;
+            } else {
+                writeln!(stdout, "\n{} run(s) pruned.", result.removed.len())?;
+            }
+            Ok(ExitStatus::Success)
+        }
+        CacheAction::Clean => {
+            let cache_dir = cwd.join(karva_cache::CACHE_DIR);
+            if karva_cache::clean_cache(&cache_dir)? {
+                writeln!(stdout, "Cache directory removed.")?;
+            } else {
+                writeln!(stdout, "No cache directory found.")?;
             }
             Ok(ExitStatus::Success)
         }

--- a/crates/karva/tests/it/cache.rs
+++ b/crates/karva/tests/it/cache.rs
@@ -1,0 +1,116 @@
+use insta_cmd::assert_cmd_snapshot;
+
+use crate::common::TestContext;
+
+#[test]
+fn prune_removes_all_but_most_recent() {
+    let context = TestContext::with_file("test_a.py", "def test_1(): pass");
+
+    context.command_no_parallel().output().unwrap();
+    context.command_no_parallel().output().unwrap();
+    context.command_no_parallel().output().unwrap();
+
+    let cache_dir = context.root().join(".karva_cache");
+    let run_count = std::fs::read_dir(&cache_dir)
+        .unwrap()
+        .filter(|e| {
+            e.as_ref()
+                .unwrap()
+                .file_name()
+                .to_str()
+                .unwrap()
+                .starts_with("run-")
+        })
+        .count();
+    assert_eq!(run_count, 3);
+
+    assert_cmd_snapshot!(context.cache("prune"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Removed: run-[TIMESTAMP]
+    Removed: run-[TIMESTAMP]
+
+    2 run(s) pruned.
+
+    ----- stderr -----
+    ");
+
+    let remaining = std::fs::read_dir(&cache_dir)
+        .unwrap()
+        .filter(|e| {
+            e.as_ref()
+                .unwrap()
+                .file_name()
+                .to_str()
+                .unwrap()
+                .starts_with("run-")
+        })
+        .count();
+    assert_eq!(remaining, 1);
+}
+
+#[test]
+fn prune_with_single_run_removes_nothing() {
+    let context = TestContext::with_file("test_a.py", "def test_1(): pass");
+
+    context.command_no_parallel().output().unwrap();
+
+    assert_cmd_snapshot!(context.cache("prune"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    No cache runs to prune.
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn prune_with_no_cache_dir() {
+    let context = TestContext::new();
+
+    assert_cmd_snapshot!(context.cache("prune"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    No cache runs to prune.
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn clean_removes_cache_directory() {
+    let context = TestContext::with_file("test_a.py", "def test_1(): pass");
+
+    context.command_no_parallel().output().unwrap();
+
+    let cache_dir = context.root().join(".karva_cache");
+    assert!(cache_dir.exists());
+
+    assert_cmd_snapshot!(context.cache("clean"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Cache directory removed.
+
+    ----- stderr -----
+    ");
+
+    assert!(!cache_dir.exists());
+}
+
+#[test]
+fn clean_with_no_cache_dir() {
+    let context = TestContext::new();
+
+    assert_cmd_snapshot!(context.cache("clean"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    No cache directory found.
+
+    ----- stderr -----
+    ");
+}

--- a/crates/karva/tests/it/common/mod.rs
+++ b/crates/karva/tests/it/common/mod.rs
@@ -63,6 +63,7 @@ impl TestContext {
         settings.add_filter(r#"\\(\w\w|\s|\.|")"#, "/$1");
         settings.add_filter(r"\x1b\[[0-9;]*m", "");
         settings.add_filter(r"(\s|\()(\d+m )?(\d+\.)?\d+(ms|s)", "$1[TIME]");
+        settings.add_filter(r"run-\d+", "run-[TIMESTAMP]");
         settings.add_filter(r"[-─]{30,}", "[LONG-LINE]");
 
         let settings_scope = settings.bind_to_scope();
@@ -147,6 +148,15 @@ impl TestContext {
         let mut command = Command::new(self.venv_binary("karva"));
         command
             .arg("snapshot")
+            .arg(subcommand)
+            .current_dir(self.root());
+        command
+    }
+
+    pub fn cache(&self, subcommand: &str) -> Command {
+        let mut command = Command::new(self.venv_binary("karva"));
+        command
+            .arg("cache")
             .arg(subcommand)
             .current_dir(self.root());
         command

--- a/crates/karva/tests/it/main.rs
+++ b/crates/karva/tests/it/main.rs
@@ -2,6 +2,7 @@ pub(crate) mod common;
 
 mod r#async;
 mod basic;
+mod cache;
 mod configuration;
 mod discovery;
 mod extensions;

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -193,6 +193,56 @@ pub fn read_recent_durations(cache_dir: &Utf8PathBuf) -> Result<HashMap<String, 
     Ok(aggregated_durations)
 }
 
+/// Result of a cache prune operation.
+pub struct PruneResult {
+    /// Names of the removed run directories.
+    pub removed: Vec<String>,
+}
+
+/// Removes all but the most recent `run-*` directory from the cache.
+pub fn prune_cache(cache_dir: &Utf8Path) -> Result<PruneResult> {
+    let mut run_dirs = Vec::new();
+
+    if let Ok(entries) = fs::read_dir(cache_dir) {
+        for entry in entries {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                if let Some(dir_name) = path.file_name().and_then(|n| n.to_str()) {
+                    if dir_name.starts_with("run-") {
+                        run_dirs.push(dir_name.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    run_dirs.sort_by_key(|hash| RunHash::from_existing(hash).sort_key());
+
+    let to_remove = run_dirs.len().saturating_sub(1);
+    let mut removed = Vec::with_capacity(to_remove);
+
+    for dir_name in run_dirs.iter().take(to_remove) {
+        let path = cache_dir.join(dir_name);
+        fs::remove_dir_all(&path)?;
+        removed.push(dir_name.clone());
+    }
+
+    Ok(PruneResult { removed })
+}
+
+/// Removes the entire cache directory.
+///
+/// Returns `true` if the directory existed and was removed.
+pub fn clean_cache(cache_dir: &Utf8Path) -> Result<bool> {
+    if cache_dir.exists() {
+        fs::remove_dir_all(cache_dir)?;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/crates/karva_cache/src/lib.rs
+++ b/crates/karva_cache/src/lib.rs
@@ -1,7 +1,9 @@
 pub(crate) mod cache;
 pub(crate) mod hash;
 
-pub use cache::{AggregatedResults, Cache, read_recent_durations};
+pub use cache::{
+    AggregatedResults, Cache, PruneResult, clean_cache, prune_cache, read_recent_durations,
+};
 pub use hash::RunHash;
 
 pub const CACHE_DIR: &str = ".karva_cache";

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -85,6 +85,9 @@ pub enum Command {
     /// Manage snapshots created by `karva.assert_snapshot()`.
     Snapshot(SnapshotCommand),
 
+    /// Manage the karva cache.
+    Cache(CacheCommand),
+
     /// Display Karva's version
     Version,
 }
@@ -143,6 +146,21 @@ pub struct SnapshotDeleteArgs {
     /// Show which snapshot files would be deleted without removing them.
     #[clap(long)]
     pub dry_run: bool,
+}
+
+#[derive(Debug, Parser)]
+pub struct CacheCommand {
+    #[command(subcommand)]
+    pub action: CacheAction,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum CacheAction {
+    /// Remove all but the most recent test run from the cache.
+    Prune,
+
+    /// Remove the entire cache directory.
+    Clean,
 }
 
 /// Shared test execution options that can be used by both main CLI and worker processes

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -16,6 +16,7 @@ karva <COMMAND>
 
 <dl class="cli-reference"><dt><a href="#karva-test"><code>karva test</code></a></dt><dd><p>Run tests</p></dd>
 <dt><a href="#karva-snapshot"><code>karva snapshot</code></a></dt><dd><p>Manage snapshots created by <code>karva.assert_snapshot()</code></p></dd>
+<dt><a href="#karva-cache"><code>karva cache</code></a></dt><dd><p>Manage the karva cache</p></dd>
 <dt><a href="#karva-version"><code>karva version</code></a></dt><dd><p>Display Karva's version</p></dd>
 <dt><a href="#karva-help"><code>karva help</code></a></dt><dd><p>Print this message or the help of the given subcommand(s)</p></dd>
 </dl>
@@ -227,6 +228,63 @@ Print this message or the help of the given subcommand(s)
 
 ```
 karva snapshot help [COMMAND]
+```
+
+## karva cache
+
+Manage the karva cache
+
+<h3 class="cli-reference">Usage</h3>
+
+```
+karva cache <COMMAND>
+```
+
+<h3 class="cli-reference">Commands</h3>
+
+<dl class="cli-reference"><dt><a href="#karva-cache-prune"><code>karva cache prune</code></a></dt><dd><p>Remove all but the most recent test run from the cache</p></dd>
+<dt><a href="#karva-cache-clean"><code>karva cache clean</code></a></dt><dd><p>Remove the entire cache directory</p></dd>
+<dt><a href="#karva-cache-help"><code>karva cache help</code></a></dt><dd><p>Print this message or the help of the given subcommand(s)</p></dd>
+</dl>
+
+### karva cache prune
+
+Remove all but the most recent test run from the cache
+
+<h3 class="cli-reference">Usage</h3>
+
+```
+karva cache prune
+```
+
+<h3 class="cli-reference">Options</h3>
+
+<dl class="cli-reference"><dt id="karva-cache-prune--help"><a href="#karva-cache-prune--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Print help</p>
+</dd></dl>
+
+### karva cache clean
+
+Remove the entire cache directory
+
+<h3 class="cli-reference">Usage</h3>
+
+```
+karva cache clean
+```
+
+<h3 class="cli-reference">Options</h3>
+
+<dl class="cli-reference"><dt id="karva-cache-clean--help"><a href="#karva-cache-clean--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Print help</p>
+</dd></dl>
+
+### karva cache help
+
+Print this message or the help of the given subcommand(s)
+
+<h3 class="cli-reference">Usage</h3>
+
+```
+karva cache help [COMMAND]
 ```
 
 ## karva version


### PR DESCRIPTION
## Summary

- Add `karva cache prune` command that removes all but the most recent `run-*` directory from `.karva_cache/`
- Add `karva cache clean` command that removes the entire `.karva_cache/` directory
- Add integration tests that run real test invocations to populate the cache, then verify prune/clean behavior

Closes #478

## Test plan

- [x] `cargo nextest run -p karva cache` — 5 integration tests pass
- [x] `just test` — full suite (676 tests) passes
- [x] `uvx prek run -a` — all pre-commit checks pass