### PR TITLE
Improve readability in traceback.rs

### DIFF
--- a/crates/karva_diagnostic/src/traceback.rs
+++ b/crates/karva_diagnostic/src/traceback.rs
@@ -105,11 +105,11 @@ fn calculate_line_range(source_text: &str, line_number: OneIndexed) -> Option<Te
 
             // Trim the line to remove leading/trailing whitespace for the range
             let line_text = &source_text[line_start.to_usize()..line_end.to_usize()];
-            let trimmed_start = line_text.len() - line_text.trim_start().len();
-            let trimmed_length = line_text.trim().len();
+            let leading_whitespace = line_text.len() - line_text.trim_start().len();
+            let content_length = line_text.trim().len();
 
-            let range_start = line_start + TextSize::new(trimmed_start as u32);
-            let range_end = range_start + TextSize::new(trimmed_length as u32);
+            let range_start = line_start + TextSize::new(leading_whitespace as u32);
+            let range_end = range_start + TextSize::new(content_length as u32);
 
             return Some(TextRange::new(range_start, range_end));
         }
@@ -135,11 +135,11 @@ fn filter_traceback(traceback: &str) -> String {
         filtered.push_str(line.strip_prefix("  ").unwrap_or(line));
         filtered.push('\n');
     }
-    filtered = filtered.trim_end_matches('\n').to_string();
-
-    filtered = filtered.trim_end_matches('^').to_string();
-
-    filtered.trim_end().to_string()
+    filtered
+        .trim_end_matches('\n')
+        .trim_end_matches('^')
+        .trim_end()
+        .to_string()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- **Chain string transformations in `filter_traceback()`**: The three sequential mutable reassignments (`filtered = filtered.trim_...().to_string()`) are replaced with a single chained expression. Chaining makes the sequence of operations read top-to-bottom as a pipeline rather than three independent mutation statements, and avoids allocating intermediate `String`s for each step.

- **Rename variables in `calculate_line_range()`**: `trimmed_start` is renamed to `leading_whitespace` and `trimmed_length` is renamed to `content_length`. The original names described *how* the values were computed (by trimming), while the new names describe *what* the values represent, making the subsequent arithmetic (`range_start`, `range_end`) easier to follow.

No functionality changed. All existing tests pass.

## Test plan

- [x] `just test` (685 tests pass)
- [x] `uvx prek run -a` (all checks pass, including clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)