### PR TITLE
Add nextest-style configuration profiles

### DIFF
--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -54,8 +54,12 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
             .unwrap_or_else(|| karva_static::max_parallelism().get())
     };
 
-    let project_options_overrides = ProjectOptionsOverrides::new(config_file, args.into_options());
-    project_metadata.apply_overrides(&project_options_overrides);
+    let profile = args.profile.clone();
+    let project_options_overrides =
+        ProjectOptionsOverrides::new(config_file, args.into_options()).with_profile(profile);
+    project_metadata
+        .apply_overrides(&project_options_overrides)
+        .map_err(|err| anyhow::anyhow!("{err}"))?;
 
     let project = Project::from_metadata(project_metadata);
 

--- a/crates/karva/tests/it/configuration/mod.rs
+++ b/crates/karva/tests/it/configuration/mod.rs
@@ -10,7 +10,7 @@ fn test_src_respect_ignore_files_false() {
         (
             "karva.toml",
             r"
-[src]
+[profile.default.src]
 respect-ignore-files = false
 ",
         ),
@@ -48,7 +48,7 @@ fn test_src_respect_ignore_files_true() {
         (
             "karva.toml",
             r"
-[src]
+[profile.default.src]
 respect-ignore-files = true
 ",
         ),
@@ -88,7 +88,7 @@ fn test_src_include_paths() {
         (
             "karva.toml",
             r#"
-[src]
+[profile.default.src]
 include = ["src", "tests"]
 "#,
         ),
@@ -131,7 +131,7 @@ fn test_src_include_single_file() {
         (
             "karva.toml",
             r#"
-[src]
+[profile.default.src]
 include = ["test_specific.py"]
 "#,
         ),
@@ -170,7 +170,7 @@ fn test_terminal_output_format_concise() {
         (
             "karva.toml",
             r#"
-[terminal]
+[profile.default.terminal]
 output-format = "concise"
 "#,
         ),
@@ -202,7 +202,7 @@ fn test_terminal_output_format_full() {
         (
             "karva.toml",
             r#"
-[terminal]
+[profile.default.terminal]
 output-format = "full"
 "#,
         ),
@@ -234,7 +234,7 @@ fn test_terminal_show_python_output_false() {
         (
             "karva.toml",
             r"
-[terminal]
+[profile.default.terminal]
 show-python-output = false
 ",
         ),
@@ -269,7 +269,7 @@ fn test_terminal_show_python_output_true() {
         (
             "karva.toml",
             r"
-[terminal]
+[profile.default.terminal]
 show-python-output = true
 ",
         ),
@@ -305,7 +305,7 @@ fn test_terminal_status_level_from_config() {
         (
             "karva.toml",
             r#"
-[terminal]
+[profile.default.terminal]
 status-level = "none"
 "#,
         ),
@@ -330,7 +330,7 @@ fn test_terminal_final_status_level_from_config() {
         (
             "karva.toml",
             r#"
-[terminal]
+[profile.default.terminal]
 final-status-level = "none"
 "#,
         ),
@@ -354,7 +354,7 @@ fn test_cli_status_level_overrides_config() {
         (
             "karva.toml",
             r#"
-[terminal]
+[profile.default.terminal]
 status-level = "none"
 "#,
         ),
@@ -381,7 +381,7 @@ fn test_test_function_prefix_custom() {
         (
             "karva.toml",
             r#"
-[test]
+[profile.default.test]
 test-function-prefix = "check"
 "#,
         ),
@@ -415,7 +415,7 @@ fn test_test_function_prefix_default() {
         (
             "karva.toml",
             r#"
-[test]
+[profile.default.test]
 test-function-prefix = "test"
 "#,
         ),
@@ -450,7 +450,7 @@ fn test_max_fail_from_config() {
         (
             "karva.toml",
             r"
-[test]
+[profile.default.test]
 max-fail = 2
 ",
         ),
@@ -528,7 +528,7 @@ fn test_fail_fast_true() {
         (
             "karva.toml",
             r"
-[test]
+[profile.default.test]
 fail-fast = true
 ",
         ),
@@ -584,7 +584,7 @@ fn test_fail_fast_false() {
         (
             "karva.toml",
             r"
-[test]
+[profile.default.test]
 fail-fast = false
 ",
         ),
@@ -662,15 +662,15 @@ fn test_combined_all_options() {
         (
             "karva.toml",
             r#"
-[src]
+[profile.default.src]
 respect-ignore-files = false
 include = ["tests"]
 
-[terminal]
+[profile.default.terminal]
 output-format = "concise"
 show-python-output = false
 
-[test]
+[profile.default.test]
 test-function-prefix = "check"
 fail-fast = true
 "#,
@@ -712,10 +712,10 @@ fn test_combined_src_and_test_options() {
         (
             "karva.toml",
             r#"
-[src]
+[profile.default.src]
 include = ["src"]
 
-[test]
+[profile.default.test]
 test-function-prefix = "verify"
 "#,
         ),
@@ -758,7 +758,7 @@ fn test_pyproject_src_options() {
 [project]
 name = "test-project"
 
-[tool.karva.src]
+[tool.karva.profile.default.src]
 respect-ignore-files = false
 include = ["src"]
 "#,
@@ -806,7 +806,7 @@ fn test_pyproject_terminal_options() {
 [project]
 name = "test-project"
 
-[tool.karva.terminal]
+[tool.karva.profile.default.terminal]
 output-format = "concise"
 show-python-output = false
 "#,
@@ -844,7 +844,7 @@ fn test_pyproject_test_options() {
 [project]
 name = "test-project"
 
-[tool.karva.test]
+[tool.karva.profile.default.test]
 test-function-prefix = "spec"
 fail-fast = true
 "#,
@@ -881,15 +881,15 @@ fn test_pyproject_all_options() {
 [project]
 name = "test-project"
 
-[tool.karva.src]
+[tool.karva.profile.default.src]
 respect-ignore-files = false
 include = ["tests"]
 
-[tool.karva.terminal]
+[tool.karva.profile.default.terminal]
 output-format = "full"
 show-python-output = true
 
-[tool.karva.test]
+[tool.karva.profile.default.test]
 test-function-prefix = "it"
 fail-fast = false
 "#,
@@ -935,7 +935,7 @@ fn test_karva_toml_takes_precedence_over_pyproject() {
         (
             "karva.toml",
             r#"
-[test]
+[profile.default.test]
 test-function-prefix = "karva"
 "#,
         ),
@@ -945,7 +945,7 @@ test-function-prefix = "karva"
 [project]
 name = "test-project"
 
-[tool.karva.test]
+[tool.karva.profile.default.test]
 test-function-prefix = "pyproject"
 "#,
         ),
@@ -1007,7 +1007,7 @@ fn test_partial_config() {
         (
             "karva.toml",
             r#"
-[test]
+[profile.default.test]
 test-function-prefix = "custom"
 "#,
         ),
@@ -1040,7 +1040,7 @@ fn test_cli_test_prefix_overrides_config() {
         (
             "karva.toml",
             r#"
-[test]
+[profile.default.test]
 test-function-prefix = "config"
 "#,
         ),
@@ -1074,7 +1074,7 @@ fn test_cli_output_format_overrides_config() {
         (
             "karva.toml",
             r#"
-[terminal]
+[profile.default.terminal]
 output-format = "full"
 "#,
         ),
@@ -1107,7 +1107,7 @@ fn test_cli_show_output_overrides_config() {
         (
             "karva.toml",
             r"
-[terminal]
+[profile.default.terminal]
 show-python-output = false
 ",
         ),
@@ -1143,7 +1143,7 @@ fn test_cli_no_ignore_overrides_config() {
         (
             "karva.toml",
             r"
-[src]
+[profile.default.src]
 respect-ignore-files = true
 ",
         ),
@@ -1181,7 +1181,7 @@ fn test_cli_fail_fast_overrides_config() {
         (
             "karva.toml",
             r"
-[test]
+[profile.default.test]
 fail-fast = false
 ",
         ),
@@ -1237,7 +1237,7 @@ fn test_cli_paths_override_config_include() {
         (
             "karva.toml",
             r#"
-[src]
+[profile.default.src]
 include = ["config_dir"]
 "#,
         ),
@@ -1274,15 +1274,15 @@ fn test_cli_multiple_arguments_override_config() {
         (
             "karva.toml",
             r#"
-[src]
+[profile.default.src]
 respect-ignore-files = true
 include = ["config_dir"]
 
-[terminal]
+[profile.default.terminal]
 output-format = "full"
 show-python-output = false
 
-[test]
+[profile.default.test]
 test-function-prefix = "config"
 fail-fast = false
 "#,
@@ -1340,11 +1340,11 @@ fn test_cli_overrides_pyproject_toml() {
 [project]
 name = "test-project"
 
-[tool.karva.test]
+[tool.karva.profile.default.test]
 test-function-prefix = "pyproject"
 fail-fast = true
 
-[tool.karva.terminal]
+[tool.karva.profile.default.terminal]
 show-python-output = false
 "#,
         ),
@@ -1389,7 +1389,7 @@ fn test_cli_overrides_both_config_files() {
         (
             "karva.toml",
             r#"
-[test]
+[profile.default.test]
 test-function-prefix = "karva"
 "#,
         ),
@@ -1399,7 +1399,7 @@ test-function-prefix = "karva"
 [project]
 name = "test-project"
 
-[tool.karva.test]
+[tool.karva.profile.default.test]
 test-function-prefix = "pyproject"
 "#,
         ),
@@ -1435,7 +1435,7 @@ fn test_config_file_flag() {
         (
             "custom-config.toml",
             r#"
-[test]
+[profile.default.test]
 test-function-prefix = "check"
 "#,
         ),
@@ -1470,7 +1470,7 @@ fn test_config_file_env_var() {
         (
             "custom.toml",
             r#"
-[test]
+[profile.default.test]
 test-function-prefix = "spec"
 "#,
         ),
@@ -1508,14 +1508,14 @@ fn test_cli_config_file_overrides_env() {
         (
             "env.toml",
             r#"
-[test]
+[profile.default.test]
 test-function-prefix = "env"
 "#,
         ),
         (
             "cli.toml",
             r#"
-[test]
+[profile.default.test]
 test-function-prefix = "cli"
 "#,
         ),
@@ -1556,7 +1556,7 @@ fn test_karva_toml_discovered_from_subdirectory() {
         (
             "karva.toml",
             r#"
-[test]
+[profile.default.test]
 test-function-prefix = "check"
 "#,
         ),

--- a/crates/karva/tests/it/configuration/mod.rs
+++ b/crates/karva/tests/it/configuration/mod.rs
@@ -1,3 +1,5 @@
+mod profile;
+
 use insta_cmd::assert_cmd_snapshot;
 
 use crate::common::TestContext;

--- a/crates/karva/tests/it/configuration/profile.rs
+++ b/crates/karva/tests/it/configuration/profile.rs
@@ -1,0 +1,346 @@
+use insta_cmd::assert_cmd_snapshot;
+
+use crate::common::TestContext;
+
+#[test]
+fn profile_named_overrides_top_level_options() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[test]
+test-function-prefix = "test"
+
+[profile.ci.test]
+test-function-prefix = "check"
+"#,
+        ),
+        (
+            "test.py",
+            r"
+def check_example(): pass
+def test_should_not_run_under_ci_profile(): pass
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command().args(["--profile", "ci"]), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::check_example
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn profile_short_flag_works() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.fast.test]
+test-function-prefix = "check"
+"#,
+        ),
+        (
+            "test.py",
+            r"
+def check_quick(): pass
+def test_normal(): pass
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command().args(["-P", "fast"]), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::check_quick
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn profile_default_overrides_apply_when_no_profile_selected() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[test]
+test-function-prefix = "test"
+
+[profile.default.test]
+test-function-prefix = "check"
+"#,
+        ),
+        (
+            "test.py",
+            r"
+def check_example(): pass
+def test_not_run(): pass
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::check_example
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn profile_named_layers_on_top_of_default_overrides() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[test]
+test-function-prefix = "test"
+
+[profile.default.test]
+retry = 1
+
+[profile.ci.test]
+test-function-prefix = "check"
+"#,
+        ),
+        (
+            "test.py",
+            r"
+def check_example(): pass
+def test_not_run(): pass
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command().args(["--profile", "ci"]), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::check_example
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn profile_unknown_errors_with_listing() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.ci.test]
+retry = 1
+
+[profile.fast.test]
+test-function-prefix = "check"
+"#,
+        ),
+        ("test.py", "def test_a(): pass"),
+    ]);
+
+    assert_cmd_snapshot!(context.command().args(["--profile", "missing"]), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Karva failed
+      Cause: profile `missing` is not defined in configuration (available: ci, default, fast)
+    ");
+}
+
+#[test]
+fn profile_env_var_selects_profile() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.fast.test]
+test-function-prefix = "check"
+"#,
+        ),
+        (
+            "test.py",
+            r"
+def check_example(): pass
+def test_not_run(): pass
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command().env("KARVA_PROFILE", "fast"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::check_example
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn profile_cli_flag_takes_precedence_over_env_var() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.fast.test]
+test-function-prefix = "check"
+
+[profile.ci.test]
+test-function-prefix = "verify"
+"#,
+        ),
+        (
+            "test.py",
+            r"
+def check_a(): pass
+def verify_b(): pass
+def test_not_run(): pass
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context
+            .command()
+            .env("KARVA_PROFILE", "fast")
+            .args(["--profile", "ci"]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::verify_b
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
+fn profile_cli_options_override_resolved_profile() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.ci.test]
+test-function-prefix = "check"
+"#,
+        ),
+        (
+            "test.py",
+            r"
+def check_a(): pass
+def verify_b(): pass
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context
+            .command()
+            .args(["--profile", "ci", "--test-prefix", "verify"]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::verify_b
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
+fn profile_pyproject_toml() {
+    let context = TestContext::with_files([
+        (
+            "pyproject.toml",
+            r#"
+[tool.karva.profile.ci.test]
+test-function-prefix = "check"
+"#,
+        ),
+        (
+            "test.py",
+            r"
+def check_example(): pass
+def test_not_run(): pass
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command().args(["--profile", "ci"]), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::check_example
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn profile_reserved_default_prefix_rejected() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r"
+[profile.default-ci.test]
+retry = 1
+",
+        ),
+        ("test.py", "def test_a(): pass"),
+    ]);
+
+    assert_cmd_snapshot!(context.command(), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Karva failed
+      Cause: <temp_dir>/karva.toml is not a valid `karva.toml`: invalid profile name `default-ci`: the `default-` prefix is reserved for built-in profiles
+      Cause: invalid profile name `default-ci`: the `default-` prefix is reserved for built-in profiles
+    ");
+}

--- a/crates/karva/tests/it/configuration/profile.rs
+++ b/crates/karva/tests/it/configuration/profile.rs
@@ -3,12 +3,12 @@ use insta_cmd::assert_cmd_snapshot;
 use crate::common::TestContext;
 
 #[test]
-fn profile_named_overrides_top_level_options() {
+fn profile_named_overrides_default_profile() {
     let context = TestContext::with_files([
         (
             "karva.toml",
             r#"
-[test]
+[profile.default.test]
 test-function-prefix = "test"
 
 [profile.ci.test]
@@ -77,9 +77,6 @@ fn profile_default_overrides_apply_when_no_profile_selected() {
         (
             "karva.toml",
             r#"
-[test]
-test-function-prefix = "test"
-
 [profile.default.test]
 test-function-prefix = "check"
 "#,
@@ -113,9 +110,6 @@ fn profile_named_layers_on_top_of_default_overrides() {
         (
             "karva.toml",
             r#"
-[test]
-test-function-prefix = "test"
-
 [profile.default.test]
 retry = 1
 
@@ -317,6 +311,40 @@ def test_not_run(): pass
          Summary [TIME] 1 test run: 1 passed, 0 skipped
 
     ----- stderr -----
+    ");
+}
+
+#[test]
+fn top_level_option_groups_rejected() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[test]
+test-function-prefix = "check"
+"#,
+        ),
+        ("test.py", "def test_a(): pass"),
+    ]);
+
+    assert_cmd_snapshot!(context.command(), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Karva failed
+      Cause: <temp_dir>/karva.toml is not a valid `karva.toml`: TOML parse error at line 2, column 2
+      |
+    2 | [test]
+      |  ^^^^
+    unknown field `test`, expected `profile`
+
+      Cause: TOML parse error at line 2, column 2
+      |
+    2 | [test]
+      |  ^^^^
+    unknown field `test`, expected `profile`
     ");
 }
 

--- a/crates/karva/tests/it/discovery/git_boundary.rs
+++ b/crates/karva/tests/it/discovery/git_boundary.rs
@@ -24,7 +24,7 @@ fn test_discovery_stops_at_git_boundary() {
 [project]
 name = "outer-project"
 
-[tool.karva.test]
+[tool.karva.profile.default.test]
 test-function-prefix = "outer_"
 "#,
         ),
@@ -82,7 +82,7 @@ fn test_discovery_finds_pyproject_within_git_repo() {
 [project]
 name = "my-project"
 
-[tool.karva.test]
+[tool.karva.profile.default.test]
 test-function-prefix = "spec"
 "#,
         ),

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -303,6 +303,24 @@ pub struct TestCommand {
         help_heading = "Config options"
     )]
     pub config_file: Option<Utf8PathBuf>,
+
+    /// Configuration profile to use.
+    ///
+    /// Profiles are defined as `[profile.<name>]` sections in `karva.toml`
+    /// (or `[tool.karva.profile.<name>]` in `pyproject.toml`) and may
+    /// override any of the `[src]`, `[terminal]`, and `[test]` settings.
+    /// The selected profile is layered on top of any `[profile.default]`
+    /// overrides, which themselves layer on top of the top-level options.
+    ///
+    /// Defaults to `default`.
+    #[arg(
+        short = 'P',
+        long,
+        env = "KARVA_PROFILE",
+        value_name = "NAME",
+        help_heading = "Config options"
+    )]
+    pub profile: Option<String>,
 }
 
 impl TestCommand {
@@ -379,6 +397,7 @@ impl SubTestCommand {
                 retry: self.retry,
                 no_tests: self.no_tests.map(Into::into),
             }),
+            profile: None,
         }
     }
 }

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -397,7 +397,6 @@ impl SubTestCommand {
                 retry: self.retry,
                 no_tests: self.no_tests.map(Into::into),
             }),
-            profile: None,
         }
     }
 }

--- a/crates/karva_combine/src/lib.rs
+++ b/crates/karva_combine/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::hash::BuildHasher;
 
 use ruff_python_ast::PythonVersion;
@@ -62,6 +62,16 @@ where
     fn combine_with(&mut self, mut other: Self) {
         // `self` takes precedence over `other` but `extend` overrides existing values.
         // Swap the hash maps so that `self` is the one that gets extended.
+        std::mem::swap(self, &mut other);
+        self.extend(other);
+    }
+}
+
+impl<K, V> Combine for BTreeMap<K, V>
+where
+    K: Ord,
+{
+    fn combine_with(&mut self, mut other: Self) {
         std::mem::swap(self, &mut other);
         self.extend(other);
     }

--- a/crates/karva_dev/src/generate_options.rs
+++ b/crates/karva_dev/src/generate_options.rs
@@ -198,13 +198,14 @@ fn format_header(
     parents: &[Set],
     configuration: ConfigurationFile,
 ) -> String {
-    let tool_parent = match configuration {
-        ConfigurationFile::PyprojectToml => Some("tool.karva"),
-        ConfigurationFile::KarvaToml => None,
+    // All option groups live under `[profile.<name>]` (nextest-style). The
+    // generated examples target the implicit `default` profile.
+    let parent_path = match configuration {
+        ConfigurationFile::PyprojectToml => "tool.karva.profile.default",
+        ConfigurationFile::KarvaToml => "profile.default",
     };
 
-    let header = tool_parent
-        .into_iter()
+    let header = std::iter::once(parent_path)
         .chain(parents.iter().filter_map(|parent| parent.name()))
         .chain(scope)
         .join(".");

--- a/crates/karva_dev/src/generate_options.rs
+++ b/crates/karva_dev/src/generate_options.rs
@@ -67,7 +67,16 @@ pub(crate) fn main(args: &Args) -> anyhow::Result<()> {
 fn generate_set(output: &mut String, set: Set, parents: &mut Vec<Set>) {
     match &set {
         Set::Toplevel(_) => {
-            output.push_str("# Configuration\n");
+            output.push_str("# Configuration\n\n");
+            output.push_str(
+                "Karva is configured through `karva.toml` (or the `[tool.karva]` table in \
+                 `pyproject.toml`). All option groups live under a `[profile.<name>]` section; \
+                 see [Profiles](profiles.md) for how to define and select profiles.\n\n",
+            );
+            output.push_str(
+                "The reference below documents every field supported inside a profile. Examples \
+                 target the implicit `default` profile.\n\n",
+            );
         }
         Set::Named { name, .. } => {
             let title = parents
@@ -191,7 +200,7 @@ fn format_example(header: &str, content: &str) -> String {
 
 /// Format the TOML header for the example usage for a given option.
 ///
-/// For example: `[tool.karva.src]`.
+/// For example: `[tool.karva.profile.default.src]`.
 fn format_header(
     scope: Option<&str>,
     example: &str,

--- a/crates/karva_metadata/src/lib.rs
+++ b/crates/karva_metadata/src/lib.rs
@@ -11,7 +11,8 @@ mod settings;
 
 pub use max_fail::MaxFail;
 pub use options::{
-    Options, OutputFormat, ProjectOptionsOverrides, SrcOptions, TerminalOptions, TestOptions,
+    DEFAULT_PROFILE, Options, OutputFormat, ProfileOptions, ProjectOptionsOverrides, SrcOptions,
+    TerminalOptions, TestOptions, UnknownProfile,
 };
 pub use pyproject::{PyProject, PyProjectError};
 pub use settings::{NoTestsMode, ProjectSettings, RunIgnoredMode};
@@ -186,8 +187,12 @@ impl ProjectMetadata {
         self
     }
 
-    pub fn apply_overrides(&mut self, overrides: &ProjectOptionsOverrides) {
-        self.options = overrides.apply_to(std::mem::take(&mut self.options));
+    pub fn apply_overrides(
+        &mut self,
+        overrides: &ProjectOptionsOverrides,
+    ) -> Result<(), UnknownProfile> {
+        self.options = overrides.apply_to(std::mem::take(&mut self.options))?;
+        Ok(())
     }
 
     /// Combine the project options with the CLI options where the CLI options take precedence.

--- a/crates/karva_metadata/src/lib.rs
+++ b/crates/karva_metadata/src/lib.rs
@@ -11,7 +11,7 @@ mod settings;
 
 pub use max_fail::MaxFail;
 pub use options::{
-    DEFAULT_PROFILE, Options, OutputFormat, ProfileOptions, ProjectOptionsOverrides, SrcOptions,
+    Config, DEFAULT_PROFILE, Options, OutputFormat, ProjectOptionsOverrides, SrcOptions,
     TerminalOptions, TestOptions, UnknownProfile,
 };
 pub use pyproject::{PyProject, PyProjectError};
@@ -19,21 +19,29 @@ pub use settings::{NoTestsMode, ProjectSettings, RunIgnoredMode};
 
 use crate::options::KarvaTomlError;
 
+/// File-level configuration paired with the resolved per-profile [`Options`].
+///
+/// `config` always reflects the file as parsed. `options` is empty until
+/// [`ProjectMetadata::apply_overrides`] selects a profile and combines CLI
+/// overrides on top of it.
 #[derive(Default, Debug, Clone)]
 pub struct ProjectMetadata {
     pub root: Utf8PathBuf,
 
     pub python_version: PythonVersion,
 
+    pub config: Config,
+
     pub options: Options,
 }
 
 impl ProjectMetadata {
-    /// Creates a project with the given name and root that uses the default options.
+    /// Creates a project with the given root and an empty configuration.
     pub fn new(root: Utf8PathBuf, python_version: PythonVersion) -> Self {
         Self {
             root,
             python_version,
+            config: Config::default(),
             options: Options::default(),
         }
     }
@@ -45,7 +53,7 @@ impl ProjectMetadata {
     ) -> Result<Self, ProjectMetadataError> {
         tracing::debug!("Using overridden configuration file at '{path}'");
 
-        let options = Options::from_karva_configuration_file(&path).map_err(|error| {
+        let config = Config::from_karva_configuration_file(&path).map_err(|error| {
             ProjectMetadataError::InvalidKarvaToml {
                 source: Box::new(error),
                 path,
@@ -55,7 +63,8 @@ impl ProjectMetadata {
         Ok(Self {
             root: cwd.to_path_buf(),
             python_version,
-            options,
+            config,
+            options: Options::default(),
         })
     }
 
@@ -65,7 +74,7 @@ impl ProjectMetadata {
         root: Utf8PathBuf,
         python_version: PythonVersion,
     ) -> Self {
-        Self::from_options(
+        Self::from_config(
             pyproject
                 .tool
                 .and_then(|tool| tool.karva)
@@ -75,16 +84,13 @@ impl ProjectMetadata {
         )
     }
 
-    /// Loads a project from a set of options with an optional pyproject-project table.
-    pub fn from_options(
-        options: Options,
-        root: Utf8PathBuf,
-        python_version: PythonVersion,
-    ) -> Self {
+    /// Loads a project from a parsed [`Config`].
+    pub fn from_config(config: Config, root: Utf8PathBuf, python_version: PythonVersion) -> Self {
         Self {
             root,
             python_version,
-            options,
+            config,
+            options: Options::default(),
         }
     }
 
@@ -116,7 +122,7 @@ impl ProjectMetadata {
         for project_root in path.ancestors() {
             let pyproject = try_load_pyproject(project_root)?;
 
-            if let Some(options) = try_load_karva_toml(project_root)? {
+            if let Some(config) = try_load_karva_toml(project_root)? {
                 if has_karva_section(pyproject.as_ref()) {
                     let pyproject_path = project_root.join("pyproject.toml");
                     let karva_toml_path = project_root.join("karva.toml");
@@ -126,8 +132,8 @@ impl ProjectMetadata {
                 }
 
                 tracing::debug!("Found project at '{}'", project_root);
-                return Ok(Self::from_options(
-                    options,
+                return Ok(Self::from_config(
+                    config,
                     project_root.to_path_buf(),
                     python_version,
                 ));
@@ -187,11 +193,14 @@ impl ProjectMetadata {
         self
     }
 
+    /// Resolve the requested profile from the parsed [`Config`] and combine
+    /// CLI overrides on top, populating `self.options`.
     pub fn apply_overrides(
         &mut self,
         overrides: &ProjectOptionsOverrides,
     ) -> Result<(), UnknownProfile> {
-        self.options = overrides.apply_to(std::mem::take(&mut self.options))?;
+        let config = std::mem::take(&mut self.config);
+        self.options = overrides.apply_to(config)?;
         Ok(())
     }
 
@@ -202,21 +211,21 @@ impl ProjectMetadata {
 }
 
 /// Checks for a `karva.toml` in `dir` and parses it if present.
-fn try_load_karva_toml(dir: &Utf8Path) -> Result<Option<Options>, ProjectMetadataError> {
+fn try_load_karva_toml(dir: &Utf8Path) -> Result<Option<Config>, ProjectMetadataError> {
     let path = dir.join("karva.toml");
 
     let Ok(content) = std::fs::read_to_string(&path) else {
         return Ok(None);
     };
 
-    let options = Options::from_toml_str(&content).map_err(|error| {
+    let config = Config::from_toml_str(&content).map_err(|error| {
         ProjectMetadataError::InvalidKarvaToml {
             source: Box::new(error),
             path,
         }
     })?;
 
-    Ok(Some(options))
+    Ok(Some(config))
 }
 
 /// Checks for a `pyproject.toml` in `dir` and parses it if present.

--- a/crates/karva_metadata/src/options.rs
+++ b/crates/karva_metadata/src/options.rs
@@ -17,47 +17,23 @@ use crate::settings::{
 /// The implicit name of the default profile.
 pub const DEFAULT_PROFILE: &str = "default";
 
-#[derive(
-    Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, OptionsMetadata, Combine,
-)]
+/// File-level configuration: a collection of named profiles.
+///
+/// Mirrors nextest: every option group lives inside `[profile.<name>]`. The
+/// implicit `default` profile is always available; other profiles inherit
+/// from it (and can override individual fields).
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
-pub struct Options {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[option_group]
-    pub src: Option<SrcOptions>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[option_group]
-    pub terminal: Option<TerminalOptions>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[option_group]
-    pub test: Option<TestOptions>,
-
-    /// Named configuration profiles, selected with `--profile <name>` or the
-    /// `KARVA_PROFILE` environment variable.
-    ///
-    /// Each profile may override `[src]`, `[terminal]`, and `[test]` settings.
-    /// Selecting a non-default profile layers its overrides on top of the
-    /// `[profile.default]` overrides (if any), which themselves layer on top
-    /// of the top-level options.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub profile: Option<BTreeMap<String, ProfileOptions>>,
+pub struct Config {
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub profile: BTreeMap<String, Options>,
 }
 
-impl Options {
+impl Config {
     pub fn from_toml_str(content: &str) -> Result<Self, KarvaTomlError> {
-        let options: Self = toml::from_str(content)?;
-        if let Some(profiles) = &options.profile {
-            validate_profile_names(profiles)?;
-        }
-        Ok(options)
-    }
-
-    pub fn to_settings(&self) -> ProjectSettings {
-        ProjectSettings {
-            terminal: self.terminal.clone().unwrap_or_default().to_settings(),
-            src: self.src.clone().unwrap_or_default().to_settings(),
-            test: self.test.clone().unwrap_or_default().to_settings(),
-        }
+        let config: Self = toml::from_str(content)?;
+        validate_profile_names(&config.profile)?;
+        Ok(config)
     }
 
     pub(crate) fn from_karva_configuration_file(
@@ -78,42 +54,28 @@ impl Options {
         if name == DEFAULT_PROFILE {
             return true;
         }
-        self.profile
-            .as_ref()
-            .is_some_and(|profiles| profiles.contains_key(name))
+        self.profile.contains_key(name)
     }
 
-    /// Resolve a profile by collapsing the `profile` map into the top-level
-    /// option groups.
+    /// Resolve a profile by collapsing the `profile` map into a single
+    /// [`Options`] value.
     ///
-    /// The returned `Options` has its `profile` field cleared. The selected
-    /// profile is layered on top of any `[profile.default]` overrides, which
-    /// themselves layer on top of the top-level options. CLI options can then
-    /// be combined with the result via the usual `Combine` precedence.
+    /// The selected profile is layered on top of any `[profile.default]`
+    /// overrides, which form the base. CLI options can then be combined with
+    /// the result via the usual `Combine` precedence.
     ///
-    /// Returns [`UnknownProfile`] when `name` is set to a profile that is
+    /// Returns [`UnknownProfile`] when `name` refers to a profile that is
     /// not defined.
-    pub fn resolve_profile(mut self, name: Option<&str>) -> Result<Self, UnknownProfile> {
+    pub fn resolve_profile(mut self, name: Option<&str>) -> Result<Options, UnknownProfile> {
         let requested = name.unwrap_or(DEFAULT_PROFILE);
-        let profiles = self.profile.take();
 
-        let Some(mut profiles) = profiles else {
-            if requested != DEFAULT_PROFILE {
-                return Err(UnknownProfile {
-                    name: requested.to_string(),
-                    available: vec![DEFAULT_PROFILE.to_string()],
-                });
-            }
-            return Ok(self);
-        };
-
-        let default_overrides = profiles.remove(DEFAULT_PROFILE);
+        let default_overrides = self.profile.remove(DEFAULT_PROFILE);
         let named_overrides = if requested == DEFAULT_PROFILE {
             None
-        } else if let Some(p) = profiles.remove(requested) {
+        } else if let Some(p) = self.profile.remove(requested) {
             Some(p)
         } else {
-            let mut available: Vec<String> = profiles.into_keys().collect();
+            let mut available: Vec<String> = self.profile.into_keys().collect();
             available.push(DEFAULT_PROFILE.to_string());
             available.sort();
             available.dedup();
@@ -123,49 +85,18 @@ impl Options {
             });
         };
 
+        let mut effective = Options::default();
         if let Some(default_p) = default_overrides {
-            self = default_p.into_options().combine(self);
+            effective = default_p.combine(effective);
         }
         if let Some(named_p) = named_overrides {
-            self = named_p.into_options().combine(self);
+            effective = named_p.combine(effective);
         }
-        Ok(self)
+        Ok(effective)
     }
 }
 
-/// The portion of [`Options`] that can appear inside a `[profile.<name>]` block.
-///
-/// Mirrors the top-level option groups but disallows nested `profile` tables.
-#[derive(
-    Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, OptionsMetadata, Combine,
-)]
-#[serde(rename_all = "kebab-case", deny_unknown_fields)]
-pub struct ProfileOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[option_group]
-    pub src: Option<SrcOptions>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[option_group]
-    pub terminal: Option<TerminalOptions>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[option_group]
-    pub test: Option<TestOptions>,
-}
-
-impl ProfileOptions {
-    fn into_options(self) -> Options {
-        Options {
-            src: self.src,
-            terminal: self.terminal,
-            test: self.test,
-            profile: None,
-        }
-    }
-}
-
-fn validate_profile_names(
-    profiles: &BTreeMap<String, ProfileOptions>,
-) -> Result<(), KarvaTomlError> {
+fn validate_profile_names(profiles: &BTreeMap<String, Options>) -> Result<(), KarvaTomlError> {
     for name in profiles.keys() {
         if name.is_empty() {
             return Err(KarvaTomlError::InvalidProfileName {
@@ -200,6 +131,32 @@ fn validate_profile_names(
 pub struct UnknownProfile {
     pub name: String,
     pub available: Vec<String>,
+}
+
+#[derive(
+    Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, OptionsMetadata, Combine,
+)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct Options {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option_group]
+    pub src: Option<SrcOptions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option_group]
+    pub terminal: Option<TerminalOptions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option_group]
+    pub test: Option<TestOptions>,
+}
+
+impl Options {
+    pub fn to_settings(&self) -> ProjectSettings {
+        ProjectSettings {
+            terminal: self.terminal.clone().unwrap_or_default().to_settings(),
+            src: self.src.clone().unwrap_or_default().to_settings(),
+            test: self.test.clone().unwrap_or_default().to_settings(),
+        }
+    }
 }
 
 #[derive(
@@ -555,12 +512,12 @@ mod tests {
     #[test]
     fn from_toml_str_rejects_unknown_key() {
         let toml = r"
-[test]
+[profile.default.test]
 fail-fast = true
 nonsense = 42
 ";
         assert_snapshot!(
-            Options::from_toml_str(toml).expect_err("unknown field"),
+            Config::from_toml_str(toml).expect_err("unknown field"),
             @"
         TOML parse error at line 4, column 1
           |
@@ -578,25 +535,40 @@ nonsense = 42
 foo = 1
 ";
         assert_snapshot!(
-            Options::from_toml_str(toml).expect_err("unknown section"),
+            Config::from_toml_str(toml).expect_err("unknown section"),
             @"
         TOML parse error at line 2, column 2
           |
         2 | [bogus]
           |  ^^^^^
-        unknown field `bogus`, expected one of `src`, `terminal`, `test`, `profile`
+        unknown field `bogus`, expected `profile`
+        "
+        );
+    }
+
+    #[test]
+    fn from_toml_str_rejects_top_level_option_groups() {
+        let toml = r#"
+[test]
+test-function-prefix = "test"
+"#;
+        assert_snapshot!(
+            Config::from_toml_str(toml).expect_err("top-level rejected"),
+            @"
+        TOML parse error at line 2, column 2
+          |
+        2 | [test]
+          |  ^^^^
+        unknown field `test`, expected `profile`
         "
         );
     }
 
     #[test]
     fn from_toml_str_empty_is_default() {
-        assert_debug_snapshot!(Options::from_toml_str("").expect("parse"), @"
-        Options {
-            src: None,
-            terminal: None,
-            test: None,
-            profile: None,
+        assert_debug_snapshot!(Config::from_toml_str("").expect("parse"), @"
+        Config {
+            profile: {},
         }
         ");
     }
@@ -606,11 +578,11 @@ foo = 1
     #[test]
     fn from_toml_str_rejects_max_fail_zero() {
         let toml = r"
-[test]
+[profile.default.test]
 max-fail = 0
 ";
         assert_snapshot!(
-            Options::from_toml_str(toml).expect_err("zero rejected"),
+            Config::from_toml_str(toml).expect_err("zero rejected"),
             @"
         TOML parse error at line 3, column 12
           |
@@ -715,16 +687,14 @@ max-fail = 0
             }),
             ..Options::default()
         };
-        let file_options = Options {
-            test: Some(TestOptions {
-                test_function_prefix: Some("file".to_string()),
-                retry: Some(2),
-                ..TestOptions::default()
-            }),
-            ..Options::default()
-        };
+        let toml = r#"
+[profile.default.test]
+test-function-prefix = "file"
+retry = 2
+"#;
+        let config = Config::from_toml_str(toml).expect("parse");
         let overrides = ProjectOptionsOverrides::new(None, cli_options);
-        assert_debug_snapshot!(overrides.apply_to(file_options).expect("resolves").test, @r#"
+        assert_debug_snapshot!(overrides.apply_to(config).expect("resolves").test, @r#"
         Some(
             TestOptions {
                 test_function_prefix: Some(
@@ -745,7 +715,7 @@ max-fail = 0
     #[test]
     fn parse_profile_section() {
         let toml = r#"
-[test]
+[profile.default.test]
 test-function-prefix = "test"
 
 [profile.ci.test]
@@ -755,27 +725,24 @@ no-tests = "fail"
 [profile.ci.terminal]
 output-format = "concise"
 "#;
-        let options = Options::from_toml_str(toml).expect("parse");
-        assert_debug_snapshot!(options.has_profile("ci"), @"true");
-        assert_debug_snapshot!(options.has_profile("default"), @"true");
-        assert_debug_snapshot!(options.has_profile("missing"), @"false");
+        let config = Config::from_toml_str(toml).expect("parse");
+        assert_debug_snapshot!(config.has_profile("ci"), @"true");
+        assert_debug_snapshot!(config.has_profile("default"), @"true");
+        assert_debug_snapshot!(config.has_profile("missing"), @"false");
     }
 
     #[test]
-    fn resolve_profile_layers_named_over_default_over_base() {
+    fn resolve_profile_layers_named_over_default() {
         let toml = r#"
-[test]
-test-function-prefix = "base"
-retry = 1
-
 [profile.default.test]
+test-function-prefix = "base"
 retry = 2
 fail-fast = true
 
 [profile.ci.test]
 retry = 5
 "#;
-        let resolved = Options::from_toml_str(toml)
+        let resolved = Config::from_toml_str(toml)
             .expect("parse")
             .resolve_profile(Some("ci"))
             .expect("resolves");
@@ -797,19 +764,15 @@ retry = 5
             },
         )
         "#);
-        assert_debug_snapshot!(resolved.profile, @"None");
     }
 
     #[test]
-    fn resolve_profile_default_applies_default_overrides() {
+    fn resolve_default_profile_applies_default_overrides() {
         let toml = r"
-[test]
-retry = 1
-
 [profile.default.test]
 retry = 9
 ";
-        let resolved = Options::from_toml_str(toml)
+        let resolved = Config::from_toml_str(toml)
             .expect("parse")
             .resolve_profile(None)
             .expect("resolves");
@@ -826,7 +789,7 @@ retry = 9
 [profile.ci.test]
 retry = 5
 ";
-        let err = Options::from_toml_str(toml)
+        let err = Config::from_toml_str(toml)
             .expect("parse")
             .resolve_profile(Some("nope"))
             .expect_err("unknown");
@@ -837,15 +800,15 @@ retry = 5
     }
 
     #[test]
-    fn resolve_profile_default_when_no_profiles_defined_is_ok() {
-        let options = Options::default();
-        assert!(options.resolve_profile(None).is_ok());
+    fn resolve_default_profile_when_empty_config_is_ok() {
+        let config = Config::default();
+        assert!(config.resolve_profile(None).is_ok());
     }
 
     #[test]
-    fn resolve_profile_non_default_when_no_profiles_errors() {
-        let options = Options::default();
-        let err = options.resolve_profile(Some("ci")).expect_err("unknown");
+    fn resolve_non_default_profile_when_empty_config_errors() {
+        let config = Config::default();
+        let err = config.resolve_profile(Some("ci")).expect_err("unknown");
         assert_snapshot!(
             err,
             @"profile `ci` is not defined in configuration (available: default)"
@@ -859,7 +822,7 @@ retry = 5
 retry = 1
 ";
         assert_snapshot!(
-            Options::from_toml_str(toml).expect_err("reserved"),
+            Config::from_toml_str(toml).expect_err("reserved"),
             @"invalid profile name `default-ci`: the `default-` prefix is reserved for built-in profiles"
         );
     }
@@ -871,18 +834,9 @@ retry = 1
 retry = 1
 "#;
         assert_snapshot!(
-            Options::from_toml_str(toml).expect_err("invalid"),
+            Config::from_toml_str(toml).expect_err("invalid"),
             @"invalid profile name `ci/fast`: profile names may only contain ASCII letters, digits, `-`, and `_`"
         );
-    }
-
-    #[test]
-    fn from_toml_str_rejects_nested_profile_table() {
-        let toml = r"
-[profile.ci.profile.nested.test]
-retry = 1
-";
-        assert!(Options::from_toml_str(toml).is_err());
     }
 
     #[test]
@@ -898,10 +852,10 @@ retry = 1
 [profile.ci.test]
 retry = 5
 ";
-        let file_options = Options::from_toml_str(toml).expect("parse");
+        let config = Config::from_toml_str(toml).expect("parse");
         let overrides =
             ProjectOptionsOverrides::new(None, cli_options).with_profile(Some("ci".to_string()));
-        let resolved = overrides.apply_to(file_options).expect("resolves");
+        let resolved = overrides.apply_to(config).expect("resolves");
         assert_debug_snapshot!(resolved.test.unwrap().retry, @r"
         Some(
             99,
@@ -932,10 +886,10 @@ impl ProjectOptionsOverrides {
         self
     }
 
-    /// Combine the file options with the CLI options, after first resolving
-    /// the requested profile against the file options.
-    pub fn apply_to(&self, options: Options) -> Result<Options, UnknownProfile> {
-        let resolved = options.resolve_profile(self.profile.as_deref())?;
+    /// Resolve the requested profile from `config` and combine the CLI
+    /// overrides on top.
+    pub fn apply_to(&self, config: Config) -> Result<Options, UnknownProfile> {
+        let resolved = config.resolve_profile(self.profile.as_deref())?;
         Ok(self.options.clone().combine(resolved))
     }
 }

--- a/crates/karva_metadata/src/options.rs
+++ b/crates/karva_metadata/src/options.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use camino::Utf8PathBuf;
 use karva_combine::Combine;
 use karva_logging::{FinalStatusLevel, StatusLevel};
@@ -11,6 +13,9 @@ use crate::max_fail::MaxFail;
 use crate::settings::{
     NoTestsMode, ProjectSettings, RunIgnoredMode, SrcSettings, TerminalSettings, TestSettings,
 };
+
+/// The implicit name of the default profile.
+pub const DEFAULT_PROFILE: &str = "default";
 
 #[derive(
     Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, OptionsMetadata, Combine,
@@ -26,11 +31,24 @@ pub struct Options {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[option_group]
     pub test: Option<TestOptions>,
+
+    /// Named configuration profiles, selected with `--profile <name>` or the
+    /// `KARVA_PROFILE` environment variable.
+    ///
+    /// Each profile may override `[src]`, `[terminal]`, and `[test]` settings.
+    /// Selecting a non-default profile layers its overrides on top of the
+    /// `[profile.default]` overrides (if any), which themselves layer on top
+    /// of the top-level options.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<BTreeMap<String, ProfileOptions>>,
 }
 
 impl Options {
     pub fn from_toml_str(content: &str) -> Result<Self, KarvaTomlError> {
-        let options = toml::from_str(content)?;
+        let options: Self = toml::from_str(content)?;
+        if let Some(profiles) = &options.profile {
+            validate_profile_names(profiles)?;
+        }
         Ok(options)
     }
 
@@ -53,6 +71,135 @@ impl Options {
 
         Self::from_toml_str(&karva_toml_str)
     }
+
+    /// Returns true if `name` is defined as a profile in this configuration.
+    /// The implicit `default` profile always exists.
+    pub fn has_profile(&self, name: &str) -> bool {
+        if name == DEFAULT_PROFILE {
+            return true;
+        }
+        self.profile
+            .as_ref()
+            .is_some_and(|profiles| profiles.contains_key(name))
+    }
+
+    /// Resolve a profile by collapsing the `profile` map into the top-level
+    /// option groups.
+    ///
+    /// The returned `Options` has its `profile` field cleared. The selected
+    /// profile is layered on top of any `[profile.default]` overrides, which
+    /// themselves layer on top of the top-level options. CLI options can then
+    /// be combined with the result via the usual `Combine` precedence.
+    ///
+    /// Returns [`UnknownProfile`] when `name` is set to a profile that is
+    /// not defined.
+    pub fn resolve_profile(mut self, name: Option<&str>) -> Result<Self, UnknownProfile> {
+        let requested = name.unwrap_or(DEFAULT_PROFILE);
+        let profiles = self.profile.take();
+
+        let Some(mut profiles) = profiles else {
+            if requested != DEFAULT_PROFILE {
+                return Err(UnknownProfile {
+                    name: requested.to_string(),
+                    available: vec![DEFAULT_PROFILE.to_string()],
+                });
+            }
+            return Ok(self);
+        };
+
+        let default_overrides = profiles.remove(DEFAULT_PROFILE);
+        let named_overrides = if requested == DEFAULT_PROFILE {
+            None
+        } else if let Some(p) = profiles.remove(requested) {
+            Some(p)
+        } else {
+            let mut available: Vec<String> = profiles.into_keys().collect();
+            available.push(DEFAULT_PROFILE.to_string());
+            available.sort();
+            available.dedup();
+            return Err(UnknownProfile {
+                name: requested.to_string(),
+                available,
+            });
+        };
+
+        if let Some(default_p) = default_overrides {
+            self = default_p.into_options().combine(self);
+        }
+        if let Some(named_p) = named_overrides {
+            self = named_p.into_options().combine(self);
+        }
+        Ok(self)
+    }
+}
+
+/// The portion of [`Options`] that can appear inside a `[profile.<name>]` block.
+///
+/// Mirrors the top-level option groups but disallows nested `profile` tables.
+#[derive(
+    Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, OptionsMetadata, Combine,
+)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct ProfileOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option_group]
+    pub src: Option<SrcOptions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option_group]
+    pub terminal: Option<TerminalOptions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option_group]
+    pub test: Option<TestOptions>,
+}
+
+impl ProfileOptions {
+    fn into_options(self) -> Options {
+        Options {
+            src: self.src,
+            terminal: self.terminal,
+            test: self.test,
+            profile: None,
+        }
+    }
+}
+
+fn validate_profile_names(
+    profiles: &BTreeMap<String, ProfileOptions>,
+) -> Result<(), KarvaTomlError> {
+    for name in profiles.keys() {
+        if name.is_empty() {
+            return Err(KarvaTomlError::InvalidProfileName {
+                name: name.clone(),
+                reason: "profile name cannot be empty",
+            });
+        }
+        if name != DEFAULT_PROFILE && name.starts_with("default-") {
+            return Err(KarvaTomlError::InvalidProfileName {
+                name: name.clone(),
+                reason: "the `default-` prefix is reserved for built-in profiles",
+            });
+        }
+        if !name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        {
+            return Err(KarvaTomlError::InvalidProfileName {
+                name: name.clone(),
+                reason: "profile names may only contain ASCII letters, digits, `-`, and `_`",
+            });
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Error)]
+#[error(
+    "profile `{name}` is not defined in configuration (available: {})",
+    available.join(", ")
+)]
+pub struct UnknownProfile {
+    pub name: String,
+    pub available: Vec<String>,
 }
 
 #[derive(
@@ -301,6 +448,8 @@ pub enum KarvaTomlError {
         source: std::io::Error,
         path: Utf8PathBuf,
     },
+    #[error("invalid profile name `{name}`: {reason}")]
+    InvalidProfileName { name: String, reason: &'static str },
 }
 
 /// The diagnostic output format.
@@ -435,7 +584,7 @@ foo = 1
           |
         2 | [bogus]
           |  ^^^^^
-        unknown field `bogus`, expected one of `src`, `terminal`, `test`
+        unknown field `bogus`, expected one of `src`, `terminal`, `test`, `profile`
         "
         );
     }
@@ -447,6 +596,7 @@ foo = 1
             src: None,
             terminal: None,
             test: None,
+            profile: None,
         }
         ");
     }
@@ -574,7 +724,7 @@ max-fail = 0
             ..Options::default()
         };
         let overrides = ProjectOptionsOverrides::new(None, cli_options);
-        assert_debug_snapshot!(overrides.apply_to(file_options).test, @r#"
+        assert_debug_snapshot!(overrides.apply_to(file_options).expect("resolves").test, @r#"
         Some(
             TestOptions {
                 test_function_prefix: Some(
@@ -591,11 +741,179 @@ max-fail = 0
         )
         "#);
     }
+
+    #[test]
+    fn parse_profile_section() {
+        let toml = r#"
+[test]
+test-function-prefix = "test"
+
+[profile.ci.test]
+retry = 5
+no-tests = "fail"
+
+[profile.ci.terminal]
+output-format = "concise"
+"#;
+        let options = Options::from_toml_str(toml).expect("parse");
+        assert_debug_snapshot!(options.has_profile("ci"), @"true");
+        assert_debug_snapshot!(options.has_profile("default"), @"true");
+        assert_debug_snapshot!(options.has_profile("missing"), @"false");
+    }
+
+    #[test]
+    fn resolve_profile_layers_named_over_default_over_base() {
+        let toml = r#"
+[test]
+test-function-prefix = "base"
+retry = 1
+
+[profile.default.test]
+retry = 2
+fail-fast = true
+
+[profile.ci.test]
+retry = 5
+"#;
+        let resolved = Options::from_toml_str(toml)
+            .expect("parse")
+            .resolve_profile(Some("ci"))
+            .expect("resolves");
+        assert_debug_snapshot!(resolved.test, @r#"
+        Some(
+            TestOptions {
+                test_function_prefix: Some(
+                    "base",
+                ),
+                fail_fast: Some(
+                    true,
+                ),
+                max_fail: None,
+                try_import_fixtures: None,
+                retry: Some(
+                    5,
+                ),
+                no_tests: None,
+            },
+        )
+        "#);
+        assert_debug_snapshot!(resolved.profile, @"None");
+    }
+
+    #[test]
+    fn resolve_profile_default_applies_default_overrides() {
+        let toml = r"
+[test]
+retry = 1
+
+[profile.default.test]
+retry = 9
+";
+        let resolved = Options::from_toml_str(toml)
+            .expect("parse")
+            .resolve_profile(None)
+            .expect("resolves");
+        assert_debug_snapshot!(resolved.test.unwrap().retry, @r"
+        Some(
+            9,
+        )
+        ");
+    }
+
+    #[test]
+    fn resolve_profile_missing_profile_errors() {
+        let toml = r"
+[profile.ci.test]
+retry = 5
+";
+        let err = Options::from_toml_str(toml)
+            .expect("parse")
+            .resolve_profile(Some("nope"))
+            .expect_err("unknown");
+        assert_snapshot!(
+            err,
+            @"profile `nope` is not defined in configuration (available: ci, default)"
+        );
+    }
+
+    #[test]
+    fn resolve_profile_default_when_no_profiles_defined_is_ok() {
+        let options = Options::default();
+        assert!(options.resolve_profile(None).is_ok());
+    }
+
+    #[test]
+    fn resolve_profile_non_default_when_no_profiles_errors() {
+        let options = Options::default();
+        let err = options.resolve_profile(Some("ci")).expect_err("unknown");
+        assert_snapshot!(
+            err,
+            @"profile `ci` is not defined in configuration (available: default)"
+        );
+    }
+
+    #[test]
+    fn from_toml_str_rejects_reserved_default_prefix() {
+        let toml = r"
+[profile.default-ci.test]
+retry = 1
+";
+        assert_snapshot!(
+            Options::from_toml_str(toml).expect_err("reserved"),
+            @"invalid profile name `default-ci`: the `default-` prefix is reserved for built-in profiles"
+        );
+    }
+
+    #[test]
+    fn from_toml_str_rejects_invalid_profile_name_chars() {
+        let toml = r#"
+[profile."ci/fast".test]
+retry = 1
+"#;
+        assert_snapshot!(
+            Options::from_toml_str(toml).expect_err("invalid"),
+            @"invalid profile name `ci/fast`: profile names may only contain ASCII letters, digits, `-`, and `_`"
+        );
+    }
+
+    #[test]
+    fn from_toml_str_rejects_nested_profile_table() {
+        let toml = r"
+[profile.ci.profile.nested.test]
+retry = 1
+";
+        assert!(Options::from_toml_str(toml).is_err());
+    }
+
+    #[test]
+    fn cli_overrides_win_over_resolved_profile() {
+        let cli_options = Options {
+            test: Some(TestOptions {
+                retry: Some(99),
+                ..TestOptions::default()
+            }),
+            ..Options::default()
+        };
+        let toml = r"
+[profile.ci.test]
+retry = 5
+";
+        let file_options = Options::from_toml_str(toml).expect("parse");
+        let overrides =
+            ProjectOptionsOverrides::new(None, cli_options).with_profile(Some("ci".to_string()));
+        let resolved = overrides.apply_to(file_options).expect("resolves");
+        assert_debug_snapshot!(resolved.test.unwrap().retry, @r"
+        Some(
+            99,
+        )
+        ");
+    }
 }
 
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct ProjectOptionsOverrides {
     pub config_file_override: Option<Utf8PathBuf>,
+    pub profile: Option<String>,
     pub options: Options,
 }
 
@@ -603,11 +921,21 @@ impl ProjectOptionsOverrides {
     pub fn new(config_file_override: Option<Utf8PathBuf>, options: Options) -> Self {
         Self {
             config_file_override,
+            profile: None,
             options,
         }
     }
 
-    pub fn apply_to(&self, options: Options) -> Options {
-        self.options.clone().combine(options)
+    #[must_use]
+    pub fn with_profile(mut self, profile: Option<String>) -> Self {
+        self.profile = profile;
+        self
+    }
+
+    /// Combine the file options with the CLI options, after first resolving
+    /// the requested profile against the file options.
+    pub fn apply_to(&self, options: Options) -> Result<Options, UnknownProfile> {
+        let resolved = options.resolve_profile(self.profile.as_deref())?;
+        Ok(self.options.clone().combine(resolved))
     }
 }

--- a/crates/karva_metadata/src/pyproject.rs
+++ b/crates/karva_metadata/src/pyproject.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::options::Options;
+use crate::options::Config;
 
 /// A `pyproject.toml` as specified in PEP 517.
 #[derive(Deserialize, Serialize, Debug, Default, Clone)]
@@ -12,7 +12,7 @@ pub struct PyProject {
 }
 
 impl PyProject {
-    pub(crate) fn karva(&self) -> Option<&Options> {
+    pub(crate) fn karva(&self) -> Option<&Config> {
         self.tool.as_ref().and_then(|tool| tool.karva.as_ref())
     }
 }
@@ -32,5 +32,5 @@ impl PyProject {
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct Tool {
-    pub karva: Option<Options>,
+    pub karva: Option<Config>,
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -87,7 +87,10 @@ karva test [OPTIONS] [PATH]...
 <ul>
 <li><code>full</code>:  Print diagnostics verbosely, with context and helpful hints (default)</li>
 <li><code>concise</code>:  Print diagnostics concisely, one per line</li>
-</ul></dd><dt id="karva-test--retry"><a href="#karva-test--retry"><code>--retry</code></a> <i>retry</i></dt><dd><p>When set, the test will retry failed tests up to this number of times</p>
+</ul></dd><dt id="karva-test--profile"><a href="#karva-test--profile"><code>--profile</code></a>, <code>-P</code> <i>name</i></dt><dd><p>Configuration profile to use.</p>
+<p>Profiles are defined as <code>[profile.&lt;name&gt;]</code> sections in <code>karva.toml</code> (or <code>[tool.karva.profile.&lt;name&gt;]</code> in <code>pyproject.toml</code>) and may override any of the <code>[src]</code>, <code>[terminal]</code>, and <code>[test]</code> settings. The selected profile is layered on top of any <code>[profile.default]</code> overrides, which themselves layer on top of the top-level options.</p>
+<p>Defaults to <code>default</code>.</p>
+<p>May also be set with the <code>KARVA_PROFILE</code> environment variable.</p></dd><dt id="karva-test--retry"><a href="#karva-test--retry"><code>--retry</code></a> <i>retry</i></dt><dd><p>When set, the test will retry failed tests up to this number of times</p>
 </dd><dt id="karva-test--run-ignored"><a href="#karva-test--run-ignored"><code>--run-ignored</code></a> <i>run-ignored</i></dt><dd><p>Run ignored tests</p>
 <p>Possible values:</p>
 <ul>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,7 +19,7 @@ are tested.
 **Example usage** (`pyproject.toml`):
 
 ```toml
-[tool.karva.src]
+[tool.karva.profile.default.src]
 include = ["tests"]
 ```
 
@@ -38,7 +38,7 @@ Enabled by default.
 **Example usage** (`pyproject.toml`):
 
 ```toml
-[tool.karva.src]
+[tool.karva.profile.default.src]
 respect-ignore-files = false
 ```
 
@@ -62,7 +62,7 @@ Defaults to `pass`.
 **Example usage** (`pyproject.toml`):
 
 ```toml
-[tool.karva.terminal]
+[tool.karva.profile.default.terminal]
 final-status-level = "fail"
 ```
 
@@ -81,7 +81,7 @@ Defaults to `full`.
 **Example usage** (`pyproject.toml`):
 
 ```toml
-[tool.karva.terminal]
+[tool.karva.profile.default.terminal]
 output-format = "concise"
 ```
 
@@ -100,7 +100,7 @@ This is the output the `print` goes to etc.
 **Example usage** (`pyproject.toml`):
 
 ```toml
-[tool.karva.terminal]
+[tool.karva.profile.default.terminal]
 show-python-output = false
 ```
 
@@ -124,7 +124,7 @@ Defaults to `pass`.
 **Example usage** (`pyproject.toml`):
 
 ```toml
-[tool.karva.terminal]
+[tool.karva.profile.default.terminal]
 status-level = "fail"
 ```
 
@@ -149,7 +149,7 @@ Defaults to `false`.
 **Example usage** (`pyproject.toml`):
 
 ```toml
-[tool.karva.test]
+[tool.karva.profile.default.test]
 fail-fast = true
 ```
 
@@ -173,7 +173,7 @@ When both [`fail_fast`](#test_fail-fast) and `max-fail` are set,
 **Example usage** (`pyproject.toml`):
 
 ```toml
-[tool.karva.test]
+[tool.karva.profile.default.test]
 max-fail = 3
 ```
 
@@ -194,7 +194,7 @@ passes silently when filters were given. Use `fail` to always fail,
 **Example usage** (`pyproject.toml`):
 
 ```toml
-[tool.karva.test]
+[tool.karva.profile.default.test]
 no-tests = "warn"
 ```
 
@@ -211,7 +211,7 @@ When set, we will retry failed tests up to this number of times.
 **Example usage** (`pyproject.toml`):
 
 ```toml
-[tool.karva.test]
+[tool.karva.profile.default.test]
 retry = 3
 ```
 
@@ -230,7 +230,7 @@ Defaults to `test`.
 **Example usage** (`pyproject.toml`):
 
 ```toml
-[tool.karva.test]
+[tool.karva.profile.default.test]
 test-function-prefix = "test"
 ```
 
@@ -249,7 +249,7 @@ This is often slower, so it is not recommended for most projects.
 **Example usage** (`pyproject.toml`):
 
 ```toml
-[tool.karva.test]
+[tool.karva.profile.default.test]
 try-import-fixtures = true
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,11 @@
 <!-- WARNING: This file is auto-generated (cargo dev generate-all). Update the doc comments on the 'Options' struct in 'crates/karva_project/src/metadata/options.rs' if you want to change anything here. -->
 
 # Configuration
+
+Karva is configured through `karva.toml` (or the `[tool.karva]` table in `pyproject.toml`). All option groups live under a `[profile.<name>]` section; see [Profiles](profiles.md) for how to define and select profiles.
+
+The reference below documents every field supported inside a profile. Examples target the implicit `default` profile.
+
 ## `src`
 
 ### `include`

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -3,13 +3,15 @@
 Karva organizes configuration into named **profiles**, modeled after
 [`cargo nextest`](https://nexte.st/docs/configuration/). A profile is a named
 group of settings that tailors a test run for a particular context — fast local
-iteration, CI, a soak run, and so on. At runtime you select the profile you
-want with `--profile` (or `-P`) and Karva resolves it into the effective
-settings for that run.
+iteration, CI, a soak run, and so on.
 
-## Defining a profile
+Configuration lives in `karva.toml` (or the `[tool.karva]` table in
+`pyproject.toml`); the path can be overridden with `--config-file`.
 
-Profiles are declared as `[profile.<name>]` sections in `karva.toml`:
+## Profiles
+
+To use multiple sets of configuration, define `[profile.<name>]` sections in
+`karva.toml`:
 
 ```toml
 [profile.default.test]
@@ -25,41 +27,21 @@ output-format = "concise"
 ```
 
 The same configuration in `pyproject.toml` lives under
-`[tool.karva.profile.<name>]`:
+`[tool.karva.profile.<name>]`.
 
-```toml
-[tool.karva.profile.default.test]
-test-function-prefix = "test"
-retry = 1
-
-[tool.karva.profile.ci.test]
-retry = 5
-no-tests = "fail"
-```
+A profile is selected at runtime with `--profile <name>` (or `-P <name>`), or
+by setting the `KARVA_PROFILE` environment variable. If neither is set, the
+implicit `default` profile is used.
 
 Every option group documented in [Configuration](configuration.md) — `src`,
-`terminal`, `test` — may appear inside a profile. Top-level `[src]`, `[test]`,
-or `[terminal]` tables (without `profile.<name>`) are not accepted.
+`terminal`, `test` — may appear inside a profile. Top-level `[src]`,
+`[terminal]`, or `[test]` tables (without `profile.<name>`) are not accepted.
 
-## The default profile
+> **Warning:** Avoid custom profile names that begin with `default-`. The
+> `default-` prefix is reserved for built-in profiles that Karva may add in
+> the future.
 
-The profile named `default` is always implicitly available. It is used when
-no `--profile` is specified, and its settings form the base that every other
-profile inherits from. You do not have to declare `[profile.default]` — an
-empty configuration is equivalent to a `[profile.default]` with no overrides.
-
-## Selecting a profile
-
-A profile can be selected in three ways, in order of precedence:
-
-1. The `--profile` (or `-P`) CLI flag: `karva test --profile ci`.
-2. The `KARVA_PROFILE` environment variable: `KARVA_PROFILE=ci karva test`.
-3. The implicit `default` profile when neither is set.
-
-Selecting a profile that is not defined in the configuration produces an
-error that lists the profiles that are available.
-
-## Inheritance
+### Profile inheritance
 
 A non-default profile is layered on top of `[profile.default]`: any field the
 named profile does not set falls back to the value from `default`, which in
@@ -74,48 +56,24 @@ retry = 1
 retry = 5
 ```
 
-`karva test --profile ci` runs with `test-function-prefix = "test"` (inherited)
-and `retry = 5` (overridden).
+`karva test --profile ci` runs with `test-function-prefix = "test"`
+(inherited from `default`) and `retry = 5` (overridden by `ci`).
 
-## Overriding a profile from the CLI
+## Hierarchical configuration
 
-CLI flags always win over the resolved profile. This means a profile can
-encode the common case while flags handle one-off tweaks:
+When resolving a setting for a run, Karva checks the following sources from
+highest to lowest priority. The first source that defines the field wins.
 
-```bash
-# `[profile.ci]` says retry = 5, but this run uses retry = 0.
-karva test --profile ci --retry 0
-```
+1. **Command-line arguments** (e.g. `--retry 3`, `--no-fail-fast`).
+1. **Environment variables** (e.g. `KARVA_PROFILE`, `KARVA_NO_TESTS`).
+1. **The selected profile**, when not `default` (`[profile.<name>]`).
+1. **The default profile** (`[profile.default]`).
+1. **Built-in defaults** compiled into Karva.
 
-## Profile name rules
+Selecting a profile that is not defined in the configuration produces an
+error that lists the profiles that are available.
 
-Profile names may contain ASCII letters, digits, `-`, and `_`. The
-`default-` prefix is reserved for built-in profiles that may be added in the
-future, so user-defined profiles must use a different prefix.
+## See also
 
-## Examples
-
-### Fast local runs
-
-```toml
-[profile.default.test]
-fail-fast = true
-
-[profile.default.terminal]
-status-level = "fail"
-final-status-level = "fail"
-```
-
-### Stricter CI runs
-
-```toml
-[profile.ci.test]
-retry = 3
-no-tests = "fail"
-
-[profile.ci.terminal]
-output-format = "concise"
-```
-
-Trigger with `karva test --profile ci` (or set `KARVA_PROFILE=ci` in the CI
-environment).
+- [Configuration](configuration.md) — reference for every supported field.
+- [CLI](cli.md) — every flag, including `--profile` and `--config-file`.

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -1,0 +1,121 @@
+# Profiles
+
+Karva organizes configuration into named **profiles**, modeled after
+[`cargo nextest`](https://nexte.st/docs/configuration/). A profile is a named
+group of settings that tailors a test run for a particular context — fast local
+iteration, CI, a soak run, and so on. At runtime you select the profile you
+want with `--profile` (or `-P`) and Karva resolves it into the effective
+settings for that run.
+
+## Defining a profile
+
+Profiles are declared as `[profile.<name>]` sections in `karva.toml`:
+
+```toml
+[profile.default.test]
+test-function-prefix = "test"
+retry = 1
+
+[profile.ci.test]
+retry = 5
+no-tests = "fail"
+
+[profile.ci.terminal]
+output-format = "concise"
+```
+
+The same configuration in `pyproject.toml` lives under
+`[tool.karva.profile.<name>]`:
+
+```toml
+[tool.karva.profile.default.test]
+test-function-prefix = "test"
+retry = 1
+
+[tool.karva.profile.ci.test]
+retry = 5
+no-tests = "fail"
+```
+
+Every option group documented in [Configuration](configuration.md) — `src`,
+`terminal`, `test` — may appear inside a profile. Top-level `[src]`, `[test]`,
+or `[terminal]` tables (without `profile.<name>`) are not accepted.
+
+## The default profile
+
+The profile named `default` is always implicitly available. It is used when
+no `--profile` is specified, and its settings form the base that every other
+profile inherits from. You do not have to declare `[profile.default]` — an
+empty configuration is equivalent to a `[profile.default]` with no overrides.
+
+## Selecting a profile
+
+A profile can be selected in three ways, in order of precedence:
+
+1. The `--profile` (or `-P`) CLI flag: `karva test --profile ci`.
+2. The `KARVA_PROFILE` environment variable: `KARVA_PROFILE=ci karva test`.
+3. The implicit `default` profile when neither is set.
+
+Selecting a profile that is not defined in the configuration produces an
+error that lists the profiles that are available.
+
+## Inheritance
+
+A non-default profile is layered on top of `[profile.default]`: any field the
+named profile does not set falls back to the value from `default`, which in
+turn falls back to Karva's built-in defaults. Concretely, given:
+
+```toml
+[profile.default.test]
+test-function-prefix = "test"
+retry = 1
+
+[profile.ci.test]
+retry = 5
+```
+
+`karva test --profile ci` runs with `test-function-prefix = "test"` (inherited)
+and `retry = 5` (overridden).
+
+## Overriding a profile from the CLI
+
+CLI flags always win over the resolved profile. This means a profile can
+encode the common case while flags handle one-off tweaks:
+
+```bash
+# `[profile.ci]` says retry = 5, but this run uses retry = 0.
+karva test --profile ci --retry 0
+```
+
+## Profile name rules
+
+Profile names may contain ASCII letters, digits, `-`, and `_`. The
+`default-` prefix is reserved for built-in profiles that may be added in the
+future, so user-defined profiles must use a different prefix.
+
+## Examples
+
+### Fast local runs
+
+```toml
+[profile.default.test]
+fail-fast = true
+
+[profile.default.terminal]
+status-level = "fail"
+final-status-level = "fail"
+```
+
+### Stricter CI runs
+
+```toml
+[profile.ci.test]
+retry = 3
+no-tests = "fail"
+
+[profile.ci.terminal]
+output-format = "concise"
+```
+
+Trigger with `karva test --profile ci` (or set `KARVA_PROFILE=ci` in the CI
+environment).

--- a/zensical.toml
+++ b/zensical.toml
@@ -31,6 +31,7 @@ nav = [
         { "Other Functions" = "usage/functions.md"},
     ]},
     { "Configuration" = "configuration.md"},
+    { "Profiles" = "profiles.md"},
     { "CLI" = "cli.md"},
 ]
 


### PR DESCRIPTION
## Summary

Adds nextest-style profiles and makes karva's configuration profile-only. All option groups must now live under `[profile.<name>]` sections — top-level `[src]`/`[terminal]`/`[test]` is no longer accepted. This is a breaking change for any existing `karva.toml` or `pyproject.toml` with karva configuration; users must migrate their settings to `[profile.default.<group>]`.

A profile is selected at runtime with `--profile`/`-P` or the `KARVA_PROFILE` environment variable. The implicit `default` profile is always available, and selecting a non-default profile layers its overrides on top of `[profile.default]` (which forms the base). CLI flags continue to override the resolved profile, so `--profile ci --retry 5` still wins over the `ci` profile's `retry`.

```toml
[profile.default.test]
test-function-prefix = "test"
retry = 1

[profile.ci.test]
retry = 5
no-tests = "fail"

[profile.ci.terminal]
output-format = "concise"
```

Profile names follow the same convention as nextest: ASCII letters, digits, `-`, and `_`, with the `default-` prefix reserved for built-in profiles. An unknown profile produces a clear error listing the available profiles.

Internally, `Options` now represents a single profile's settings (the unit that combines/resolves), while a new `Config` type holds the file-level `profile: BTreeMap<String, Options>` map. `ProjectMetadata` stores both: the parsed `Config` and the resolved `Options` (populated by `apply_overrides`).

## Test Plan

ci