### PR TITLE
Improve readability in karva_test_semantic

### DIFF
--- a/crates/karva_test_semantic/src/extensions/tags/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/mod.rs
@@ -48,21 +48,17 @@ pub fn parse_pytest_mark_args(py_mark: &Bound<'_, PyAny>) -> Option<ParsedMarkAr
         }
     }
 
-    let reason = kwargs.get_item("reason").map_or_else(
-        |_| {
-            if conditions.is_empty() {
-                args.extract::<Bound<'_, pyo3::types::PyTuple>>()
-                    .map_or(None, |args_tuple| {
-                        args_tuple
-                            .get_item(0)
-                            .map_or(None, |first_arg| first_arg.extract::<String>().ok())
-                    })
-            } else {
-                None
-            }
-        },
-        |reason| reason.extract::<String>().ok(),
-    );
+    let reason = if let Ok(reason_item) = kwargs.get_item("reason") {
+        reason_item.extract::<String>().ok()
+    } else if conditions.is_empty() {
+        // Fall back to first positional arg as reason
+        args.extract::<Bound<'_, pyo3::types::PyTuple>>()
+            .ok()
+            .and_then(|t| t.get_item(0).ok())
+            .and_then(|a| a.extract::<String>().ok())
+    } else {
+        None
+    };
 
     Some(ParsedMarkArgs { conditions, reason })
 }

--- a/crates/karva_test_semantic/src/runner/finalizer_cache.rs
+++ b/crates/karva_test_semantic/src/runner/finalizer_cache.rs
@@ -1,9 +1,8 @@
-use std::cell::RefCell;
-
 use pyo3::prelude::*;
 
 use crate::Context;
 use crate::extensions::fixtures::{Finalizer, FixtureScope};
+use crate::runner::scoped_storage::ScopedStorage;
 
 /// Manages fixture teardown callbacks at different scope levels.
 ///
@@ -11,31 +10,13 @@ use crate::extensions::fixtures::{Finalizer, FixtureScope};
 /// order when their scope ends (e.g., after a test, module, or package).
 #[derive(Debug, Default)]
 pub struct FinalizerCache {
-    /// Session-scoped finalizers (run at end of test run).
-    session: RefCell<Vec<Finalizer>>,
-
-    /// Package-scoped finalizers (run after each package).
-    package: RefCell<Vec<Finalizer>>,
-
-    /// Module-scoped finalizers (run after each module).
-    module: RefCell<Vec<Finalizer>>,
-
-    /// Function-scoped finalizers (run after each test).
-    function: RefCell<Vec<Finalizer>>,
+    storage: ScopedStorage<Vec<Finalizer>>,
 }
 
 impl FinalizerCache {
-    fn scope_storage(&self, scope: FixtureScope) -> &RefCell<Vec<Finalizer>> {
-        match scope {
-            FixtureScope::Session => &self.session,
-            FixtureScope::Package => &self.package,
-            FixtureScope::Module => &self.module,
-            FixtureScope::Function => &self.function,
-        }
-    }
-
     pub(crate) fn add_finalizer(&self, finalizer: Finalizer) {
-        self.scope_storage(finalizer.scope)
+        self.storage
+            .get(finalizer.scope)
             .borrow_mut()
             .push(finalizer);
     }
@@ -47,7 +28,8 @@ impl FinalizerCache {
         scope: FixtureScope,
     ) {
         // Run finalizers in reverse order (LIFO)
-        self.scope_storage(scope)
+        self.storage
+            .get(scope)
             .borrow_mut()
             .drain(..)
             .rev()

--- a/crates/karva_test_semantic/src/runner/fixture_cache.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_cache.rs
@@ -1,9 +1,9 @@
-use std::cell::RefCell;
 use std::collections::HashMap;
 
 use pyo3::prelude::*;
 
 use crate::extensions::fixtures::FixtureScope;
+use crate::runner::scoped_storage::ScopedStorage;
 
 /// Caches fixture values at different scope levels.
 ///
@@ -11,32 +11,14 @@ use crate::extensions::fixtures::FixtureScope;
 /// setup when the same fixture is used multiple times within a scope.
 #[derive(Debug, Default)]
 pub struct FixtureCache {
-    /// Session-scoped fixture values (persist for entire test run).
-    session: RefCell<HashMap<String, Py<PyAny>>>,
-
-    /// Package-scoped fixture values (cleared after each package).
-    package: RefCell<HashMap<String, Py<PyAny>>>,
-
-    /// Module-scoped fixture values (cleared after each module).
-    module: RefCell<HashMap<String, Py<PyAny>>>,
-
-    /// Function-scoped fixture values (cleared after each test).
-    function: RefCell<HashMap<String, Py<PyAny>>>,
+    storage: ScopedStorage<HashMap<String, Py<PyAny>>>,
 }
 
 impl FixtureCache {
-    fn scope_storage(&self, scope: FixtureScope) -> &RefCell<HashMap<String, Py<PyAny>>> {
-        match scope {
-            FixtureScope::Session => &self.session,
-            FixtureScope::Package => &self.package,
-            FixtureScope::Module => &self.module,
-            FixtureScope::Function => &self.function,
-        }
-    }
-
     /// Get a fixture value from the cache based on its scope
     pub(crate) fn get(&self, py: Python, name: &str, scope: FixtureScope) -> Option<Py<PyAny>> {
-        self.scope_storage(scope)
+        self.storage
+            .get(scope)
             .borrow()
             .get(name)
             .map(|v| v.clone_ref(py))
@@ -44,10 +26,10 @@ impl FixtureCache {
 
     /// Insert a fixture value into the cache based on its scope
     pub(crate) fn insert(&self, name: String, value: Py<PyAny>, scope: FixtureScope) {
-        self.scope_storage(scope).borrow_mut().insert(name, value);
+        self.storage.get(scope).borrow_mut().insert(name, value);
     }
 
     pub(crate) fn clear_fixtures(&self, scope: FixtureScope) {
-        self.scope_storage(scope).borrow_mut().clear();
+        self.storage.get(scope).borrow_mut().clear();
     }
 }

--- a/crates/karva_test_semantic/src/runner/mod.rs
+++ b/crates/karva_test_semantic/src/runner/mod.rs
@@ -2,6 +2,7 @@ mod finalizer_cache;
 mod fixture_cache;
 mod fixture_resolver;
 mod package_runner;
+mod scoped_storage;
 mod test_iterator;
 
 use finalizer_cache::FinalizerCache;

--- a/crates/karva_test_semantic/src/runner/scoped_storage.rs
+++ b/crates/karva_test_semantic/src/runner/scoped_storage.rs
@@ -1,0 +1,26 @@
+use std::cell::RefCell;
+
+use crate::extensions::fixtures::FixtureScope;
+
+/// A per-scope storage container that maps each `FixtureScope` to its own `RefCell<T>`.
+///
+/// Used by both `FixtureCache` and `FinalizerCache` to avoid duplicating the same
+/// four-field struct and `match`-based accessor.
+#[derive(Debug, Default)]
+pub(super) struct ScopedStorage<T: Default> {
+    session: RefCell<T>,
+    package: RefCell<T>,
+    module: RefCell<T>,
+    function: RefCell<T>,
+}
+
+impl<T: Default> ScopedStorage<T> {
+    pub(super) fn get(&self, scope: FixtureScope) -> &RefCell<T> {
+        match scope {
+            FixtureScope::Session => &self.session,
+            FixtureScope::Package => &self.package,
+            FixtureScope::Module => &self.module,
+            FixtureScope::Function => &self.function,
+        }
+    }
+}

--- a/crates/karva_test_semantic/src/utils.rs
+++ b/crates/karva_test_semantic/src/utils.rs
@@ -216,6 +216,10 @@ pub(crate) fn full_test_name(
     }
 }
 
+/// Maximum display length for parameter keys and values in test names.
+///
+/// Keeps parameterized test names (e.g., `test_foo(key=value)`) readable in
+/// CLI output by truncating long values with an ellipsis.
 const TRUNCATE_LENGTH: usize = 30;
 
 pub(crate) fn truncate_string(value: &str) -> String {


### PR DESCRIPTION
## Summary

- **Simplify `parse_pytest_mark_args` reason extraction**: The deeply nested `map_or_else` / `map_or` closures for extracting the `reason` field were hard to follow because the happy path (`kwargs` lookup) was buried in the fallback arm of `map_or_else`, while the error path (positional-arg fallback) was in the primary closure. Replaced with a straightforward `if let` / `else if` / `else` chain that reads top-to-bottom in priority order.
- **Extract shared `ScopedStorage<T>` pattern**: Both `FixtureCache` (storing `HashMap<String, Py<PyAny>>`) and `FinalizerCache` (storing `Vec<Finalizer>`) had identical four-field structs and `scope_storage()` methods that matched on `FixtureScope`. Extracted a generic `ScopedStorage<T>` struct that encapsulates the per-scope `RefCell<T>` fields and the match dispatch, removing the duplication.
- **Document the `TRUNCATE_LENGTH` constant**: Added a doc comment explaining that the 30-character limit keeps parameterized test names readable in CLI output.

No functionality was changed.

## Test plan

- [x] `just test` passes (685/685 tests)
- [x] `uvx prek run -a` passes all checks (clippy, fmt, etc.)


🤖 Generated with [Claude Code](https://claude.com/claude-code)