### PR TITLE
Simplify quiet check and standardize From impl params

### DIFF
--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -42,9 +42,8 @@ impl Verbosity {
     /// Returns `None` if the user did not specify any verbosity flags.
     pub fn level(&self) -> VerbosityLevel {
         // `--quiet` and `--verbose` are mutually exclusive in Clap, so we can just check one first.
-        match self.quiet {
-            0 => {}
-            _ => return VerbosityLevel::Quiet,
+        if self.quiet > 0 {
+            return VerbosityLevel::Quiet;
         }
 
         match self.verbose {
@@ -311,8 +310,8 @@ impl From<OutputFormat> for DiagnosticFormat {
 }
 
 impl From<OutputFormat> for karva_metadata::OutputFormat {
-    fn from(format: OutputFormat) -> Self {
-        match format {
+    fn from(value: OutputFormat) -> Self {
+        match value {
             OutputFormat::Full => Self::Full,
             OutputFormat::Concise => Self::Concise,
         }


### PR DESCRIPTION
## Summary
- Replace `match self.quiet { 0 => {}, _ => return ... }` with a simpler `if self.quiet > 0 { return ... }` in `Verbosity::level()`
- Standardize the parameter name in `From<OutputFormat> for karva_metadata::OutputFormat` from `format` to `value`, matching the adjacent `From<OutputFormat> for DiagnosticFormat` impl
- Reviewed `karva_static/src/lib.rs` — no changes needed, code is already idiomatic

## Test plan
- [x] `just test` passes (685/685 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)