### PR TITLE
Add handler attribute to caplog fixture

### DIFF
--- a/crates/karva/tests/it/extensions/fixtures/builtins.rs
+++ b/crates/karva/tests/it/extensions/fixtures/builtins.rs
@@ -1435,6 +1435,32 @@ def test_caplog_record_tuples(caplog):
 }
 
 #[test]
+fn test_caplog_handler() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import logging
+
+def test_caplog_handler(caplog):
+    with caplog.at_level(logging.INFO):
+        logging.info('hello')
+        assert isinstance(caplog.handler, logging.Handler)
+        assert caplog.handler.level == logging.INFO
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command().arg("-q"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_capsys_readouterr_resets_buffer() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva_test_semantic/src/extensions/fixtures/builtins/caplog.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/builtins/caplog.rs
@@ -100,6 +100,11 @@ impl CapLog {
     }
 
     #[getter]
+    fn handler<'py>(&self, py: Python<'py>) -> Bound<'py, PyAny> {
+        self.handler.bind(py).clone()
+    }
+
+    #[getter]
     fn record_tuples<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
         let records = self.records.bind(py);
         let tuples: Vec<_> = records


### PR DESCRIPTION
## Summary

The `caplog` fixture was missing the `handler` attribute, which pytest exposes as the underlying `LogCaptureHandler` instance. Some test suites access `caplog.handler` directly to inspect or manipulate the log handler (for example, to check the active capture level or use handler-specific APIs).

This change adds a `#[getter]` for the `handler` field on `CapLog`, returning the Python `_CapLogHandler` object. Since the handler is a `logging.Handler` subclass, callers can use all standard handler attributes and methods on it.

```python
def test_caplog_handler(caplog):
    with caplog.at_level(logging.INFO):
        logging.info('hello')
        assert isinstance(caplog.handler, logging.Handler)
        assert caplog.handler.level == logging.INFO
```

Closes #628.

## Test Plan

Added `test_caplog_handler` to the builtin fixtures integration tests, verifying that `caplog.handler` is a `logging.Handler` instance and reflects the active capture level set by `at_level()`.