### PR TITLE
Fix capsysbinary to accept bytes writes to sys.stdout/sys.stderr

### DIFF
--- a/.github/workflows/primer.yml
+++ b/.github/workflows/primer.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: "Run primer"
         run: |
-          uv run --script scripts/primer.py \
+          uv run --script scripts/primer.py -v \
             --wheel "$(ls target/wheels-pr/*.whl)" \
             --baseline-wheel "$(ls target/wheels-main/*.whl)" \
             --markdown-output primer-comment.md

--- a/crates/karva/tests/it/extensions/fixtures/builtins.rs
+++ b/crates/karva/tests/it/extensions/fixtures/builtins.rs
@@ -1849,6 +1849,44 @@ def test_capsysbinary_stderr(capsysbinary):
 }
 
 #[test]
+fn test_capsysbinary_accepts_bytes_writes() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import sys
+
+def test_write_bytes_to_stdout(capsysbinary):
+    sys.stdout.write(b'raw bytes')
+    captured = capsysbinary.readouterr()
+    assert captured.out == b'raw bytes'
+    assert captured.err == b''
+
+def test_write_bytes_to_stderr(capsysbinary):
+    sys.stderr.write(b'error bytes')
+    captured = capsysbinary.readouterr()
+    assert captured.out == b''
+    assert captured.err == b'error bytes'
+
+def test_mixed_str_and_bytes_writes(capsysbinary):
+    sys.stdout.write('hello ')
+    sys.stdout.write(b'world')
+    captured = capsysbinary.readouterr()
+    assert captured.out == b'hello world'
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("-q"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 3 tests run: 3 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_capfdbinary_captures_output() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva_test_semantic/src/extensions/fixtures/builtins/capsys.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/builtins/capsys.rs
@@ -1,3 +1,4 @@
+use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 
@@ -154,18 +155,63 @@ impl CapsysFixture {
     }
 }
 
+/// A write buffer that accepts both `str` and `bytes` writes, storing everything as raw bytes.
+///
+/// Used by [`CapsysBinaryFixture`] as the replacement for `sys.stdout`/`sys.stderr` so that
+/// code writing bytes directly (e.g. `sys.stdout.write(b"..."`) does not fail with a
+/// `StringIO`-style "string argument expected" error.
+#[pyclass]
+struct BinaryCaptureStream {
+    data: Vec<u8>,
+}
+
+#[pymethods]
+impl BinaryCaptureStream {
+    /// Write `str` or `bytes` to the buffer, returning the number of bytes written.
+    fn write(&mut self, obj: &Bound<'_, PyAny>) -> PyResult<usize> {
+        if let Ok(s) = obj.extract::<&str>() {
+            let bytes = s.as_bytes();
+            let len = bytes.len();
+            self.data.extend_from_slice(bytes);
+            Ok(len)
+        } else if let Ok(b) = obj.extract::<&[u8]>() {
+            let len = b.len();
+            self.data.extend_from_slice(b);
+            Ok(len)
+        } else {
+            Err(PyTypeError::new_err(
+                "write() argument must be str or bytes-like object",
+            ))
+        }
+    }
+
+    #[expect(clippy::unused_self)]
+    fn flush(&self) {}
+
+    fn getvalue<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
+        PyBytes::new(py, &self.data)
+    }
+
+    #[getter]
+    #[expect(clippy::unused_self)]
+    fn encoding(&self) -> &'static str {
+        "utf-8"
+    }
+}
+
 /// Like [`CapsysFixture`] but `readouterr()` returns `(bytes, bytes)` instead of `(str, str)`.
 ///
-/// The captured strings are UTF-8 encoded before being returned.
+/// Installs a [`BinaryCaptureStream`] (rather than `io.StringIO`) so that code writing raw bytes
+/// to `sys.stdout`/`sys.stderr` does not fail.
 #[pyclass]
 pub struct CapsysBinaryFixture {
     /// The real `sys.stdout` saved at fixture creation time.
     real_stdout: Py<PyAny>,
     /// The real `sys.stderr` saved at fixture creation time.
     real_stderr: Py<PyAny>,
-    /// The `io.StringIO` buffer currently installed as `sys.stdout`.
+    /// The [`BinaryCaptureStream`] currently installed as `sys.stdout`.
     capture_stdout: Py<PyAny>,
-    /// The `io.StringIO` buffer currently installed as `sys.stderr`.
+    /// The [`BinaryCaptureStream`] currently installed as `sys.stderr`.
     capture_stderr: Py<PyAny>,
     /// The `CaptureResult` namedtuple class, created once and reused across `readouterr()` calls.
     capture_result_class: Py<PyAny>,
@@ -174,13 +220,12 @@ pub struct CapsysBinaryFixture {
 impl CapsysBinaryFixture {
     fn new(py: Python<'_>) -> PyResult<Self> {
         let sys = py.import("sys")?;
-        let io = py.import("io")?;
 
         let real_stdout = sys.getattr("stdout")?.unbind();
         let real_stderr = sys.getattr("stderr")?.unbind();
 
-        let capture_stdout = io.call_method0("StringIO")?.unbind();
-        let capture_stderr = io.call_method0("StringIO")?.unbind();
+        let capture_stdout = Self::fresh_binary_stream(py)?;
+        let capture_stderr = Self::fresh_binary_stream(py)?;
 
         sys.setattr("stdout", &capture_stdout)?;
         sys.setattr("stderr", &capture_stderr)?;
@@ -199,8 +244,8 @@ impl CapsysBinaryFixture {
         })
     }
 
-    fn fresh_stringio(py: Python<'_>) -> PyResult<Py<PyAny>> {
-        Ok(py.import("io")?.call_method0("StringIO")?.unbind())
+    fn fresh_binary_stream(py: Python<'_>) -> PyResult<Py<PyAny>> {
+        Ok(Py::new(py, BinaryCaptureStream { data: Vec::new() })?.into_any())
     }
 }
 
@@ -215,20 +260,19 @@ impl CapsysBinaryFixture {
     /// Return a `CaptureResult(out, err)` namedtuple with captured output as `bytes` and reset
     /// the buffers.
     fn readouterr(&mut self, py: Python<'_>) -> PyResult<Py<PyAny>> {
-        let out = self
+        let out_bytes = self
             .capture_stdout
             .bind(py)
             .call_method0("getvalue")?
-            .extract::<String>()?;
-        let err = self
+            .unbind();
+        let err_bytes = self
             .capture_stderr
             .bind(py)
             .call_method0("getvalue")?
-            .extract::<String>()?;
+            .unbind();
 
-        // Reset both buffers to fresh StringIO instances.
-        let new_stdout = Self::fresh_stringio(py)?;
-        let new_stderr = Self::fresh_stringio(py)?;
+        let new_stdout = Self::fresh_binary_stream(py)?;
+        let new_stderr = Self::fresh_binary_stream(py)?;
 
         let sys = py.import("sys")?;
         sys.setattr("stdout", &new_stdout)?;
@@ -236,9 +280,6 @@ impl CapsysBinaryFixture {
 
         self.capture_stdout = new_stdout;
         self.capture_stderr = new_stderr;
-
-        let out_bytes = PyBytes::new(py, out.as_bytes()).unbind();
-        let err_bytes = PyBytes::new(py, err.as_bytes()).unbind();
 
         Ok(self
             .capture_result_class

--- a/scripts/primer.py
+++ b/scripts/primer.py
@@ -44,7 +44,7 @@ ROOT = Path(__file__).parent.parent
 PRIMER_DIR = ROOT / "target" / "primer_projects"
 
 # Per-project karva run timeout in seconds.
-KARVA_TIMEOUT = 120
+KARVA_TIMEOUT = 240
 
 # Number of times karva retries a failed test to reduce flakiness noise.
 KARVA_RETRY = 10

--- a/scripts/primer.py
+++ b/scripts/primer.py
@@ -273,6 +273,7 @@ PROJECTS: list[Project] = [
         repo="https://github.com/tqdm/tqdm",
         commit="75bdb6c379bcfc6c592b6342dc791a092b5d6ae0",
         test_paths=["tests/"],
+        extra_deps=["numpy", "pandas"],
         pip_only=True,
     ),
     Project(


### PR DESCRIPTION
## Summary

The `capsysbinary` fixture was installing `io.StringIO` as `sys.stdout` and `sys.stderr`
during capture. This caused a `TypeError: string argument expected, got 'bytes'` whenever
test code wrote bytes directly to `sys.stdout` — for example, tqdm's `test_main` iterates
over binary stdin and writes each chunk with `sys.stdout.write(i)` where `i` is `bytes`.

The fix introduces `BinaryCaptureStream`, a small PyO3-backed write buffer that accepts
both `str` and `bytes`, encoding strings as UTF-8 and appending raw bytes as-is:

```rust
fn write(&mut self, obj: &Bound<'_, PyAny>) -> PyResult<usize> {
    if let Ok(s) = obj.extract::<&str>() {
        self.data.extend_from_slice(s.as_bytes());
        Ok(s.as_bytes().len())
    } else if let Ok(b) = obj.extract::<&[u8]>() {
        self.data.extend_from_slice(b);
        Ok(b.len())
    } else {
        Err(PyTypeError::new_err("write() argument must be str or bytes-like object"))
    }
}
```

`CapsysBinaryFixture` now installs `BinaryCaptureStream` instead of `StringIO`, and
`readouterr()` calls `getvalue()` directly to return the accumulated bytes without an
intermediate string-encode step.

## Test plan

- Existing tests `test_capsysbinary_captures_output` and `test_capfdbinary_captures_output`
  continue to pass (str writes still work correctly).
- New test `test_capsysbinary_accepts_bytes_writes` covers three cases: bytes-only stdout
  write, bytes-only stderr write, and mixed str + bytes writes to the same stream.