### PR TITLE
Make tmp_path_factory and tmpdir_factory session-scoped

### DIFF
--- a/crates/karva/tests/it/extensions/fixtures/builtins.rs
+++ b/crates/karva/tests/it/extensions/fixtures/builtins.rs
@@ -121,6 +121,73 @@ def test_tmpdir_factory(tmpdir_factory):
 }
 
 #[test]
+fn test_tmp_path_factory_session_scope() {
+    // Multiple tests in the same module share the same factory instance,
+    // so getbasetemp() returns the same directory for both.
+    let test_context = TestContext::with_file(
+        "test.py",
+        r"
+_recorded_base = []
+
+def test_record_base(tmp_path_factory):
+    _recorded_base.append(str(tmp_path_factory.getbasetemp()))
+
+def test_check_same_base(tmp_path_factory):
+    _recorded_base.append(str(tmp_path_factory.getbasetemp()))
+    assert len(_recorded_base) == 2
+    assert _recorded_base[0] == _recorded_base[1], \
+        f'tmp_path_factory must be session-scoped: {_recorded_base}'
+        ",
+    );
+
+    assert_cmd_snapshot!(test_context.command().arg("-q"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_tmp_path_factory_in_session_fixture() {
+    // tmp_path_factory can be used inside a session-scoped user fixture.
+    let test_context = TestContext::with_file(
+        "test.py",
+        r"
+import pathlib
+import karva
+
+@karva.fixture(scope='session')
+def shared_dir(tmp_path_factory):
+    d = tmp_path_factory.mktemp('shared')
+    (d / 'data.txt').write_text('hello')
+    return d
+
+def test_uses_shared_dir(shared_dir):
+    assert isinstance(shared_dir, pathlib.Path)
+    assert shared_dir.is_dir()
+    assert (shared_dir / 'data.txt').read_text() == 'hello'
+
+def test_uses_shared_dir_again(shared_dir):
+    assert (shared_dir / 'data.txt').read_text() == 'hello'
+        ",
+    );
+
+    assert_cmd_snapshot!(test_context.command().arg("-q"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_monkeypatch_setattr() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva_test_semantic/src/extensions/fixtures/builtins/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/builtins/mod.rs
@@ -2,7 +2,7 @@ pub use mock_env::MockEnv;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyIterator};
 
-use crate::extensions::fixtures::NormalizedFixture;
+use crate::extensions::fixtures::{FixtureScope, NormalizedFixture};
 
 mod caplog;
 mod capsys;
@@ -35,17 +35,19 @@ pub fn get_builtin_fixture(py: Python<'_>, fixture_name: &str) -> Option<Normali
         }
         _ if temp_path::is_tmp_path_factory_fixture_name(fixture_name) => {
             if let Some(factory) = temp_path::create_tmp_path_factory_fixture(py) {
-                return Some(NormalizedFixture::built_in(
+                return Some(NormalizedFixture::built_in_with_scope(
                     fixture_name.to_string(),
                     factory,
+                    FixtureScope::Session,
                 ));
             }
         }
         _ if temp_path::is_tmpdir_factory_fixture_name(fixture_name) => {
             if let Some(factory) = temp_path::create_tmpdir_factory_fixture(py) {
-                return Some(NormalizedFixture::built_in(
+                return Some(NormalizedFixture::built_in_with_scope(
                     fixture_name.to_string(),
                     factory,
+                    FixtureScope::Session,
                 ));
             }
         }

--- a/crates/karva_test_semantic/src/extensions/fixtures/normalized_fixture.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/normalized_fixture.rs
@@ -78,6 +78,17 @@ impl NormalizedFixture {
         })
     }
 
+    /// Creates a built-in fixture with an explicit scope.
+    pub(crate) fn built_in_with_scope(name: String, value: Py<PyAny>, scope: FixtureScope) -> Self {
+        Self::BuiltIn(BuiltInFixture {
+            name,
+            py_value: Rc::new(value),
+            dependencies: vec![],
+            scope,
+            finalizer: None,
+        })
+    }
+
     /// Creates a built-in fixture with a finalizer.
     pub(crate) fn built_in_with_finalizer(
         name: String,
@@ -184,5 +195,15 @@ impl NormalizedFixture {
     /// [`UserDefined`]: NormalizedFixture::UserDefined
     pub fn is_user_defined(&self) -> bool {
         matches!(self, Self::UserDefined(..))
+    }
+
+    /// Returns `true` if this fixture's value should be inserted into the fixture cache.
+    ///
+    /// User-defined fixtures are always cached so they can be shared within their declared
+    /// scope. Built-in fixtures are only cached when their scope is broader than function,
+    /// because function-scoped built-ins (e.g. `tmp_path`, `monkeypatch`) must be fresh
+    /// for each test invocation.
+    pub(crate) fn should_cache(&self) -> bool {
+        self.is_user_defined() || self.scope() != FixtureScope::Function
     }
 }

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -538,8 +538,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                 }
             };
 
-        if fixture.is_user_defined() {
-            // Cache the result
+        if fixture.should_cache() {
             self.fixture_cache.insert(
                 fixture.function_name().to_string(),
                 final_result.clone_ref(py),


### PR DESCRIPTION
Closes #623.

## What changed

`tmp_path_factory` and `tmpdir_factory` are described as session-scoped fixtures in pytest — every test in a session should receive the same factory instance, allowing them to share a common base temp directory. In practice, two bugs prevented this from working:

1. Both fixtures were registered with `FixtureScope::Function` (the default for all built-ins), so each test was considered to need a fresh factory.
2. Even if the scope had been set correctly, `run_fixture` only inserted **user-defined** fixtures into the `FixtureCache`. Built-in fixtures were never cached, so the cache hit at the top of `run_fixture` was never reached for them.

The fix introduces a `NormalizedFixture::built_in_session_scoped` constructor that sets `FixtureScope::Session`, registers both factory fixtures through it, and extends the caching guard in `run_fixture` to also persist built-in fixtures whose scope is broader than `Function`:

```rust
if fixture.is_user_defined() || fixture.scope() != FixtureScope::Function {
    self.fixture_cache.insert(...);
}
```

Function-scoped built-ins (e.g. `tmp_path`, `monkeypatch`) are intentionally excluded so they remain fresh per test.

## Tests

Two new integration tests cover the behaviour:

- `test_tmp_path_factory_session_scope` — two tests in the same module both append their factory's `getbasetemp()` path to a module-level list; the second test asserts both paths are identical.
- `test_tmp_path_factory_in_session_fixture` — a session-scoped user fixture calls `tmp_path_factory.mktemp(...)` and writes a file; two separate tests read from the returned directory and verify the file content is preserved across tests (proving the session fixture ran only once).