### PR TITLE
docs: document caplog, capsys, capfd, recwarn, tmp_path_factory built-in fixtures

### DIFF
--- a/docs/usage/fixtures/builtin.md
+++ b/docs/usage/fixtures/builtin.md
@@ -1,4 +1,4 @@
-Karva provides a few built-in fixtures that can be used in your tests.
+Karva provides a set of built-in fixtures that can be used in your tests without any setup. They are all compatible with their pytest counterparts, so existing pytest tests can use them unchanged.
 
 We will try to add more built-in fixtures from pytest in the future.
 
@@ -16,6 +16,30 @@ You can use any of the following fixture names:
 ```py title="test.py"
 def test_tmp_path(tmp_path):
     assert tmp_path.is_dir()
+```
+
+## Temporary Directory Factory
+
+A session-scoped factory for creating temporary directories. Use this when you need to allocate a temporary directory from a `session`, `package`, or `module`-scoped fixture — `tmp_path` itself is function-scoped and cannot be consumed by longer-lived fixtures.
+
+You can use any of the following fixture names:
+
+- `tmp_path_factory` (from pytest) — returns `pathlib.Path` objects.
+- `tmpdir_factory` (from pytest) — returns `py.path.local` objects.
+
+The factory has two methods: `mktemp(name)` creates a fresh numbered subdirectory under the session's base temp directory, and `getbasetemp()` returns that base directory.
+
+```py title="test.py"
+import karva
+
+@karva.fixture(scope="session")
+def shared_dir(tmp_path_factory):
+    d = tmp_path_factory.mktemp("shared")
+    (d / "data.txt").write_text("hello")
+    return d
+
+def test_uses_shared_dir(shared_dir):
+    assert (shared_dir / "data.txt").read_text() == "hello"
 ```
 
 ## Mock Environment
@@ -141,3 +165,164 @@ def test_get_num_threads_default(monkeypatch):
 ```
 
 See the [pytest documentation](https://docs.pytest.org/en/6.2.x/monkeypatch.html) for more information.
+
+## Capturing Log Records
+
+The `caplog` fixture captures log records emitted during a test. It is function-scoped and resets between tests, so each test sees a clean slate.
+
+Use `caplog.at_level(level)` as a context manager to enable capture at a given level for a block, or `caplog.set_level(level)` to enable capture for the remainder of the test. Captured records are exposed as `caplog.records` (a list of `logging.LogRecord`), `caplog.messages` (the formatted messages only), `caplog.record_tuples` (tuples of `(logger_name, levelno, message)`), and `caplog.text` (the full formatted text). Call `caplog.clear()` to drop any records captured so far.
+
+```py title="test.py"
+import logging
+
+
+def test_caplog_records(caplog):
+    with caplog.at_level(logging.WARNING):
+        logging.warning("something happened")
+
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelname == "WARNING"
+    assert caplog.records[0].getMessage() == "something happened"
+    assert "something happened" in caplog.text
+```
+
+```py title="test.py"
+import logging
+
+
+def test_caplog_messages(caplog):
+    caplog.set_level(logging.INFO)
+    logging.info("first")
+    logging.info("second")
+
+    assert caplog.messages == ["first", "second"]
+    assert caplog.record_tuples == [
+        ("root", logging.INFO, "first"),
+        ("root", logging.INFO, "second"),
+    ]
+```
+
+## Capturing Standard Output and Standard Error
+
+The `capsys` fixture captures writes to `sys.stdout` and `sys.stderr` at the Python level. Call `capsys.readouterr()` to retrieve everything written since the last call; the return value has `.out` and `.err` string attributes, and the buffers are reset after each read.
+
+```py title="test.py"
+def test_capsys_stdout(capsys):
+    print("hello")
+    captured = capsys.readouterr()
+    assert captured.out == "hello\n"
+    assert captured.err == ""
+```
+
+```py title="test.py"
+import sys
+
+
+def test_capsys_stderr(capsys):
+    print("error message", file=sys.stderr)
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "error message\n"
+```
+
+Log messages emitted during the test are also routed through the captured streams, so you can assert on them from `captured.err`:
+
+```py title="test.py"
+import logging
+
+
+def test_capsys_captures_logging(capsys):
+    logging.warning("something went wrong")
+    captured = capsys.readouterr()
+    assert "something went wrong" in captured.err
+```
+
+Use `capsys.disabled()` as a context manager to temporarily restore the real `sys.stdout` and `sys.stderr` inside a test — anything written while capture is disabled goes straight to the terminal instead of being captured:
+
+```py title="test.py"
+def test_capsys_disabled(capsys):
+    with capsys.disabled():
+        print("this goes to the real stdout")
+
+    print("this is captured")
+    captured = capsys.readouterr()
+    assert "this is captured" in captured.out
+```
+
+## Capturing File Descriptors
+
+The `capfd` fixture is identical in shape to `capsys`, but it captures output at the file-descriptor level (file descriptors 1 and 2). Use `capfd` when the code under test writes directly to the underlying file descriptors — for example via a C extension or a subprocess — rather than through Python's `sys.stdout`/`sys.stderr` objects.
+
+```py title="test.py"
+def test_capfd_stdout(capfd):
+    print("hello from capfd")
+    captured = capfd.readouterr()
+    assert captured.out == "hello from capfd\n"
+    assert captured.err == ""
+```
+
+```py title="test.py"
+import sys
+
+
+def test_capfd_stderr(capfd):
+    print("error output", file=sys.stderr)
+    captured = capfd.readouterr()
+    assert captured.err == "error output\n"
+```
+
+## Binary Capture
+
+`capsysbinary` and `capfdbinary` behave like `capsys` and `capfd`, but `readouterr()` returns `bytes` instead of `str`. Reach for them when you need to assert on raw bytes or when the code under test writes binary data directly to the output streams.
+
+```py title="test.py"
+def test_capsysbinary_stdout(capsysbinary):
+    print("hello bytes")
+    captured = capsysbinary.readouterr()
+    assert captured.out == b"hello bytes\n"
+    assert captured.err == b""
+```
+
+```py title="test.py"
+import sys
+
+
+def test_capfdbinary_stderr(capfdbinary):
+    print("error fd bytes", file=sys.stderr)
+    captured = capfdbinary.readouterr()
+    assert captured.err == b"error fd bytes\n"
+```
+
+## Capturing Warnings
+
+The `recwarn` fixture captures every warning raised during the test. It behaves like a list of `warnings.WarningMessage` objects — you can index into it, iterate it, and take its length.
+
+```py title="test.py"
+import warnings
+
+
+def test_recwarn_captures(recwarn):
+    warnings.warn("deprecated", DeprecationWarning)
+
+    assert len(recwarn) == 1
+    assert recwarn[0].category is DeprecationWarning
+```
+
+Use `recwarn.pop(category)` to remove and return the first warning matching a given category — it raises `AssertionError` if no matching warning was recorded. Call `recwarn.clear()` to drop everything captured so far.
+
+```py title="test.py"
+import warnings
+
+
+def test_recwarn_pop(recwarn):
+    warnings.warn("deprecated", DeprecationWarning)
+    warnings.warn("runtime issue", RuntimeWarning)
+
+    w = recwarn.pop(DeprecationWarning)
+    assert issubclass(w.category, DeprecationWarning)
+    assert "deprecated" in str(w.message)
+    assert len(recwarn) == 1
+
+    recwarn.clear()
+    assert len(recwarn) == 0
+```


### PR DESCRIPTION
## Summary

The built-in fixtures page at `docs/usage/fixtures/builtin.md` only documented `tmp_path` and `monkeypatch`, but since alpha.4 Karva has shipped several more built-in fixtures that are fully implemented and integration-tested: `caplog`, `capsys`, `capfd`, `capsysbinary`, `capfdbinary`, `recwarn`, and the session-scoped `tmp_path_factory`/`tmpdir_factory`. None of them were discoverable from the docs, so users looking for pytest-equivalents had no way to find them short of reading the source. This PR closes that gap.

The new sections follow the existing tone and structure of the page. Each fixture gets a short description of what it does, a note about which names are accepted (where there are multiple aliases), and one or two minimal runnable examples lifted directly from the integration tests in `crates/karva/tests/it/extensions/fixtures/builtins.rs` — so everything documented is behaviour the test suite already pins down.

For `caplog`, the page explains `at_level` vs `set_level` and walks through `records`, `messages`, `record_tuples`, and `text`:

```py
import logging


def test_caplog_records(caplog):
    with caplog.at_level(logging.WARNING):
        logging.warning("something happened")

    assert len(caplog.records) == 1
    assert caplog.records[0].levelname == "WARNING"
    assert "something happened" in caplog.text
```

For `capsys`, the page covers `readouterr()`, the fact that log messages are captured through stderr, and the `capsys.disabled()` context manager. `capfd` is documented as the file-descriptor-level counterpart, and `capsysbinary`/`capfdbinary` get a shorter section that points out the only difference (`.out`/`.err` are `bytes`). `recwarn` is documented as a list-like container with `pop(category)` and `clear()`.

`tmp_path_factory` is slotted in right after `tmp_path` and notes that it is session-scoped, so it can be consumed by longer-lived user fixtures — `tmp_path` itself is function-scoped and cannot.

## Test Plan

- `uvx prek run -a` passes clean (markdownlint-fix, mdformat, typos, and the rest).
- Examples are lifted verbatim from passing integration tests in `crates/karva/tests/it/extensions/fixtures/builtins.rs`, so the documented behaviour is what the test suite already asserts.