### PR TITLE
Fix function-scoped built-in fixtures not isolated across parametrize variants

### DIFF
--- a/crates/karva/tests/it/extensions/fixtures/builtins.rs
+++ b/crates/karva/tests/it/extensions/fixtures/builtins.rs
@@ -1535,3 +1535,29 @@ def test_stdout_works_after(capsys):
     ----- stderr -----
     ");
 }
+
+#[test]
+fn test_tmp_path_isolated_per_parametrize_variant() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+@karva.tags.parametrize('value', [1, 2, 3])
+def test_creates_subdir(value, tmp_path):
+    sub = tmp_path / 'subdir'
+    sub.mkdir()
+    assert sub.exists()
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("-q"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 3 tests run: 3 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -101,8 +101,10 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             // Create a new resolver for each test to handle fixture resolution
             let mut test_resolver = RuntimeFixtureResolver::new(parents, module);
 
-            // Iterate over all test variants (parametrize combinations × fixture combinations)
-            for variant in TestVariantIterator::new(py, test_function, &mut test_resolver) {
+            // Iterate over all test variants (parametrize combinations × fixture combinations).
+            // Uses next_with_py so each variant gets fresh function-scoped built-in fixtures.
+            let mut iterator = TestVariantIterator::new(py, test_function, &mut test_resolver);
+            while let Some(variant) = iterator.next_with_py(py) {
                 passed &= self.execute_test_variant(py, variant);
 
                 if self.context.settings().test().fail_fast && !passed {

--- a/crates/karva_test_semantic/src/runner/test_iterator.rs
+++ b/crates/karva_test_semantic/src/runner/test_iterator.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 use pyo3::prelude::*;
 
 use crate::discovery::DiscoveredTestFunction;
-use crate::extensions::fixtures::{NormalizedFixture, RequiresFixtures};
+use crate::extensions::fixtures::{
+    FixtureScope, NormalizedFixture, RequiresFixtures, get_builtin_fixture,
+};
 use crate::extensions::tags::Tags;
 use crate::extensions::tags::parametrize::ParametrizationArgs;
 use crate::runner::fixture_resolver::RuntimeFixtureResolver;
@@ -128,10 +130,13 @@ impl TestVariantIterator {
     }
 }
 
-impl Iterator for TestVariantIterator {
-    type Item = TestVariant;
-
-    fn next(&mut self) -> Option<Self::Item> {
+impl TestVariantIterator {
+    /// Returns the next test variant, creating fresh instances of function-scoped
+    /// built-in fixtures (e.g. `tmp_path`, `monkeypatch`) for each variant.
+    ///
+    /// Built-in fixtures are pre-computed once during construction, but function-scoped
+    /// ones must be fresh per invocation so parametrize combinations don't share state.
+    pub(super) fn next_with_py(&mut self, py: Python<'_>) -> Option<TestVariant> {
         if self.param_index >= self.param_args.len() {
             return None;
         }
@@ -144,9 +149,12 @@ impl Iterator for TestVariantIterator {
         let variant = TestVariant {
             test: Rc::clone(&self.test),
             params: param_args.values.clone(),
-            fixture_dependencies: self.fixture_dependencies.clone(),
-            use_fixture_dependencies: self.use_fixture_dependencies.clone(),
-            auto_use_fixtures: self.auto_use_fixtures.clone(),
+            fixture_dependencies: fresh_function_scoped_builtins(py, &self.fixture_dependencies),
+            use_fixture_dependencies: fresh_function_scoped_builtins(
+                py,
+                &self.use_fixture_dependencies,
+            ),
+            auto_use_fixtures: fresh_function_scoped_builtins(py, &self.auto_use_fixtures),
             tags: new_tags,
         };
 
@@ -154,4 +162,28 @@ impl Iterator for TestVariantIterator {
 
         Some(variant)
     }
+}
+
+/// Replace function-scoped built-in fixtures with fresh instances.
+///
+/// When a test has multiple parametrize variants, each variant must receive
+/// independent built-in fixtures (e.g. a separate `tmp_path` directory).
+/// Non-built-in and non-function-scoped fixtures are cloned as-is.
+fn fresh_function_scoped_builtins(
+    py: Python<'_>,
+    fixtures: &[Rc<NormalizedFixture>],
+) -> Vec<Rc<NormalizedFixture>> {
+    fixtures
+        .iter()
+        .map(|f| {
+            if let NormalizedFixture::BuiltIn(builtin) = f.as_ref() {
+                if builtin.scope == FixtureScope::Function {
+                    if let Some(fresh) = get_builtin_fixture(py, &builtin.name) {
+                        return Rc::new(fresh);
+                    }
+                }
+            }
+            Rc::clone(f)
+        })
+        .collect()
 }


### PR DESCRIPTION
## Summary

Function-scoped built-in fixtures (`tmp_path`, `monkeypatch`, etc.) were shared across all parametrize variants of a test function, causing `FileExistsError` when multiple variants tried to create the same subdirectory inside their `tmp_path`.

## Root cause

`TestVariantIterator::new` resolved all fixtures once per test function, then the `Iterator::next` impl cloned the same `fixture_dependencies` for every variant. For `NormalizedFixture::BuiltIn`, cloning shares the same pre-computed `Py<PyAny>` value via `Rc`, so every variant received the identical `tmp_path` directory.

## Fix

Re-create function-scoped built-in fixtures per variant in `TestVariantIterator::next_with_py`.

## Test plan

`test_tmp_path_isolated_per_parametrize_variant` verifies that 3 parametrize variants can each create `subdir/` inside their own `tmp_path`. Full suite: 761/761 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)