### PR TITLE
Use exit code 2 for collection errors when tests pass

### DIFF
--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -100,10 +100,12 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
         durations,
     )?;
 
-    if result.stats.is_success() && result.discovery_diagnostics.is_empty() {
-        Ok(ExitStatus::Success)
-    } else {
+    if !result.stats.is_success() {
         Ok(ExitStatus::Failure)
+    } else if !result.discovery_diagnostics.is_empty() {
+        Ok(ExitStatus::CollectionError)
+    } else {
+        Ok(ExitStatus::Success)
     }
 }
 

--- a/crates/karva/src/lib.rs
+++ b/crates/karva/src/lib.rs
@@ -52,14 +52,17 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
 
 #[derive(Copy, Clone)]
 pub enum ExitStatus {
-    /// Checking was successful and there were no errors.
+    /// All tests passed and no collection errors occurred.
     Success = 0,
 
-    /// Checking was successful but there were errors.
+    /// At least one test failed.
     Failure = 1,
 
-    /// Checking failed.
-    Error = 2,
+    /// Collection errors occurred (e.g. failed to import a module), but no tests failed.
+    CollectionError = 2,
+
+    /// Karva itself failed (internal error).
+    Error = 3,
 }
 
 impl Termination for ExitStatus {

--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -501,7 +501,7 @@ fn test_text_file() {
         context.command().args(["random.txt"]),
         @r"
     success: false
-    exit_code: 2
+    exit_code: 3
     ----- stdout -----
 
     ----- stderr -----
@@ -558,7 +558,7 @@ fn test_invalid_path() {
 
     assert_cmd_snapshot!(context.command().arg("non_existing_path.py"), @r"
     success: false
-    exit_code: 2
+    exit_code: 3
     ----- stdout -----
 
     ----- stderr -----
@@ -1393,7 +1393,7 @@ def test_pass():
 
     assert_cmd_snapshot!(context.command_no_parallel().arg("--output-format=concise"), @"
     success: false
-    exit_code: 1
+    exit_code: 2
     ----- stdout -----
         Starting 1 test across 1 worker
     discovery diagnostics:
@@ -1402,6 +1402,45 @@ def test_pass():
 
     ────────────
          Summary [TIME] 0 tests run: 0 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_collection_error_exit_code_when_other_tests_pass() {
+    let context = TestContext::with_files([
+        (
+            "test_good.py",
+            r"
+def test_pass():
+    assert True
+",
+        ),
+        (
+            "test_bad.py",
+            r"
+import nonexistent_module_xyz
+
+def test_unreachable():
+    assert True
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            PASS [TIME] test_good::test_pass
+
+    discovery diagnostics:
+
+    error[failed-to-import-module]: Failed to import python module `test_bad`: No module named 'nonexistent_module_xyz'
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
 
     ----- stderr -----
     ");

--- a/crates/karva/tests/it/configuration/mod.rs
+++ b/crates/karva/tests/it/configuration/mod.rs
@@ -1307,7 +1307,7 @@ fn test_config_file_flag_nonexistent_unix() {
 
     assert_cmd_snapshot!(context.command().arg("--config-file").arg("nonexistent.toml"), @r"
     success: false
-    exit_code: 2
+    exit_code: 3
     ----- stdout -----
 
     ----- stderr -----
@@ -1325,7 +1325,7 @@ fn test_config_file_flag_nonexistent_windows() {
 
     assert_cmd_snapshot!(context.command().arg("--config-file").arg("nonexistent.toml"), @r"
     success: false
-    exit_code: 2
+    exit_code: 3
     ----- stdout -----
 
     ----- stderr -----

--- a/crates/karva/tests/it/extensions/tags/custom.rs
+++ b/crates/karva/tests/it/extensions/tags/custom.rs
@@ -14,7 +14,7 @@ fn test_tag_filter_unexpected_character() {
     let context = TestContext::with_file("test.py", MINIMAL_TEST_FILE);
     assert_cmd_snapshot!(context.command().arg("-t").arg("slow!"), @r"
     success: false
-    exit_code: 2
+    exit_code: 3
     ----- stdout -----
 
     ----- stderr -----
@@ -28,7 +28,7 @@ fn test_tag_filter_unclosed_parenthesis() {
     let context = TestContext::with_file("test.py", MINIMAL_TEST_FILE);
     assert_cmd_snapshot!(context.command().arg("-t").arg("(slow"), @r"
     success: false
-    exit_code: 2
+    exit_code: 3
     ----- stdout -----
 
     ----- stderr -----
@@ -42,7 +42,7 @@ fn test_tag_filter_trailing_operator() {
     let context = TestContext::with_file("test.py", MINIMAL_TEST_FILE);
     assert_cmd_snapshot!(context.command().arg("-t").arg("slow and"), @r"
     success: false
-    exit_code: 2
+    exit_code: 3
     ----- stdout -----
 
     ----- stderr -----
@@ -56,7 +56,7 @@ fn test_tag_filter_leading_operator() {
     let context = TestContext::with_file("test.py", MINIMAL_TEST_FILE);
     assert_cmd_snapshot!(context.command().arg("-t").arg("and slow"), @r"
     success: false
-    exit_code: 2
+    exit_code: 3
     ----- stdout -----
 
     ----- stderr -----
@@ -70,7 +70,7 @@ fn test_tag_filter_extra_closing_paren() {
     let context = TestContext::with_file("test.py", MINIMAL_TEST_FILE);
     assert_cmd_snapshot!(context.command().arg("-t").arg("slow)"), @r"
     success: false
-    exit_code: 2
+    exit_code: 3
     ----- stdout -----
 
     ----- stderr -----
@@ -84,7 +84,7 @@ fn test_tag_filter_empty_parentheses() {
     let context = TestContext::with_file("test.py", MINIMAL_TEST_FILE);
     assert_cmd_snapshot!(context.command().arg("-t").arg("()"), @r"
     success: false
-    exit_code: 2
+    exit_code: 3
     ----- stdout -----
 
     ----- stderr -----
@@ -98,7 +98,7 @@ fn test_tag_filter_double_operator() {
     let context = TestContext::with_file("test.py", MINIMAL_TEST_FILE);
     assert_cmd_snapshot!(context.command().arg("-t").arg("slow and and fast"), @r"
     success: false
-    exit_code: 2
+    exit_code: 3
     ----- stdout -----
 
     ----- stderr -----
@@ -112,7 +112,7 @@ fn test_tag_filter_whitespace_only() {
     let context = TestContext::with_file("test.py", MINIMAL_TEST_FILE);
     assert_cmd_snapshot!(context.command().arg("-t").arg(" "), @r"
     success: false
-    exit_code: 2
+    exit_code: 3
     ----- stdout -----
 
     ----- stderr -----

--- a/crates/karva/tests/it/extensions/tags/parametrize.rs
+++ b/crates/karva/tests/it/extensions/tags/parametrize.rs
@@ -710,7 +710,7 @@ def test_invalid(x):
 
     assert_cmd_snapshot!(context.command(), @"
     success: false
-    exit_code: 1
+    exit_code: 2
     ----- stdout -----
         Starting 1 test across 1 worker
     discovery diagnostics:

--- a/crates/karva/tests/it/extensions/tags/skip.rs
+++ b/crates/karva/tests/it/extensions/tags/skip.rs
@@ -453,7 +453,7 @@ def test_1():
 
     assert_cmd_snapshot!(context.command(), @"
     success: false
-    exit_code: 1
+    exit_code: 2
     ----- stdout -----
         Starting 1 test across 1 worker
     discovery diagnostics:
@@ -482,7 +482,7 @@ def test_1():
 
     assert_cmd_snapshot!(context.command(), @"
     success: false
-    exit_code: 1
+    exit_code: 2
     ----- stdout -----
         Starting 1 test across 1 worker
     discovery diagnostics:

--- a/crates/karva/tests/it/extensions/tags/use_fixtures.rs
+++ b/crates/karva/tests/it/extensions/tags/use_fixtures.rs
@@ -486,7 +486,7 @@ def test_1():
 
     assert_cmd_snapshot!(test_context.command(), @"
     success: false
-    exit_code: 1
+    exit_code: 2
     ----- stdout -----
         Starting 1 test across 1 worker
     discovery diagnostics:

--- a/crates/karva/tests/it/name_filter.rs
+++ b/crates/karva/tests/it/name_filter.rs
@@ -87,7 +87,7 @@ fn name_filter_invalid_regex() {
     let context = TestContext::with_file("test.py", TWO_TESTS);
     assert_cmd_snapshot!(context.command_no_parallel().arg("-m").arg("[invalid"), @r"
     success: false
-    exit_code: 2
+    exit_code: 3
     ----- stdout -----
 
     ----- stderr -----
@@ -408,7 +408,7 @@ fn name_filter_invalid_regex_unclosed_group() {
     let context = TestContext::with_file("test.py", TWO_TESTS);
     assert_cmd_snapshot!(context.command_no_parallel().arg("-m").arg("(unclosed"), @r"
     success: false
-    exit_code: 2
+    exit_code: 3
     ----- stdout -----
 
     ----- stderr -----
@@ -425,7 +425,7 @@ fn name_filter_invalid_regex_invalid_repetition() {
     let context = TestContext::with_file("test.py", TWO_TESTS);
     assert_cmd_snapshot!(context.command_no_parallel().arg("-m").arg("*invalid"), @r"
     success: false
-    exit_code: 2
+    exit_code: 3
     ----- stdout -----
 
     ----- stderr -----
@@ -442,7 +442,7 @@ fn name_filter_invalid_regex_bad_escape() {
     let context = TestContext::with_file("test.py", TWO_TESTS);
     assert_cmd_snapshot!(context.command_no_parallel().arg("-m").arg(r"\p{Invalid}"), @r"
     success: false
-    exit_code: 2
+    exit_code: 3
     ----- stdout -----
 
     ----- stderr -----

--- a/crates/karva/tests/it/watch.rs
+++ b/crates/karva/tests/it/watch.rs
@@ -8,7 +8,7 @@ fn test_watch_and_dry_run_conflict() {
 
     assert_cmd_snapshot!(context.command().args(["--watch", "--dry-run"]), @r"
     success: false
-    exit_code: 2
+    exit_code: 3
     ----- stdout -----
 
     ----- stderr -----


### PR DESCRIPTION
Closes #606

Distinguishes collection errors (exit 2) from test failures (exit 1).

## Summary

- Adds `ExitStatus::CollectionError = 2` for when collection errors occur (e.g. `failed-to-import-module`) but no tests failed
- Shifts `ExitStatus::Error` (internal Karva failures) from `2` to `3`
- Updates the exit code decision logic in `commands::test` to use the new variant
- Updates all existing snapshot tests to reflect the new exit codes
- Adds a new integration test `test_collection_error_exit_code_when_other_tests_pass` verifying exit code 2 when a file fails to import but other tests pass

## Exit code table

| Code | Meaning |
|------|---------|
| 0 | All tests passed, no collection errors |
| 1 | At least one test failed |
| 2 | Collection errors occurred, but no tests failed |
| 3 | Karva itself failed (internal error) |

## Test plan

- [x] `just test` passes (736/736 tests)
- [x] `uvx prek run -a` passes all pre-commit checks
- [x] New integration test `test_collection_error_exit_code_when_other_tests_pass` verifies exit code 2