### PR TITLE
Remove primer projects with zero test signal

### DIFF
--- a/scripts/primer.py
+++ b/scripts/primer.py
@@ -269,12 +269,6 @@ PROJECTS: list[Project] = [
         test_paths=["tests/"],
     ),
     Project(
-        name="tenacity",
-        repo="https://github.com/jd/tenacity",
-        commit="8779333a4759e56427b5d7ba23cacd3fe6054d61",
-        test_paths=["tests/"],
-    ),
-    Project(
         name="tqdm",
         repo="https://github.com/tqdm/tqdm",
         commit="75bdb6c379bcfc6c592b6342dc791a092b5d6ae0",


### PR DESCRIPTION
Removes six projects from the primer that currently produce zero useful signal: either all tests fail with no passes, the test count is 0/0/0 despite reporting PASS, or the configured test path does not exist in the repository.

The six projects removed are textual (0 passed, 2 failed), mypy (0 passed, 13 failed), more-itertools (0 passed, 0 failed — no tests discovered), mkdocs (0 passed, 1 failed), pyyaml (test path tests/lib/ does not exist), and jsonschema (test path tests/ does not exist — tests live in jsonschema/tests/).