### PR TITLE
Fix skipping tests with run ignored

### DIFF
--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -217,6 +217,7 @@ fn collect_test_names(
             let ctx = EvalContext {
                 test_name: &qualified,
                 tags: &[],
+                has_skip_tag: false,
             };
             if filter.matches(&ctx) {
                 tests.push((module_name.clone(), function_name));

--- a/crates/karva/tests/it/filterset.rs
+++ b/crates/karva/tests/it/filterset.rs
@@ -1031,7 +1031,7 @@ fn filterset_unknown_predicate() {
     ----- stderr -----
     Karva failed
       Cause: invalid `--filter` expression
-      Cause: unknown predicate `package` in filter expression `package(foo)` (expected `test` or `tag`)
+      Cause: unknown predicate `package` in filter expression `package(foo)` (expected `test`, `tag`, or `runignored`)
     "
     );
 }

--- a/crates/karva/tests/it/main.rs
+++ b/crates/karva/tests/it/main.rs
@@ -9,5 +9,6 @@ mod durations;
 mod extensions;
 mod filterset;
 mod last_failed;
+mod run_ignored;
 mod version;
 mod watch;

--- a/crates/karva/tests/it/run_ignored.rs
+++ b/crates/karva/tests/it/run_ignored.rs
@@ -1,0 +1,193 @@
+use insta_cmd::assert_cmd_snapshot;
+
+use crate::common::TestContext;
+
+const MIXED_TESTS: &str = r"
+import karva
+
+@karva.tags.skip
+def test_skipped():
+    assert False
+
+@karva.tags.skip('reason here')
+def test_skipped_with_reason():
+    assert False
+
+def test_normal():
+    assert True
+";
+
+#[test]
+fn runignored_runs_only_skipped_tests() {
+    let context = TestContext::with_file("test.py", MIXED_TESTS);
+    assert_cmd_snapshot!(context.command_no_parallel().arg("-E").arg("runignored(only)"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 3 tests across 1 worker
+            FAIL [TIME] test::test_skipped
+            FAIL [TIME] test::test_skipped_with_reason
+            SKIP [TIME] test::test_normal
+
+    diagnostics:
+
+    error[test-failure]: Test `test_skipped` failed
+     --> test.py:5:5
+      |
+    4 | @karva.tags.skip
+    5 | def test_skipped():
+      |     ^^^^^^^^^^^^
+    6 |     assert False
+      |
+    info: Test failed here
+     --> test.py:6:5
+      |
+    4 | @karva.tags.skip
+    5 | def test_skipped():
+    6 |     assert False
+      |     ^^^^^^^^^^^^
+    7 |
+    8 | @karva.tags.skip('reason here')
+      |
+
+    error[test-failure]: Test `test_skipped_with_reason` failed
+      --> test.py:9:5
+       |
+     8 | @karva.tags.skip('reason here')
+     9 | def test_skipped_with_reason():
+       |     ^^^^^^^^^^^^^^^^^^^^^^^^
+    10 |     assert False
+       |
+    info: Test failed here
+      --> test.py:10:5
+       |
+     8 | @karva.tags.skip('reason here')
+     9 | def test_skipped_with_reason():
+    10 |     assert False
+       |     ^^^^^^^^^^^^
+    11 |
+    12 | def test_normal():
+       |
+
+    ────────────
+         Summary [TIME] 3 tests run: 0 passed, 2 failed, 1 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn runignored_all_runs_skipped_alongside_normal() {
+    let context = TestContext::with_file("test.py", MIXED_TESTS);
+    assert_cmd_snapshot!(context.command_no_parallel().arg("-E").arg("runignored(all)"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 3 tests across 1 worker
+            FAIL [TIME] test::test_skipped
+            FAIL [TIME] test::test_skipped_with_reason
+            PASS [TIME] test::test_normal
+
+    diagnostics:
+
+    error[test-failure]: Test `test_skipped` failed
+     --> test.py:5:5
+      |
+    4 | @karva.tags.skip
+    5 | def test_skipped():
+      |     ^^^^^^^^^^^^
+    6 |     assert False
+      |
+    info: Test failed here
+     --> test.py:6:5
+      |
+    4 | @karva.tags.skip
+    5 | def test_skipped():
+    6 |     assert False
+      |     ^^^^^^^^^^^^
+    7 |
+    8 | @karva.tags.skip('reason here')
+      |
+
+    error[test-failure]: Test `test_skipped_with_reason` failed
+      --> test.py:9:5
+       |
+     8 | @karva.tags.skip('reason here')
+     9 | def test_skipped_with_reason():
+       |     ^^^^^^^^^^^^^^^^^^^^^^^^
+    10 |     assert False
+       |
+    info: Test failed here
+      --> test.py:10:5
+       |
+     8 | @karva.tags.skip('reason here')
+     9 | def test_skipped_with_reason():
+    10 |     assert False
+       |     ^^^^^^^^^^^^
+    11 |
+    12 | def test_normal():
+       |
+
+    ────────────
+         Summary [TIME] 3 tests run: 1 passed, 2 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn runignored_with_no_skipped_tests_skips_all() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+def test_alpha():
+    assert True
+
+def test_beta():
+    assert True
+",
+    );
+    assert_cmd_snapshot!(context.command_no_parallel().arg("-E").arg("runignored(only)"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            SKIP [TIME] test::test_alpha
+            SKIP [TIME] test::test_beta
+
+    ────────────
+         Summary [TIME] 2 tests run: 0 passed, 2 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn runignored_skipif_false_not_matched() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+@karva.tags.skip(False, reason='Condition is false')
+def test_conditional():
+    assert True
+
+def test_normal():
+    assert True
+",
+    );
+    assert_cmd_snapshot!(context.command_no_parallel().arg("-E").arg("runignored(only)"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            PASS [TIME] test::test_conditional
+            SKIP [TIME] test::test_normal
+
+    ────────────
+         Summary [TIME] 2 tests run: 1 passed, 1 skipped
+
+    ----- stderr -----
+    ");
+}

--- a/crates/karva_metadata/src/filter.rs
+++ b/crates/karva_metadata/src/filter.rs
@@ -29,6 +29,13 @@ impl Matcher {
     }
 }
 
+/// The mode for the `runignored(mode)` predicate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunIgnoredMode {
+    Only,
+    All,
+}
+
 /// A single predicate in the filter DSL, e.g. `test(~login)` or `tag(slow)`.
 #[derive(Debug, Clone)]
 pub enum Predicate {
@@ -36,6 +43,8 @@ pub enum Predicate {
     Test(Matcher),
     /// Evaluated against each custom tag on the test; matches if any tag matches.
     Tag(Matcher),
+    /// Matches tests based on their `@karva.tags.skip` decorator.
+    RunIgnored(RunIgnoredMode),
 }
 
 /// The value a [`Filterset`] is evaluated against.
@@ -43,6 +52,7 @@ pub enum Predicate {
 pub struct EvalContext<'a> {
     pub test_name: &'a str,
     pub tags: &'a [&'a str],
+    pub has_skip_tag: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -60,9 +70,22 @@ impl Expr {
             Self::Predicate(Predicate::Tag(matcher)) => {
                 ctx.tags.iter().any(|tag| matcher.matches(tag))
             }
+            Self::Predicate(Predicate::RunIgnored(RunIgnoredMode::Only)) => ctx.has_skip_tag,
+            Self::Predicate(Predicate::RunIgnored(RunIgnoredMode::All)) => true,
             Self::Not(inner) => !inner.matches(ctx),
             Self::And(lhs, rhs) => lhs.matches(ctx) && rhs.matches(ctx),
             Self::Or(lhs, rhs) => lhs.matches(ctx) || rhs.matches(ctx),
+        }
+    }
+
+    fn contains_runignored(&self) -> bool {
+        match self {
+            Self::Predicate(Predicate::RunIgnored(_)) => true,
+            Self::Predicate(_) => false,
+            Self::Not(inner) => inner.contains_runignored(),
+            Self::And(lhs, rhs) | Self::Or(lhs, rhs) => {
+                lhs.contains_runignored() || rhs.contains_runignored()
+            }
         }
     }
 }
@@ -90,6 +113,10 @@ impl Filterset {
     pub fn matches(&self, ctx: &EvalContext<'_>) -> bool {
         self.expr.matches(ctx)
     }
+
+    pub fn contains_runignored(&self) -> bool {
+        self.expr.contains_runignored()
+    }
 }
 
 /// A set of filterset expressions combined with OR semantics (matches if any
@@ -106,6 +133,10 @@ impl FiltersetSet {
             .map(|expr| Filterset::new(expr))
             .collect::<Result<_, _>>()?;
         Ok(Self { filters })
+    }
+
+    pub fn contains_runignored(&self) -> bool {
+        self.filters.iter().any(|filter| filter.contains_runignored())
     }
 
     pub fn is_empty(&self) -> bool {
@@ -146,13 +177,17 @@ pub enum FilterError {
         expression: String,
     },
     #[error(
-        "unknown predicate `{name}` in filter expression `{expression}` (expected `test` or `tag`)"
+        "unknown predicate `{name}` in filter expression `{expression}` (expected `test`, `tag`, or `runignored`)"
     )]
     UnknownPredicate { name: String, expression: String },
     #[error("expected `(` after predicate in filter expression `{expression}`")]
     ExpectedPredicateOpenParen { expression: String },
     #[error("expected a matcher body in filter expression `{expression}`")]
     ExpectedMatcher { expression: String },
+    #[error(
+        "expected `only` or `all` inside `runignored(...)` in filter expression `{expression}`"
+    )]
+    ExpectedRunIgnoredMode { expression: String },
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -418,6 +453,37 @@ impl<'a> Parser<'a> {
                 let kind = match name.as_str() {
                     "test" => PredicateKind::Test,
                     "tag" => PredicateKind::Tag,
+                    "runignored" => {
+                        self.advance();
+                        if self.peek() != Some(&Token::LParen) {
+                            return Err(FilterError::ExpectedPredicateOpenParen {
+                                expression: self.expr_str(),
+                            });
+                        }
+                        self.advance();
+                        let mode = match self.peek() {
+                            Some(Token::Ident(s)) if s == "only" => {
+                                self.advance();
+                                RunIgnoredMode::Only
+                            }
+                            Some(Token::Ident(s)) if s == "all" => {
+                                self.advance();
+                                RunIgnoredMode::All
+                            }
+                            _ => {
+                                return Err(FilterError::ExpectedRunIgnoredMode {
+                                    expression: self.expr_str(),
+                                });
+                            }
+                        };
+                        if self.peek() != Some(&Token::RParen) {
+                            return Err(FilterError::UnclosedParenthesis {
+                                expression: self.expr_str(),
+                            });
+                        }
+                        self.advance();
+                        return Ok(Expr::Predicate(Predicate::RunIgnored(mode)));
+                    }
                     _ => {
                         return Err(FilterError::UnknownPredicate {
                             name,
@@ -531,6 +597,7 @@ mod tests {
         EvalContext {
             test_name,
             tags: tag_list,
+            has_skip_tag: false,
         }
     }
 
@@ -855,5 +922,46 @@ mod tests {
         assert!(f.matches(&ctx("x", &["test"])));
         let f = Filterset::new("test(tag)").expect("parse");
         assert!(f.matches(&ctx("mod::test_tag_something", &[])));
+    }
+
+    fn ctx_with_skip<'a>(test_name: &'a str, tag_list: &'a [&'a str]) -> EvalContext<'a> {
+        EvalContext {
+            test_name,
+            tags: tag_list,
+            has_skip_tag: true,
+        }
+    }
+
+    #[test]
+    fn runignored_matches_skip_tagged() {
+        let f = Filterset::new("runignored(only)").expect("parse");
+        assert!(f.matches(&ctx_with_skip("mod::test_slow", &[])));
+        assert!(!f.matches(&ctx("mod::test_fast", &[])));
+    }
+
+    #[test]
+    fn runignored_all_matches_everything() {
+        let f = Filterset::new("runignored(all)").expect("parse");
+        assert!(f.matches(&ctx_with_skip("mod::test_slow", &[])));
+        assert!(f.matches(&ctx("mod::test_fast", &[])));
+    }
+
+    #[test]
+    fn runignored_with_not() {
+        let f = Filterset::new("not runignored(only)").expect("parse");
+        assert!(!f.matches(&ctx_with_skip("mod::test_slow", &[])));
+        assert!(f.matches(&ctx("mod::test_fast", &[])));
+    }
+
+    #[test]
+    fn runignored_requires_valid_mode() {
+        assert!(matches!(
+            Filterset::new("runignored()"),
+            Err(FilterError::ExpectedRunIgnoredMode { .. })
+        ));
+        assert!(matches!(
+            Filterset::new("runignored(foo)"),
+            Err(FilterError::ExpectedRunIgnoredMode { .. })
+        ));
     }
 }

--- a/crates/karva_test_semantic/src/extensions/tags/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/mod.rs
@@ -262,6 +262,11 @@ impl Tags {
             .collect()
     }
 
+    /// Returns true if the test has any skip decorator, regardless of conditions.
+    pub(crate) fn has_skip_tag(&self) -> bool {
+        self.inner.iter().any(|tag| matches!(tag, Tag::Skip(_)))
+    }
+
     /// Returns true if any skip tag should be skipped.
     pub(crate) fn should_skip(&self) -> (bool, Option<String>) {
         for tag in &self.inner {

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -219,7 +219,9 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             let ctx = EvalContext {
                 test_name: &display_name,
                 tags: &custom_names,
+                has_skip_tag: tags.has_skip_tag(),
             };
+            let should_skip = tags.should_skip();
             if !filter.matches(&ctx) {
                 return Some(self.context.register_test_case_result(
                     &qualified,
@@ -227,6 +229,14 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                     std::time::Duration::ZERO,
                 ));
             }
+            if should_skip.0 && !filter.contains_runignored() {
+                return Some(self.context.register_test_case_result(
+                    &qualified,
+                    IndividualTestResultKind::Skipped { reason: None },
+                    std::time::Duration::ZERO,
+                ));
+            }
+            return None;
         }
 
         if let (true, reason) = tags.should_skip() {


### PR DESCRIPTION
#### Fixes #548

### Summary

This PR adds run-ignored support through filter expressions and fixes skip-handling behavior so existing filter semantics stay correct.

You can now run:
```

-E "runignored(only)" to run only skipped tests
-E "runignored(all)" to run skipped + normal tests
```

###What Changed

- Added a new filter predicate: [runignored(mode)], with supported modes:
 ```
only
all
 ```

- Extended filter evaluation context to track whether a test has a skip decorator.
- Updated runner skip logic so skip decorators are only overridden when runignored(...) is explicitly used.
- Preserved prior behavior for regular filters like [tag(...)].


### Added integration coverage for:

- runignored(only)
- runignored(all)
- No-skipped-tests behavior under runignored(only)
- Conditional skip behavior (skipif(False, ...))
- Updated filter error snapshot text to include runignored in expected predicate list.


### Behavior

- Without runignored(...): skipped tests remain skipped.
- With runignored(only): only skipped tests execute.
- With runignored(all): skipped and non-skipped tests execute together.


### Validation

- Ran integration tests and resolved snapshot mismatches.
- Verified targeted runs for both modes with expected outcomes.


### Screenshots

Before 
<img width="805" height="310" alt="Screenshot from 2026-04-12 09-47-45" src="https://github.com/user-attachments/assets/56a97088-071e-47a7-b2ff-a67c84e3f7e2" />


runignored(only)
<img width="805" height="303" alt="Screenshot from 2026-04-12 09-47-51" src="https://github.com/user-attachments/assets/edbf1005-ee97-4262-a8e2-847bdce87581" />


runignored(all) 
<img width="805" height="303" alt="Screenshot from 2026-04-12 09-48-01" src="https://github.com/user-attachments/assets/55b6e443-f67f-419a-b36a-1b33db499564" />



### Notes
This PR introduces run-ignored behavior via filter expressions (-E ...).
A dedicated CLI flag like [--run-ignored {only|all}] is not introduced in this change.