### PR TITLE
Improve readability in karva_collector

### DIFF
--- a/crates/karva_collector/src/lib.rs
+++ b/crates/karva_collector/src/lib.rs
@@ -53,15 +53,28 @@ pub fn collect_file(
                 continue;
             }
 
-            let should_collect = (function_names.is_empty()
-                && function_def.name.starts_with(settings.test_function_prefix))
-                || function_names.iter().any(|name| function_def.name == *name);
-
-            if should_collect {
+            if is_test_function_to_collect(
+                &function_def.name,
+                function_names,
+                settings.test_function_prefix,
+            ) {
                 collected_module.add_test_function_def(function_def);
             }
         }
     }
 
     Some(collected_module)
+}
+
+/// Returns `true` if a function should be collected as a test.
+///
+/// When `explicit_names` is empty, any function whose name starts with
+/// `prefix` is considered a test. When `explicit_names` is provided,
+/// only functions whose name appears in the list are collected.
+fn is_test_function_to_collect(name: &str, explicit_names: &[String], prefix: &str) -> bool {
+    if explicit_names.is_empty() {
+        name.starts_with(prefix)
+    } else {
+        explicit_names.iter().any(|n| n == name)
+    }
 }

--- a/crates/karva_collector/src/models.rs
+++ b/crates/karva_collector/src/models.rs
@@ -224,24 +224,21 @@ impl CollectedModule {
     /// Merges function definitions from the other module into this one.
     pub(crate) fn update(&mut self, module: Self) {
         if self.path == module.path {
-            for function_def in module.test_function_defs {
-                if !self
-                    .test_function_defs
-                    .iter()
-                    .any(|existing| existing.name == function_def.name)
-                {
-                    self.test_function_defs.push(function_def);
-                }
-            }
-            for function_def in module.fixture_function_defs {
-                if !self
-                    .fixture_function_defs
-                    .iter()
-                    .any(|existing| existing.name == function_def.name)
-                {
-                    self.fixture_function_defs.push(function_def);
-                }
-            }
+            add_unique_definitions(&mut self.test_function_defs, module.test_function_defs);
+            add_unique_definitions(
+                &mut self.fixture_function_defs,
+                module.fixture_function_defs,
+            );
+        }
+    }
+}
+
+/// Adds function definitions from `new_defs` into `existing`, skipping any
+/// whose name already appears.
+fn add_unique_definitions(existing: &mut Vec<StmtFunctionDef>, new_defs: Vec<StmtFunctionDef>) {
+    for def in new_defs {
+        if !existing.iter().any(|e| e.name == def.name) {
+            existing.push(def);
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Extract `add_unique_definitions` helper in `models.rs`**: The `CollectedModule::update()` method duplicated the same deduplication loop for both `test_function_defs` and `fixture_function_defs`. If one loop was updated but not the other, they could silently diverge. The new helper captures the shared pattern in one place.

- **Extract `is_test_function_to_collect` helper in `lib.rs`**: The inline boolean expression `(function_names.is_empty() && name.starts_with(prefix)) || function_names.iter().any(...)` mixed two distinct collection strategies (prefix-based vs explicit-name-based) into a single compound condition that was hard to read at a glance. The named function makes the branching logic and intent immediately clear.

No functionality changed -- both helpers preserve the original behavior exactly.

## Test plan

- [x] `cargo test -p karva_collector` passes
- [x] `cargo check` and `clippy` pass
- [x] All `prek` pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)