### PR TITLE
Fix monkeypatch.context() so __exit__ undoes patches from the yielded instance

### DIFF
--- a/crates/karva/tests/it/extensions/fixtures/builtins.rs
+++ b/crates/karva/tests/it/extensions/fixtures/builtins.rs
@@ -516,8 +516,8 @@ def test_context_classmethod():
     with MockEnv.context() as mp:
         mp.setattr(A, 'x', 2)
         assert A.x == 2
-        mp.undo()
 
+    # patches are undone automatically on __exit__, no manual undo() needed
     assert A.x == 1
         ",
     );
@@ -531,6 +531,58 @@ def test_context_classmethod():
 
     ────────────
          Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_monkeypatch_context() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import os
+
+def test_context_auto_undo(monkeypatch):
+    class A:
+        x = 1
+
+    with monkeypatch.context() as m:
+        m.setattr(A, 'x', 2)
+        assert A.x == 2
+    # patches are undone automatically on __exit__, no manual undo() needed
+    assert A.x == 1
+
+def test_context_env_auto_undo(monkeypatch):
+    with monkeypatch.context() as m:
+        m.setenv('_KARVA_CTX_TEST', 'hello')
+        assert os.environ['_KARVA_CTX_TEST'] == 'hello'
+    assert '_KARVA_CTX_TEST' not in os.environ
+
+def test_context_independent_of_outer(monkeypatch):
+    class B:
+        y = 10
+
+    monkeypatch.setattr(B, 'y', 20)
+    with monkeypatch.context() as m:
+        m.setattr(B, 'y', 30)
+        assert B.y == 30
+    # inner context undone, but outer monkeypatch patch remains active
+    assert B.y == 20
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 3 tests across 1 worker
+            PASS [TIME] test::test_context_auto_undo(monkeypatch=<MockEnv object>)
+            PASS [TIME] test::test_context_env_auto_undo(monkeypatch=<MockEnv object>)
+            PASS [TIME] test::test_context_independent_of_outer(monkeypatch=<MockEnv object>)
+
+    ────────────
+         Summary [TIME] 3 tests run: 3 passed, 0 skipped
 
     ----- stderr -----
     ");

--- a/crates/karva_test_semantic/src/extensions/fixtures/builtins/mock_env.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/builtins/mock_env.rs
@@ -144,13 +144,17 @@ impl MockEnv {
         "<MockEnv object>".to_string()
     }
 
-    /// Context manager that returns a new Mock object which undoes any patching
-    /// done inside the with block upon exit.
+    /// Context manager that returns a new `MockEnv` instance which undoes any
+    /// patching done inside the `with` block upon exit, independent of the
+    /// outer fixture's teardown.
+    ///
+    /// Accessible both as a classmethod (`MockEnv.context()`) and as an
+    /// instance method (`monkeypatch.context()`), matching the pytest API.
     #[classmethod]
-    fn context(_cls: &Bound<'_, PyType>) -> MockEnvContext {
-        MockEnvContext {
-            mock_env: Self::new(),
-        }
+    fn context(_cls: &Bound<'_, PyType>, py: Python<'_>) -> PyResult<MockEnvContext> {
+        Ok(MockEnvContext {
+            mock_env: Py::new(py, Self::new())?,
+        })
     }
 
     /// Set attribute value on target, memorising the old value.
@@ -503,18 +507,20 @@ impl MockEnv {
     }
 }
 
-/// Context manager wrapper for `MockEnv`
+/// Context manager wrapper for `MockEnv`.
+///
+/// Holds a `Py<MockEnv>` so that `__enter__` returns the exact same instance
+/// that `__exit__` calls `undo()` on.
 #[pyclass]
 struct MockEnvContext {
-    mock_env: MockEnv,
+    mock_env: Py<MockEnv>,
 }
 
 #[pymethods]
 impl MockEnvContext {
     #[expect(clippy::needless_pass_by_value)]
-    fn __enter__(slf: PyRef<'_, Self>) -> PyResult<Py<MockEnv>> {
-        let py = slf.py();
-        Py::new(py, MockEnv::new())
+    fn __enter__(slf: PyRef<'_, Self>) -> Py<MockEnv> {
+        slf.mock_env.clone_ref(slf.py())
     }
 
     fn __exit__(
@@ -524,7 +530,7 @@ impl MockEnvContext {
         _exc_val: Py<PyAny>,
         _exc_tb: Py<PyAny>,
     ) -> PyResult<bool> {
-        self.mock_env.undo(py)?;
+        self.mock_env.bind(py).borrow_mut().undo(py)?;
         Ok(false)
     }
 }


### PR DESCRIPTION
Closes #621.

## The bug

`monkeypatch.context()` (and `MockEnv.context()`) returned a context manager that appeared to work but silently failed to undo patches when the `with` block exited. The root cause was a mismatch between the `MockEnv` instance returned by `__enter__` and the one stored inside `MockEnvContext`:

```python
with monkeypatch.context() as m:
    m.setattr(A, 'x', 2)
    assert A.x == 2
# __exit__ ran but undid nothing — A.x was still 2
```

`MockEnvContext.__enter__` allocated a brand-new `MockEnv` via `MockEnv::new()` and returned it to the caller, while `__exit__` called `undo()` on a *different* `MockEnv` stored in the struct field. Since the struct's copy never recorded any patches, its `undo()` was a no-op.

## The fix

`MockEnvContext` now holds a `Py<MockEnv>` instead of a bare `MockEnv`. `__enter__` returns a clone of that reference (not a fresh object), so both `__enter__` and `__exit__` operate on the exact same Python-managed instance. When the `with` block exits, `__exit__` borrows the same object and calls `undo()` on the patches that were actually recorded.

The `context()` classmethod signature was also updated to accept `py: Python<'_>` so it can allocate the `Py<MockEnv>` upfront, and it now propagates allocation errors via `PyResult` rather than hiding them.

## Testing

Three new integration tests cover the fixed behaviour: automatic undo of `setattr` patches, automatic undo of environment variable patches, and independence between an inner context and the outer `monkeypatch` fixture (inner patches are undone while outer ones remain active). The existing `test_monkeypatch_context_classmethod` test was updated to remove its now-unnecessary manual `mp.undo()` call and confirm that auto-undo alone is sufficient.