### PR TITLE
Remove redundant manual counters and simplify version()

### DIFF
--- a/crates/karva/src/commands/snapshot/delete.rs
+++ b/crates/karva/src/commands/snapshot/delete.rs
@@ -31,13 +31,11 @@ pub fn delete(filter_paths: &[String], dry_run: bool) -> Result<ExitStatus> {
             filtered.len()
         )?;
     } else {
-        let mut deleted = 0;
         for info in &filtered {
             karva_snapshot::storage::remove_snapshot(&info.path)?;
             writeln!(stdout, "Deleted: {}", info.path)?;
-            deleted += 1;
         }
-        writeln!(stdout, "\n{deleted} snapshot file(s) deleted.")?;
+        writeln!(stdout, "\n{} snapshot file(s) deleted.", filtered.len())?;
     }
     Ok(ExitStatus::Success)
 }

--- a/crates/karva/src/commands/snapshot/prune.rs
+++ b/crates/karva/src/commands/snapshot/prune.rs
@@ -40,13 +40,11 @@ pub fn prune(filter_paths: &[String], dry_run: bool) -> Result<ExitStatus> {
             filtered.len()
         )?;
     } else {
-        let mut removed = 0;
         for info in &filtered {
             karva_snapshot::storage::remove_snapshot(&info.snap_path)?;
             writeln!(stdout, "Removed: {} ({})", info.snap_path, info.reason)?;
-            removed += 1;
         }
-        writeln!(stdout, "\n{removed} snapshot(s) pruned.")?;
+        writeln!(stdout, "\n{} snapshot(s) pruned.", filtered.len())?;
     }
     Ok(ExitStatus::Success)
 }

--- a/crates/karva/src/commands/snapshot/reject.rs
+++ b/crates/karva/src/commands/snapshot/reject.rs
@@ -21,12 +21,10 @@ pub fn reject(filter_paths: &[String]) -> Result<ExitStatus> {
         writeln!(stdout, "No pending snapshots found.")?;
         return Ok(ExitStatus::Success);
     }
-    let mut rejected = 0;
     for info in &filtered {
         karva_snapshot::storage::reject_pending(&info.pending_path)?;
         writeln!(stdout, "Rejected: {}", info.pending_path)?;
-        rejected += 1;
     }
-    writeln!(stdout, "\n{rejected} snapshot(s) rejected.")?;
+    writeln!(stdout, "\n{} snapshot(s) rejected.", filtered.len())?;
     Ok(ExitStatus::Success)
 }

--- a/crates/karva/src/version.rs
+++ b/crates/karva/src/version.rs
@@ -13,7 +13,7 @@ impl fmt::Display for VersionInfo {
 }
 
 pub fn version() -> Option<VersionInfo> {
-    let version = option_env!("CARGO_PKG_VERSION").map(ToString::to_string);
-
-    version.map(|version| VersionInfo { version })
+    option_env!("CARGO_PKG_VERSION").map(|version| VersionInfo {
+        version: version.to_string(),
+    })
 }


### PR DESCRIPTION
## Summary
- Replace manual `+= 1` counters in snapshot `delete`, `reject`, and `prune` commands with `filtered.len()`, since every item in the filtered list is always processed
- Simplify `version()` by combining the intermediate variable and two `.map()` calls into a single `option_env!(...).map(...)` expression

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy --workspace` passes with no warnings
- [x] No functional changes -- all operations remain identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)