### PR TITLE
Add regression tests for autouse fixtures from subdirectory conftests

### DIFF
--- a/crates/karva/tests/it/extensions/fixtures/autouse.rs
+++ b/crates/karva/tests/it/extensions/fixtures/autouse.rs
@@ -365,56 +365,6 @@ def test_second():
     "#);
 }
 
-/// Autouse fixtures defined in a conftest.py that is in the same directory as the tests
-/// must be applied when there are multiple conftest.py files at different directory levels.
-/// This mirrors the cibuildwheel scenario where a monkeypatch-dependent autouse fixture
-/// in a subdirectory conftest was not being applied.
-#[rstest]
-fn test_auto_use_fixture_in_subdirectory_conftest_with_parent_conftest(
-    #[values("pytest", "karva")] framework: &str,
-) {
-    let sub_conftest = format!(
-        r#"
-import os
-import {framework}
-
-@{framework}.fixture({auto_use_kw}=True)
-def auto_fixture(monkeypatch):
-    monkeypatch.setenv("TEST_WAS_SET", "1")
-"#,
-        auto_use_kw = get_auto_use_kw(framework)
-    );
-    let parent_conftest = format!("import {framework}");
-    let context = TestContext::with_files([
-        ("unit_test/conftest.py", parent_conftest.as_str()),
-        ("unit_test/main_tests/conftest.py", sub_conftest.as_str()),
-        (
-            "unit_test/main_tests/test_something.py",
-            "
-import os
-
-def test_fixture_ran():
-    assert os.environ.get('TEST_WAS_SET') == '1'
-",
-        ),
-    ]);
-
-    allow_duplicates! {
-        assert_cmd_snapshot!(context.command_no_parallel(), @"
-        success: true
-        exit_code: 0
-        ----- stdout -----
-            Starting 1 test across 1 worker
-                PASS [TIME] unit_test.main_tests.test_something::test_fixture_ran
-
-        ────────────
-             Summary [TIME] 1 test run: 1 passed, 0 skipped
-
-        ----- stderr -----
-        ");
-    }
-}
-
 /// Mirrors the cibuildwheel scenario exactly: multiple autouse fixtures in a subdirectory
 /// conftest, where one depends on a non-autouse fixture from the parent conftest.
 ///

--- a/crates/karva/tests/it/extensions/fixtures/autouse.rs
+++ b/crates/karva/tests/it/extensions/fixtures/autouse.rs
@@ -365,6 +365,120 @@ def test_second():
     "#);
 }
 
+/// Autouse fixtures defined in a conftest.py that is in the same directory as the tests
+/// must be applied when there are multiple conftest.py files at different directory levels.
+/// This mirrors the cibuildwheel scenario where a monkeypatch-dependent autouse fixture
+/// in a subdirectory conftest was not being applied.
+#[rstest]
+fn test_auto_use_fixture_in_subdirectory_conftest_with_parent_conftest(
+    #[values("pytest", "karva")] framework: &str,
+) {
+    let sub_conftest = format!(
+        r#"
+import os
+import {framework}
+
+@{framework}.fixture({auto_use_kw}=True)
+def auto_fixture(monkeypatch):
+    monkeypatch.setenv("TEST_WAS_SET", "1")
+"#,
+        auto_use_kw = get_auto_use_kw(framework)
+    );
+    let parent_conftest = format!("import {framework}");
+    let context = TestContext::with_files([
+        ("unit_test/conftest.py", parent_conftest.as_str()),
+        ("unit_test/main_tests/conftest.py", sub_conftest.as_str()),
+        (
+            "unit_test/main_tests/test_something.py",
+            "
+import os
+
+def test_fixture_ran():
+    assert os.environ.get('TEST_WAS_SET') == '1'
+",
+        ),
+    ]);
+
+    allow_duplicates! {
+        assert_cmd_snapshot!(context.command_no_parallel(), @"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+            Starting 1 test across 1 worker
+                PASS [TIME] unit_test.main_tests.test_something::test_fixture_ran
+
+        ────────────
+             Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+        ----- stderr -----
+        ");
+    }
+}
+
+/// Mirrors the cibuildwheel scenario exactly: multiple autouse fixtures in a subdirectory
+/// conftest, where one depends on a non-autouse fixture from the parent conftest.
+///
+/// Before the fix for #633/#635, only the first autouse fixture from each conftest
+/// was applied (due to a spurious `break`). The second autouse (`set_second`) would
+/// never run, and `fake_pkg` (which depends on a parent fixture) would also be missed.
+#[rstest]
+fn test_multiple_autouse_fixtures_in_subdirectory_conftest(
+    #[values("pytest", "karva")] framework: &str,
+) {
+    let parent_conftest = format!(
+        r#"
+import {framework}
+
+@{framework}.fixture
+def parent_value():
+    return "from_parent"
+"#
+    );
+    let sub_conftest = format!(
+        r#"
+import {framework}
+
+@{framework}.fixture({auto_use_kw}=True)
+def first_autouse(monkeypatch):
+    monkeypatch.setenv("FIRST_SET", "yes")
+
+@{framework}.fixture({auto_use_kw}=True)
+def second_autouse(monkeypatch, parent_value):
+    monkeypatch.setenv("SECOND_SET", parent_value)
+"#,
+        auto_use_kw = get_auto_use_kw(framework)
+    );
+    let context = TestContext::with_files([
+        ("unit_test/conftest.py", parent_conftest.as_str()),
+        ("unit_test/main_tests/conftest.py", sub_conftest.as_str()),
+        (
+            "unit_test/main_tests/test_something.py",
+            "
+import os
+
+def test_both_autouse_ran():
+    assert os.environ.get('FIRST_SET') == 'yes', os.environ.get('FIRST_SET')
+    assert os.environ.get('SECOND_SET') == 'from_parent', os.environ.get('SECOND_SET')
+",
+        ),
+    ]);
+
+    allow_duplicates! {
+        assert_cmd_snapshot!(context.command_no_parallel(), @"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+            Starting 1 test across 1 worker
+                PASS [TIME] unit_test.main_tests.test_something::test_both_autouse_ran
+
+        ────────────
+             Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+        ----- stderr -----
+        ");
+    }
+}
+
 /// All autouse fixtures in a module must be applied, not just the first one.
 #[rstest]
 fn test_multiple_auto_use_fixtures(#[values("pytest", "karva")] framework: &str) {


### PR DESCRIPTION
## Summary

Issue karva-dev/karva#633 reported that autouse fixtures defined in a subdirectory `conftest.py` were silently skipped. The specific case was cibuildwheel's `unit_test/main_tests/conftest.py`, which defines `mock_protection` and `fake_package_dir_autouse` as autouse fixtures. Karva ran only `mock_protection` (the first), while `fake_package_dir_autouse` (the second) was never applied, leaving `sys.argv` unpatched and causing argparse failures.

The root cause was a spurious `break` in `get_auto_use_fixtures` that was removed by karva-dev/karva#635. That fix correctly allowed all autouse fixtures per conftest to be collected, but the regression tests added in #635 only covered multiple autouse fixtures in the same test file — not in a subdirectory conftest.

This PR adds two integration tests that close karva-dev/karva#633 with proper regression coverage:

`test_auto_use_fixture_in_subdirectory_conftest_with_parent_conftest` exercises a single autouse fixture that uses `monkeypatch` in a subdirectory conftest, with a parent conftest present at an ancestor level.

`test_multiple_autouse_fixtures_in_subdirectory_conftest` mirrors the exact cibuildwheel scenario: two autouse fixtures in a subdirectory conftest, where the second depends on a non-autouse fixture from the parent conftest. Before karva-dev/karva#635, the `break` would drop the second fixture; this test would have failed.

Both tests run against `pytest` and `karva` fixture APIs using `#[rstest]`.

## Test Plan

- `cargo nextest run -p karva --test it "extensions::fixtures::autouse"` — all 21 autouse tests pass.
- `uvx prek run -a` — all pre-commit checks pass.

Closes karva-dev/karva#633