### PR TITLE
Remove duplicate tracing directive and extract worker cwd helper

### DIFF
--- a/crates/karva_logging/src/lib.rs
+++ b/crates/karva_logging/src/lib.rs
@@ -25,13 +25,7 @@ pub fn setup_tracing(level: VerbosityLevel) -> TracingGuard {
         level => {
             let level_filter = level.level_filter();
 
-            let filter = EnvFilter::default().add_directive(
-                format!("karva={level_filter}")
-                    .parse()
-                    .expect("Hardcoded directive to be valid"),
-            );
-
-            filter.add_directive(
+            EnvFilter::default().add_directive(
                 format!("karva={level_filter}")
                     .parse()
                     .expect("Hardcoded directive to be valid"),

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -118,16 +118,7 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
 
     let _guard = setup_tracing(verbosity);
 
-    let cwd = {
-        let cwd = std::env::current_dir().context("Failed to get the current working directory")?;
-        Utf8PathBuf::from_path_buf(cwd)
-            .map_err(|path| {
-                anyhow::anyhow!(
-                    "The current working directory `{}` contains non-Unicode characters. karva only supports Unicode paths.",
-                    path.display()
-                )
-            })?
-    };
+    let cwd = cwd()?;
 
     let python_version = current_python_version();
 
@@ -220,4 +211,15 @@ impl FileResolver for DiagnosticFileResolver<'_> {
     fn current_directory(&self) -> &std::path::Path {
         self.cwd.as_std_path()
     }
+}
+
+/// Get the current working directory as a UTF-8 path.
+fn cwd() -> anyhow::Result<Utf8PathBuf> {
+    let cwd = std::env::current_dir().context("Failed to get the current working directory")?;
+    Utf8PathBuf::from_path_buf(cwd).map_err(|path| {
+        anyhow::anyhow!(
+            "The current working directory `{}` contains non-Unicode characters. karva only supports Unicode paths.",
+            path.display()
+        )
+    })
 }


### PR DESCRIPTION
## Summary

- **Remove duplicate directive in `setup_tracing`**: In `karva_logging/src/lib.rs`, the directive `karva={level_filter}` was being parsed and added to the `EnvFilter` twice — first when creating the filter, then again immediately after via a second `.add_directive()` call. This was likely a copy-paste bug. The duplicate call has been removed.
- **Extract `cwd()` helper in `karva_worker`**: In `karva_worker/src/cli.rs`, the inline block that fetched and validated the current working directory as UTF-8 has been extracted into a named `cwd()` function, matching the pattern already used in `karva/src/utils.rs`. The worker keeps its own local copy rather than sharing via `karva_cli`, since `karva_cli` does not depend on `anyhow` and adding that dependency for a single utility would be disproportionate.

No functionality changed.

## Test plan

- [x] `just test` passes (685/685)
- [x] `uvx prek run -a` passes all checks (fmt, clippy, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)