### PR TITLE
Add `--run-ignored` option

### DIFF
--- a/crates/karva/tests/it/main.rs
+++ b/crates/karva/tests/it/main.rs
@@ -9,5 +9,6 @@ mod durations;
 mod extensions;
 mod filterset;
 mod last_failed;
+mod run_ignored;
 mod version;
 mod watch;

--- a/crates/karva/tests/it/run_ignored.rs
+++ b/crates/karva/tests/it/run_ignored.rs
@@ -1,0 +1,193 @@
+use insta_cmd::assert_cmd_snapshot;
+
+use crate::common::TestContext;
+
+const MIXED_TESTS: &str = r"
+import karva
+
+@karva.tags.skip
+def test_skipped():
+    assert False
+
+@karva.tags.skip('reason here')
+def test_skipped_with_reason():
+    assert False
+
+def test_normal():
+    assert True
+";
+
+#[test]
+fn runignored_runs_only_skipped_tests() {
+    let context = TestContext::with_file("test.py", MIXED_TESTS);
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--run-ignored").arg("only"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 3 tests across 1 worker
+            FAIL [TIME] test::test_skipped
+            FAIL [TIME] test::test_skipped_with_reason
+            SKIP [TIME] test::test_normal
+
+    diagnostics:
+
+    error[test-failure]: Test `test_skipped` failed
+     --> test.py:5:5
+      |
+    4 | @karva.tags.skip
+    5 | def test_skipped():
+      |     ^^^^^^^^^^^^
+    6 |     assert False
+      |
+    info: Test failed here
+     --> test.py:6:5
+      |
+    4 | @karva.tags.skip
+    5 | def test_skipped():
+    6 |     assert False
+      |     ^^^^^^^^^^^^
+    7 |
+    8 | @karva.tags.skip('reason here')
+      |
+
+    error[test-failure]: Test `test_skipped_with_reason` failed
+      --> test.py:9:5
+       |
+     8 | @karva.tags.skip('reason here')
+     9 | def test_skipped_with_reason():
+       |     ^^^^^^^^^^^^^^^^^^^^^^^^
+    10 |     assert False
+       |
+    info: Test failed here
+      --> test.py:10:5
+       |
+     8 | @karva.tags.skip('reason here')
+     9 | def test_skipped_with_reason():
+    10 |     assert False
+       |     ^^^^^^^^^^^^
+    11 |
+    12 | def test_normal():
+       |
+
+    ────────────
+         Summary [TIME] 3 tests run: 0 passed, 2 failed, 1 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn runignored_all_runs_skipped_alongside_normal() {
+    let context = TestContext::with_file("test.py", MIXED_TESTS);
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--run-ignored").arg("all"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 3 tests across 1 worker
+            FAIL [TIME] test::test_skipped
+            FAIL [TIME] test::test_skipped_with_reason
+            PASS [TIME] test::test_normal
+
+    diagnostics:
+
+    error[test-failure]: Test `test_skipped` failed
+     --> test.py:5:5
+      |
+    4 | @karva.tags.skip
+    5 | def test_skipped():
+      |     ^^^^^^^^^^^^
+    6 |     assert False
+      |
+    info: Test failed here
+     --> test.py:6:5
+      |
+    4 | @karva.tags.skip
+    5 | def test_skipped():
+    6 |     assert False
+      |     ^^^^^^^^^^^^
+    7 |
+    8 | @karva.tags.skip('reason here')
+      |
+
+    error[test-failure]: Test `test_skipped_with_reason` failed
+      --> test.py:9:5
+       |
+     8 | @karva.tags.skip('reason here')
+     9 | def test_skipped_with_reason():
+       |     ^^^^^^^^^^^^^^^^^^^^^^^^
+    10 |     assert False
+       |
+    info: Test failed here
+      --> test.py:10:5
+       |
+     8 | @karva.tags.skip('reason here')
+     9 | def test_skipped_with_reason():
+    10 |     assert False
+       |     ^^^^^^^^^^^^
+    11 |
+    12 | def test_normal():
+       |
+
+    ────────────
+         Summary [TIME] 3 tests run: 1 passed, 2 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn runignored_with_no_skipped_tests_skips_all() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+def test_alpha():
+    assert True
+
+def test_beta():
+    assert True
+",
+    );
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--run-ignored").arg("only"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            SKIP [TIME] test::test_alpha
+            SKIP [TIME] test::test_beta
+
+    ────────────
+         Summary [TIME] 2 tests run: 0 passed, 2 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn runignored_skipif_false_not_matched() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+@karva.tags.skip(False, reason='Condition is false')
+def test_conditional():
+    assert True
+
+def test_normal():
+    assert True
+",
+    );
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--run-ignored").arg("only"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            PASS [TIME] test::test_conditional
+            SKIP [TIME] test::test_normal
+
+    ────────────
+         Summary [TIME] 2 tests run: 1 passed, 1 skipped
+
+    ----- stderr -----
+    ");
+}

--- a/crates/karva/tests/it/run_ignored.rs
+++ b/crates/karva/tests/it/run_ignored.rs
@@ -182,11 +182,11 @@ def test_normal():
     exit_code: 0
     ----- stdout -----
         Starting 2 tests across 1 worker
-            PASS [TIME] test::test_conditional
+            SKIP [TIME] test::test_conditional
             SKIP [TIME] test::test_normal
 
     ────────────
-         Summary [TIME] 2 tests run: 1 passed, 1 skipped
+         Summary [TIME] 2 tests run: 0 passed, 2 skipped
 
     ----- stderr -----
     ");

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 use clap::builder::Styles;
 use clap::builder::styling::{AnsiColor, Effects};
 use karva_logging::{TerminalColor, VerbosityLevel};
-use karva_metadata::{MaxFail, Options, SrcOptions, TerminalOptions, TestOptions};
+use karva_metadata::{MaxFail, Options, RunIgnoredMode, SrcOptions, TerminalOptions, TestOptions};
 use ruff_db::diagnostic::DiagnosticFormat;
 
 const STYLES: Styles = Styles::styled()
@@ -245,12 +245,8 @@ pub struct SubTestCommand {
     pub filter_expressions: Vec<String>,
 
     /// Run ignored tests.
-    ///
-    /// - default: Run non-ignored tests
-    /// - only:    Run ignored tests
-    /// - all:     Run both ignored and non-ignored tests
-    #[clap(long, value_name = "WHICH", default_value = "default")]
-    pub run_ignored: RunIgnored,
+    #[arg(long)]
+    pub run_ignored: Option<RunIgnored>,
 
     /// Update snapshots directly instead of creating pending `.snap.new` files.
     ///
@@ -385,13 +381,29 @@ impl TestCommand {
 }
 
 /// Whether to run ignored/skipped tests.
-#[derive(Copy, Clone, Hash, Debug, PartialEq, Eq, Default, clap::ValueEnum)]
+#[derive(Copy, Clone, Hash, Debug, PartialEq, Eq, clap::ValueEnum)]
 pub enum RunIgnored {
-    #[default]
-    #[value(name = "default")]
-    Default,
-    #[value(name = "only")]
+    /// Run only ignored tests.
     Only,
-    #[value(name = "all")]
+
+    /// Run both ignored and non-ignored tests.
     All,
+}
+
+impl RunIgnored {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Only => "only",
+            Self::All => "all",
+        }
+    }
+}
+
+impl From<RunIgnored> for RunIgnoredMode {
+    fn from(value: RunIgnored) -> Self {
+        match value {
+            RunIgnored::Only => Self::Only,
+            RunIgnored::All => Self::All,
+        }
+    }
 }

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -244,6 +244,14 @@ pub struct SubTestCommand {
     #[clap(short = 'E', long = "filter")]
     pub filter_expressions: Vec<String>,
 
+    /// Run ignored tests.
+    ///
+    /// - default: Run non-ignored tests
+    /// - only:    Run ignored tests
+    /// - all:     Run both ignored and non-ignored tests
+    #[clap(long, value_name = "WHICH", default_value = "default")]
+    pub run_ignored: RunIgnored,
+
     /// Update snapshots directly instead of creating pending `.snap.new` files.
     ///
     /// When set, `karva.assert_snapshot()` will write directly to `.snap` files,
@@ -374,4 +382,16 @@ impl TestCommand {
     pub fn into_options(self) -> Options {
         self.sub_command.into_options()
     }
+}
+
+/// Whether to run ignored/skipped tests.
+#[derive(Copy, Clone, Hash, Debug, PartialEq, Eq, Default, clap::ValueEnum)]
+pub enum RunIgnored {
+    #[default]
+    #[value(name = "default")]
+    Default,
+    #[value(name = "only")]
+    Only,
+    #[value(name = "all")]
+    All,
 }

--- a/crates/karva_metadata/src/lib.rs
+++ b/crates/karva_metadata/src/lib.rs
@@ -14,7 +14,7 @@ pub use options::{
     Options, OutputFormat, ProjectOptionsOverrides, SrcOptions, TerminalOptions, TestOptions,
 };
 pub use pyproject::{PyProject, PyProjectError};
-pub use settings::ProjectSettings;
+pub use settings::{ProjectSettings, RunIgnoredMode};
 
 use crate::options::KarvaTomlError;
 

--- a/crates/karva_metadata/src/options.rs
+++ b/crates/karva_metadata/src/options.rs
@@ -7,7 +7,9 @@ use thiserror::Error;
 
 use crate::filter::FiltersetSet;
 use crate::max_fail::MaxFail;
-use crate::settings::{ProjectSettings, SrcSettings, TerminalSettings, TestSettings};
+use crate::settings::{
+    ProjectSettings, RunIgnoredMode, SrcSettings, TerminalSettings, TestSettings,
+};
 
 #[derive(
     Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, OptionsMetadata, Combine,
@@ -231,6 +233,7 @@ impl TestOptions {
             try_import_fixtures: self.try_import_fixtures.unwrap_or_default(),
             retry: self.retry.unwrap_or_default(),
             filter: FiltersetSet::default(),
+            run_ignored: RunIgnoredMode::default(),
         }
     }
 }

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -2,6 +2,14 @@ use crate::filter::FiltersetSet;
 use crate::max_fail::MaxFail;
 use crate::options::OutputFormat;
 
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunIgnoredMode {
+    #[default]
+    Default,
+    Only,
+    All,
+}
+
 #[derive(Default, Debug, Clone)]
 pub struct ProjectSettings {
     pub(crate) terminal: TerminalSettings,
@@ -29,6 +37,10 @@ impl ProjectSettings {
     pub fn set_filter(&mut self, filter: FiltersetSet) {
         self.test.filter = filter;
     }
+
+    pub fn set_run_ignored(&mut self, mode: RunIgnoredMode) {
+        self.test.run_ignored = mode;
+    }
 }
 
 #[derive(Default, Debug, Clone)]
@@ -50,4 +62,5 @@ pub struct TestSettings {
     pub try_import_fixtures: bool,
     pub retry: u32,
     pub filter: FiltersetSet,
+    pub run_ignored: RunIgnoredMode,
 }

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -13,7 +13,7 @@ use karva_cache::{
     AggregatedResults, CACHE_DIR, Cache, RunHash, read_last_failed, read_recent_durations,
     write_last_failed,
 };
-use karva_cli::SubTestCommand;
+use karva_cli::{RunIgnored, SubTestCommand};
 use karva_collector::{CollectedPackage, CollectionSettings};
 use karva_logging::Printer;
 use karva_logging::time::format_duration;
@@ -430,6 +430,18 @@ fn inner_cli_args(settings: &ProjectSettings, args: &SubTestCommand) -> Vec<Stri
     for expr in &args.filter_expressions {
         cli_args.push("--filter".to_string());
         cli_args.push(expr.clone());
+    }
+
+    match args.run_ignored {
+        RunIgnored::Default => {}
+        RunIgnored::Only => {
+            cli_args.push("--run-ignored".to_string());
+            cli_args.push("only".to_string());
+        }
+        RunIgnored::All => {
+            cli_args.push("--run-ignored".to_string());
+            cli_args.push("all".to_string());
+        }
     }
 
     cli_args

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -13,7 +13,7 @@ use karva_cache::{
     AggregatedResults, CACHE_DIR, Cache, RunHash, read_last_failed, read_recent_durations,
     write_last_failed,
 };
-use karva_cli::{RunIgnored, SubTestCommand};
+use karva_cli::SubTestCommand;
 use karva_collector::{CollectedPackage, CollectionSettings};
 use karva_logging::Printer;
 use karva_logging::time::format_duration;
@@ -432,16 +432,9 @@ fn inner_cli_args(settings: &ProjectSettings, args: &SubTestCommand) -> Vec<Stri
         cli_args.push(expr.clone());
     }
 
-    match args.run_ignored {
-        RunIgnored::Default => {}
-        RunIgnored::Only => {
-            cli_args.push("--run-ignored".to_string());
-            cli_args.push("only".to_string());
-        }
-        RunIgnored::All => {
-            cli_args.push("--run-ignored".to_string());
-            cli_args.push("all".to_string());
-        }
+    if let Some(mode) = args.run_ignored {
+        cli_args.push("--run-ignored".to_string());
+        cli_args.push(mode.as_str().to_string());
     }
 
     cli_args

--- a/crates/karva_test_semantic/src/extensions/tags/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/mod.rs
@@ -274,11 +274,6 @@ impl Tags {
         (false, None)
     }
 
-    /// Returns true if any skip marker exists, regardless of its condition.
-    pub(crate) fn has_skip_tag(&self) -> bool {
-        self.inner.iter().any(|tag| matches!(tag, Tag::Skip(_)))
-    }
-
     /// Return the names of all custom tags.
     pub(crate) fn custom_tag_names(&self) -> Vec<&str> {
         self.inner

--- a/crates/karva_test_semantic/src/extensions/tags/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/mod.rs
@@ -274,6 +274,11 @@ impl Tags {
         (false, None)
     }
 
+    /// Returns true if any skip marker exists, regardless of its condition.
+    pub(crate) fn has_skip_tag(&self) -> bool {
+        self.inner.iter().any(|tag| matches!(tag, Tag::Skip(_)))
+    }
+
     /// Return the names of all custom tags.
     pub(crate) fn custom_tag_names(&self) -> Vec<&str> {
         self.inner

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -243,14 +243,14 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                 }
             }
             RunIgnoredMode::Only => {
-                if !tags.has_skip_tag() {
+                if !tags.should_skip().0 {
                     return Some(self.context.register_test_case_result(
                         &QualifiedTestName::new(name.clone(), None),
                         IndividualTestResultKind::Skipped { reason: None },
                         std::time::Duration::ZERO,
                     ));
                 }
-                // has skip tag → override skip, let the test run
+                // skip condition is active → override skip, let the test run
             }
             RunIgnoredMode::All => {
                 // run everything regardless of skip tags

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 type FixtureArguments = HashMap<String, Py<PyAny>>;
 
 use karva_diagnostic::IndividualTestResultKind;
+use karva_metadata::RunIgnoredMode;
 use karva_metadata::filter::EvalContext;
 use karva_python_semantic::{FunctionKind, QualifiedFunctionName, QualifiedTestName};
 use pyo3::prelude::*;
@@ -212,6 +213,8 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         tags: &crate::extensions::tags::Tags,
     ) -> Option<bool> {
         let filter = &self.context.settings().test().filter;
+        let run_ignored = self.context.settings().test().run_ignored;
+
         if !filter.is_empty() {
             let qualified = QualifiedTestName::new(name.clone(), None);
             let display_name = qualified.to_string();
@@ -229,12 +232,29 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             }
         }
 
-        if let (true, reason) = tags.should_skip() {
-            return Some(self.context.register_test_case_result(
-                &QualifiedTestName::new(name.clone(), None),
-                IndividualTestResultKind::Skipped { reason },
-                std::time::Duration::ZERO,
-            ));
+        match run_ignored {
+            RunIgnoredMode::Default => {
+                if let (true, reason) = tags.should_skip() {
+                    return Some(self.context.register_test_case_result(
+                        &QualifiedTestName::new(name.clone(), None),
+                        IndividualTestResultKind::Skipped { reason },
+                        std::time::Duration::ZERO,
+                    ));
+                }
+            }
+            RunIgnoredMode::Only => {
+                if !tags.has_skip_tag() {
+                    return Some(self.context.register_test_case_result(
+                        &QualifiedTestName::new(name.clone(), None),
+                        IndividualTestResultKind::Skipped { reason: None },
+                        std::time::Duration::ZERO,
+                    ));
+                }
+                // has skip tag → override skip, let the test run
+            }
+            RunIgnoredMode::All => {
+                // run everything regardless of skip tags
+            }
         }
 
         None

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -243,14 +243,15 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                 }
             }
             RunIgnoredMode::Only => {
-                if !tags.should_skip().0 {
+                // Skip tests whose skip condition is not active; only tests
+                // that would actually be skipped in a normal run are included.
+                if let (false, _) = tags.should_skip() {
                     return Some(self.context.register_test_case_result(
                         &QualifiedTestName::new(name.clone(), None),
                         IndividualTestResultKind::Skipped { reason: None },
                         std::time::Duration::ZERO,
                     ));
                 }
-                // skip condition is active → override skip, let the test run
             }
             RunIgnoredMode::All => {
                 // run everything regardless of skip tags

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -7,7 +7,7 @@ use camino::Utf8PathBuf;
 use clap::Parser;
 use colored::Colorize;
 use karva_cache::{Cache, RunHash};
-use karva_cli::{RunIgnored, SubTestCommand, Verbosity};
+use karva_cli::{SubTestCommand, Verbosity};
 use karva_diagnostic::{DummyReporter, Reporter, TestCaseReporter};
 use karva_logging::{Printer, set_colored_override, setup_tracing};
 use karva_metadata::RunIgnoredMode;
@@ -138,12 +138,11 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
     let filter = FiltersetSet::new(&args.sub_command.filter_expressions)
         .context("invalid `--filter` expression")?;
 
-    let run_ignored = match args.sub_command.run_ignored {
-        RunIgnored::Default => RunIgnoredMode::Default,
-        RunIgnored::Only => RunIgnoredMode::Only,
-        RunIgnored::All => RunIgnoredMode::All,
-    };
-
+    let run_ignored = args
+        .sub_command
+        .run_ignored
+        .map(RunIgnoredMode::from)
+        .unwrap_or_default();
     let mut settings = args.sub_command.into_options().to_settings();
     settings.set_filter(filter);
     settings.set_run_ignored(run_ignored);

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -7,9 +7,10 @@ use camino::Utf8PathBuf;
 use clap::Parser;
 use colored::Colorize;
 use karva_cache::{Cache, RunHash};
-use karva_cli::{SubTestCommand, Verbosity};
+use karva_cli::{RunIgnored, SubTestCommand, Verbosity};
 use karva_diagnostic::{DummyReporter, Reporter, TestCaseReporter};
 use karva_logging::{Printer, set_colored_override, setup_tracing};
+use karva_metadata::RunIgnoredMode;
 use karva_metadata::filter::FiltersetSet;
 use karva_project::path::{TestPath, TestPathError, absolute};
 use karva_python_semantic::current_python_version;
@@ -137,8 +138,15 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
     let filter = FiltersetSet::new(&args.sub_command.filter_expressions)
         .context("invalid `--filter` expression")?;
 
+    let run_ignored = match args.sub_command.run_ignored {
+        RunIgnored::Default => RunIgnoredMode::Default,
+        RunIgnored::Only => RunIgnoredMode::Only,
+        RunIgnored::All => RunIgnoredMode::All,
+    };
+
     let mut settings = args.sub_command.into_options().to_settings();
     settings.set_filter(filter);
+    settings.set_run_ignored(run_ignored);
 
     let run_hash = RunHash::from_existing(&args.run_hash);
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -74,15 +74,11 @@ karva test [OPTIONS] [PATH]...
 <li><code>concise</code>:  Print diagnostics concisely, one per line</li>
 </ul></dd><dt id="karva-test--quiet"><a href="#karva-test--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output (or <code>-qq</code> for silent output)</p>
 </dd><dt id="karva-test--retry"><a href="#karva-test--retry"><code>--retry</code></a> <i>retry</i></dt><dd><p>When set, the test will retry failed tests up to this number of times</p>
-</dd><dt id="karva-test--run-ignored"><a href="#karva-test--run-ignored"><code>--run-ignored</code></a> <i>which</i></dt><dd><p>Run ignored tests.</p>
+</dd><dt id="karva-test--run-ignored"><a href="#karva-test--run-ignored"><code>--run-ignored</code></a> <i>run-ignored</i></dt><dd><p>Run ignored tests</p>
+<p>Possible values:</p>
 <ul>
-<li>default: Run non-ignored tests - only:    Run ignored tests - all:     Run both ignored and non-ignored tests</li>
-</ul>
-<p>[default: default]</p><p>Possible values:</p>
-<ul>
-<li><code>default</code></li>
-<li><code>only</code></li>
-<li><code>all</code></li>
+<li><code>only</code>:  Run only ignored tests</li>
+<li><code>all</code>:  Run both ignored and non-ignored tests</li>
 </ul></dd><dt id="karva-test--snapshot-update"><a href="#karva-test--snapshot-update"><code>--snapshot-update</code></a></dt><dd><p>Update snapshots directly instead of creating pending <code>.snap.new</code> files.</p>
 <p>When set, <code>karva.assert_snapshot()</code> will write directly to <code>.snap</code> files, accepting any changes automatically.</p>
 </dd><dt id="karva-test--test-prefix"><a href="#karva-test--test-prefix"><code>--test-prefix</code></a> <i>test-prefix</i></dt><dd><p>The prefix of the test functions</p>

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -74,7 +74,16 @@ karva test [OPTIONS] [PATH]...
 <li><code>concise</code>:  Print diagnostics concisely, one per line</li>
 </ul></dd><dt id="karva-test--quiet"><a href="#karva-test--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output (or <code>-qq</code> for silent output)</p>
 </dd><dt id="karva-test--retry"><a href="#karva-test--retry"><code>--retry</code></a> <i>retry</i></dt><dd><p>When set, the test will retry failed tests up to this number of times</p>
-</dd><dt id="karva-test--snapshot-update"><a href="#karva-test--snapshot-update"><code>--snapshot-update</code></a></dt><dd><p>Update snapshots directly instead of creating pending <code>.snap.new</code> files.</p>
+</dd><dt id="karva-test--run-ignored"><a href="#karva-test--run-ignored"><code>--run-ignored</code></a> <i>which</i></dt><dd><p>Run ignored tests.</p>
+<ul>
+<li>default: Run non-ignored tests - only:    Run ignored tests - all:     Run both ignored and non-ignored tests</li>
+</ul>
+<p>[default: default]</p><p>Possible values:</p>
+<ul>
+<li><code>default</code></li>
+<li><code>only</code></li>
+<li><code>all</code></li>
+</ul></dd><dt id="karva-test--snapshot-update"><a href="#karva-test--snapshot-update"><code>--snapshot-update</code></a></dt><dd><p>Update snapshots directly instead of creating pending <code>.snap.new</code> files.</p>
 <p>When set, <code>karva.assert_snapshot()</code> will write directly to <code>.snap</code> files, accepting any changes automatically.</p>
 </dd><dt id="karva-test--test-prefix"><a href="#karva-test--test-prefix"><code>--test-prefix</code></a> <i>test-prefix</i></dt><dd><p>The prefix of the test functions</p>
 </dd><dt id="karva-test--try-import-fixtures"><a href="#karva-test--try-import-fixtures"><code>--try-import-fixtures</code></a></dt><dd><p>When set, we will try to import functions in each test file as well as parsing the ast to find them.</p>


### PR DESCRIPTION
#### Fixes #548

### Summary
This PR adds run-ignored support through a dedicated CLI option and fixes skip-handling behavior while preserving existing filter semantics.

You can now run:

```
karva test --run-ignored only
karva test --run-ignored all
```

### What Changed

Added a new test CLI option: --run-ignored WHICH

```
Supported modes:
default
only
all
```

Wired run-ignored mode through CLI, runner orchestration, worker settings, and semantic test execution.

Updated skip handling so:

- default: skipped tests stay skipped
- only: only skipped tests are executed
- all: skipped and non-skipped tests are both executed
- Added skip-marker presence handling in tag evaluation to support only mode correctly.

### Added Integration Coverage For

1. run-ignored only mode
2. run-ignored all mode
3. no-skipped-tests behavior under only mode
4. conditional skip behavior with skipif(False, ...)
5. module wiring for the new run_ignored integration test suite

### Behavior

1. Without --run-ignored: skipped tests remain skipped.
2. With --run-ignored only: only skipped tests execute.
3. With --run-ignored all: skipped and non-skipped tests execute together.


### Validation

1. Ran targeted integration tests for run_ignored scenarios.
2. Verified expected outcomes for both only and all modes.
3. Confirmed compile and test consistency for updated semantic runner flow.

### Screenshots
Before
<img width="663" height="381" alt="Screenshot from 2026-04-12 18-41-32" src="https://github.com/user-attachments/assets/3820259d-38b9-43aa-98ad-cfe2780101bf" />


--run-ignored only
<img width="663" height="353" alt="Screenshot from 2026-04-12 18-41-41" src="https://github.com/user-attachments/assets/a2e808f2-753c-49ac-b214-132922b87f16" />


--run-ignored all
<img width="663" height="353" alt="Screenshot from 2026-04-12 18-41-49" src="https://github.com/user-attachments/assets/dd9d2285-54a2-4f12-819f-31230da419d2" />



Notes
This PR introduces run-ignored behavior via a dedicated CLI option, not via filter expressions.