### PR TITLE
Add regression test for monkeypatch.setattr(module, attr, None)

### DIFF
--- a/crates/karva/tests/it/extensions/fixtures/builtins.rs
+++ b/crates/karva/tests/it/extensions/fixtures/builtins.rs
@@ -1210,6 +1210,40 @@ def test_setattr_none_as_new_value(monkeypatch):
     ");
 }
 
+/// Regression test for issue #620: `setattr(module, attr, None)` must not fail.
+/// The reproduce case from the issue uses a real module and sets a dunder attribute to `None`,
+/// which is the exact pattern that failed (e.g. `monkeypatch.setattr(i18n, "__spec__", None)`
+/// in humanize and `monkeypatch.setattr(..., "__file__", None)` in structlog).
+#[test]
+fn test_monkeypatch_setattr_module_attr_none() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import sys
+
+def test_setattr_module_spec_none(monkeypatch):
+    original = sys.__spec__
+    monkeypatch.setattr(sys, '__spec__', None)
+    assert sys.__spec__ is None
+    monkeypatch.undo()
+    assert sys.__spec__ is original
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_setattr_module_spec_none(monkeypatch=<MockEnv object>)
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
 #[test]
 fn test_caplog_records() {
     let context = TestContext::with_file(


### PR DESCRIPTION
## Summary

Closes #620.

The root bug — PyO3 mapping an explicit `None` value and "argument not provided" to the same Rust `None` for `Option<Py<PyAny>>` — was already fixed in #626 by switching `setattr` to `*args`-based dispatch. That change correctly counts positional arguments (2 = dotted import form, 3 = direct object form), so `None` as an explicit new value is now accepted.

However, the tests added in #626 only covered setting `None` on class attributes. The original issue specifically describes failures on module attributes (`monkeypatch.setattr(i18n, "__spec__", None)` in humanize, `monkeypatch.setattr(..., "__file__", None)` in structlog). This PR adds a direct regression test using `sys.__spec__` that matches the exact reproduce case from the issue, ensuring the fix holds for module attributes and documents the intent clearly.

## Test Plan

`test_monkeypatch_setattr_module_attr_none` uses `sys` as the target module and patches `__spec__` to `None`, asserting both the patch and the undo both work correctly.

Full suite: 778/778 pass.