### PR TITLE
Have capsys/capfd save and restore logging.disable level

### DIFF
--- a/crates/karva/tests/it/extensions/fixtures/builtins.rs
+++ b/crates/karva/tests/it/extensions/fixtures/builtins.rs
@@ -1974,3 +1974,59 @@ def test_capsys_logging_warning(capsys):
     ----- stderr -----
     ");
 }
+
+/// `capsys` must re-enable logging for the duration of the test even when an earlier call to
+/// `logging.disable()` has suppressed all log levels globally. Without the fix, `readouterr()`
+/// would return empty strings and the assertion would fail.
+#[test]
+fn test_capsys_restores_logging_disable() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import logging
+
+logging.disable(logging.CRITICAL)
+
+def test_capsys_with_disabled_logging(capsys):
+    logging.warning('should be captured')
+    captured = capsys.readouterr()
+    assert 'should be captured' in captured.err, f'Expected log in stderr, got: {captured.err!r}'
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command().arg("-q"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+/// `capfd` shares the same implementation as `capsys` and must also capture logging output.
+#[test]
+fn test_capfd_captures_logging_warning() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import logging
+
+def test_capfd_logging_warning(capfd):
+    logging.warning('capfd regression check')
+    captured = capfd.readouterr()
+    assert 'capfd regression check' in captured.err, f'Expected log output in stderr, got: {captured.err!r}'
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command().arg("-q"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}

--- a/crates/karva_test_semantic/src/extensions/fixtures/builtins/capsys.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/builtins/capsys.rs
@@ -60,6 +60,8 @@ pub struct CapsysFixture {
     /// The `CaptureResult` namedtuple class, created once and reused across `readouterr()` calls
     /// so that consecutive instances satisfy `isinstance` checks against each other.
     capture_result_class: Py<PyAny>,
+    /// The `logging.disable` level saved at construction time, restored at teardown.
+    saved_disable_level: Option<i32>,
 }
 
 impl CapsysFixture {
@@ -81,12 +83,23 @@ impl CapsysFixture {
             .call_method1("namedtuple", ("CaptureResult", ["out", "err"]))?
             .unbind();
 
+        let logging = py.import("logging")?;
+        let saved_disable_level = logging
+            .getattr("root")?
+            .getattr("manager")?
+            .getattr("disable")
+            .and_then(|v| v.extract::<i32>())
+            .ok();
+        let notset = logging.getattr("NOTSET")?;
+        logging.call_method1("disable", (notset,))?;
+
         Ok(Self {
             real_stdout,
             real_stderr,
             capture_stdout,
             capture_stderr,
             capture_result_class,
+            saved_disable_level,
         })
     }
 
@@ -150,6 +163,11 @@ impl CapsysFixture {
         let sys = py.import("sys")?;
         sys.setattr("stdout", &self.real_stdout)?;
         sys.setattr("stderr", &self.real_stderr)?;
+
+        let logging = py.import("logging")?;
+        let restore_level = self.saved_disable_level.unwrap_or(0);
+        logging.call_method1("disable", (restore_level,))?;
+
         Ok(())
     }
 }
@@ -169,6 +187,8 @@ pub struct CapsysBinaryFixture {
     capture_stderr: Py<PyAny>,
     /// The `CaptureResult` namedtuple class, created once and reused across `readouterr()` calls.
     capture_result_class: Py<PyAny>,
+    /// The `logging.disable` level saved at construction time, restored at teardown.
+    saved_disable_level: Option<i32>,
 }
 
 impl CapsysBinaryFixture {
@@ -190,12 +210,23 @@ impl CapsysBinaryFixture {
             .call_method1("namedtuple", ("CaptureResult", ["out", "err"]))?
             .unbind();
 
+        let logging = py.import("logging")?;
+        let saved_disable_level = logging
+            .getattr("root")?
+            .getattr("manager")?
+            .getattr("disable")
+            .and_then(|v| v.extract::<i32>())
+            .ok();
+        let notset = logging.getattr("NOTSET")?;
+        logging.call_method1("disable", (notset,))?;
+
         Ok(Self {
             real_stdout,
             real_stderr,
             capture_stdout,
             capture_stderr,
             capture_result_class,
+            saved_disable_level,
         })
     }
 
@@ -262,6 +293,11 @@ impl CapsysBinaryFixture {
         let sys = py.import("sys")?;
         sys.setattr("stdout", &self.real_stdout)?;
         sys.setattr("stderr", &self.real_stderr)?;
+
+        let logging = py.import("logging")?;
+        let restore_level = self.saved_disable_level.unwrap_or(0);
+        logging.call_method1("disable", (restore_level,))?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Closes #634.

The root cause of the bug (a `logging.disable(CRITICAL)` call in
`redirect_python_output`) was already removed in #636, but the `capsys`
and `capfd` fixtures were still not robust against externally-disabled
logging. If a test file or conftest calls `logging.disable()` at module
level, any capsys-based assertion on log output would silently see an
empty string.

This change mirrors what the `caplog` fixture already does: on
construction, `CapsysFixture` and `CapsysBinaryFixture` now save the
current value of `logging.root.manager.disable` and call
`logging.disable(NOTSET)` so that log records are delivered during the
test. The saved level is restored in `_restore()` (the fixture
finalizer), leaving the global logging state unchanged for subsequent
tests.

```python
import logging

logging.disable(logging.CRITICAL)   # e.g. set at module level

def test_capsys_with_disabled_logging(capsys):
    logging.warning("should be captured")
    captured = capsys.readouterr()
    assert "should be captured" in captured.err  # now passes
```

Two new integration tests cover this:
- `test_capsys_restores_logging_disable` — verifies that capsys
  re-enables logging even when it was globally suppressed before the
  test.
- `test_capfd_captures_logging_warning` — exercises the capfd variant
  (which shares the capsys implementation) with a logging assertion.

## Test plan

- [ ] `just test` passes (779/779)
- [ ] `test_capsys_restores_logging_disable` passes
- [ ] `test_capfd_captures_logging_warning` passes
- [ ] `test_capsys_captures_logging_warning` (existing regression test) still passes