### PR TITLE
Fix snapshot diff trailing-newline and show relative paths

### DIFF
--- a/crates/karva/tests/it/extensions/snapshot/basic.rs
+++ b/crates/karva/tests/it/extensions/snapshot/basic.rs
@@ -41,7 +41,7 @@ def test_hello():
       |
     info: New snapshot for 'test_hello'.
           Run `karva snapshot accept` to accept, or re-run with `--snapshot-update`.
-          Pending file: <temp_dir>/snapshots/test__test_hello.snap.new
+          Pending file: snapshots/test__test_hello.snap.new
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -176,7 +176,7 @@ def test_hello():
       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
     info: Snapshot mismatch for 'test_hello'.
-          Snapshot file: <temp_dir>/snapshots/test__test_hello.snap
+          Snapshot file: snapshots/test__test_hello.snap
           ────────────┬───────────────────────────
               1       │ -hello world
                     1 │ +goodbye world
@@ -395,7 +395,7 @@ def test_two():
       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
     info: Snapshot mismatch for 'test_two'.
-          Snapshot file: <temp_dir>/snapshots/test__test_two.snap
+          Snapshot file: snapshots/test__test_two.snap
           ────────────┬───────────────────────────
               1       │ -second
                     1 │ +changed

--- a/crates/karva/tests/it/extensions/snapshot/cmd.rs
+++ b/crates/karva/tests/it/extensions/snapshot/cmd.rs
@@ -85,7 +85,7 @@ def test_echo():
       |
     info: New snapshot for 'test_echo'.
           Run `karva snapshot accept` to accept, or re-run with `--snapshot-update`.
-          Pending file: <temp_dir>/snapshots/test__test_echo.snap.new
+          Pending file: snapshots/test__test_echo.snap.new
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -617,7 +617,7 @@ def test_change():
       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
     info: Snapshot mismatch for 'test_change'.
-          Snapshot file: <temp_dir>/snapshots/test__test_change.snap
+          Snapshot file: snapshots/test__test_change.snap
           ────────────┬───────────────────────────
               1     1 │  success: true
               2     2 │  exit_code: 0

--- a/crates/karva/tests/it/extensions/snapshot/content.rs
+++ b/crates/karva/tests/it/extensions/snapshot/content.rs
@@ -245,7 +245,7 @@ def test_poem():
       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
     info: Snapshot mismatch for 'test_poem'.
-          Snapshot file: <temp_dir>/snapshots/test__test_poem.snap
+          Snapshot file: snapshots/test__test_poem.snap
           ────────────┬───────────────────────────
               1     1 │  roses are red
               2       │ -violets are blue

--- a/crates/karva/tests/it/extensions/snapshot/json.rs
+++ b/crates/karva/tests/it/extensions/snapshot/json.rs
@@ -399,13 +399,12 @@ def test_json():
       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
     info: Snapshot mismatch for 'test_json'.
-          Snapshot file: <temp_dir>/snapshots/test__test_json.snap
+          Snapshot file: snapshots/test__test_json.snap
           ────────────┬───────────────────────────
               1     1 │  {
               2       │ -  "key": "original"
-              3       │ -}
                     2 │ +  "key": "changed"
-                    3 │ +}
+              3     3 │  }
           ────────────┴───────────────────────────
 
     ────────────

--- a/crates/karva/tests/it/extensions/snapshot/mod.rs
+++ b/crates/karva/tests/it/extensions/snapshot/mod.rs
@@ -9,3 +9,4 @@ mod json;
 mod named;
 mod prune;
 mod review;
+mod update;

--- a/crates/karva/tests/it/extensions/snapshot/named.rs
+++ b/crates/karva/tests/it/extensions/snapshot/named.rs
@@ -120,7 +120,7 @@ def test_hello():
       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
     info: Snapshot mismatch for 'test_hello--greeting'.
-          Snapshot file: <temp_dir>/snapshots/test__test_hello--greeting.snap
+          Snapshot file: snapshots/test__test_hello--greeting.snap
           ────────────┬───────────────────────────
               1       │ -hello world
                     1 │ +goodbye world

--- a/crates/karva/tests/it/extensions/snapshot/update.rs
+++ b/crates/karva/tests/it/extensions/snapshot/update.rs
@@ -1,0 +1,378 @@
+use insta_cmd::assert_cmd_snapshot;
+
+use crate::common::TestContext;
+
+#[test]
+fn test_accept_then_unchanged_source_passes() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+def test_hello():
+    karva.assert_snapshot('hello world')
+        ",
+    );
+
+    let _ = context.command_no_parallel().output();
+    let _ = context.snapshot("accept").output();
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_hello
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_accept_then_modify_source_fails() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+def test_hello():
+    karva.assert_snapshot('hello world')
+        ",
+    );
+
+    let _ = context.command_no_parallel().output();
+    let _ = context.snapshot("accept").output();
+
+    context.write_file(
+        "test.py",
+        r"
+import karva
+
+def test_hello():
+    karva.assert_snapshot('goodbye world')
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_hello
+
+    diagnostics:
+
+    error[test-failure]: Test `test_hello` failed
+     --> test.py:4:5
+      |
+    2 | import karva
+    3 |
+    4 | def test_hello():
+      |     ^^^^^^^^^^
+    5 |     karva.assert_snapshot('goodbye world')
+      |
+    info: Test failed here
+     --> test.py:5:5
+      |
+    4 | def test_hello():
+    5 |     karva.assert_snapshot('goodbye world')
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: Snapshot mismatch for 'test_hello'.
+          Snapshot file: snapshots/test__test_hello.snap
+          ────────────┬───────────────────────────
+              1       │ -hello world
+                    1 │ +goodbye world
+          ────────────┴───────────────────────────
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_accept_json_then_add_role_fails() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+
+def get_user_data():
+    return {"id": 1, "name": "Alice", "roles": ["admin", "user"]}
+
+def test_user_data():
+    result = get_user_data()
+    karva.assert_json_snapshot(result)
+        "#,
+    );
+
+    let _ = context.command_no_parallel().output();
+    let _ = context.snapshot("accept").output();
+
+    let content = context.read_file("snapshots/test__test_user_data.snap");
+    insta::assert_snapshot!(content, @r#"
+    ---
+    source: test.py:9::test_user_data
+    ---
+    {
+      "id": 1,
+      "name": "Alice",
+      "roles": [
+        "admin",
+        "user"
+      ]
+    }
+    "#);
+
+    context.write_file(
+        "test.py",
+        r#"
+import karva
+
+def get_user_data():
+    return {"id": 1, "name": "Alice", "roles": ["admin", "user", "hr"]}
+
+def test_user_data():
+    result = get_user_data()
+    karva.assert_json_snapshot(result)
+        "#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_user_data
+
+    diagnostics:
+
+    error[test-failure]: Test `test_user_data` failed
+     --> test.py:7:5
+      |
+    5 |     return {"id": 1, "name": "Alice", "roles": ["admin", "user", "hr"]}
+    6 |
+    7 | def test_user_data():
+      |     ^^^^^^^^^^^^^^
+    8 |     result = get_user_data()
+    9 |     karva.assert_json_snapshot(result)
+      |
+    info: Test failed here
+     --> test.py:9:5
+      |
+    7 | def test_user_data():
+    8 |     result = get_user_data()
+    9 |     karva.assert_json_snapshot(result)
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: Snapshot mismatch for 'test_user_data'.
+          Snapshot file: snapshots/test__test_user_data.snap
+          ────────────┬───────────────────────────
+              2     2 │    "id": 1,
+              3     3 │    "name": "Alice",
+              4     4 │    "roles": [
+              5     5 │      "admin",
+              6       │ -    "user"
+                    6 │ +    "user",
+                    7 │ +    "hr"
+              7     8 │    ]
+              8     9 │  }
+          ────────────┴───────────────────────────
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    "#);
+}
+
+#[test]
+fn test_accept_json_then_add_role_then_accept_again() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+
+def get_user_data():
+    return {"id": 1, "name": "Alice", "roles": ["admin", "user"]}
+
+def test_user_data():
+    result = get_user_data()
+    karva.assert_json_snapshot(result)
+        "#,
+    );
+
+    let _ = context.command_no_parallel().output();
+    let _ = context.snapshot("accept").output();
+
+    context.write_file(
+        "test.py",
+        r#"
+import karva
+
+def get_user_data():
+    return {"id": 1, "name": "Alice", "roles": ["admin", "user", "hr"]}
+
+def test_user_data():
+    result = get_user_data()
+    karva.assert_json_snapshot(result)
+        "#,
+    );
+
+    let _ = context.command_no_parallel().output();
+    let _ = context.snapshot("accept").output();
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_user_data
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+
+    let content = context.read_file("snapshots/test__test_user_data.snap");
+    insta::assert_snapshot!(content, @r#"
+    ---
+    source: test.py:9::test_user_data
+    ---
+    {
+      "id": 1,
+      "name": "Alice",
+      "roles": [
+        "admin",
+        "user",
+        "hr"
+      ]
+    }
+    "#);
+}
+
+#[test]
+fn test_accept_then_update_with_snapshot_update_overwrites() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+def test_hello():
+    karva.assert_snapshot('first')
+        ",
+    );
+
+    let _ = context.command_no_parallel().output();
+    let _ = context.snapshot("accept").output();
+
+    context.write_file(
+        "test.py",
+        r"
+import karva
+
+def test_hello():
+    karva.assert_snapshot('second')
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--snapshot-update"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_hello
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+
+    let content = context.read_file("snapshots/test__test_hello.snap");
+    insta::assert_snapshot!(content, @"
+    ---
+    source: test.py:5::test_hello
+    ---
+    second
+    ");
+}
+
+#[test]
+fn test_accept_multiple_then_modify_one_fails_only_one() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+
+def test_first():
+    karva.assert_json_snapshot({"value": 1})
+
+def test_second():
+    karva.assert_json_snapshot({"value": 2})
+        "#,
+    );
+
+    let _ = context.command_no_parallel().output();
+    let _ = context.snapshot("accept").output();
+
+    context.write_file(
+        "test.py",
+        r#"
+import karva
+
+def test_first():
+    karva.assert_json_snapshot({"value": 1})
+
+def test_second():
+    karva.assert_json_snapshot({"value": 99})
+        "#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            PASS [TIME] test::test_first
+            FAIL [TIME] test::test_second
+
+    diagnostics:
+
+    error[test-failure]: Test `test_second` failed
+     --> test.py:7:5
+      |
+    5 |     karva.assert_json_snapshot({"value": 1})
+    6 |
+    7 | def test_second():
+      |     ^^^^^^^^^^^
+    8 |     karva.assert_json_snapshot({"value": 99})
+      |
+    info: Test failed here
+     --> test.py:8:5
+      |
+    7 | def test_second():
+    8 |     karva.assert_json_snapshot({"value": 99})
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: Snapshot mismatch for 'test_second'.
+          Snapshot file: snapshots/test__test_second.snap
+          ────────────┬───────────────────────────
+              1     1 │  {
+              2       │ -  "value": 2
+                    2 │ +  "value": 99
+              3     3 │  }
+          ────────────┴───────────────────────────
+
+    ────────────
+         Summary [TIME] 2 tests run: 1 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    "#);
+}

--- a/crates/karva_snapshot/src/diff.rs
+++ b/crates/karva_snapshot/src/diff.rs
@@ -1,17 +1,33 @@
+use std::borrow::Cow;
 use std::fmt::Write;
 use std::io;
 
 use colored::Colorize;
 use similar::{Algorithm, ChangeTag, TextDiff};
 
+/// Append a trailing newline if the input is non-empty and doesn't already end
+/// with one. `diff_lines` keeps each line's terminator as part of the line,
+/// so `}\n` and `}` are treated as different lines — normalizing both sides
+/// to end with `\n` keeps that comparison stable.
+fn ensure_trailing_newline(s: &str) -> Cow<'_, str> {
+    if s.is_empty() || s.ends_with('\n') {
+        Cow::Borrowed(s)
+    } else {
+        Cow::Owned(format!("{s}\n"))
+    }
+}
+
 /// Render a diff between `old` and `new` content into `output`.
 ///
 /// Uses `grouped_ops` for context-aware output with separators between groups,
 /// and `iter_inline_changes` for word-level emphasis on changed portions.
 fn render_diff(output: &mut String, old: &str, new: &str, width: usize) {
+    let old = ensure_trailing_newline(old);
+    let new = ensure_trailing_newline(new);
+
     let diff = TextDiff::configure()
         .algorithm(Algorithm::Patience)
-        .diff_lines(old, new);
+        .diff_lines(&old, &new);
     let ops = diff.grouped_ops(4);
 
     if ops.is_empty() {
@@ -257,6 +273,35 @@ mod tests {
                    100000 │ +CHANGED 100000
             ──────────────┴─────────────────────────
             ");
+        });
+    }
+
+    #[test]
+    fn trailing_newline_difference_is_ignored() {
+        let old = "{\n  \"a\": 1\n}\n";
+        let new = "{\n  \"a\": 1\n}";
+        assert!(
+            format_diff(old, new).is_empty(),
+            "trailing-newline-only difference should produce no diff",
+        );
+    }
+
+    #[test]
+    fn one_sided_trailing_newline_in_real_change() {
+        let old = "{\n  \"roles\": [\n    \"user\"\n  ]\n}\n";
+        let new = "{\n  \"roles\": [\n    \"user\",\n    \"hr\"\n  ]\n}";
+        settings().bind(|| {
+            insta::assert_snapshot!(format_diff(old, new), @r#"
+            ────────────┬───────────────────────────
+                1     1 │  {
+                2     2 │    "roles": [
+                3       │ -    "user"
+                      3 │ +    "user",
+                      4 │ +    "hr"
+                4     5 │    ]
+                5     6 │  }
+            ────────────┴───────────────────────────
+            "#);
         });
     }
 

--- a/crates/karva_test_semantic/src/extensions/functions/snapshot.rs
+++ b/crates/karva_test_semantic/src/extensions/functions/snapshot.rs
@@ -230,6 +230,19 @@ fn apply_active_filters(input: &str) -> PyResult<String> {
     })
 }
 
+/// Format a snapshot path for display, relativized against the current
+/// working directory when possible so users see e.g. `snapshots/foo.snap`
+/// instead of an absolute path.
+fn display_relative(path: &Utf8Path) -> String {
+    if let Ok(cwd) = std::env::current_dir()
+        && let Ok(cwd) = Utf8PathBuf::try_from(cwd)
+        && let Ok(rel) = path.strip_prefix(&cwd)
+    {
+        return rel.to_string();
+    }
+    path.to_string()
+}
+
 /// Called by the test runner before each test to set snapshot context.
 pub fn set_snapshot_context(test_file: String, test_name: String) {
     SNAPSHOT_CONTEXT.with(|ctx| {
@@ -394,8 +407,9 @@ fn assert_snapshot_impl(
         })?;
 
         let diff = format_diff(&existing.content, serialized);
+        let display_path = display_relative(&snap_path);
         return Err(SnapshotMismatchError::new_err(format!(
-            "Snapshot mismatch for '{snapshot_name}'.\nSnapshot file: {snap_path}\n{diff}"
+            "Snapshot mismatch for '{snapshot_name}'.\nSnapshot file: {display_path}\n{diff}"
         )));
     }
 
@@ -410,8 +424,9 @@ fn assert_snapshot_impl(
         })?;
 
         let pending = Utf8PathBuf::from(format!("{snap_path}.new"));
+        let display_path = display_relative(&pending);
         return Err(SnapshotMismatchError::new_err(format!(
-            "New snapshot for '{snapshot_name}'.\nRun `karva snapshot accept` to accept, or re-run with `--snapshot-update`.\nPending file: {pending}"
+            "New snapshot for '{snapshot_name}'.\nRun `karva snapshot accept` to accept, or re-run with `--snapshot-update`.\nPending file: {display_path}"
         )));
     }
 
@@ -481,8 +496,9 @@ fn handle_inline_snapshot(
 
     if is_empty {
         let pending = Utf8PathBuf::from(format!("{snap_path}.new"));
+        let display_path = display_relative(&pending);
         return Err(SnapshotMismatchError::new_err(format!(
-            "New inline snapshot for '{test_name}'.\nRun `karva snapshot accept` to accept, or re-run with `--snapshot-update`.\nPending file: {pending}"
+            "New inline snapshot for '{test_name}'.\nRun `karva snapshot accept` to accept, or re-run with `--snapshot-update`.\nPending file: {display_path}"
         )));
     }
 


### PR DESCRIPTION
## Summary

The snapshot mismatch diff rendered a spurious delete + insert pair for the closing brace whenever the on-disk content ended with a newline but the freshly serialized value did not. `diff_lines` keeps the newline as part of each line, so `}\n` and `}` were treated as distinct lines. For example, adding `"hr"` to a roles list would produce:

```
1     1 │  {
2     2 │    "roles": [
3       │ -    "user"
      3 │ +    "user",
      4 │ +    "hr"
4     5 │    ]
5       │ -}
      6 │ +}
```

Both inputs are now normalized to end with a trailing newline before diffing, so the closing brace lines up as an equal line.

Snapshot paths reported in `Snapshot file:` and `Pending file:` error messages are now relativized against the current working directory, so users see `snapshots/test__foo.snap` instead of an absolute path.

Adds an `update.rs` integration test file covering the accept-then-edit-source-then-rerun flow, including a JSON snapshot whose list grows between runs.

## Test Plan

ci