### PR TITLE
Remove unused public exports

### DIFF
--- a/crates/karva_benchmark/src/real_world_projects.rs
+++ b/crates/karva_benchmark/src/real_world_projects.rs
@@ -366,7 +366,3 @@ pub static KARVA_BENCHMARK_PROJECT: RealWorldProject<'static> = RealWorldProject
     try_import_fixtures: false,
     retry: None,
 };
-
-pub fn all_projects() -> Vec<&'static RealWorldProject<'static>> {
-    vec![&KARVA_BENCHMARK_PROJECT]
-}

--- a/crates/karva_project/src/path/mod.rs
+++ b/crates/karva_project/src/path/mod.rs
@@ -1,4 +1,4 @@
-pub mod test_path;
+mod test_path;
 mod utils;
 
 pub use test_path::{TestPath, TestPathError, TestPathFunction};

--- a/crates/karva_test_semantic/src/extensions/tags/python.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/python.rs
@@ -131,7 +131,7 @@ pub mod tags {
     }
 
     #[pyfunction]
-    pub fn parametrize(
+    fn parametrize(
         arg_names: &Bound<'_, PyAny>,
         arg_values: &Bound<'_, PyAny>,
     ) -> PyResult<PyTags> {
@@ -154,7 +154,7 @@ pub mod tags {
 
     #[pyfunction]
     #[pyo3(signature = (*fixture_names))]
-    pub fn use_fixtures(fixture_names: &Bound<'_, PyTuple>) -> PyResult<PyTags> {
+    fn use_fixtures(fixture_names: &Bound<'_, PyTuple>) -> PyResult<PyTags> {
         let mut names = Vec::new();
         for item in fixture_names.iter() {
             if let Ok(name) = item.extract::<String>() {
@@ -220,7 +220,7 @@ pub mod tags {
 
     #[pyfunction]
     #[pyo3(signature = (*conditions, reason = None))]
-    pub fn skip(
+    fn skip(
         py: Python<'_>,
         conditions: &Bound<'_, PyTuple>,
         reason: Option<String>,
@@ -233,7 +233,7 @@ pub mod tags {
 
     #[pyfunction]
     #[pyo3(signature = (*conditions, reason = None))]
-    pub fn expect_fail(
+    fn expect_fail(
         py: Python<'_>,
         conditions: &Bound<'_, PyTuple>,
         reason: Option<String>,


### PR DESCRIPTION
## Summary

With https://github.com/MatthewMckee4/cargo-unused we have identifies some unused pub exports, so we decrease visibility or remove the symbol.

## Test Plan

ci
