### PR TITLE
Add record_tuples property to caplog fixture

### DIFF
--- a/crates/karva/tests/it/extensions/fixtures/builtins.rs
+++ b/crates/karva/tests/it/extensions/fixtures/builtins.rs
@@ -1339,6 +1339,35 @@ def test_caplog_messages(caplog):
 }
 
 #[test]
+fn test_caplog_record_tuples() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import logging
+
+def test_caplog_record_tuples(caplog):
+    with caplog.at_level(logging.INFO):
+        logging.info('first')
+        logging.warning('second')
+    assert caplog.record_tuples == [
+        ('root', logging.INFO, 'first'),
+        ('root', logging.WARNING, 'second'),
+    ]
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command().arg("-q"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_capsys_readouterr_resets_buffer() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva_test_semantic/src/extensions/fixtures/builtins/caplog.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/builtins/caplog.rs
@@ -1,6 +1,6 @@
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyDict, PyList, PyTuple};
 
 pub fn is_caplog_fixture_name(fixture_name: &str) -> bool {
     matches!(fixture_name, "caplog")
@@ -97,6 +97,21 @@ impl CapLog {
     #[getter]
     fn records<'py>(&self, py: Python<'py>) -> Bound<'py, PyList> {
         self.records.bind(py).clone()
+    }
+
+    #[getter]
+    fn record_tuples<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
+        let records = self.records.bind(py);
+        let tuples: Vec<_> = records
+            .iter()
+            .map(|r| {
+                let name = r.getattr("name")?;
+                let levelno = r.getattr("levelno")?;
+                let message = r.call_method0("getMessage")?;
+                PyTuple::new(py, [name, levelno, message])
+            })
+            .collect::<PyResult<_>>()?;
+        PyList::new(py, tuples)
     }
 
     #[getter]


### PR DESCRIPTION
The `caplog` fixture was missing the `record_tuples` attribute, which caused failures when running test suites that depend on it. Projects like httpcore use `caplog.record_tuples` to assert on log output in the form of `(logger_name, level, message)` tuples, and without this attribute those tests raised `'builtins.CapLog' object has no attribute 'record_tuples'`.

The new `record_tuples` property iterates over `self.records` and builds a `PyTuple` for each log record containing the logger name, numeric level, and the formatted message string — exactly matching the pytest specification `[(r.name, r.levelno, r.getMessage()) for r in self.records]`. For example:

```python
def test_http_warning(caplog):
    with caplog.at_level(logging.WARNING):
        logging.warning("connection refused")
    assert caplog.record_tuples == [("root", logging.WARNING, "connection refused")]
```

An integration test covering both single-level and multi-level capture has been added alongside the existing `test_caplog_messages` test.