### PR TITLE
Move from karva-dev to MatthewMckee4

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yaml
@@ -6,7 +6,7 @@ body:
       value: |
         Thank you for taking the time to report an issue! We're glad to have you involved with Karva.
 
-        **Before reporting, please make sure to search through [existing issues](https://github.com/karva-dev/karva/issues?q=is:issue+is:open+label:bug) (including [closed](https://github.com/karva-dev/karva/issues?q=is:issue%20state:closed%20label:bug)).**
+        **Before reporting, please make sure to search through [existing issues](https://github.com/MatthewMckee4/karva/issues?q=is:issue+is:open+label:bug) (including [closed](https://github.com/MatthewMckee4/karva/issues?q=is:issue%20state:closed%20label:bug)).**
 
   - type: textarea
     attributes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,25 +4,25 @@
 
 ### CLI
 
-- Add `--watch` flag to `karva test` ([#486](https://github.com/karva-dev/karva/pull/486))
-- Add `--dry-run` flag to `karva test` ([#479](https://github.com/karva-dev/karva/pull/479))
+- Add `--watch` flag to `karva test` ([#486](https://github.com/MatthewMckee4/karva/pull/486))
+- Add `--dry-run` flag to `karva test` ([#479](https://github.com/MatthewMckee4/karva/pull/479))
 
 ### Extensions
 
-- Show span annotations for each fixture in dependency chain ([#488](https://github.com/karva-dev/karva/pull/488))
-- Show fixture dependency chain in error messages ([#487](https://github.com/karva-dev/karva/pull/487))
-- Fully support async tests and fixtures ([#485](https://github.com/karva-dev/karva/pull/485))
+- Show span annotations for each fixture in dependency chain ([#488](https://github.com/MatthewMckee4/karva/pull/488))
+- Show fixture dependency chain in error messages ([#487](https://github.com/MatthewMckee4/karva/pull/487))
+- Fully support async tests and fixtures ([#485](https://github.com/MatthewMckee4/karva/pull/485))
 
 ### Snapshot Testing
 
-- Add assert_cmd_snapshot function and Command class ([#461](https://github.com/karva-dev/karva/pull/461))
-- Add `assert_json_snapshot` function ([#458](https://github.com/karva-dev/karva/pull/458))
-- Add `name=` parameter to `assert_snapshot` for named snapshots ([#457](https://github.com/karva-dev/karva/pull/457))
-- Add `karva snapshot delete` command and fix snapshot path filtering ([#455](https://github.com/karva-dev/karva/pull/455))
-- Add snapshot_settings context manager with filter support ([#454](https://github.com/karva-dev/karva/pull/454))
-- Add `karva snapshot prune` command ([#453](https://github.com/karva-dev/karva/pull/453))
-- Add inline snapshots (insta-style) ([#450](https://github.com/karva-dev/karva/pull/450))
-- Add snapshot testing ([#444](https://github.com/karva-dev/karva/pull/444))
+- Add assert_cmd_snapshot function and Command class ([#461](https://github.com/MatthewMckee4/karva/pull/461))
+- Add `assert_json_snapshot` function ([#458](https://github.com/MatthewMckee4/karva/pull/458))
+- Add `name=` parameter to `assert_snapshot` for named snapshots ([#457](https://github.com/MatthewMckee4/karva/pull/457))
+- Add `karva snapshot delete` command and fix snapshot path filtering ([#455](https://github.com/MatthewMckee4/karva/pull/455))
+- Add snapshot_settings context manager with filter support ([#454](https://github.com/MatthewMckee4/karva/pull/454))
+- Add `karva snapshot prune` command ([#453](https://github.com/MatthewMckee4/karva/pull/453))
+- Add inline snapshots (insta-style) ([#450](https://github.com/MatthewMckee4/karva/pull/450))
+- Add snapshot testing ([#444](https://github.com/MatthewMckee4/karva/pull/444))
 
 ### Contributors
 
@@ -32,13 +32,13 @@
 
 ### Extensions
 
-- Add `-t` / `--tag` flag for filtering tests by custom tag expressions ([#422](https://github.com/karva-dev/karva/pull/422))
+- Add `-t` / `--tag` flag for filtering tests by custom tag expressions ([#422](https://github.com/MatthewMckee4/karva/pull/422))
 
 ### Test Running
 
-- Add `karva.raises` context manager for asserting exceptions ([#430](https://github.com/karva-dev/karva/pull/430))
-- Add `-m` / `--match` flag for regex-based test name filtering ([#428](https://github.com/karva-dev/karva/pull/428))
-- Replace body_length heuristic with random ordering ([#425](https://github.com/karva-dev/karva/pull/425))
+- Add `karva.raises` context manager for asserting exceptions ([#430](https://github.com/MatthewMckee4/karva/pull/430))
+- Add `-m` / `--match` flag for regex-based test name filtering ([#428](https://github.com/MatthewMckee4/karva/pull/428))
+- Replace body_length heuristic with random ordering ([#425](https://github.com/MatthewMckee4/karva/pull/425))
 
 ### Contributors
 
@@ -48,30 +48,30 @@
 
 ### Bug Fixes
 
-- Fix ctrl-c ([#357](https://github.com/karva-dev/karva/pull/357))
-- Fix run hash timestamp ([#356](https://github.com/karva-dev/karva/pull/356))
-- Fix `pytest.parametrize` with kwargs ([#342](https://github.com/karva-dev/karva/pull/342))
+- Fix ctrl-c ([#357](https://github.com/MatthewMckee4/karva/pull/357))
+- Fix run hash timestamp ([#356](https://github.com/MatthewMckee4/karva/pull/356))
+- Fix `pytest.parametrize` with kwargs ([#342](https://github.com/MatthewMckee4/karva/pull/342))
 
 ### CLI
 
-- Add --no-cache flag to disable reading cache ([#400](https://github.com/karva-dev/karva/pull/400))
+- Add --no-cache flag to disable reading cache ([#400](https://github.com/MatthewMckee4/karva/pull/400))
 
 ### Documentation
 
-- Document that --no-parallel is equivalent to --num-workers 1 ([#399](https://github.com/karva-dev/karva/pull/399))
-- Update documentation URLs to karva-dev.github.io ([#398](https://github.com/karva-dev/karva/pull/398))
-- Add disclaimer to docs that we won't support request ([#387](https://github.com/karva-dev/karva/pull/387))
-- Remove README note ([#340](https://github.com/karva-dev/karva/pull/340))
+- Document that --no-parallel is equivalent to --num-workers 1 ([#399](https://github.com/MatthewMckee4/karva/pull/399))
+- Update documentation URLs to matthewmckee4.github.io ([#398](https://github.com/MatthewMckee4/karva/pull/398))
+- Add disclaimer to docs that we won't support request ([#387](https://github.com/MatthewMckee4/karva/pull/387))
+- Remove README note ([#340](https://github.com/MatthewMckee4/karva/pull/340))
 
 ### Extensions
 
-- Remove `request` and fixture params ([#384](https://github.com/karva-dev/karva/pull/384))
-- Request node and custom tags ([#352](https://github.com/karva-dev/karva/pull/352))
-- Try import fixtures ([#351](https://github.com/karva-dev/karva/pull/351))
+- Remove `request` and fixture params ([#384](https://github.com/MatthewMckee4/karva/pull/384))
+- Request node and custom tags ([#352](https://github.com/MatthewMckee4/karva/pull/352))
+- Try import fixtures ([#351](https://github.com/MatthewMckee4/karva/pull/351))
 
 ### Test Running
 
-- Support retrying tests ([#354](https://github.com/karva-dev/karva/pull/354))
+- Support retrying tests ([#354](https://github.com/MatthewMckee4/karva/pull/354))
 
 ### Contributors
 
@@ -86,36 +86,36 @@ See the documentation for more information.
 
 ### Bug Fixes
 
-- Follow symlinks in directory walker ([#307](https://github.com/karva-dev/karva/pull/307))
-- Dont import all files in discovery ([#269](https://github.com/karva-dev/karva/pull/269))
-- Support dependent fixtures ([#70](https://github.com/karva-dev/karva/pull/70))
-- Add initial pytest fixture parsing ([#69](https://github.com/karva-dev/karva/pull/69))
-- Fix karva fail when no path provided ([#23](https://github.com/karva-dev/karva/pull/23))
+- Follow symlinks in directory walker ([#307](https://github.com/MatthewMckee4/karva/pull/307))
+- Dont import all files in discovery ([#269](https://github.com/MatthewMckee4/karva/pull/269))
+- Support dependent fixtures ([#70](https://github.com/MatthewMckee4/karva/pull/70))
+- Add initial pytest fixture parsing ([#69](https://github.com/MatthewMckee4/karva/pull/69))
+- Fix karva fail when no path provided ([#23](https://github.com/MatthewMckee4/karva/pull/23))
 
 ### Configuration
 
-- Support configuration files ([#317](https://github.com/karva-dev/karva/pull/317))
+- Support configuration files ([#317](https://github.com/MatthewMckee4/karva/pull/317))
 
 ### Extensions
 
-- Support `karva.param` in fixtures ([#289](https://github.com/karva-dev/karva/pull/289))
-- Support `karva.param` in parametrized tests ([#288](https://github.com/karva-dev/karva/pull/288))
-- Support `pytest.param` in `tags.parametrize` ([#279](https://github.com/karva-dev/karva/pull/279))
-- Support mocked environment fixture ([#277](https://github.com/karva-dev/karva/pull/277))
-- Support dynamically imported fixtures ([#256](https://github.com/karva-dev/karva/pull/256))
-- Support pytest param in fixtures ([#250](https://github.com/karva-dev/karva/pull/250))
-- Support expect fail ([#243](https://github.com/karva-dev/karva/pull/243))
-- Add diagnostics for fixtures having missing fixtures ([#232](https://github.com/karva-dev/karva/pull/232))
-- Show fixture diagnostics ([#231](https://github.com/karva-dev/karva/pull/231))
-- Support skip if ([#228](https://github.com/karva-dev/karva/pull/228))
-- Support skip in function ([#227](https://github.com/karva-dev/karva/pull/227))
-- Support parametrize args in a single string ([#187](https://github.com/karva-dev/karva/pull/187))
-- Allow fixture override ([#129](https://github.com/karva-dev/karva/pull/129))
-- Add support for dynamic fixture scopes ([#124](https://github.com/karva-dev/karva/pull/124))
+- Support `karva.param` in fixtures ([#289](https://github.com/MatthewMckee4/karva/pull/289))
+- Support `karva.param` in parametrized tests ([#288](https://github.com/MatthewMckee4/karva/pull/288))
+- Support `pytest.param` in `tags.parametrize` ([#279](https://github.com/MatthewMckee4/karva/pull/279))
+- Support mocked environment fixture ([#277](https://github.com/MatthewMckee4/karva/pull/277))
+- Support dynamically imported fixtures ([#256](https://github.com/MatthewMckee4/karva/pull/256))
+- Support pytest param in fixtures ([#250](https://github.com/MatthewMckee4/karva/pull/250))
+- Support expect fail ([#243](https://github.com/MatthewMckee4/karva/pull/243))
+- Add diagnostics for fixtures having missing fixtures ([#232](https://github.com/MatthewMckee4/karva/pull/232))
+- Show fixture diagnostics ([#231](https://github.com/MatthewMckee4/karva/pull/231))
+- Support skip if ([#228](https://github.com/MatthewMckee4/karva/pull/228))
+- Support skip in function ([#227](https://github.com/MatthewMckee4/karva/pull/227))
+- Support parametrize args in a single string ([#187](https://github.com/MatthewMckee4/karva/pull/187))
+- Allow fixture override ([#129](https://github.com/MatthewMckee4/karva/pull/129))
+- Add support for dynamic fixture scopes ([#124](https://github.com/MatthewMckee4/karva/pull/124))
 
 ### Reporting
 
-- Use ruff diagnostics ([#275](https://github.com/karva-dev/karva/pull/275))
+- Use ruff diagnostics ([#275](https://github.com/MatthewMckee4/karva/pull/275))
 
 ### Contributors
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ are welcome, and we try to keep the development process as smooth as possible.
 
 If you hit a bug, have a feature idea, or want to suggest an improvement to
 the contributing docs themselves, please
-[open an issue](https://github.com/karva-dev/karva/issues/new).
+[open an issue](https://github.com/MatthewMckee4/karva/issues/new).
 
 For small changes like bug fixes, feel free to jump straight to a pull request.
 For anything larger, it's usually worth opening an issue first to discuss the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,9 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.93"
-homepage = "https://github.com/karva-dev/karva"
-documentation = "https://github.com/karva-dev/karva"
-repository = "https://github.com/karva-dev/karva"
+homepage = "https://github.com/MatthewMckee4/karva"
+documentation = "https://github.com/MatthewMckee4/karva"
+repository = "https://github.com/MatthewMckee4/karva"
 authors = ["Matthew Mckee <matthewmckee04@yahoo.co.uk>"]
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A Python test framework, written in Rust.
 
 <div align="center">
-  <img src="https://raw.githubusercontent.com/karva-dev/karva/main/docs/assets/benchmark_results.svg" alt="Benchmark results" width="70%">
+  <img src="https://raw.githubusercontent.com/MatthewMckee4/karva/main/docs/assets/benchmark_results.svg" alt="Benchmark results" width="70%">
 </div>
 
 **We'd love for you to try Karva!** It's currently in alpha, and your feedback helps shape the project. [Get started](#getting-started) or join us on [Discord](https://discord.gg/XG95vNz4Zu).
@@ -70,6 +70,6 @@ karva test tests/test_example.py
 
 ## Contributing
 
-Contributions are welcome! See [CONTRIBUTING.md](https://github.com/karva-dev/karva/blob/main/CONTRIBUTING.md) for more information.
+Contributions are welcome! See [CONTRIBUTING.md](https://github.com/MatthewMckee4/karva/blob/main/CONTRIBUTING.md) for more information.
 
 You can also join us on [Discord](https://discord.gg/XG95vNz4Zu)

--- a/crates/karva_benchmark/src/lib.rs
+++ b/crates/karva_benchmark/src/lib.rs
@@ -1,6 +1,6 @@
 //! Wall-time benchmark for karva.
 //!
-//! Clones a fixed snapshot of <https://github.com/karva-dev/karva-benchmark-1>
+//! Clones a fixed snapshot of <https://github.com/MatthewMckee4/karva-benchmark-1>
 //! into `target/benchmark_cache/`, installs its dependencies via uv, and runs
 //! `karva test` against it. The snapshot is pinned to a specific commit so
 //! results stay stable across runs.
@@ -18,7 +18,7 @@ use karva_project::Project;
 use ruff_python_ast::PythonVersion;
 
 const PROJECT_NAME: &str = "karva-benchmark-1";
-const REPOSITORY: &str = "https://github.com/karva-dev/karva-benchmark-1";
+const REPOSITORY: &str = "https://github.com/MatthewMckee4/karva-benchmark-1";
 const COMMIT: &str = "89791b99d8b13a1e104af7a0b55b3741e315268a";
 const DEPENDENCIES: &[&str] = &["pytest"];
 const MAX_DEP_DATE: &str = "2026-12-01";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,10 +32,10 @@ docs = ["zensical==0.0.10"]
 release = ["tbump"]
 
 [project.urls]
-Documentation = "https://karva-dev.github.io/karva/"
-Homepage = "https://karva-dev.github.io/karva/"
-Issues = "https://github.com/karva-dev/karva/issues"
-Repository = "https://github.com/karva-dev/karva"
+Documentation = "https://matthewmckee4.github.io/karva/"
+Homepage = "https://matthewmckee4.github.io/karva/"
+Issues = "https://github.com/MatthewMckee4/karva/issues"
+Repository = "https://github.com/MatthewMckee4/karva"
 
 [tool.maturin]
 manifest-path = "crates/karva_python/Cargo.toml"

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,10 +1,10 @@
 [project]
 site_name = "Karva"
-site_url = "https://karva-dev.github.io/karva"
+site_url = "https://matthewmckee4.github.io/karva"
 site_description = "A Python test framework, written in Rust"
 site_author = "Matthew McKee"
-repo_url = "https://github.com/karva-dev/karva"
-repo_name = "karva-dev/karva"
+repo_url = "https://github.com/MatthewMckee4/karva"
+repo_name = "MatthewMckee4/karva"
 
 docs_dir = "docs"
 site_dir = "site"


### PR DESCRIPTION
## Summary

The repository was transferred from the `karva-dev` org to my personal account, so this updates the corresponding URLs in the workspace metadata, docs config, README, CHANGELOG, contributing guide, issue template, and the `karva-benchmark-1` reference in `karva_benchmark` (which was also transferred).

## Test plan

ci