### PR TITLE
Split accept_pending_batch() into focused helpers

### DIFF
--- a/crates/karva_snapshot/src/storage.rs
+++ b/crates/karva_snapshot/src/storage.rs
@@ -149,22 +149,21 @@ pub fn accept_pending(pending_path: &Utf8Path) -> io::Result<()> {
     std::fs::rename(pending_path, snap_path)
 }
 
-/// Accept multiple pending snapshots, processing inline snapshots in reverse
-/// line order within each source file.
-///
-/// When multiple inline snapshots target the same source file, each multiline
-/// expansion shifts line numbers for subsequent snapshots. By processing in
-/// descending line order (bottom-to-top), edits at higher lines don't affect
-/// line numbers above.
-pub fn accept_pending_batch(pending: &[&PendingSnapshotInfo]) -> io::Result<()> {
-    struct InlineInfo<'a> {
-        pending_path: &'a Utf8Path,
-        source_file: String,
-        line: u32,
-        content: String,
-        function_name: Option<String>,
-    }
+struct InlineInfo<'a> {
+    pending_path: &'a Utf8Path,
+    source_file: String,
+    line: u32,
+    content: String,
+    function_name: Option<String>,
+}
 
+/// Classify pending snapshots into inline (grouped by source file) and file-based.
+fn classify_pending_snapshots<'a>(
+    pending: &'a [&PendingSnapshotInfo],
+) -> (
+    std::collections::HashMap<String, Vec<InlineInfo<'a>>>,
+    Vec<&'a Utf8Path>,
+) {
     let mut inline_by_source: std::collections::HashMap<String, Vec<InlineInfo<'_>>> =
         std::collections::HashMap::new();
     let mut file_based: Vec<&Utf8Path> = Vec::new();
@@ -193,7 +192,16 @@ pub fn accept_pending_batch(pending: &[&PendingSnapshotInfo]) -> io::Result<()> 
         file_based.push(&info.pending_path);
     }
 
-    // Process each source file's inline snapshots in descending line order
+    (inline_by_source, file_based)
+}
+
+/// Process inline snapshots in descending line order within each source file.
+///
+/// Processing bottom-to-top ensures that multiline expansions at higher lines
+/// don't shift line numbers for edits above them.
+fn process_inline_snapshots(
+    inline_by_source: &mut std::collections::HashMap<String, Vec<InlineInfo<'_>>>,
+) -> io::Result<()> {
     for group in inline_by_source.values_mut() {
         group.sort_by(|a, b| b.line.cmp(&a.line));
         for item in group.iter() {
@@ -207,13 +215,28 @@ pub fn accept_pending_batch(pending: &[&PendingSnapshotInfo]) -> io::Result<()> 
             std::fs::remove_file(item.pending_path)?;
         }
     }
+    Ok(())
+}
 
-    // File-based snapshots don't have ordering issues
+/// Process file-based pending snapshots by renaming `.snap.new` to `.snap`.
+fn process_file_based_snapshots(file_based: &[&Utf8Path]) -> io::Result<()> {
     for path in file_based {
         accept_pending(path)?;
     }
-
     Ok(())
+}
+
+/// Accept multiple pending snapshots, processing inline snapshots in reverse
+/// line order within each source file.
+///
+/// When multiple inline snapshots target the same source file, each multiline
+/// expansion shifts line numbers for subsequent snapshots. By processing in
+/// descending line order (bottom-to-top), edits at higher lines don't affect
+/// line numbers above.
+pub fn accept_pending_batch(pending: &[&PendingSnapshotInfo]) -> io::Result<()> {
+    let (mut inline_by_source, file_based) = classify_pending_snapshots(pending);
+    process_inline_snapshots(&mut inline_by_source)?;
+    process_file_based_snapshots(&file_based)
 }
 
 /// Reject a pending snapshot by deleting the `.snap.new` file.


### PR DESCRIPTION
## Summary

`accept_pending_batch()` in `karva_snapshot/src/storage.rs` mixed three distinct phases into a single 59-line function:

1. **Classifying** each pending snapshot as inline or file-based, and grouping inline snapshots by source file
2. **Processing inline snapshots** — sorting each group in descending line order and rewriting source files bottom-to-top (so multiline expansions don't shift line numbers for earlier edits)
3. **Processing file-based snapshots** — renaming `.snap.new` to `.snap`

This PR extracts each phase into its own function:

- `classify_pending_snapshots()` — reads each pending snapshot and partitions it into the inline-by-source map or the file-based list
- `process_inline_snapshots()` — sorts each source file's group by descending line number and applies the inline rewrites
- `process_file_based_snapshots()` — iterates the file-based list and delegates to `accept_pending()`
- `InlineInfo` struct is moved to module scope (still private)

`accept_pending_batch()` now reads as a three-line orchestrator: classify, process inline, process file-based.

Snapshot acceptance behavior is unchanged — all existing tests pass.

## Test plan

- [x] `cargo nextest run -p karva_snapshot` — all 81 tests pass
- [x] `cargo clippy -p karva_snapshot` — no warnings
- [x] `uvx prek run -a` — all pre-commit checks pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)