### PR TITLE
Add `--no-capture` flag for serial test execution with raw output

### DIFF
--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -47,7 +47,7 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
     let durations = args.durations;
     let last_failed = args.last_failed;
     let no_cache = args.no_cache.unwrap_or(false);
-    let num_workers = if args.no_parallel.unwrap_or(false) {
+    let num_workers = if args.no_parallel.unwrap_or(false) || args.no_capture {
         1
     } else {
         args.num_workers

--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -1629,6 +1629,32 @@ def test_with_print():
 }
 
 #[test]
+fn test_no_capture() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+def test_with_print():
+    print("hello from test")
+    assert True
+        "#,
+    );
+
+    assert_cmd_snapshot!(context.command().arg("--no-capture"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+    hello from test
+            PASS [TIME] test::test_with_print
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_retry_flag() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -302,6 +302,15 @@ pub struct TestCommand {
     #[clap(long, default_missing_value = "true", num_args=0..1, help_heading = "Runner options")]
     pub no_parallel: Option<bool>,
 
+    /// Disable output capture and run tests serially.
+    ///
+    /// Lets stdout/stderr from tests flow directly to the terminal,
+    /// useful when debugging with print statements or interactive
+    /// debuggers. Implies `--show-output` and forces a single worker
+    /// so output from concurrent tests cannot interleave.
+    #[clap(long, action = clap::ArgAction::SetTrue, help_heading = "Runner options")]
+    pub no_capture: bool,
+
     /// Disable reading the karva cache for test duration history
     #[clap(long, default_missing_value = "true", num_args=0..1, help_heading = "Runner options")]
     pub no_cache: Option<bool>,
@@ -424,7 +433,11 @@ impl SubTestCommand {
 
 impl TestCommand {
     pub fn into_options(self) -> Options {
-        self.sub_command.into_options()
+        let mut sub_command = self.sub_command;
+        if self.no_capture {
+            sub_command.show_output = Some(true);
+        }
+        sub_command.into_options()
     }
 }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -72,6 +72,8 @@ karva test [OPTIONS] [PATH]...
 </dd><dt id="karva-test--max-fail"><a href="#karva-test--max-fail"><code>--max-fail</code></a> <i>n</i></dt><dd><p>Stop scheduling new tests after this many failures.</p>
 <p>Accepts a positive integer such as <code>--max-fail=3</code>. <code>--max-fail=1</code> is equivalent to the legacy <code>--fail-fast</code>, and <code>--no-fail-fast</code> clears the limit. When <code>--max-fail</code> is provided alongside <code>--fail-fast</code> or <code>--no-fail-fast</code>, <code>--max-fail</code> takes precedence.</p>
 </dd><dt id="karva-test--no-cache"><a href="#karva-test--no-cache"><code>--no-cache</code></a></dt><dd><p>Disable reading the karva cache for test duration history</p>
+</dd><dt id="karva-test--no-capture"><a href="#karva-test--no-capture"><code>--no-capture</code></a></dt><dd><p>Disable output capture and run tests serially.</p>
+<p>Lets stdout/stderr from tests flow directly to the terminal, useful when debugging with print statements or interactive debuggers. Implies <code>--show-output</code> and forces a single worker so output from concurrent tests cannot interleave.</p>
 </dd><dt id="karva-test--no-fail-fast"><a href="#karva-test--no-fail-fast"><code>--no-fail-fast</code></a></dt><dd><p>Run every test regardless of how many fail.</p>
 <p>Clears any <code>fail-fast</code> or <code>max-fail</code> value set in configuration. When <code>--max-fail</code> is provided alongside <code>--no-fail-fast</code>, <code>--max-fail</code> takes precedence.</p>
 </dd><dt id="karva-test--no-ignore"><a href="#karva-test--no-ignore"><code>--no-ignore</code></a></dt><dd><p>When set, .gitignore files will not be respected</p>


### PR DESCRIPTION
## Summary

Closes #595. Adds a `--no-capture` flag to `karva test` for debugging with print statements or interactive debuggers, similar to nextest's `--no-capture` and pytest's `-s`. When set, it implies `--show-output` (so Python `stdout`/`stderr` are not muted) and forces a single worker so concurrent tests cannot interleave their output.

```bash
karva test --no-capture test_debug
```

The flag lives on `TestCommand` (alongside `--no-parallel`) since it affects orchestration. `TestCommand::into_options()` propagates the implied `show_output = true` into the resolved settings, which the runner already forwards to workers as `-s`.

## Test Plan

ci