### PR TITLE
Extract style helpers from diff render loop

### DIFF
--- a/crates/karva_snapshot/src/diff.rs
+++ b/crates/karva_snapshot/src/diff.rs
@@ -43,44 +43,11 @@ fn render_diff(output: &mut String, old: &str, new: &str, width: usize) {
 
                 let mut content = String::new();
                 for (emphasized, value) in change.iter_strings_lossy() {
-                    if emphasized {
-                        match style {
-                            Style::Delete => {
-                                let _ = write!(content, "{}", value.red().underline());
-                            }
-                            Style::Insert => {
-                                let _ = write!(content, "{}", value.green().underline());
-                            }
-                            Style::Equal => {
-                                let _ = write!(content, "{value}");
-                            }
-                        }
-                    } else {
-                        match style {
-                            Style::Delete => {
-                                let _ = write!(content, "{}", value.red());
-                            }
-                            Style::Insert => {
-                                let _ = write!(content, "{}", value.green());
-                            }
-                            Style::Equal => {
-                                let _ = write!(content, "{}", value.dimmed());
-                            }
-                        }
-                    }
+                    let _ = write!(content, "{}", style_content(&value, &style, emphasized));
                 }
 
-                let colored_marker = match style {
-                    Style::Delete => marker.red().to_string(),
-                    Style::Insert => marker.green().to_string(),
-                    Style::Equal => marker.to_string(),
-                };
-
-                let (styled_old, styled_new) = match style {
-                    Style::Delete => (old_num.cyan().dimmed().to_string(), new_num.clone()),
-                    Style::Insert => (old_num.clone(), new_num.cyan().dimmed().bold().to_string()),
-                    Style::Equal => (old_num.dimmed().to_string(), new_num.dimmed().to_string()),
-                };
+                let colored_marker = style.apply_to_marker(marker);
+                let (styled_old, styled_new) = style.apply_to_line_numbers(old_num, new_num);
 
                 let _ = write!(
                     output,
@@ -123,10 +90,42 @@ fn format_line_num(num: Option<usize>, width: usize) -> String {
     }
 }
 
+/// Apply color and emphasis to a diff content fragment based on the change style.
+fn style_content(value: &str, style: &Style, emphasized: bool) -> String {
+    match (style, emphasized) {
+        (Style::Delete, true) => value.red().underline().to_string(),
+        (Style::Delete, false) => value.red().to_string(),
+        (Style::Insert, true) => value.green().underline().to_string(),
+        (Style::Insert, false) => value.green().to_string(),
+        (Style::Equal, true) => value.to_string(),
+        (Style::Equal, false) => value.dimmed().to_string(),
+    }
+}
+
 enum Style {
     Delete,
     Insert,
     Equal,
+}
+
+impl Style {
+    /// Color a gutter marker (`-`, `+`, or space) to match the change style.
+    fn apply_to_marker(&self, marker: &str) -> String {
+        match self {
+            Self::Delete => marker.red().to_string(),
+            Self::Insert => marker.green().to_string(),
+            Self::Equal => marker.to_string(),
+        }
+    }
+
+    /// Style old/new line number strings to match the change style.
+    fn apply_to_line_numbers(&self, old_num: String, new_num: String) -> (String, String) {
+        match self {
+            Self::Delete => (old_num.cyan().dimmed().to_string(), new_num),
+            Self::Insert => (old_num, new_num.cyan().dimmed().bold().to_string()),
+            Self::Equal => (old_num.dimmed().to_string(), new_num.dimmed().to_string()),
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

The `render_diff()` function in `karva_snapshot/src/diff.rs` contained a triple-nested match on `(change_tag, style, emphasized)` that produced 9+ near-identical `write!` calls — one for every combination of `Style::{Delete, Insert, Equal}` and `emphasized: bool`. The marker and line-number styling had similar per-style match blocks inlined in the loop body.

This PR extracts three focused helpers:

- **`style_content(value, style, emphasized)`** — a single flat match on `(Style, bool)` that returns the colored (and optionally underlined) string for a diff fragment.
- **`Style::apply_to_marker(marker)`** — colors the gutter marker (`-`/`+`/space) to match the change style.
- **`Style::apply_to_line_numbers(old_num, new_num)`** — applies the appropriate coloring to the old/new line number pair.

The inner loop now reads as three one-liners instead of ~40 lines of nested matches. This makes the styling rules easy to find, easy to change, and possible to unit-test in isolation.

No visual output changed — all existing snapshot tests pass unmodified.

## Test plan

- [x] All 685 existing tests pass (`just test`), including every diff snapshot test
- [x] All pre-commit checks pass (`uvx prek run -a`)
- [x] No snapshot updates required (output is byte-identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)