### PR TITLE
Pin benchmark workers to 2 for consistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,6 +290,5 @@ jobs:
         env:
           PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
         with:
-          token: ${{ secrets.CODSPEED_TOKEN }}
           run: cargo codspeed run --bench karva_benchmark_walltime
           mode: walltime

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,7 +1108,6 @@ dependencies = [
  "karva_metadata",
  "karva_project",
  "karva_runner",
- "karva_static",
  "ruff_python_ast",
  "serde",
  "serde_json",

--- a/crates/karva_benchmark/Cargo.toml
+++ b/crates/karva_benchmark/Cargo.toml
@@ -20,7 +20,6 @@ karva_logging = { workspace = true }
 karva_metadata = { workspace = true }
 karva_project = { workspace = true }
 karva_runner = { workspace = true }
-karva_static = { workspace = true }
 ruff_python_ast = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/karva_benchmark/src/lib.rs
+++ b/crates/karva_benchmark/src/lib.rs
@@ -36,7 +36,7 @@ pub fn setup_project() -> Project {
 /// Run karva tests against the prepared project once.
 pub fn run_karva(project: &Project) {
     let config = karva_runner::ParallelTestConfig {
-        num_workers: karva_static::max_parallelism().get(),
+        num_workers: 2,
         no_cache: false,
         create_ctrlc_handler: false,
         last_failed: false,


### PR DESCRIPTION
## Summary

The walltime benchmark was sizing its worker pool via `karva_static::max_parallelism()`, which means the measurement varied with whatever core count the CI runner happened to expose. Pinning `num_workers: 2` makes the bench deterministic across runners and matches what `cargo nextest` already uses in CI (`KARVA_MAX_PARALLELISM: 2`). Also drops the now-unused `CODSPEED_TOKEN` secret from the workflow — the action authenticates via the GitHub OIDC token.

## Test Plan

ci