### PR TITLE
Add --skip flag to exclude tests by name pattern

### DIFF
--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -75,6 +75,7 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
 
     TagFilterSet::new(&sub_command.tag_expressions)?;
     NameFilterSet::new(&sub_command.name_patterns)?;
+    NameFilterSet::new(&sub_command.skip_patterns)?;
 
     let config = karva_runner::ParallelTestConfig {
         num_workers,

--- a/crates/karva/tests/it/main.rs
+++ b/crates/karva/tests/it/main.rs
@@ -9,5 +9,6 @@ mod durations;
 mod extensions;
 mod last_failed;
 mod name_filter;
+mod skip_filter;
 mod version;
 mod watch;

--- a/crates/karva/tests/it/skip_filter.rs
+++ b/crates/karva/tests/it/skip_filter.rs
@@ -1,0 +1,101 @@
+use insta_cmd::assert_cmd_snapshot;
+
+use crate::common::TestContext;
+
+const TWO_TESTS: &str = r"
+def test_alpha():
+    assert True
+
+def test_beta():
+    assert True
+";
+
+#[test]
+fn skip_filter_substring_match() {
+    let context = TestContext::with_file("test.py", TWO_TESTS);
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--skip").arg("alpha"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            SKIP [TIME] test::test_alpha
+            PASS [TIME] test::test_beta
+
+    ────────────
+         Summary [TIME] 2 tests run: 1 passed, 1 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn skip_filter_multiple_flags_or_semantics() {
+    let context = TestContext::with_file("test.py", TWO_TESTS);
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--skip").arg("alpha").arg("--skip").arg("beta"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            SKIP [TIME] test::test_alpha
+            SKIP [TIME] test::test_beta
+
+    ────────────
+         Summary [TIME] 2 tests run: 0 passed, 2 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn skip_filter_no_matches() {
+    let context = TestContext::with_file("test.py", TWO_TESTS);
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--skip").arg("nonexistent"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            PASS [TIME] test::test_alpha
+            PASS [TIME] test::test_beta
+
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn skip_filter_invalid_regex() {
+    let context = TestContext::with_file("test.py", TWO_TESTS);
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--skip").arg("[invalid"), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Karva failed
+      Cause: invalid regex pattern `[invalid`: regex parse error:
+        [invalid
+        ^
+    error: unclosed character class
+    ");
+}
+
+#[test]
+fn skip_filter_combined_with_match() {
+    // --match selects alpha and beta, --skip removes beta → only alpha runs
+    let context = TestContext::with_file("test.py", TWO_TESTS);
+    assert_cmd_snapshot!(context.command_no_parallel().arg("-m").arg("alpha|beta").arg("--skip").arg("beta"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            PASS [TIME] test::test_alpha
+            SKIP [TIME] test::test_beta
+
+    ────────────
+         Summary [TIME] 2 tests run: 1 passed, 1 skipped
+
+    ----- stderr -----
+    ");
+}

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -218,6 +218,16 @@ pub struct SubTestCommand {
     #[clap(short = 'm', long = "match")]
     pub name_patterns: Vec<String>,
 
+    /// Exclude tests by name using a regular expression.
+    ///
+    /// Tests whose fully qualified name matches the pattern will be skipped.
+    /// Uses partial matching (the pattern can match anywhere in the name).
+    /// When specified multiple times, a test is skipped if it matches any of the patterns.
+    ///
+    /// Examples: `--skip slow_`, `--skip '^test::test_integration'`.
+    #[clap(long = "skip")]
+    pub skip_patterns: Vec<String>,
+
     /// Update snapshots directly instead of creating pending `.snap.new` files.
     ///
     /// When set, `karva.assert_snapshot()` will write directly to `.snap` files,

--- a/crates/karva_metadata/src/filter.rs
+++ b/crates/karva_metadata/src/filter.rs
@@ -41,6 +41,10 @@ impl NameFilterSet {
         self.filters.is_empty()
     }
 
+    pub fn is_match(&self, name: &str) -> bool {
+        self.matches(name)
+    }
+
     pub fn matches(&self, name: &str) -> bool {
         self.filters.is_empty() || self.filters.iter().any(|f| f.matches(name))
     }

--- a/crates/karva_metadata/src/options.rs
+++ b/crates/karva_metadata/src/options.rs
@@ -204,6 +204,7 @@ impl TestOptions {
             retry: self.retry.unwrap_or_default(),
             tag_filter: TagFilterSet::default(),
             name_filter: NameFilterSet::default(),
+            skip_filter: NameFilterSet::default(),
         }
     }
 }

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -32,6 +32,10 @@ impl ProjectSettings {
     pub fn set_name_filter(&mut self, name_filter: NameFilterSet) {
         self.test.name_filter = name_filter;
     }
+
+    pub fn set_skip_filter(&mut self, skip_filter: NameFilterSet) {
+        self.test.skip_filter = skip_filter;
+    }
 }
 
 #[derive(Default, Debug, Clone)]
@@ -54,4 +58,5 @@ pub struct TestSettings {
     pub retry: u32,
     pub tag_filter: TagFilterSet,
     pub name_filter: NameFilterSet,
+    pub skip_filter: NameFilterSet,
 }

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -439,6 +439,11 @@ fn inner_cli_args(settings: &ProjectSettings, args: &SubTestCommand) -> Vec<Stri
         cli_args.push(pattern);
     }
 
+    for pattern in &args.skip_patterns {
+        cli_args.push("--skip");
+        cli_args.push(pattern);
+    }
+
     cli_args.iter().map(ToString::to_string).collect()
 }
 

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -194,9 +194,12 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         }
 
         let name_filter = &self.context.settings().test().name_filter;
-        if !name_filter.is_empty() {
+        let skip_filter = &self.context.settings().test().skip_filter;
+        if !name_filter.is_empty() || !skip_filter.is_empty() {
             let display_name = QualifiedTestName::new(name.clone(), None).to_string();
-            if !name_filter.matches(&display_name) {
+            if (!name_filter.is_empty() && !name_filter.matches(&display_name))
+                || (!skip_filter.is_empty() && skip_filter.matches(&display_name))
+            {
                 return Some(self.context.register_test_case_result(
                     &QualifiedTestName::new(name.clone(), None),
                     IndividualTestResultKind::Skipped { reason: None },

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -137,10 +137,12 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
     let tag_filter = TagFilterSet::new(&args.sub_command.tag_expressions)?;
 
     let name_filter = NameFilterSet::new(&args.sub_command.name_patterns)?;
+    let skip_filter = NameFilterSet::new(&args.sub_command.skip_patterns)?;
 
     let mut settings = args.sub_command.into_options().to_settings();
     settings.set_tag_filter(tag_filter);
     settings.set_name_filter(name_filter);
+    settings.set_skip_filter(skip_filter);
 
     let run_hash = RunHash::from_existing(&args.run_hash);
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -66,6 +66,9 @@ karva test [OPTIONS] [PATH]...
 <li><code>concise</code>:  Print diagnostics concisely, one per line</li>
 </ul></dd><dt id="karva-test--quiet"><a href="#karva-test--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output (or <code>-qq</code> for silent output)</p>
 </dd><dt id="karva-test--retry"><a href="#karva-test--retry"><code>--retry</code></a> <i>retry</i></dt><dd><p>When set, the test will retry failed tests up to this number of times</p>
+</dd><dt id="karva-test--skip"><a href="#karva-test--skip"><code>--skip</code></a> <i>skip-patterns</i></dt><dd><p>Exclude tests by name using a regular expression.</p>
+<p>Tests whose fully qualified name matches the pattern will be skipped. Uses partial matching (the pattern can match anywhere in the name). When specified multiple times, a test is skipped if it matches any of the patterns.</p>
+<p>Examples: <code>--skip slow_</code>, <code>--skip '^test::test_integration'</code>.</p>
 </dd><dt id="karva-test--snapshot-update"><a href="#karva-test--snapshot-update"><code>--snapshot-update</code></a></dt><dd><p>Update snapshots directly instead of creating pending <code>.snap.new</code> files.</p>
 <p>When set, <code>karva.assert_snapshot()</code> will write directly to <code>.snap</code> files, accepting any changes automatically.</p>
 </dd><dt id="karva-test--tag"><a href="#karva-test--tag"><code>--tag</code></a>, <code>-t</code> <i>tag-expressions</i></dt><dd><p>Filter tests by tag expression. Only tests with matching custom tags will run.</p>


### PR DESCRIPTION
### Closes #549.

This adds a --skip flag to karva test that excludes tests whose fully qualified name matches a regular expression the inverse of --match. Multiple patterns can be combined; a test is skipped if it matches any of them.


```
- karva test --skip slow_
- karva test --skip "test_integration_"
- karva test --skip slow_ --skip integration_   # skips either
- karva test -m auth --skip auth_legacy         # match auth, then drop legacy
```


### Implementation

The flag reuses the existing NameFilterSet type from karva_metadata — no new filter type was needed. The skip logic sits alongside the name-filter check in should_skip_variant: a test is filtered out if name_filter rejects it or skip_filter matches it, computing display_name only once when either filter is active.

Invalid regex patterns are caught upfront in the main process (before any workers spawn), consistent with the existing --match and --tag validation, so users get a clean error with exit_code: 2 immediately.

The flag is forwarded from the orchestrator to each worker via --skip <pattern> in inner_cli_args, mirroring how --match is forwarded.

### Changes

- karva_cli --skip <SKIP_PATTERNS> field on SubTestCommand
- karva_metadata — skip_filter: NameFilterSet on TestSettings with setter on ProjectSettings; default in TestOptions::to_settings
- karva/src/commands/test/mod.rs  : upfront regex validation
- karva_runner/src/orchestration.rs : forwards --skip to worker args
- karva_worker/src/cli.rs :  parses patterns and applies set_skip_filter
- karva_test_semantic  :  filter applied in should_skip_variant
- Integration tests in crates/karva/tests/it/skip_filter.rs covering: substring match, multiple patterns (OR semantics), no matches, invalid regex error, and combined with --match


### Screenshots

A] All tests running
<img width="845" height="498" alt="Screenshot from 2026-04-10 23-54-19" src="https://github.com/user-attachments/assets/dde4ac6a-15fe-4bca-a064-cbbfe771abb8" />



B] Skipping tests with `--skip` flag for `slow_`

<img width="845" height="385" alt="Screenshot from 2026-04-10 23-54-33" src="https://github.com/user-attachments/assets/a299dc37-38db-4502-b876-ef6cca2b672e" />



C] Skipping tests wiht `--skip` flag for `integration`

<img width="845" height="385" alt="Screenshot from 2026-04-10 23-55-59" src="https://github.com/user-attachments/assets/1a0f1b71-b097-4ad3-a98c-51233aaeab2a" />
