### PR TITLE
Add capsys built-in fixture

### DIFF
--- a/crates/karva/tests/it/extensions/fixtures/builtins.rs
+++ b/crates/karva/tests/it/extensions/fixtures/builtins.rs
@@ -1171,6 +1171,38 @@ def test_capsys_disabled(capsys):
     ");
 }
 
+/// Regression test: `CaptureResult` namedtuple class must be created once so that consecutive
+/// instances pass `isinstance` checks against each other.
+#[test]
+fn test_capsys_readouterr_isinstance() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+def test_capsys_isinstance(capsys):
+    print('first')
+    first = capsys.readouterr()
+    print('second')
+    second = capsys.readouterr()
+    assert isinstance(second, type(first)), (
+        f'Expected same CaptureResult type, got {type(first)} vs {type(second)}'
+    )
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_capsys_isinstance(capsys=<CapsysFixture object>)
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
 #[test]
 fn test_caplog_clear() {
     let context = TestContext::with_file(

--- a/crates/karva_test_semantic/src/extensions/fixtures/builtins/capsys.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/builtins/capsys.rs
@@ -24,6 +24,9 @@ pub struct CapsysFixture {
     capture_stdout: Py<PyAny>,
     /// The `io.StringIO` buffer currently installed as `sys.stderr`.
     capture_stderr: Py<PyAny>,
+    /// The `CaptureResult` namedtuple class, created once and reused across `readouterr()` calls
+    /// so that consecutive instances satisfy `isinstance` checks against each other.
+    capture_result_class: Py<PyAny>,
 }
 
 impl CapsysFixture {
@@ -40,11 +43,17 @@ impl CapsysFixture {
         sys.setattr("stdout", &capture_stdout)?;
         sys.setattr("stderr", &capture_stderr)?;
 
+        let capture_result_class = py
+            .import("collections")?
+            .call_method1("namedtuple", ("CaptureResult", ["out", "err"]))?
+            .unbind();
+
         Ok(Self {
             real_stdout,
             real_stderr,
             capture_stdout,
             capture_stderr,
+            capture_result_class,
         })
     }
 
@@ -86,11 +95,11 @@ impl CapsysFixture {
         self.capture_stdout = new_stdout;
         self.capture_stderr = new_stderr;
 
-        // Build a CaptureResult namedtuple.
-        let collections = py.import("collections")?;
-        let capture_result_class =
-            collections.call_method1("namedtuple", ("CaptureResult", ["out", "err"]))?;
-        Ok(capture_result_class.call1((out, err))?.unbind())
+        Ok(self
+            .capture_result_class
+            .bind(py)
+            .call1((out, err))?
+            .unbind())
     }
 
     /// Return a context manager that temporarily disables capture (restores real stdout/stderr).

--- a/crates/karva_test_semantic/src/extensions/fixtures/builtins/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/builtins/mod.rs
@@ -66,7 +66,11 @@ def _builtin_finalizer(value, finalizer):
 
     let locals = PyDict::new(py);
 
-    py.run(&std::ffi::CString::new(code).unwrap(), None, Some(&locals))?;
+    py.run(
+        &std::ffi::CString::new(code).expect("fixture code contains null byte"),
+        None,
+        Some(&locals),
+    )?;
 
     let generator_function = locals
         .get_item("_builtin_finalizer")?


### PR DESCRIPTION
Closes #603

Adds `capsys` as a built-in fixture. It redirects `sys.stdout` and `sys.stderr` to in-memory `StringIO` buffers for the duration of the test. Calling `readouterr()` returns a `CaptureResult(out, err)` namedtuple containing everything written since the last call, and resets the buffers. The `disabled()` method returns a context manager that temporarily restores real stdout and stderr for code that must write to the actual terminal. A finalizer unconditionally restores the real streams after each test so subsequent tests are not affected.

Five integration tests cover stdout capture, stderr capture, buffer reset across multiple `readouterr()` calls, the `disabled()` context manager, and finalizer isolation.