### PR TITLE
Add PR template guideline to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,4 +16,5 @@
 - AVOID useless inline comments in tests (e.g., `// Run tests`, `// Accept remaining`, `// Review again`). The code should speak for itself. Only add comments when the intent is non-obvious.
 - PREFER function comments over inline comments.
 - ALWAYS add labels to PRs.
+- ALWAYS use the pull request template when writing PR descriptions.
 - ALWAYS write human-readable PR descriptions using paragraphs and code examples instead of bullet points.


### PR DESCRIPTION
## Summary

This change adds a guideline to `CLAUDE.md` instructing Claude to always use the pull request template when writing PR descriptions. The repository already has a template at `.github/PULL_REQUEST_TEMPLATE.md` with `## Summary` and `## Test Plan` sections, but there was no explicit instruction telling Claude to follow it.

The new rule is placed alongside the two existing PR-related rules (adding labels, and writing human-readable descriptions), so all PR authoring guidelines are grouped together.

## Test Plan

The change is a one-line addition to a markdown guidelines file with no executable code, so no automated tests apply. The pre-commit suite (mdformat, markdownlint, typos) was run and passed cleanly.