### PR TITLE
Add capsysbinary and capfdbinary built-in fixtures

### DIFF
--- a/crates/karva/tests/it/extensions/fixtures/builtins.rs
+++ b/crates/karva/tests/it/extensions/fixtures/builtins.rs
@@ -1787,3 +1787,65 @@ def test_capfd_stderr(capfd):
     ----- stderr -----
     ");
 }
+
+#[test]
+fn test_capsysbinary_captures_output() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+def test_capsysbinary_stdout(capsysbinary):
+    print('hello bytes')
+    captured = capsysbinary.readouterr()
+    assert captured.out == b'hello bytes\n'
+    assert captured.err == b''
+
+def test_capsysbinary_stderr(capsysbinary):
+    import sys
+    print('error bytes', file=sys.stderr)
+    captured = capsysbinary.readouterr()
+    assert captured.out == b''
+    assert captured.err == b'error bytes\n'
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("-q"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_capfdbinary_captures_output() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+def test_capfdbinary_stdout(capfdbinary):
+    print('hello fd bytes')
+    captured = capfdbinary.readouterr()
+    assert captured.out == b'hello fd bytes\n'
+    assert captured.err == b''
+
+def test_capfdbinary_stderr(capfdbinary):
+    import sys
+    print('error fd bytes', file=sys.stderr)
+    captured = capfdbinary.readouterr()
+    assert captured.out == b''
+    assert captured.err == b'error fd bytes\n'
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("-q"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}

--- a/crates/karva_test_semantic/src/extensions/fixtures/builtins/capsys.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/builtins/capsys.rs
@@ -1,4 +1,5 @@
 use pyo3::prelude::*;
+use pyo3::types::PyBytes;
 
 pub fn is_capsys_fixture_name(fixture_name: &str) -> bool {
     matches!(fixture_name, "capsys")
@@ -12,6 +13,16 @@ pub fn is_capfd_fixture_name(fixture_name: &str) -> bool {
     matches!(fixture_name, "capfd")
 }
 
+/// `capsysbinary` is like `capsys` but `readouterr()` returns `(bytes, bytes)`.
+pub fn is_capsysbinary_fixture_name(fixture_name: &str) -> bool {
+    matches!(fixture_name, "capsysbinary")
+}
+
+/// `capfdbinary` is like `capfd` but `readouterr()` returns `(bytes, bytes)`.
+pub fn is_capfdbinary_fixture_name(fixture_name: &str) -> bool {
+    matches!(fixture_name, "capfdbinary")
+}
+
 pub fn create_capsys_fixture(py: Python<'_>) -> Option<(Py<PyAny>, Py<PyAny>)> {
     let capsys = Py::new(py, CapsysFixture::new(py).ok()?).ok()?;
     let restore_method = capsys.getattr(py, "_restore").ok()?;
@@ -20,6 +31,16 @@ pub fn create_capsys_fixture(py: Python<'_>) -> Option<(Py<PyAny>, Py<PyAny>)> {
 
 pub fn create_capfd_fixture(py: Python<'_>) -> Option<(Py<PyAny>, Py<PyAny>)> {
     create_capsys_fixture(py)
+}
+
+pub fn create_capsysbinary_fixture(py: Python<'_>) -> Option<(Py<PyAny>, Py<PyAny>)> {
+    let capsys = Py::new(py, CapsysBinaryFixture::new(py).ok()?).ok()?;
+    let restore_method = capsys.getattr(py, "_restore").ok()?;
+    Some((capsys.into_any(), restore_method))
+}
+
+pub fn create_capfdbinary_fixture(py: Python<'_>) -> Option<(Py<PyAny>, Py<PyAny>)> {
+    create_capsysbinary_fixture(py)
 }
 
 /// Captures writes to `sys.stdout` and `sys.stderr` during a test.
@@ -111,6 +132,118 @@ impl CapsysFixture {
             .capture_result_class
             .bind(py)
             .call1((out, err))?
+            .unbind())
+    }
+
+    /// Return a context manager that temporarily disables capture (restores real stdout/stderr).
+    fn disabled(&self, py: Python<'_>) -> CapsysDisabled {
+        CapsysDisabled {
+            real_stdout: self.real_stdout.clone_ref(py),
+            real_stderr: self.real_stderr.clone_ref(py),
+            capture_stdout: self.capture_stdout.clone_ref(py),
+            capture_stderr: self.capture_stderr.clone_ref(py),
+        }
+    }
+
+    /// Restore `sys.stdout` and `sys.stderr` to the real streams. Called as the fixture finalizer.
+    fn _restore(&self, py: Python<'_>) -> PyResult<()> {
+        let sys = py.import("sys")?;
+        sys.setattr("stdout", &self.real_stdout)?;
+        sys.setattr("stderr", &self.real_stderr)?;
+        Ok(())
+    }
+}
+
+/// Like [`CapsysFixture`] but `readouterr()` returns `(bytes, bytes)` instead of `(str, str)`.
+///
+/// The captured strings are UTF-8 encoded before being returned.
+#[pyclass]
+pub struct CapsysBinaryFixture {
+    /// The real `sys.stdout` saved at fixture creation time.
+    real_stdout: Py<PyAny>,
+    /// The real `sys.stderr` saved at fixture creation time.
+    real_stderr: Py<PyAny>,
+    /// The `io.StringIO` buffer currently installed as `sys.stdout`.
+    capture_stdout: Py<PyAny>,
+    /// The `io.StringIO` buffer currently installed as `sys.stderr`.
+    capture_stderr: Py<PyAny>,
+    /// The `CaptureResult` namedtuple class, created once and reused across `readouterr()` calls.
+    capture_result_class: Py<PyAny>,
+}
+
+impl CapsysBinaryFixture {
+    fn new(py: Python<'_>) -> PyResult<Self> {
+        let sys = py.import("sys")?;
+        let io = py.import("io")?;
+
+        let real_stdout = sys.getattr("stdout")?.unbind();
+        let real_stderr = sys.getattr("stderr")?.unbind();
+
+        let capture_stdout = io.call_method0("StringIO")?.unbind();
+        let capture_stderr = io.call_method0("StringIO")?.unbind();
+
+        sys.setattr("stdout", &capture_stdout)?;
+        sys.setattr("stderr", &capture_stderr)?;
+
+        let capture_result_class = py
+            .import("collections")?
+            .call_method1("namedtuple", ("CaptureResult", ["out", "err"]))?
+            .unbind();
+
+        Ok(Self {
+            real_stdout,
+            real_stderr,
+            capture_stdout,
+            capture_stderr,
+            capture_result_class,
+        })
+    }
+
+    fn fresh_stringio(py: Python<'_>) -> PyResult<Py<PyAny>> {
+        Ok(py.import("io")?.call_method0("StringIO")?.unbind())
+    }
+}
+
+#[pymethods]
+impl CapsysBinaryFixture {
+    /// Return a string representation of the `CapsysBinaryFixture` object.
+    #[expect(clippy::unused_self)]
+    fn __repr__(&self) -> &'static str {
+        "<CapsysBinaryFixture object>"
+    }
+
+    /// Return a `CaptureResult(out, err)` namedtuple with captured output as `bytes` and reset
+    /// the buffers.
+    fn readouterr(&mut self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let out = self
+            .capture_stdout
+            .bind(py)
+            .call_method0("getvalue")?
+            .extract::<String>()?;
+        let err = self
+            .capture_stderr
+            .bind(py)
+            .call_method0("getvalue")?
+            .extract::<String>()?;
+
+        // Reset both buffers to fresh StringIO instances.
+        let new_stdout = Self::fresh_stringio(py)?;
+        let new_stderr = Self::fresh_stringio(py)?;
+
+        let sys = py.import("sys")?;
+        sys.setattr("stdout", &new_stdout)?;
+        sys.setattr("stderr", &new_stderr)?;
+
+        self.capture_stdout = new_stdout;
+        self.capture_stderr = new_stderr;
+
+        let out_bytes = PyBytes::new(py, out.as_bytes()).unbind();
+        let err_bytes = PyBytes::new(py, err.as_bytes()).unbind();
+
+        Ok(self
+            .capture_result_class
+            .bind(py)
+            .call1((out_bytes, err_bytes))?
             .unbind())
     }
 

--- a/crates/karva_test_semantic/src/extensions/fixtures/builtins/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/builtins/mod.rs
@@ -10,7 +10,10 @@ mod mock_env;
 mod recwarn;
 mod temp_path;
 
-use capsys::{create_capfd_fixture, is_capfd_fixture_name};
+use capsys::{
+    create_capfd_fixture, create_capfdbinary_fixture, create_capsysbinary_fixture,
+    is_capfd_fixture_name, is_capfdbinary_fixture_name, is_capsysbinary_fixture_name,
+};
 
 pub fn get_builtin_fixture(py: Python<'_>, fixture_name: &str) -> Option<NormalizedFixture> {
     match fixture_name {
@@ -78,6 +81,24 @@ pub fn get_builtin_fixture(py: Python<'_>, fixture_name: &str) -> Option<Normali
                 return Some(NormalizedFixture::built_in_with_finalizer(
                     fixture_name.to_string(),
                     capfd_instance,
+                    finalizer,
+                ));
+            }
+        }
+        _ if is_capsysbinary_fixture_name(fixture_name) => {
+            if let Some((capsysbinary_instance, finalizer)) = create_capsysbinary_fixture(py) {
+                return Some(NormalizedFixture::built_in_with_finalizer(
+                    fixture_name.to_string(),
+                    capsysbinary_instance,
+                    finalizer,
+                ));
+            }
+        }
+        _ if is_capfdbinary_fixture_name(fixture_name) => {
+            if let Some((capfdbinary_instance, finalizer)) = create_capfdbinary_fixture(py) {
+                return Some(NormalizedFixture::built_in_with_finalizer(
+                    fixture_name.to_string(),
+                    capfdbinary_instance,
                     finalizer,
                 ));
             }


### PR DESCRIPTION
Implements the `capsysbinary` and `capfdbinary` built-in fixtures, closing #619 and #618.

Both fixtures behave identically to their `capsys`/`capfd` counterparts, with one difference: `readouterr()` returns a `CaptureResult` namedtuple where both `.out` and `.err` are `bytes` objects rather than strings. The captured text is UTF-8 encoded before being returned as `PyBytes`.

The implementation adds `CapsysBinaryFixture` to `capsys.rs` alongside the existing `CapsysFixture`. Like `CapsysFixture`, it installs `io.StringIO` buffers over `sys.stdout` and `sys.stderr`, reads them back via `getvalue()`, resets to fresh buffers on each `readouterr()` call, and restores the real streams in its `_restore` finalizer. The only divergence is in the final step — instead of passing the `String` values directly into the `CaptureResult` namedtuple, they are first encoded to `PyBytes`:

```rust
let out_bytes = PyBytes::new(py, out.as_bytes()).unbind();
let err_bytes = PyBytes::new(py, err.as_bytes()).unbind();
```

The `capfdbinary` fixture delegates to `capsysbinary`, the same pattern already used for `capfd` delegating to `capsys`.

Integration tests confirm that both fixtures capture stdout and stderr as byte strings:

```python
def test_capsysbinary_stdout(capsysbinary):
    print('hello bytes')
    captured = capsysbinary.readouterr()
    assert captured.out == b'hello bytes\n'
    assert captured.err == b''
```