### PR TITLE
fix: apply filter expressions in --dry-run and make -qq silent

### DIFF
--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -9,7 +9,7 @@ use karva_cache::AggregatedResults;
 use karva_cli::{OutputFormat, TestCommand};
 use karva_collector::CollectedPackage;
 use karva_logging::{Printer, Stdout, set_colored_override, setup_tracing};
-use karva_metadata::filter::FiltersetSet;
+use karva_metadata::filter::{EvalContext, FiltersetSet};
 use karva_metadata::{ProjectMetadata, ProjectOptionsOverrides};
 use karva_project::Project;
 use karva_project::path::absolute;
@@ -67,13 +67,14 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
 
     let project = Project::from_metadata(project_metadata);
 
+    let filter = FiltersetSet::new(&sub_command.filter_expressions)
+        .context("invalid `--filter` expression")?;
+
     if dry_run {
         let collected = karva_runner::collect_tests(&project)?;
-        print_collected_tests(printer, &collected)?;
+        print_collected_tests(printer, &collected, &filter)?;
         return Ok(ExitStatus::Success);
     }
-
-    FiltersetSet::new(&sub_command.filter_expressions).context("invalid `--filter` expression")?;
 
     let config = karva_runner::ParallelTestConfig {
         num_workers,
@@ -199,22 +200,42 @@ fn print_durations_section(
 }
 
 /// Recursively collect test names from a `CollectedPackage` as `(module_name, function_name)` pairs.
-fn collect_test_names(package: &CollectedPackage, tests: &mut Vec<(String, String)>) {
+///
+/// Applies `filter` against each test by qualified name. Tags are unknown at
+/// collection time (they come from Python runtime state), so filters that
+/// reference `tag(...)` will match against an empty tag set.
+fn collect_test_names(
+    package: &CollectedPackage,
+    filter: &FiltersetSet,
+    tests: &mut Vec<(String, String)>,
+) {
     for module in package.modules.values() {
         let module_name = module.path.module_name().to_string();
         for func in &module.test_function_defs {
-            tests.push((module_name.clone(), func.name.to_string()));
+            let function_name = func.name.to_string();
+            let qualified = format!("{module_name}::{function_name}");
+            let ctx = EvalContext {
+                test_name: &qualified,
+                tags: &[],
+            };
+            if filter.matches(&ctx) {
+                tests.push((module_name.clone(), function_name));
+            }
         }
     }
     for sub_package in package.packages.values() {
-        collect_test_names(sub_package, tests);
+        collect_test_names(sub_package, filter, tests);
     }
 }
 
 /// Print collected tests in dry-run mode.
-fn print_collected_tests(printer: Printer, collected: &CollectedPackage) -> Result<()> {
+fn print_collected_tests(
+    printer: Printer,
+    collected: &CollectedPackage,
+    filter: &FiltersetSet,
+) -> Result<()> {
     let mut tests = Vec::new();
-    collect_test_names(collected, &mut tests);
+    collect_test_names(collected, filter, &mut tests);
     tests.sort();
 
     let mut stdout = printer.stream_for_requested_summary().lock();

--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -1920,3 +1920,24 @@ def test_2(): pass
     ----- stderr -----
     ");
 }
+
+/// `-qq` is silent: even the summary line emitted by `-q` must be suppressed,
+/// so a failing run under `-qq` produces no stdout at all.
+#[test]
+fn qq_is_silent_not_quiet() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+def test_pass(): pass
+def test_fail(): assert False
+",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("-qq"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+}

--- a/crates/karva/tests/it/filterset.rs
+++ b/crates/karva/tests/it/filterset.rs
@@ -1073,6 +1073,28 @@ fn filterset_empty_matcher_body() {
 }
 
 #[test]
+fn dry_run_applies_filter_expression() {
+    let context = TestContext::with_file("test.py", TWO_TESTS);
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .arg("--dry-run")
+            .arg("-E")
+            .arg("test(~alpha)"),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    <test> test::test_alpha
+
+    1 tests collected
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
 fn filterset_empty_expression() {
     let context = TestContext::with_file("test.py", "def test_x(): assert True\n");
     assert_cmd_snapshot!(

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -44,8 +44,10 @@ impl Verbosity {
     /// Returns `None` if the user did not specify any verbosity flags.
     pub fn level(&self) -> VerbosityLevel {
         // `--quiet` and `--verbose` are mutually exclusive in Clap, so we can just check one first.
-        if self.quiet > 0 {
-            return VerbosityLevel::Quiet;
+        match self.quiet {
+            0 => {}
+            1 => return VerbosityLevel::Quiet,
+            _ => return VerbosityLevel::Silent,
         }
 
         match self.verbose {


### PR DESCRIPTION
## Summary

`karva test --dry-run -E <expr>` printed every collected test regardless of the filter expression. The dry-run branch was calling `collect_tests` and `print_collected_tests` before `FiltersetSet::new` had even been constructed — the parse call further down was only validating user input and then throwing the result away. This change parses the filterset first, stores it, and threads it through `collect_test_names` so each qualified name is evaluated against an `EvalContext` before being printed. Tag filters still degrade to an empty tag set because tag metadata is a runtime Python concept and is not available at collection time, but the common `test(...)` predicates now work as documented.

`-qq` was silently equivalent to `-q` even though `Verbosity` exposes `quiet` as `ArgAction::Count` and `VerbosityLevel::Silent` is already wired through `Printer::stdout_important` to disable the failure-summary stream. `Verbosity::level()` only checked `self.quiet > 0` and returned `Quiet`, so `Silent` was unreachable. The fix mirrors the existing `self.verbose` match:

```rust
match self.quiet {
    0 => {}
    1 => return VerbosityLevel::Quiet,
    _ => return VerbosityLevel::Silent,
}
```

`cli_arg()` already returns `"-qq"` for `Silent`, so the flag is correctly propagated to workers via `inner_cli_args` without further changes.

## Test Plan

- [x] `dry_run_applies_filter_expression` in `crates/karva/tests/it/filterset.rs` — asserts that `--dry-run -E test(~alpha)` against a two-test file prints only `test::test_alpha` and `1 tests collected`.
- [x] `qq_is_silent_not_quiet` in `crates/karva/tests/it/basic.rs` — asserts that `-qq` on a failing run produces empty stdout, where the existing `test_quiet_output_failing` (invoked with `-q`) still prints the summary line.
- [x] `just test` — 826 passed, 0 failed.
- [x] `uvx prek run -a` — all hooks green.