### PR TITLE
Extract shared boilerplate from snapshot commands

### DIFF
--- a/crates/karva/src/commands/snapshot/accept.rs
+++ b/crates/karva/src/commands/snapshot/accept.rs
@@ -1,26 +1,23 @@
 use std::fmt::Write;
 
 use anyhow::Result;
-use karva_logging::Printer;
 
-use super::{matches_filter, resolve_filter_paths};
+use super::{filter_or_empty, snapshot_setup};
 use crate::ExitStatus;
-use crate::utils::cwd;
 
 pub fn accept(filter_paths: &[String]) -> Result<ExitStatus> {
-    let cwd = cwd()?;
-    let printer = Printer::default();
-    let mut stdout = printer.stream_for_requested_summary().lock();
+    let (mut stdout, cwd, resolved) = snapshot_setup(filter_paths)?;
     let pending = karva_snapshot::storage::find_pending_snapshots(&cwd);
-    let resolved = resolve_filter_paths(filter_paths, &cwd);
-    let filtered: Vec<_> = pending
-        .iter()
-        .filter(|info| matches_filter(&info.pending_path, &resolved))
-        .collect();
-    if filtered.is_empty() {
-        writeln!(stdout, "No pending snapshots found.")?;
+    let Some(filtered) = filter_or_empty(
+        &pending,
+        &resolved,
+        |i| &i.pending_path,
+        "No pending snapshots found.",
+        &mut stdout,
+    )?
+    else {
         return Ok(ExitStatus::Success);
-    }
+    };
     karva_snapshot::storage::accept_pending_batch(&filtered)?;
     for info in &filtered {
         writeln!(stdout, "Accepted: {}", info.pending_path)?;

--- a/crates/karva/src/commands/snapshot/delete.rs
+++ b/crates/karva/src/commands/snapshot/delete.rs
@@ -1,26 +1,23 @@
 use std::fmt::Write;
 
 use anyhow::Result;
-use karva_logging::Printer;
 
-use super::{matches_filter, resolve_filter_paths};
+use super::{filter_or_empty, snapshot_setup};
 use crate::ExitStatus;
-use crate::utils::cwd;
 
 pub fn delete(filter_paths: &[String], dry_run: bool) -> Result<ExitStatus> {
-    let cwd = cwd()?;
-    let printer = Printer::default();
-    let mut stdout = printer.stream_for_requested_summary().lock();
+    let (mut stdout, cwd, resolved) = snapshot_setup(filter_paths)?;
     let all = karva_snapshot::storage::find_all_snapshots(&cwd);
-    let resolved = resolve_filter_paths(filter_paths, &cwd);
-    let filtered: Vec<_> = all
-        .iter()
-        .filter(|info| matches_filter(&info.path, &resolved))
-        .collect();
-    if filtered.is_empty() {
-        writeln!(stdout, "No snapshot files found.")?;
+    let Some(filtered) = filter_or_empty(
+        &all,
+        &resolved,
+        |i| &i.path,
+        "No snapshot files found.",
+        &mut stdout,
+    )?
+    else {
         return Ok(ExitStatus::Success);
-    }
+    };
     if dry_run {
         for info in &filtered {
             writeln!(stdout, "Would delete: {}", info.path)?;

--- a/crates/karva/src/commands/snapshot/mod.rs
+++ b/crates/karva/src/commands/snapshot/mod.rs
@@ -5,12 +5,16 @@ mod prune;
 mod reject;
 mod review;
 
+use std::fmt::Write;
+
 use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
 use karva_cli::{SnapshotAction, SnapshotCommand};
+use karva_logging::{Printer, Stdout};
 use karva_project::path::absolute;
 
 use crate::ExitStatus;
+use crate::utils::cwd;
 
 pub fn snapshot(args: SnapshotCommand) -> Result<ExitStatus> {
     match args.action {
@@ -23,6 +27,38 @@ pub fn snapshot(args: SnapshotCommand) -> Result<ExitStatus> {
             delete::delete(&delete_args.paths, delete_args.dry_run)
         }
     }
+}
+
+/// Common setup for snapshot commands: resolves the cwd, creates a printer
+/// with locked stdout, and resolves filter paths to absolute paths.
+fn snapshot_setup(filter_paths: &[String]) -> Result<(Stdout, Utf8PathBuf, Vec<Utf8PathBuf>)> {
+    let cwd = cwd()?;
+    let printer = Printer::default();
+    let stdout = printer.stream_for_requested_summary().lock();
+    let resolved = resolve_filter_paths(filter_paths, &cwd);
+    Ok((stdout, cwd, resolved))
+}
+
+/// Filters items by resolved path prefixes and handles the empty case.
+///
+/// Returns `None` (after writing `empty_message`) when no items match,
+/// or `Some(filtered)` with the matching subset.
+fn filter_or_empty<'a, T>(
+    items: &'a [T],
+    resolved: &[Utf8PathBuf],
+    path_fn: impl Fn(&T) -> &Utf8Path,
+    empty_message: &str,
+    stdout: &mut Stdout,
+) -> Result<Option<Vec<&'a T>>> {
+    let filtered: Vec<_> = items
+        .iter()
+        .filter(|item| matches_filter(path_fn(item), resolved))
+        .collect();
+    if filtered.is_empty() {
+        writeln!(stdout, "{empty_message}")?;
+        return Ok(None);
+    }
+    Ok(Some(filtered))
 }
 
 /// Resolve user-provided filter strings to absolute paths.

--- a/crates/karva/src/commands/snapshot/pending.rs
+++ b/crates/karva/src/commands/snapshot/pending.rs
@@ -1,26 +1,23 @@
 use std::fmt::Write;
 
 use anyhow::Result;
-use karva_logging::Printer;
 
-use super::{matches_filter, resolve_filter_paths};
+use super::{filter_or_empty, snapshot_setup};
 use crate::ExitStatus;
-use crate::utils::cwd;
 
 pub fn pending(filter_paths: &[String]) -> Result<ExitStatus> {
-    let cwd = cwd()?;
-    let printer = Printer::default();
-    let mut stdout = printer.stream_for_requested_summary().lock();
+    let (mut stdout, cwd, resolved) = snapshot_setup(filter_paths)?;
     let pending = karva_snapshot::storage::find_pending_snapshots(&cwd);
-    let resolved = resolve_filter_paths(filter_paths, &cwd);
-    let filtered: Vec<_> = pending
-        .iter()
-        .filter(|info| matches_filter(&info.pending_path, &resolved))
-        .collect();
-    if filtered.is_empty() {
-        writeln!(stdout, "No pending snapshots.")?;
+    let Some(filtered) = filter_or_empty(
+        &pending,
+        &resolved,
+        |i| &i.pending_path,
+        "No pending snapshots.",
+        &mut stdout,
+    )?
+    else {
         return Ok(ExitStatus::Success);
-    }
+    };
     for info in &filtered {
         writeln!(stdout, "{}", info.pending_path)?;
     }

--- a/crates/karva/src/commands/snapshot/prune.rs
+++ b/crates/karva/src/commands/snapshot/prune.rs
@@ -2,11 +2,9 @@ use std::fmt::Write;
 
 use anyhow::Result;
 use colored::Colorize;
-use karva_logging::Printer;
 
-use super::{matches_filter, resolve_filter_paths};
+use super::{filter_or_empty, snapshot_setup};
 use crate::ExitStatus;
-use crate::utils::cwd;
 
 pub fn prune(filter_paths: &[String], dry_run: bool) -> Result<ExitStatus> {
     {
@@ -17,19 +15,18 @@ pub fn prune(filter_paths: &[String], dry_run: bool) -> Result<ExitStatus> {
             "warning:".yellow().bold()
         )?;
     }
-    let cwd = cwd()?;
-    let printer = Printer::default();
-    let mut stdout = printer.stream_for_requested_summary().lock();
+    let (mut stdout, cwd, resolved) = snapshot_setup(filter_paths)?;
     let unreferenced = karva_snapshot::storage::find_unreferenced_snapshots(&cwd);
-    let resolved = resolve_filter_paths(filter_paths, &cwd);
-    let filtered: Vec<_> = unreferenced
-        .iter()
-        .filter(|info| matches_filter(&info.snap_path, &resolved))
-        .collect();
-    if filtered.is_empty() {
-        writeln!(stdout, "No unreferenced snapshots found.")?;
+    let Some(filtered) = filter_or_empty(
+        &unreferenced,
+        &resolved,
+        |i| &i.snap_path,
+        "No unreferenced snapshots found.",
+        &mut stdout,
+    )?
+    else {
         return Ok(ExitStatus::Success);
-    }
+    };
     if dry_run {
         for info in &filtered {
             writeln!(stdout, "Would remove: {} ({})", info.snap_path, info.reason)?;

--- a/crates/karva/src/commands/snapshot/reject.rs
+++ b/crates/karva/src/commands/snapshot/reject.rs
@@ -1,26 +1,23 @@
 use std::fmt::Write;
 
 use anyhow::Result;
-use karva_logging::Printer;
 
-use super::{matches_filter, resolve_filter_paths};
+use super::{filter_or_empty, snapshot_setup};
 use crate::ExitStatus;
-use crate::utils::cwd;
 
 pub fn reject(filter_paths: &[String]) -> Result<ExitStatus> {
-    let cwd = cwd()?;
-    let printer = Printer::default();
-    let mut stdout = printer.stream_for_requested_summary().lock();
+    let (mut stdout, cwd, resolved) = snapshot_setup(filter_paths)?;
     let pending = karva_snapshot::storage::find_pending_snapshots(&cwd);
-    let resolved = resolve_filter_paths(filter_paths, &cwd);
-    let filtered: Vec<_> = pending
-        .iter()
-        .filter(|info| matches_filter(&info.pending_path, &resolved))
-        .collect();
-    if filtered.is_empty() {
-        writeln!(stdout, "No pending snapshots found.")?;
+    let Some(filtered) = filter_or_empty(
+        &pending,
+        &resolved,
+        |i| &i.pending_path,
+        "No pending snapshots found.",
+        &mut stdout,
+    )?
+    else {
         return Ok(ExitStatus::Success);
-    }
+    };
     for info in &filtered {
         karva_snapshot::storage::reject_pending(&info.pending_path)?;
         writeln!(stdout, "Rejected: {}", info.pending_path)?;

--- a/crates/karva_logging/src/lib.rs
+++ b/crates/karva_logging/src/lib.rs
@@ -14,7 +14,7 @@ mod printer;
 pub mod time;
 mod verbosity;
 
-pub use printer::Printer;
+pub use printer::{Printer, Stdout};
 pub use verbosity::VerbosityLevel;
 
 pub fn setup_tracing(level: VerbosityLevel) -> TracingGuard {

--- a/crates/karva_logging/src/printer.rs
+++ b/crates/karva_logging/src/printer.rs
@@ -101,6 +101,7 @@ impl Stdout {
         }
     }
 
+    #[must_use]
     pub fn lock(mut self) -> Self {
         match self.status {
             StreamStatus::Enabled => {


### PR DESCRIPTION
## Summary

- All 5 snapshot subcommands (`accept`, `reject`, `pending`, `delete`, `prune`) repeated identical boilerplate: get cwd, create a `Printer`, lock stdout, resolve filter paths to absolute paths, filter items against those paths, and handle the empty-result case with an early return.
- Extracted two shared helpers in `snapshot/mod.rs`: `snapshot_setup()` consolidates the cwd/printer/stdout/resolve pipeline, and `filter_or_empty()` encapsulates the generic filter-and-early-return pattern with a path accessor closure.
- Each command file now delegates to these helpers instead of duplicating ~5 setup lines, reducing maintenance burden when the shared pattern needs to change.
- Re-exported `Stdout` from `karva_logging` (previously only used crate-internally) so the helpers can name it in their signatures, and added the `#[must_use]` attribute required by clippy for its `lock()` method.

## Test plan

- [x] `just test` — all 685 tests pass
- [x] `uvx prek run -a` — all pre-commit checks pass (including clippy)
- No functionality changed; this is a pure readability refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)