### PR TITLE
Remove `--dry-run` flag from `karva test`

### DIFF
--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -7,9 +7,8 @@ use std::time::{Duration, Instant};
 use anyhow::{Context as _, Result};
 use karva_cache::AggregatedResults;
 use karva_cli::{OutputFormat, TestCommand};
-use karva_collector::CollectedPackage;
 use karva_logging::{Printer, Stdout, set_colored_override, setup_tracing};
-use karva_metadata::filter::{EvalContext, FiltersetSet};
+use karva_metadata::filter::FiltersetSet;
 use karva_metadata::{ProjectMetadata, ProjectOptionsOverrides};
 use karva_project::Project;
 use karva_project::path::absolute;
@@ -45,12 +44,7 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
         ProjectMetadata::discover(&cwd, python_version)?
     };
 
-    if args.watch && args.dry_run {
-        anyhow::bail!("`--watch` and `--dry-run` cannot be used together");
-    }
-
     let sub_command = args.sub_command.clone();
-    let dry_run = args.dry_run;
     let watch = args.watch;
     let durations = args.durations;
     let last_failed = args.last_failed;
@@ -67,14 +61,7 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
 
     let project = Project::from_metadata(project_metadata);
 
-    let filter = FiltersetSet::new(&sub_command.filter_expressions)
-        .context("invalid `--filter` expression")?;
-
-    if dry_run {
-        let collected = karva_runner::collect_tests(&project)?;
-        print_collected_tests(printer, &collected, &filter)?;
-        return Ok(ExitStatus::Success);
-    }
+    FiltersetSet::new(&sub_command.filter_expressions).context("invalid `--filter` expression")?;
 
     let config = karva_runner::ParallelTestConfig {
         num_workers,
@@ -197,58 +184,4 @@ fn print_durations_section(
     writeln!(stdout)?;
 
     Ok(true)
-}
-
-/// Recursively collect test names from a `CollectedPackage` as `(module_name, function_name)` pairs.
-///
-/// Applies `filter` against each test by qualified name. Tags are unknown at
-/// collection time (they come from Python runtime state), so filters that
-/// reference `tag(...)` will match against an empty tag set.
-fn collect_test_names(
-    package: &CollectedPackage,
-    filter: &FiltersetSet,
-    tests: &mut Vec<(String, String)>,
-) {
-    for module in package.modules.values() {
-        let module_name = module.path.module_name().to_string();
-        for func in &module.test_function_defs {
-            let function_name = func.name.to_string();
-            let qualified = format!("{module_name}::{function_name}");
-            let ctx = EvalContext {
-                test_name: &qualified,
-                tags: &[],
-            };
-            if filter.matches(&ctx) {
-                tests.push((module_name.clone(), function_name));
-            }
-        }
-    }
-    for sub_package in package.packages.values() {
-        collect_test_names(sub_package, filter, tests);
-    }
-}
-
-/// Print collected tests in dry-run mode.
-fn print_collected_tests(
-    printer: Printer,
-    collected: &CollectedPackage,
-    filter: &FiltersetSet,
-) -> Result<()> {
-    let mut tests = Vec::new();
-    collect_test_names(collected, filter, &mut tests);
-    tests.sort();
-
-    let mut stdout = printer.stream_for_requested_summary().lock();
-
-    for (module_name, function_name) in &tests {
-        writeln!(stdout, "<test> {module_name}::{function_name}")?;
-    }
-
-    if !tests.is_empty() {
-        writeln!(stdout)?;
-    }
-
-    writeln!(stdout, "{} tests collected", tests.len())?;
-
-    Ok(())
 }

--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -1271,83 +1271,6 @@ def test_3(): pass",
 }
 
 #[test]
-fn test_dry_run() {
-    let context = TestContext::with_files([
-        (
-            "test_file1.py",
-            r"
-def test_alpha(): pass
-def test_beta(): pass
-",
-        ),
-        (
-            "test_file2.py",
-            r"
-def test_gamma(): pass
-",
-        ),
-    ]);
-
-    assert_cmd_snapshot!(context.command().arg("--dry-run"), @r"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    <test> test_file1::test_alpha
-    <test> test_file1::test_beta
-    <test> test_file2::test_gamma
-
-    3 tests collected
-
-    ----- stderr -----
-    ");
-}
-
-#[test]
-fn test_dry_run_empty() {
-    let context = TestContext::new();
-
-    assert_cmd_snapshot!(context.command().arg("--dry-run"), @r"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    0 tests collected
-
-    ----- stderr -----
-    ");
-}
-
-#[test]
-fn test_dry_run_with_path_filter() {
-    let context = TestContext::with_files([
-        (
-            "test_file1.py",
-            r"
-def test_alpha(): pass
-def test_beta(): pass
-",
-        ),
-        (
-            "test_file2.py",
-            r"
-def test_gamma(): pass
-",
-        ),
-    ]);
-
-    assert_cmd_snapshot!(context.command().args(["--dry-run", "test_file1.py"]), @r"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    <test> test_file1::test_alpha
-    <test> test_file1::test_beta
-
-    2 tests collected
-
-    ----- stderr -----
-    ");
-}
-
-#[test]
 fn test_concise_output_format_with_failure() {
     let context = TestContext::with_file(
         "test.py",
@@ -1715,36 +1638,6 @@ def test_b_pass():
     assert!(!output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("failed"), "should report failure");
-}
-
-#[test]
-fn test_dry_run_nested_packages() {
-    let context = TestContext::with_files([
-        (
-            "tests/test_root.py",
-            r"
-def test_root(): pass
-            ",
-        ),
-        (
-            "tests/sub/test_nested.py",
-            r"
-def test_nested(): pass
-            ",
-        ),
-    ]);
-
-    assert_cmd_snapshot!(context.command().arg("--dry-run"), @r"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    <test> tests.sub.test_nested::test_nested
-    <test> tests.test_root::test_root
-
-    2 tests collected
-
-    ----- stderr -----
-    ");
 }
 
 #[test]

--- a/crates/karva/tests/it/filterset.rs
+++ b/crates/karva/tests/it/filterset.rs
@@ -1073,28 +1073,6 @@ fn filterset_empty_matcher_body() {
 }
 
 #[test]
-fn dry_run_applies_filter_expression() {
-    let context = TestContext::with_file("test.py", TWO_TESTS);
-    assert_cmd_snapshot!(
-        context
-            .command_no_parallel()
-            .arg("--dry-run")
-            .arg("-E")
-            .arg("test(~alpha)"),
-        @r"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    <test> test::test_alpha
-
-    1 tests collected
-
-    ----- stderr -----
-    "
-    );
-}
-
-#[test]
 fn filterset_empty_expression() {
     let context = TestContext::with_file("test.py", "def test_x(): assert True\n");
     assert_cmd_snapshot!(

--- a/crates/karva/tests/it/watch.rs
+++ b/crates/karva/tests/it/watch.rs
@@ -1,21 +1,4 @@
-use insta_cmd::assert_cmd_snapshot;
-
 use crate::common::TestContext;
-
-#[test]
-fn test_watch_and_dry_run_conflict() {
-    let context = TestContext::with_file("test.py", "def test_1(): pass");
-
-    assert_cmd_snapshot!(context.command().args(["--watch", "--dry-run"]), @r"
-    success: false
-    exit_code: 2
-    ----- stdout -----
-
-    ----- stderr -----
-    Karva failed
-      Cause: `--watch` and `--dry-run` cannot be used together
-    ");
-}
 
 #[cfg(unix)]
 #[test]

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -286,10 +286,6 @@ pub struct TestCommand {
     #[clap(long, value_name = "N")]
     pub durations: Option<usize>,
 
-    /// Print discovered tests without executing them.
-    #[clap(long)]
-    pub dry_run: bool,
-
     /// Re-run tests when Python source files change.
     #[clap(long)]
     pub watch: bool,

--- a/crates/karva_runner/src/lib.rs
+++ b/crates/karva_runner/src/lib.rs
@@ -3,5 +3,5 @@ mod orchestration;
 mod partition;
 mod shutdown;
 
-pub use orchestration::{ParallelTestConfig, collect_tests, run_parallel_tests};
+pub use orchestration::{ParallelTestConfig, run_parallel_tests};
 pub use shutdown::shutdown_receiver;

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -46,8 +46,7 @@ karva test [OPTIONS] [PATH]...
 <li><code>never</code>:  Never display colors</li>
 </ul></dd><dt id="karva-test--config-file"><a href="#karva-test--config-file"><code>--config-file</code></a> <i>path</i></dt><dd><p>The path to a <code>karva.toml</code> file to use for configuration.</p>
 <p>While karva configuration can be included in a <code>pyproject.toml</code> file, it is not allowed in this context.</p>
-<p>May also be set with the <code>KARVA_CONFIG_FILE</code> environment variable.</p></dd><dt id="karva-test--dry-run"><a href="#karva-test--dry-run"><code>--dry-run</code></a></dt><dd><p>Print discovered tests without executing them</p>
-</dd><dt id="karva-test--durations"><a href="#karva-test--durations"><code>--durations</code></a> <i>n</i></dt><dd><p>Show the N slowest tests after the run completes</p>
+<p>May also be set with the <code>KARVA_CONFIG_FILE</code> environment variable.</p></dd><dt id="karva-test--durations"><a href="#karva-test--durations"><code>--durations</code></a> <i>n</i></dt><dd><p>Show the N slowest tests after the run completes</p>
 </dd><dt id="karva-test--fail-fast"><a href="#karva-test--fail-fast"><code>--fail-fast</code></a></dt><dd><p>Stop scheduling new tests after the first failure.</p>
 <p>Equivalent to <code>--max-fail=1</code>. Use <code>--no-fail-fast</code> to keep running after failures.</p>
 </dd><dt id="karva-test--filter"><a href="#karva-test--filter"><code>--filter</code></a>, <code>-E</code> <i>filter-expressions</i></dt><dd><p>Filter tests using a filterset expression.</p>


### PR DESCRIPTION
## Summary

This removes the `--dry-run` flag from `karva test`, along with its associated test collection/printing logic and all related tests.

The early filter expression validation that previously happened as a side effect of the dry-run setup is preserved so that invalid `--filter` expressions still fail fast in the main process rather than propagating to workers.

Snapshot subcommand `--dry-run` flags (`karva snapshot prune --dry-run` and `karva snapshot delete --dry-run`) are intentionally kept.

## Test plan

- [x] `just test` — all 824 tests pass
- [x] `uvx prek run -a` — all checks pass
- [x] CLI reference docs regenerated via `cargo run -p karva_dev generate-all`