### PR TITLE
Add `--last-failed` / `--lf` flag

### DIFF
--- a/crates/karva/src/lib.rs
+++ b/crates/karva/src/lib.rs
@@ -317,6 +317,7 @@ pub(crate) fn test(args: TestCommand) -> Result<ExitStatus> {
     let num_workers = args.num_workers;
     let dry_run = args.dry_run;
     let watch = args.watch;
+    let last_failed = args.last_failed;
 
     if watch && dry_run {
         anyhow::bail!("`--watch` and `--dry-run` cannot be used together");
@@ -346,6 +347,7 @@ pub(crate) fn test(args: TestCommand) -> Result<ExitStatus> {
         num_workers,
         no_cache,
         create_ctrlc_handler: true,
+        last_failed,
     };
 
     if watch {

--- a/crates/karva/tests/it/last_failed.rs
+++ b/crates/karva/tests/it/last_failed.rs
@@ -1,0 +1,133 @@
+use insta_cmd::assert_cmd_snapshot;
+
+use crate::common::TestContext;
+
+#[test]
+fn last_failed_reruns_only_failures() {
+    let context = TestContext::with_files([(
+        "test_a.py",
+        "
+            def test_pass(): pass
+            def test_fail(): assert False
+            ",
+    )]);
+
+    context.command_no_parallel().output().unwrap();
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--last-failed"), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    test test_a::test_fail ... FAILED
+
+    diagnostics:
+
+    error[test-failure]: Test `test_fail` failed
+     --> test_a.py:3:5
+      |
+    2 | def test_pass(): pass
+    3 | def test_fail(): assert False
+      |     ^^^^^^^^^
+      |
+    info: Test failed here
+     --> test_a.py:3:1
+      |
+    2 | def test_pass(): pass
+    3 | def test_fail(): assert False
+      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+
+    test result: FAILED. 0 passed; 1 failed; 0 skipped; finished in [TIME]
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn last_failed_lf_alias() {
+    let context = TestContext::with_files([(
+        "test_a.py",
+        "
+            def test_pass(): pass
+            def test_fail(): assert False
+            ",
+    )]);
+
+    context.command_no_parallel().output().unwrap();
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--lf"), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    test test_a::test_fail ... FAILED
+
+    diagnostics:
+
+    error[test-failure]: Test `test_fail` failed
+     --> test_a.py:3:5
+      |
+    2 | def test_pass(): pass
+    3 | def test_fail(): assert False
+      |     ^^^^^^^^^
+      |
+    info: Test failed here
+     --> test_a.py:3:1
+      |
+    2 | def test_pass(): pass
+    3 | def test_fail(): assert False
+      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+
+    test result: FAILED. 0 passed; 1 failed; 0 skipped; finished in [TIME]
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn last_failed_with_no_previous_failures_runs_all() {
+    let context = TestContext::with_files([(
+        "test_a.py",
+        "
+            def test_one(): pass
+            def test_two(): pass
+            ",
+    )]);
+
+    context.command_no_parallel().output().unwrap();
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--last-failed"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    test test_a::test_one ... ok
+    test test_a::test_two ... ok
+
+    test result: ok. 2 passed; 0 failed; 0 skipped; finished in [TIME]
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn last_failed_without_previous_run_runs_all() {
+    let context = TestContext::with_files([(
+        "test_a.py",
+        "
+            def test_one(): pass
+            def test_two(): pass
+            ",
+    )]);
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--last-failed"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    test test_a::test_one ... ok
+    test test_a::test_two ... ok
+
+    test result: ok. 2 passed; 0 failed; 0 skipped; finished in [TIME]
+
+    ----- stderr -----
+    ");
+}

--- a/crates/karva/tests/it/main.rs
+++ b/crates/karva/tests/it/main.rs
@@ -6,5 +6,6 @@ mod cache;
 mod configuration;
 mod discovery;
 mod extensions;
+mod last_failed;
 mod name_filter;
 mod watch;

--- a/crates/karva_benchmark/src/walltime.rs
+++ b/crates/karva_benchmark/src/walltime.rs
@@ -53,6 +53,7 @@ fn test_project(project: &Project) {
         num_workers,
         no_cache: false,
         create_ctrlc_handler: false,
+        last_failed: false,
     };
 
     let args = SubTestCommand {

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -8,8 +8,8 @@ use karva_diagnostic::{TestResultStats, TestRunResult};
 use ruff_db::diagnostic::{DisplayDiagnosticConfig, DisplayDiagnostics, FileResolver};
 
 use crate::{
-    DIAGNOSTICS_FILE, DISCOVER_DIAGNOSTICS_FILE, DURATIONS_FILE, FAIL_FAST_SIGNAL_FILE, RunHash,
-    STATS_FILE, worker_folder,
+    DIAGNOSTICS_FILE, DISCOVER_DIAGNOSTICS_FILE, DURATIONS_FILE, FAIL_FAST_SIGNAL_FILE,
+    FAILED_TESTS_FILE, LAST_FAILED_FILE, RunHash, STATS_FILE, worker_folder,
 };
 
 /// Aggregated test results collected from all worker processes.
@@ -17,6 +17,7 @@ pub struct AggregatedResults {
     pub stats: TestResultStats,
     pub diagnostics: String,
     pub discovery_diagnostics: String,
+    pub failed_tests: Vec<String>,
 }
 
 /// Reads and writes test results in the cache directory for a specific run.
@@ -49,6 +50,7 @@ impl Cache {
         let mut test_stats = TestResultStats::default();
         let mut all_diagnostics = String::new();
         let mut all_discovery_diagnostics = String::new();
+        let mut all_failed_tests = Vec::new();
 
         if self.run_dir.exists() {
             let mut worker_dirs: Vec<Utf8PathBuf> = fs::read_dir(&self.run_dir)?
@@ -74,6 +76,7 @@ impl Cache {
                     &mut test_stats,
                     &mut all_diagnostics,
                     &mut all_discovery_diagnostics,
+                    &mut all_failed_tests,
                 )?;
             }
         }
@@ -82,6 +85,7 @@ impl Cache {
             stats: test_stats,
             diagnostics: all_diagnostics,
             discovery_diagnostics: all_discovery_diagnostics,
+            failed_tests: all_failed_tests,
         })
     }
 
@@ -116,6 +120,17 @@ impl Cache {
         let json = serde_json::to_string_pretty(result.durations())?;
         fs::write(&durations_path, json)?;
 
+        if !result.failed_tests().is_empty() {
+            let failed_tests: Vec<String> = result
+                .failed_tests()
+                .iter()
+                .map(ToString::to_string)
+                .collect();
+            let failed_path = worker_dir.join(FAILED_TESTS_FILE);
+            let json = serde_json::to_string_pretty(&failed_tests)?;
+            fs::write(failed_path, json)?;
+        }
+
         Ok(())
     }
 }
@@ -126,6 +141,7 @@ fn read_worker_results(
     aggregated_stats: &mut TestResultStats,
     all_diagnostics: &mut String,
     all_discovery_diagnostics: &mut String,
+    all_failed_tests: &mut Vec<String>,
 ) -> Result<()> {
     let stats_path = worker_dir.join(STATS_FILE);
 
@@ -147,7 +163,38 @@ fn read_worker_results(
         all_discovery_diagnostics.push_str(&content);
     }
 
+    let failed_tests_path = worker_dir.join(FAILED_TESTS_FILE);
+    if failed_tests_path.exists() {
+        let content = fs::read_to_string(&failed_tests_path)?;
+        let failed_tests: Vec<String> = serde_json::from_str(&content)?;
+        all_failed_tests.extend(failed_tests);
+    }
+
     Ok(())
+}
+
+/// Writes the list of failed tests to the cache directory root.
+///
+/// This overwrites any previous last-failed list.
+pub fn write_last_failed(cache_dir: &Utf8Path, failed_tests: &[String]) -> Result<()> {
+    fs::create_dir_all(cache_dir)?;
+    let path = cache_dir.join(LAST_FAILED_FILE);
+    let json = serde_json::to_string_pretty(failed_tests)?;
+    fs::write(path, json)?;
+    Ok(())
+}
+
+/// Reads the list of previously failed tests from the cache directory root.
+///
+/// Returns an empty list if the file does not exist.
+pub fn read_last_failed(cache_dir: &Utf8Path) -> Result<Vec<String>> {
+    let path = cache_dir.join(LAST_FAILED_FILE);
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let content = fs::read_to_string(&path)?;
+    let failed_tests: Vec<String> = serde_json::from_str(&content)?;
+    Ok(failed_tests)
 }
 
 /// Reads durations from the most recent test run.

--- a/crates/karva_cache/src/lib.rs
+++ b/crates/karva_cache/src/lib.rs
@@ -2,7 +2,8 @@ pub(crate) mod cache;
 pub(crate) mod hash;
 
 pub use cache::{
-    AggregatedResults, Cache, PruneResult, clean_cache, prune_cache, read_recent_durations,
+    AggregatedResults, Cache, PruneResult, clean_cache, prune_cache, read_last_failed,
+    read_recent_durations, write_last_failed,
 };
 pub use hash::RunHash;
 
@@ -11,7 +12,9 @@ pub(crate) const STATS_FILE: &str = "stats.json";
 pub(crate) const DIAGNOSTICS_FILE: &str = "diagnostics.txt";
 pub(crate) const DISCOVER_DIAGNOSTICS_FILE: &str = "discover_diagnostics.txt";
 pub(crate) const DURATIONS_FILE: &str = "durations.json";
+pub(crate) const FAILED_TESTS_FILE: &str = "failed_tests.json";
 const FAIL_FAST_SIGNAL_FILE: &str = "fail-fast";
+const LAST_FAILED_FILE: &str = "last-failed.json";
 
 pub(crate) fn worker_folder(worker_id: usize) -> String {
     format!("worker-{worker_id}")

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -272,6 +272,10 @@ pub struct TestCommand {
     /// Re-run tests when Python source files change.
     #[clap(long)]
     pub watch: bool,
+
+    /// Re-run only the tests that failed in the previous run.
+    #[clap(long, alias = "lf")]
+    pub last_failed: bool,
 }
 
 impl TestCommand {

--- a/crates/karva_diagnostic/src/result.rs
+++ b/crates/karva_diagnostic/src/result.rs
@@ -26,6 +26,9 @@ pub struct TestRunResult {
     stats: TestResultStats,
 
     durations: HashMap<QualifiedFunctionName, std::time::Duration>,
+
+    /// Names of tests that failed during this run.
+    failed_tests: Vec<QualifiedFunctionName>,
 }
 
 impl TestRunResult {
@@ -72,6 +75,11 @@ impl TestRunResult {
     ) {
         self.stats.add(result.clone().into());
 
+        if matches!(result, IndividualTestResultKind::Failed) {
+            self.failed_tests
+                .push(test_case_name.function_name().clone());
+        }
+
         if let Some(reporter) = reporter {
             reporter.report_test_case_result(test_case_name, result);
         }
@@ -90,6 +98,10 @@ impl TestRunResult {
 
     pub const fn durations(&self) -> &HashMap<QualifiedFunctionName, std::time::Duration> {
         &self.durations
+    }
+
+    pub fn failed_tests(&self) -> &[QualifiedFunctionName] {
+        &self.failed_tests
     }
 }
 

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
@@ -6,7 +7,10 @@ use camino::Utf8PathBuf;
 use crossbeam_channel::{Receiver, TryRecvError};
 
 use crate::shutdown::shutdown_receiver;
-use karva_cache::{AggregatedResults, CACHE_DIR, Cache, RunHash, read_recent_durations};
+use karva_cache::{
+    AggregatedResults, CACHE_DIR, Cache, RunHash, read_last_failed, read_recent_durations,
+    write_last_failed,
+};
 use karva_cli::SubTestCommand;
 use karva_collector::{CollectedPackage, CollectionSettings};
 use karva_logging::time::format_duration;
@@ -133,6 +137,8 @@ pub struct ParallelTestConfig {
     /// Ctrl+C and gracefully stop workers. Set to `false` in contexts where
     /// the handler should not be installed (e.g., benchmarks).
     pub create_ctrlc_handler: bool,
+    /// When `true`, only tests that failed in the previous run will be executed.
+    pub last_failed: bool,
 }
 
 /// Spawn worker processes for each partition
@@ -262,7 +268,21 @@ pub fn run_parallel_tests(
         );
     }
 
-    let partitions = partition_collected_tests(&collected, num_workers, &previous_durations);
+    let last_failed_set: HashSet<String> = if config.last_failed {
+        read_last_failed(&cache_dir)
+            .unwrap_or_default()
+            .into_iter()
+            .collect()
+    } else {
+        HashSet::new()
+    };
+
+    let partitions = partition_collected_tests(
+        &collected,
+        num_workers,
+        &previous_durations,
+        &last_failed_set,
+    );
 
     let run_hash = RunHash::current_time();
 
@@ -288,6 +308,10 @@ pub fn run_parallel_tests(
     worker_manager.kill_remaining();
 
     let result = cache.aggregate_results()?;
+
+    if !config.no_cache {
+        let _ = write_last_failed(&cache_dir, &result.failed_tests);
+    }
 
     Ok(result)
 }

--- a/crates/karva_runner/src/partition.rs
+++ b/crates/karva_runner/src/partition.rs
@@ -1,10 +1,12 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 /// Test metadata used for partitioning decisions
 #[derive(Debug, Clone)]
 struct TestInfo {
     module_name: String,
+    /// The qualified name of the test (e.g., `test_a::test_1`), used for last-failed filtering.
+    qualified_name: String,
     path: String,
     /// Actual runtime from previous test run (if available)
     duration: Option<Duration>,
@@ -94,9 +96,14 @@ pub fn partition_collected_tests(
     package: &karva_collector::CollectedPackage,
     num_workers: usize,
     previous_durations: &HashMap<String, Duration>,
+    last_failed: &HashSet<String>,
 ) -> Vec<Partition> {
     let mut test_infos = Vec::new();
     collect_test_paths_recursive(package, &mut test_infos, previous_durations);
+
+    if !last_failed.is_empty() {
+        test_infos.retain(|info| last_failed.contains(&info.qualified_name));
+    }
 
     // Shuffle tests without durations so they distribute randomly across partitions
     shuffle_tests_without_durations(&mut test_infos);
@@ -214,11 +221,12 @@ fn collect_test_paths_recursive(
 ) {
     for module in package.modules.values() {
         for test_fn_def in &module.test_function_defs {
-            let path = format!("{}::{}", module.path.module_name(), test_fn_def.name);
-            let duration = previous_durations.get(&path).copied();
+            let qualified_name = format!("{}::{}", module.path.module_name(), test_fn_def.name);
+            let duration = previous_durations.get(&qualified_name).copied();
 
             test_infos.push(TestInfo {
                 module_name: module.path.module_name().to_string(),
+                qualified_name,
                 path: format!("{}::{}", module.path.path(), test_fn_def.name),
                 duration,
             });

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -49,6 +49,7 @@ karva test [OPTIONS] [PATH]...
 <p>May also be set with the <code>KARVA_CONFIG_FILE</code> environment variable.</p></dd><dt id="karva-test--dry-run"><a href="#karva-test--dry-run"><code>--dry-run</code></a></dt><dd><p>Print discovered tests without executing them</p>
 </dd><dt id="karva-test--fail-fast"><a href="#karva-test--fail-fast"><code>--fail-fast</code></a></dt><dd><p>When set, the test will fail immediately if any test fails</p>
 </dd><dt id="karva-test--help"><a href="#karva-test--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Print help (see a summary with '-h')</p>
+</dd><dt id="karva-test--last-failed"><a href="#karva-test--last-failed"><code>--last-failed</code></a>, <code>--lf</code></dt><dd><p>Re-run only the tests that failed in the previous run</p>
 </dd><dt id="karva-test--match"><a href="#karva-test--match"><code>--match</code></a>, <code>-m</code> <i>name-patterns</i></dt><dd><p>Filter tests by name using a regular expression.</p>
 <p>Only tests whose fully qualified name matches the pattern will run. Uses partial matching (the pattern can match anywhere in the name). When specified multiple times, a test runs if it matches any of the patterns.</p>
 <p>Examples: <code>-m auth</code>, <code>-m '^test::test_login'</code>, <code>-m 'slow|fast'</code>.</p>


### PR DESCRIPTION
## Summary

Closes #464.

- Add `--last-failed` / `--lf` CLI flag to re-run only tests that failed in the previous run
- Workers now write per-run `failed_tests.json` files alongside existing stats/diagnostics/durations
- Aggregated failed test names are persisted to `last-failed.json` at the cache root after each run
- When `--last-failed` is passed, the partition step filters collected tests against the last-failed list
- If no previous failures exist (or no cache), all tests run normally

## Test plan

- [x] `last_failed_reruns_only_failures` -- verifies only failing tests re-run
- [x] `last_failed_lf_alias` -- verifies the `--lf` alias works
- [x] `last_failed_with_no_previous_failures_runs_all` -- all pass on previous run, so all re-run
- [x] `last_failed_without_previous_run_runs_all` -- no cache at all, all tests run
- [x] Full test suite passes (681/681)
- [x] CLI docs regenerated
- [x] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)