### PR TITLE
Prefer idiomatic iterator patterns and method chaining

### DIFF
--- a/crates/karva_metadata/src/filter.rs
+++ b/crates/karva_metadata/src/filter.rs
@@ -30,10 +30,10 @@ pub struct NameFilterSet {
 
 impl NameFilterSet {
     pub fn new(patterns: &[String]) -> Result<Self, NameFilterError> {
-        let mut filters = Vec::with_capacity(patterns.len());
-        for pattern in patterns {
-            filters.push(NameFilter::new(pattern)?);
-        }
+        let filters = patterns
+            .iter()
+            .map(|pattern| NameFilter::new(pattern))
+            .collect::<Result<_, _>>()?;
         Ok(Self { filters })
     }
 
@@ -100,10 +100,10 @@ pub struct TagFilterSet {
 
 impl TagFilterSet {
     pub fn new(expressions: &[String]) -> Result<Self, TagFilterError> {
-        let mut filters = Vec::with_capacity(expressions.len());
-        for expr in expressions {
-            filters.push(TagFilter::new(expr)?);
-        }
+        let filters = expressions
+            .iter()
+            .map(|expr| TagFilter::new(expr))
+            .collect::<Result<_, _>>()?;
         Ok(Self { filters })
     }
 

--- a/crates/karva_metadata/src/options.rs
+++ b/crates/karva_metadata/src/options.rs
@@ -31,22 +31,10 @@ impl Options {
     }
 
     pub fn to_settings(&self) -> ProjectSettings {
-        let terminal_options = self.terminal.clone().unwrap_or_default();
-
-        let terminal = terminal_options.to_settings();
-
-        let src_options = self.src.clone().unwrap_or_default();
-
-        let src = src_options.to_settings();
-
-        let test_options = self.test.clone().unwrap_or_default();
-
-        let test = test_options.to_settings();
-
         ProjectSettings {
-            terminal,
-            src,
-            test,
+            terminal: self.terminal.clone().unwrap_or_default().to_settings(),
+            src: self.src.clone().unwrap_or_default().to_settings(),
+            test: self.test.clone().unwrap_or_default().to_settings(),
         }
     }
 

--- a/crates/karva_python_semantic/src/lib.rs
+++ b/crates/karva_python_semantic/src/lib.rs
@@ -38,7 +38,7 @@ pub fn module_name(cwd: &Utf8PathBuf, path: &Utf8Path) -> Option<String> {
 
     let components: Vec<_> = relative_path
         .components()
-        .map(|c| c.as_os_str().to_string_lossy().to_string())
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
         .collect();
 
     Some(components.join(".").trim_end_matches(".py").to_string())


### PR DESCRIPTION
## Summary
- Replace manual `for` loops with `.map().collect::<Result<_, _>>()` in `NameFilterSet::new()` and `TagFilterSet::new()` (`karva_metadata/src/filter.rs`)
- Remove unnecessary intermediate variables in `Options::to_settings()`, chaining method calls directly (`karva_metadata/src/options.rs`)
- Use `.into_owned()` instead of `.to_string()` on `Cow<str>` in `module_name()` (`karva_python_semantic/src/lib.rs`)

## Test plan
- [x] `cargo nextest run -p karva_metadata` — all 59 tests pass
- [x] `cargo check -p karva_python_semantic` — compiles cleanly
- [x] No functional changes; all modifications are purely stylistic

🤖 Generated with [Claude Code](https://claude.com/claude-code)