### PR TITLE
fix: don't panic when a source file disappears during diagnostic rendering

### DIFF
--- a/crates/karva_test_semantic/src/utils.rs
+++ b/crates/karva_test_semantic/src/utils.rs
@@ -8,12 +8,13 @@ use pyo3::{PyResult, Python};
 use ruff_source_file::{SourceFile, SourceFileBuilder};
 
 /// Get the source file for the given utf8 path.
+///
+/// If the file cannot be read (e.g., it was removed between discovery and diagnostic rendering),
+/// returns a `SourceFile` with an empty body so downstream span rendering degrades gracefully
+/// instead of panicking.
 pub(crate) fn source_file(path: &Utf8Path) -> SourceFile {
-    SourceFileBuilder::new(
-        path.as_str(),
-        std::fs::read_to_string(path).expect("Failed to read source file"),
-    )
-    .finish()
+    let source_text = std::fs::read_to_string(path).unwrap_or_default();
+    SourceFileBuilder::new(path.as_str(), source_text).finish()
 }
 
 /// Runs a Python coroutine to completion using `asyncio.run()`.
@@ -232,6 +233,14 @@ mod tests {
 
     mod utils_tests {
         use super::*;
+
+        #[test]
+        fn source_file_missing_path_does_not_panic() {
+            let path = Utf8Path::new("/nonexistent/path/to/file.py");
+            let file = source_file(path);
+            assert_eq!(file.name(), path.as_str());
+            assert_eq!(file.source_text(), "");
+        }
 
         #[test]
         fn test_iter_with_ancestors() {


### PR DESCRIPTION
## Summary

`utils::source_file` is called from the diagnostic rendering path whenever we
need to attribute a span back to a test file on disk. It used to read the file
with `.expect(\"Failed to read source file\")`, which races against test files
being moved or deleted between discovery and diagnostic rendering and tears down
the entire worker process:

```rust
pub(crate) fn source_file(path: &Utf8Path) -> SourceFile {
    SourceFileBuilder::new(
        path.as_str(),
        std::fs::read_to_string(path).expect(\"Failed to read source file\"),
    )
    .finish()
}
```

It now falls back to an empty-bodied `SourceFile` via `unwrap_or_default()` —
the filename is still shown in diagnostics, but spans that reference the missing
file render as empty instead of crashing the run. A unit test exercises the
non-existent-path branch so the function is guaranteed not to panic on a missing
file.

This PR originally also tried to defuse two `.expect(\"builtin fixtures to not
fail\")` panics in `package_runner::run_fixture`. Those sites were removed
entirely by #645, which rewrote built-in fixtures to run as pure Python, so
there is no longer a \"this fixture has no AST\" case at the Rust layer. The
rebase onto post-#645 main dropped those changes.

## Test Plan

- `just test` (818 tests passing)
- `uvx prek run -a`