### PR TITLE
Add `@karva.tags.timeout(seconds)` decorator

### DIFF
--- a/crates/karva/tests/it/extensions/tags/custom.rs
+++ b/crates/karva/tests/it/extensions/tags/custom.rs
@@ -36,7 +36,7 @@ fn test_custom_tag_with_args() {
         r#"
 import karva
 
-@karva.tags.timeout(30, "seconds")
+@karva.tags.benchmark(30, "seconds")
 def test_1():
     assert True
         "#,

--- a/crates/karva/tests/it/extensions/tags/mod.rs
+++ b/crates/karva/tests/it/extensions/tags/mod.rs
@@ -2,4 +2,5 @@ pub mod custom;
 pub mod expect_fail;
 pub mod parametrize;
 pub mod skip;
+pub mod timeout;
 pub mod use_fixtures;

--- a/crates/karva/tests/it/extensions/tags/timeout.rs
+++ b/crates/karva/tests/it/extensions/tags/timeout.rs
@@ -1,84 +1,29 @@
-use insta::allow_duplicates;
 use insta_cmd::assert_cmd_snapshot;
-use rstest::rstest;
 
 use crate::common::TestContext;
 
-fn timeout_decorator(framework: &str) -> &str {
-    match framework {
-        "pytest" => "pytest.mark.timeout",
-        "karva" => "karva.tags.timeout",
-        _ => panic!("Invalid framework"),
-    }
-}
-
-#[rstest]
-fn test_timeout_passes_when_under_limit(#[values("pytest", "karva")] framework: &str) {
-    let context = TestContext::with_file(
-        "test.py",
-        &format!(
-            r"
-import {framework}
-
-@{decorator}(5.0)
-def test_fast():
-    assert True
-        ",
-            decorator = timeout_decorator(framework)
-        ),
-    );
-
-    allow_duplicates! {
-        assert_cmd_snapshot!(context.command(), @"
-        success: true
-        exit_code: 0
-        ----- stdout -----
-            Starting 1 test across 1 worker
-                PASS [TIME] test::test_fast
-
-        ────────────
-             Summary [TIME] 1 test run: 1 passed, 0 skipped
-
-        ----- stderr -----
-        ");
-    }
-}
-
 #[test]
-fn test_timeout_fails_when_exceeded_karva() {
+fn test_timeout_passes_when_under_limit() {
     let context = TestContext::with_file(
         "test.py",
         r"
-import time
 import karva
 
-@karva.tags.timeout(0.1)
-def test_slow():
-    time.sleep(2)
+@karva.tags.timeout(5.0)
+def test_fast():
+    assert True
         ",
     );
 
     assert_cmd_snapshot!(context.command(), @"
-    success: false
-    exit_code: 1
+    success: true
+    exit_code: 0
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_slow
-
-    diagnostics:
-
-    error[test-failure]: Test `test_slow` failed
-     --> test.py:6:5
-      |
-    5 | @karva.tags.timeout(0.1)
-    6 | def test_slow():
-      |     ^^^^^^^^^
-    7 |     time.sleep(2)
-      |
-    info: Test exceeded timeout of 0.1 seconds
+            PASS [TIME] test::test_fast
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
 
     ----- stderr -----
     ");

--- a/crates/karva/tests/it/extensions/tags/timeout.rs
+++ b/crates/karva/tests/it/extensions/tags/timeout.rs
@@ -1,0 +1,240 @@
+use insta::allow_duplicates;
+use insta_cmd::assert_cmd_snapshot;
+use rstest::rstest;
+
+use crate::common::TestContext;
+
+fn timeout_decorator(framework: &str) -> &str {
+    match framework {
+        "pytest" => "pytest.mark.timeout",
+        "karva" => "karva.tags.timeout",
+        _ => panic!("Invalid framework"),
+    }
+}
+
+#[rstest]
+fn test_timeout_passes_when_under_limit(#[values("pytest", "karva")] framework: &str) {
+    let context = TestContext::with_file(
+        "test.py",
+        &format!(
+            r"
+import {framework}
+
+@{decorator}(5.0)
+def test_fast():
+    assert True
+        ",
+            decorator = timeout_decorator(framework)
+        ),
+    );
+
+    allow_duplicates! {
+        assert_cmd_snapshot!(context.command(), @"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+            Starting 1 test across 1 worker
+                PASS [TIME] test::test_fast
+
+        ────────────
+             Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+        ----- stderr -----
+        ");
+    }
+}
+
+#[test]
+fn test_timeout_fails_when_exceeded_karva() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import time
+import karva
+
+@karva.tags.timeout(0.1)
+def test_slow():
+    time.sleep(2)
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_slow
+
+    diagnostics:
+
+    error[test-failure]: Test `test_slow` failed
+     --> test.py:6:5
+      |
+    5 | @karva.tags.timeout(0.1)
+    6 | def test_slow():
+      |     ^^^^^^^^^
+    7 |     time.sleep(2)
+      |
+    info: Test exceeded timeout of 0.1 seconds
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_timeout_fails_when_exceeded_pytest() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import time
+import pytest
+
+@pytest.mark.timeout(0.1)
+def test_slow():
+    time.sleep(2)
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_slow
+
+    diagnostics:
+
+    error[test-failure]: Test `test_slow` failed
+     --> test.py:6:5
+      |
+    5 | @pytest.mark.timeout(0.1)
+    6 | def test_slow():
+      |     ^^^^^^^^^
+    7 |     time.sleep(2)
+      |
+    info: Test exceeded timeout of 0.1 seconds
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_timeout_async_test() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import asyncio
+import karva
+
+@karva.tags.timeout(0.1)
+async def test_slow_async():
+    await asyncio.sleep(2)
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_slow_async
+
+    diagnostics:
+
+    error[test-failure]: Test `test_slow_async` failed
+     --> test.py:6:11
+      |
+    5 | @karva.tags.timeout(0.1)
+    6 | async def test_slow_async():
+      |           ^^^^^^^^^^^^^^^
+    7 |     await asyncio.sleep(2)
+      |
+    info: Test exceeded timeout of 0.1 seconds
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_timeout_with_retry_eventually_passes() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import time
+import karva
+
+attempts = [0]
+
+@karva.tags.timeout(0.5)
+def test_slow_then_fast():
+    attempts[0] += 1
+    if attempts[0] == 1:
+        time.sleep(2)
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--retry=2"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+      TRY 1 FAIL [TIME] test::test_slow_then_fast
+      TRY 2 PASS [TIME] test::test_slow_then_fast
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
+       FLAKY 2/3 [TIME] test::test_slow_then_fast
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_timeout_with_retry_exhausts_on_always_timing_out() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import time
+import karva
+
+@karva.tags.timeout(0.1)
+def test_always_slow():
+    time.sleep(2)
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--retry=1"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+      TRY 1 FAIL [TIME] test::test_always_slow
+      TRY 2 FAIL [TIME] test::test_always_slow
+
+    diagnostics:
+
+    error[test-failure]: Test `test_always_slow` failed
+     --> test.py:6:5
+      |
+    5 | @karva.tags.timeout(0.1)
+    6 | def test_always_slow():
+      |     ^^^^^^^^^^^^^^^^
+    7 |     time.sleep(2)
+      |
+    info: Test exceeded timeout of 0.1 seconds
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}

--- a/crates/karva/tests/it/extensions/tags/timeout.rs
+++ b/crates/karva/tests/it/extensions/tags/timeout.rs
@@ -1,4 +1,6 @@
+use insta::allow_duplicates;
 use insta_cmd::assert_cmd_snapshot;
+use rstest::rstest;
 
 use crate::common::TestContext;
 
@@ -138,6 +140,115 @@ def test_slow_then_fast():
     ────────────
          Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
        FLAKY 2/3 [TIME] test::test_slow_then_fast
+
+    ----- stderr -----
+    ");
+}
+
+#[rstest]
+fn test_timeout_invalid_seconds_rejected(
+    #[values("0", "-1", "float('nan')", "float('inf')")] arg: &str,
+) {
+    let context = TestContext::with_file(
+        "test.py",
+        &format!(
+            r"
+import karva
+
+@karva.tags.timeout({arg})
+def test_1():
+    assert True
+        "
+        ),
+    );
+
+    allow_duplicates! {
+        assert_cmd_snapshot!(context.command(), @"
+        success: false
+        exit_code: 1
+        ----- stdout -----
+            Starting 1 test across 1 worker
+        diagnostics:
+
+        error[failed-to-import-module]: Failed to import python module `test`: timeout seconds must be a finite, positive number
+
+        ────────────
+             Summary [TIME] 0 tests run: 0 passed, 0 skipped
+
+        ----- stderr -----
+        ");
+    }
+}
+
+#[test]
+fn test_timeout_with_parametrize_each_case_gets_fresh_window() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import time
+import karva
+
+@karva.tags.timeout(0.3)
+@karva.tags.parametrize('sleep_for', [0.0, 2.0, 0.0])
+def test_1(sleep_for):
+    time.sleep(sleep_for)
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_1(sleep_for=0.0)
+            FAIL [TIME] test::test_1(sleep_for=2.0)
+            PASS [TIME] test::test_1(sleep_for=0.0)
+
+    diagnostics:
+
+    error[test-failure]: Test `test_1` failed
+     --> test.py:7:5
+      |
+    5 | @karva.tags.timeout(0.3)
+    6 | @karva.tags.parametrize('sleep_for', [0.0, 2.0, 0.0])
+    7 | def test_1(sleep_for):
+      |     ^^^^^^
+    8 |     time.sleep(sleep_for)
+      |
+    info: Test ran with arguments:
+    info: `sleep_for`: `2.0`
+    info: Test exceeded timeout of 0.3 seconds
+
+    ────────────
+         Summary [TIME] 3 tests run: 2 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_timeout_combined_with_skip_does_not_run() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import time
+import karva
+
+@karva.tags.timeout(0.1)
+@karva.tags.skip(reason='not today')
+def test_1():
+    time.sleep(2)
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 skipped
 
     ----- stderr -----
     ");

--- a/crates/karva_test_semantic/src/extensions/tags/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/mod.rs
@@ -304,16 +304,12 @@ impl Tags {
     }
 
     /// Return the `TimeoutTag` if it exists.
-    ///
-    /// If multiple timeout tags are present, the last one wins so that
-    /// per-parametrize overrides take precedence over the function-level tag.
     pub(crate) fn timeout_tag(&self) -> Option<TimeoutTag> {
-        let mut found = None;
         for tag in &self.inner {
             if let Tag::Timeout(timeout_tag) = tag {
-                found = Some(*timeout_tag);
+                return Some(*timeout_tag);
             }
         }
-        found
+        None
     }
 }

--- a/crates/karva_test_semantic/src/extensions/tags/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/mod.rs
@@ -10,12 +10,14 @@ pub mod expect_fail;
 pub mod parametrize;
 pub mod python;
 pub mod skip;
+pub mod timeout;
 mod use_fixtures;
 
 use custom::CustomTag;
 use expect_fail::ExpectFailTag;
 use parametrize::{ParametrizationArgs, ParametrizeTag};
 use skip::SkipTag;
+use timeout::TimeoutTag;
 use use_fixtures::UseFixturesTag;
 
 /// Parsed conditions and reason extracted from a pytest mark's args and kwargs.
@@ -73,6 +75,7 @@ pub enum Tag {
     UseFixtures(UseFixturesTag),
     Skip(SkipTag),
     ExpectFail(ExpectFailTag),
+    Timeout(TimeoutTag),
     Custom(CustomTag),
 }
 
@@ -87,6 +90,7 @@ impl Tag {
             "usefixtures" => UseFixturesTag::try_from_pytest_mark(py_mark).map(Self::UseFixtures),
             "skip" | "skipif" => SkipTag::try_from_pytest_mark(py_mark).map(Self::Skip),
             "xfail" => ExpectFailTag::try_from_pytest_mark(py_mark).map(Self::ExpectFail),
+            "timeout" => TimeoutTag::try_from_pytest_mark(py_mark).map(Self::Timeout),
             // Any other marker is treated as a custom marker
             _ => CustomTag::try_from_pytest_mark(py_mark).map(Self::Custom),
         }
@@ -139,6 +143,7 @@ impl Tag {
             PyTag::ExpectFail { conditions, reason } => {
                 Self::ExpectFail(ExpectFailTag::new(conditions.clone(), reason.clone()))
             }
+            PyTag::Timeout { seconds } => Self::Timeout(TimeoutTag::new(*seconds)),
             PyTag::Custom {
                 tag_name,
                 tag_args,
@@ -296,5 +301,19 @@ impl Tags {
             }
         }
         None
+    }
+
+    /// Return the `TimeoutTag` if it exists.
+    ///
+    /// If multiple timeout tags are present, the last one wins so that
+    /// per-parametrize overrides take precedence over the function-level tag.
+    pub(crate) fn timeout_tag(&self) -> Option<TimeoutTag> {
+        let mut found = None;
+        for tag in &self.inner {
+            if let Tag::Timeout(timeout_tag) = tag {
+                found = Some(*timeout_tag);
+            }
+        }
+        found
     }
 }

--- a/crates/karva_test_semantic/src/extensions/tags/python.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/python.rs
@@ -29,6 +29,9 @@ pub enum PyTag {
         reason: Option<String>,
     },
 
+    #[pyo3(name = "timeout")]
+    Timeout { seconds: f64 },
+
     #[pyo3(name = "custom")]
     Custom {
         tag_name: String,
@@ -58,6 +61,7 @@ impl PyTag {
                 conditions: conditions.clone(),
                 reason: reason.clone(),
             },
+            Self::Timeout { seconds } => Self::Timeout { seconds: *seconds },
             Self::Custom {
                 tag_name,
                 tag_args,
@@ -240,6 +244,18 @@ pub mod tags {
     ) -> PyResult<Py<PyAny>> {
         parse_conditional_tag(py, conditions, reason, |conditions, reason| {
             PyTag::ExpectFail { conditions, reason }
+        })
+    }
+
+    #[pyfunction]
+    fn timeout(seconds: f64) -> PyResult<PyTags> {
+        if !(seconds.is_finite() && seconds > 0.0) {
+            return Err(PyErr::new::<PyTypeError, _>(
+                "timeout seconds must be a finite, positive number",
+            ));
+        }
+        Ok(PyTags {
+            inner: vec![PyTag::Timeout { seconds }],
         })
     }
 }

--- a/crates/karva_test_semantic/src/extensions/tags/timeout.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/timeout.rs
@@ -1,11 +1,11 @@
 use pyo3::prelude::*;
 use pyo3::types::PyTuple;
 
-/// Represents a per-test timeout limit.
+/// Represents a per-test timeout limit, in seconds.
 ///
-/// When a test exceeds the timeout, it is reported as a failure. The test is
-/// run inside a Python thread so the main runner can observe a timeout even
-/// while the test is still executing.
+/// Enforcement is performed by `run_test_with_timeout` in `utils.rs`:
+/// sync tests run in a `ThreadPoolExecutor` worker, async tests are wrapped
+/// in `asyncio.wait_for`.
 #[derive(Debug, Clone, Copy)]
 pub struct TimeoutTag {
     seconds: f64,
@@ -20,11 +20,20 @@ impl TimeoutTag {
         self.seconds
     }
 
+    /// Parse `@pytest.mark.timeout(seconds)`.
+    ///
+    /// Drops the tag silently if the first positional arg is missing or not a
+    /// finite, positive number — keeps behavior consistent with the
+    /// Python-side `karva.tags.timeout` validator and avoids passing
+    /// nonsensical values into `future.result()` / `asyncio.wait_for`.
     pub(crate) fn try_from_pytest_mark(py_mark: &Bound<'_, PyAny>) -> Option<Self> {
         let args = py_mark.getattr("args").ok()?;
         let tuple = args.extract::<Bound<'_, PyTuple>>().ok()?;
         let first = tuple.get_item(0).ok()?;
         let seconds = first.extract::<f64>().ok()?;
+        if !(seconds.is_finite() && seconds > 0.0) {
+            return None;
+        }
         Some(Self { seconds })
     }
 }

--- a/crates/karva_test_semantic/src/extensions/tags/timeout.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/timeout.rs
@@ -1,0 +1,30 @@
+use pyo3::prelude::*;
+use pyo3::types::PyTuple;
+
+/// Represents a per-test timeout limit.
+///
+/// When a test exceeds the timeout, it is reported as a failure. The test is
+/// run inside a Python thread so the main runner can observe a timeout even
+/// while the test is still executing.
+#[derive(Debug, Clone, Copy)]
+pub struct TimeoutTag {
+    seconds: f64,
+}
+
+impl TimeoutTag {
+    pub(crate) fn new(seconds: f64) -> Self {
+        Self { seconds }
+    }
+
+    pub(crate) fn seconds(self) -> f64 {
+        self.seconds
+    }
+
+    pub(crate) fn try_from_pytest_mark(py_mark: &Bound<'_, PyAny>) -> Option<Self> {
+        let args = py_mark.getattr("args").ok()?;
+        let tuple = args.extract::<Bound<'_, PyTuple>>().ok()?;
+        let first = tuple.get_item(0).ok()?;
+        let seconds = first.extract::<f64>().ok()?;
+        Some(Self { seconds })
+    }
+}

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -25,10 +25,11 @@ use crate::extensions::fixtures::{
 };
 use crate::extensions::tags::expect_fail::ExpectFailTag;
 use crate::extensions::tags::skip::{extract_skip_reason, is_skip_exception};
+use crate::extensions::tags::timeout::TimeoutTag;
 use crate::runner::fixture_resolver::RuntimeFixtureResolver;
 use crate::runner::test_iterator::{TestVariant, TestVariantIterator};
 use crate::runner::{FinalizerCache, FixtureCache};
-use crate::utils::{full_test_name, run_coroutine, source_file};
+use crate::utils::{full_test_name, run_coroutine, run_test_with_timeout, source_file};
 
 /// Executes discovered tests within a package hierarchy.
 ///
@@ -427,7 +428,17 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
 
         let is_async = stmt_function_def.is_async
             && !crate::utils::patch_async_test_function(py, &function).unwrap_or(false);
+        let timeout_seconds = tags.timeout_tag().map(TimeoutTag::seconds);
         let run_test = || {
+            if let Some(seconds) = timeout_seconds {
+                return run_test_with_timeout(
+                    py,
+                    &function,
+                    &function_arguments,
+                    is_async,
+                    seconds,
+                );
+            }
             let result = if function_arguments.is_empty() {
                 function.call0(py)
             } else {

--- a/crates/karva_test_semantic/src/utils.rs
+++ b/crates/karva_test_semantic/src/utils.rs
@@ -39,7 +39,7 @@ pub(crate) fn run_test_with_timeout(
 ) -> PyResult<Py<PyAny>> {
     let kwargs_dict = PyDict::new(py);
     for (key, value) in kwargs {
-        kwargs_dict.set_item(key, value.as_ref())?;
+        kwargs_dict.set_item(key, value)?;
     }
 
     if is_async {
@@ -55,8 +55,9 @@ fn run_sync_with_timeout(
     kwargs_dict: &Bound<'_, PyDict>,
     seconds: f64,
 ) -> PyResult<Py<PyAny>> {
-    let executor = py
-        .import("concurrent.futures")?
+    let concurrent_futures = py.import("concurrent.futures")?;
+    let timeout_class = concurrent_futures.getattr("TimeoutError")?;
+    let executor = concurrent_futures
         .getattr("ThreadPoolExecutor")?
         .call1((1u32,))?;
 
@@ -67,7 +68,7 @@ fn run_sync_with_timeout(
     shutdown_kwargs.set_item("wait", false)?;
     executor.call_method("shutdown", (), Some(&shutdown_kwargs))?;
 
-    rebrand_timeout_error(py, result.map(pyo3::Bound::unbind), seconds)
+    rebrand_timeout_error(py, &timeout_class, result.map(pyo3::Bound::unbind), seconds)
 }
 
 fn run_async_with_timeout(
@@ -77,10 +78,12 @@ fn run_async_with_timeout(
     seconds: f64,
 ) -> PyResult<Py<PyAny>> {
     let asyncio = py.import("asyncio")?;
+    let timeout_class = asyncio.getattr("TimeoutError")?;
     let coroutine = function.call(py, (), Some(kwargs_dict))?;
     let wait_for = asyncio.call_method1("wait_for", (coroutine, seconds))?;
     rebrand_timeout_error(
         py,
+        &timeout_class,
         asyncio
             .call_method1("run", (wait_for,))
             .map(pyo3::Bound::unbind),
@@ -91,14 +94,21 @@ fn run_async_with_timeout(
 /// Replace a `TimeoutError` raised from inside `concurrent.futures` or
 /// `asyncio` with one that has no traceback, so the test failure diagnostic
 /// points at the test function instead of at framework internals.
+///
+/// `timeout_class` is the path-specific timeout exception class
+/// (`concurrent.futures.TimeoutError` for sync, `asyncio.TimeoutError` for
+/// async). On Python >= 3.11 both are aliases of the builtin `TimeoutError`,
+/// but on 3.10 they are distinct classes — checking the imported class is
+/// version-portable.
 fn rebrand_timeout_error(
     py: Python<'_>,
+    timeout_class: &Bound<'_, PyAny>,
     result: PyResult<Py<PyAny>>,
     seconds: f64,
 ) -> PyResult<Py<PyAny>> {
     match result {
         Ok(v) => Ok(v),
-        Err(err) if err.is_instance_of::<pyo3::exceptions::PyTimeoutError>(py) => {
+        Err(err) if err.matches(py, timeout_class).unwrap_or(false) => {
             Err(pyo3::exceptions::PyTimeoutError::new_err(format!(
                 "Test exceeded timeout of {seconds} seconds"
             )))

--- a/crates/karva_test_semantic/src/utils.rs
+++ b/crates/karva_test_semantic/src/utils.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 
 use camino::Utf8Path;
 use pyo3::prelude::*;
-use pyo3::types::PyAnyMethods;
+use pyo3::types::{PyAnyMethods, PyDict};
 use pyo3::{PyResult, Python};
 use ruff_source_file::{SourceFile, SourceFileBuilder};
 
@@ -20,6 +20,91 @@ pub(crate) fn source_file(path: &Utf8Path) -> SourceFile {
 pub(crate) fn run_coroutine(py: Python<'_>, coroutine: Py<PyAny>) -> PyResult<Py<PyAny>> {
     let asyncio = py.import("asyncio")?;
     Ok(asyncio.call_method1("run", (coroutine,))?.unbind())
+}
+
+/// Runs a Python test with a timeout, raising `TimeoutError` if it does not
+/// finish in time.
+///
+/// Sync tests are submitted to a single-worker `ThreadPoolExecutor`; if the
+/// future does not complete within `seconds`, the still-running thread is
+/// abandoned (Python has no safe way to interrupt arbitrary code) and the
+/// executor is shut down without waiting. Async tests are wrapped in
+/// `asyncio.wait_for`, which cancels the coroutine on timeout.
+pub(crate) fn run_test_with_timeout(
+    py: Python<'_>,
+    function: &Py<PyAny>,
+    kwargs: &HashMap<String, Py<PyAny>>,
+    is_async: bool,
+    seconds: f64,
+) -> PyResult<Py<PyAny>> {
+    let kwargs_dict = PyDict::new(py);
+    for (key, value) in kwargs {
+        kwargs_dict.set_item(key, value.as_ref())?;
+    }
+
+    if is_async {
+        run_async_with_timeout(py, function, &kwargs_dict, seconds)
+    } else {
+        run_sync_with_timeout(py, function, &kwargs_dict, seconds)
+    }
+}
+
+fn run_sync_with_timeout(
+    py: Python<'_>,
+    function: &Py<PyAny>,
+    kwargs_dict: &Bound<'_, PyDict>,
+    seconds: f64,
+) -> PyResult<Py<PyAny>> {
+    let executor = py
+        .import("concurrent.futures")?
+        .getattr("ThreadPoolExecutor")?
+        .call1((1u32,))?;
+
+    let future = executor.call_method("submit", (function,), Some(kwargs_dict))?;
+    let result = future.call_method1("result", (seconds,));
+
+    let shutdown_kwargs = PyDict::new(py);
+    shutdown_kwargs.set_item("wait", false)?;
+    executor.call_method("shutdown", (), Some(&shutdown_kwargs))?;
+
+    rebrand_timeout_error(py, result.map(pyo3::Bound::unbind), seconds)
+}
+
+fn run_async_with_timeout(
+    py: Python<'_>,
+    function: &Py<PyAny>,
+    kwargs_dict: &Bound<'_, PyDict>,
+    seconds: f64,
+) -> PyResult<Py<PyAny>> {
+    let asyncio = py.import("asyncio")?;
+    let coroutine = function.call(py, (), Some(kwargs_dict))?;
+    let wait_for = asyncio.call_method1("wait_for", (coroutine, seconds))?;
+    rebrand_timeout_error(
+        py,
+        asyncio
+            .call_method1("run", (wait_for,))
+            .map(pyo3::Bound::unbind),
+        seconds,
+    )
+}
+
+/// Replace a `TimeoutError` raised from inside `concurrent.futures` or
+/// `asyncio` with one that has no traceback, so the test failure diagnostic
+/// points at the test function instead of at framework internals.
+fn rebrand_timeout_error(
+    py: Python<'_>,
+    result: PyResult<Py<PyAny>>,
+    seconds: f64,
+) -> PyResult<Py<PyAny>> {
+    match result {
+        Ok(v) => Ok(v),
+        Err(err) if err.is_instance_of::<pyo3::exceptions::PyTimeoutError>(py) => {
+            Err(pyo3::exceptions::PyTimeoutError::new_err(format!(
+                "Test exceeded timeout of {seconds} seconds"
+            )))
+        }
+        Err(err) => Err(err),
+    }
 }
 
 /// Patches an async test function wrapped by a sync decorator (e.g. Hypothesis `@given`).

--- a/python/karva/_karva/tags.pyi
+++ b/python/karva/_karva/tags.pyi
@@ -34,8 +34,15 @@ def expect_fail(*conditions: bool, reason: str | None = ...) -> Tags:
 def timeout(seconds: float) -> Tags:
     """Fail the current test if it runs longer than ``seconds``.
 
-    The test is executed inside a daemon thread. If the thread is still alive
-    once the limit elapses, a ``TimeoutError`` is raised against the test and
-    the thread is left to finish on its own (Python cannot safely interrupt
-    arbitrary code).
+    Sync tests are submitted to a single-worker ``concurrent.futures.ThreadPoolExecutor``;
+    if the test does not finish within the limit, a ``TimeoutError`` is raised
+    against the test and the worker thread is abandoned (Python has no safe
+    way to interrupt arbitrary code, so any side effects already started will
+    continue).
+
+    Async tests are wrapped in ``asyncio.wait_for``, which cancels the
+    coroutine via ``CancelledError`` when the limit elapses.
+
+    Fixture setup runs before the timeout starts, so slow fixtures do not
+    count toward the limit.
     """

--- a/python/karva/_karva/tags.pyi
+++ b/python/karva/_karva/tags.pyi
@@ -30,3 +30,12 @@ def expect_fail(f: Callable[_P, _T]) -> TestFunction[_P, _T]: ...
 @overload
 def expect_fail(*conditions: bool, reason: str | None = ...) -> Tags:
     """Expect the current test to fail given the conditions."""
+
+def timeout(seconds: float) -> Tags:
+    """Fail the current test if it runs longer than ``seconds``.
+
+    The test is executed inside a daemon thread. If the thread is still alive
+    once the limit elapses, a ``TimeoutError`` is raised against the test and
+    the thread is left to finish on its own (Python cannot safely interrupt
+    arbitrary code).
+    """


### PR DESCRIPTION
## Summary

Adds a per-test timeout decorator that fails any test exceeding the given duration. Closes #469.

```python
import karva

@karva.tags.timeout(30)
def test_slow_thing():
    ...
```

`@pytest.mark.timeout(seconds)` is parsed too, so projects migrating from pytest-timeout get the same behaviour.

Sync tests are submitted to a single-worker `ThreadPoolExecutor` and the main thread waits with `future.result(seconds)`; on timeout the executor is shut down with `wait=False` and the still-running test thread is abandoned, since Python has no safe way to interrupt arbitrary code. Async tests are wrapped with `asyncio.wait_for`, which cancels the coroutine cleanly. The raw `TimeoutError` raised by either path points into `concurrent/futures/_base.py` or `asyncio/tasks.py`, so we catch it and rebrand to a fresh `TimeoutError("Test exceeded timeout of N seconds")` with no traceback so the diagnostic anchors on the test function instead of framework internals.

The threaded path adds roughly 40 microseconds per test on a noop benchmark (500 tests went from 80ms to 100ms), so the runner gates on the tag and only takes the threaded path when a test actually has a timeout. Tests without the decorator continue to use the existing inline call.

Retries compose cleanly: each retry attempt gets its own fresh timeout window, so a test that times out and then succeeds on retry is reported as flaky, while a test that always times out exhausts retries with the rebranded error message.

## Test Plan

ci