### PR TITLE
Fix get_auto_use_fixtures collecting only first autouse fixture

### DIFF
--- a/crates/karva/tests/it/extensions/fixtures/autouse.rs
+++ b/crates/karva/tests/it/extensions/fixtures/autouse.rs
@@ -364,3 +364,45 @@ def test_second():
     ----- stderr -----
     "#);
 }
+
+/// All autouse fixtures in a module must be applied, not just the first one.
+#[rstest]
+fn test_multiple_auto_use_fixtures(#[values("pytest", "karva")] framework: &str) {
+    let context = TestContext::with_file(
+        "test.py",
+        &format!(
+            r#"
+import {framework}
+
+arr = []
+
+@{framework}.fixture({auto_use_kw}=True)
+def first_fixture():
+    arr.append("first")
+
+@{framework}.fixture({auto_use_kw}=True)
+def second_fixture():
+    arr.append("second")
+
+def test_both_fixtures_run():
+    assert arr == ["first", "second"], arr
+"#,
+            auto_use_kw = get_auto_use_kw(framework),
+        ),
+    );
+
+    allow_duplicates! {
+        assert_cmd_snapshot!(context.command_no_parallel(), @"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+            Starting 1 test across 1 worker
+                PASS [TIME] test::test_both_fixtures_run
+
+        ────────────
+             Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+        ----- stderr -----
+        ");
+    }
+}

--- a/crates/karva_test_semantic/src/extensions/fixtures/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/mod.rs
@@ -257,7 +257,6 @@ pub fn get_auto_use_fixtures<'a>(
         }
 
         auto_use_fixtures_called.push(fixture);
-        break;
     }
 
     for parent in parents {
@@ -273,7 +272,6 @@ pub fn get_auto_use_fixtures<'a>(
             }
 
             auto_use_fixtures_called.push(fixture);
-            break;
         }
     }
 


### PR DESCRIPTION
In `get_auto_use_fixtures`, each of the two collection loops contained a spurious `break` statement placed immediately after pushing a fixture onto the result vector. This meant that regardless of how many autouse fixtures existed in a module or its parent packages, at most one fixture from each source would ever be collected and applied to a test.

For example, with two autouse fixtures in the same module:

```python
@karva.fixture(auto_use=True)
def first_fixture():
    arr.append("first")

@karva.fixture(auto_use=True)
def second_fixture():
    arr.append("second")
```

Only `first_fixture` would be applied; `second_fixture` would never run. The same problem affected autouse fixtures contributed by parent packages — only the first one from each parent was applied.

The fix removes both `break` statements, allowing the loops to iterate over all available autouse fixtures and collect each one that has not already been seen (the existing deduplication logic remains intact).

A regression test covering multiple autouse fixtures in the same module has been added for both the `karva` and `pytest` fixture APIs.