### PR TITLE
Add `--cov-report=term-missing` to show uncovered lines per file

### DIFF
--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context as _, Result};
 use karva_cache::{AggregatedResults, DisplayFlakyTests};
-use karva_cli::{OutputFormat, TestCommand};
+use karva_cli::{CovReport, OutputFormat, TestCommand};
 use karva_logging::{Printer, Stdout, set_colored_override, setup_tracing};
 use karva_metadata::filter::FiltersetSet;
 use karva_metadata::{NoTestsMode, ProjectMetadata, ProjectOptionsOverrides};
@@ -100,7 +100,7 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
         let show_missing = sub_command
             .cov_report
             .iter()
-            .any(|kind| kind == "term-missing");
+            .any(|kind| matches!(kind, CovReport::TermMissing));
         if let Err(err) =
             karva_coverage::combine_and_report(project.cwd(), &coverage_dir, show_missing)
         {

--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -97,7 +97,13 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
     if !sub_command.cov.is_empty() {
         let cache_dir = project.cwd().join(karva_cache::CACHE_DIR);
         let coverage_dir = karva_runner::coverage_data_dir(&cache_dir);
-        if let Err(err) = karva_coverage::combine_and_report(project.cwd(), &coverage_dir) {
+        let show_missing = sub_command
+            .cov_report
+            .iter()
+            .any(|kind| kind == "term-missing");
+        if let Err(err) =
+            karva_coverage::combine_and_report(project.cwd(), &coverage_dir, show_missing)
+        {
             tracing::error!("Coverage report failed: {err:#}");
         }
     }

--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -97,10 +97,7 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
     if !sub_command.cov.is_empty() {
         let cache_dir = project.cwd().join(karva_cache::CACHE_DIR);
         let coverage_dir = karva_runner::coverage_data_dir(&cache_dir);
-        let show_missing = sub_command
-            .cov_report
-            .iter()
-            .any(|kind| matches!(kind, CovReport::TermMissing));
+        let show_missing = matches!(sub_command.cov_report, Some(CovReport::TermMissing));
         if let Err(err) =
             karva_coverage::combine_and_report(project.cwd(), &coverage_dir, show_missing)
         {

--- a/crates/karva/src/lib.rs
+++ b/crates/karva/src/lib.rs
@@ -42,7 +42,7 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
     let args = Args::parse_from(args);
 
     match args.command {
-        Command::Test(test_args) => commands::test::test(test_args),
+        Command::Test(test_args) => commands::test::test(*test_args),
         Command::Snapshot(snapshot_args) => commands::snapshot::snapshot(snapshot_args),
         Command::Cache(cache_args) => commands::cache::cache(&cache_args),
         Command::Version => commands::version::version().map(|()| ExitStatus::Success),

--- a/crates/karva/src/lib.rs
+++ b/crates/karva/src/lib.rs
@@ -42,7 +42,7 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
     let args = Args::parse_from(args);
 
     match args.command {
-        Command::Test(test_args) => commands::test::test(*test_args),
+        Command::Test(test_args) => commands::test::test(test_args),
         Command::Snapshot(snapshot_args) => commands::snapshot::snapshot(snapshot_args),
         Command::Cache(cache_args) => commands::cache::cache(&cache_args),
         Command::Version => commands::version::version().map(|()| ExitStatus::Success),

--- a/crates/karva/tests/it/coverage.rs
+++ b/crates/karva/tests/it/coverage.rs
@@ -246,6 +246,93 @@ def test_only_covered():
 }
 
 #[test]
+fn test_cov_report_term_missing() {
+    let context = TestContext::with_file(
+        "test_missing.py",
+        r"
+def covered():
+    return 1
+
+def uncovered_a():
+    return 2
+
+def uncovered_b():
+    x = 3
+    y = 4
+    return x + y
+
+def test_only_covered():
+    assert covered() == 1
+",
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel()
+            .arg("--cov")
+            .arg("--cov-report=term-missing")
+            .arg("--status-level=none")
+            .arg("test_missing.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    Name              Stmts   Miss   Cover   Missing
+    [LONG-LINE]
+    test_missing.py      10      4     60%   6, 9-11
+    [LONG-LINE]
+    TOTAL                10      4     60%
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
+fn test_cov_report_term_default_no_missing_column() {
+    let context = TestContext::with_file(
+        "test_partial.py",
+        r"
+def covered():
+    return 1
+
+def uncovered():
+    return 2
+
+def test_only_covered():
+    assert covered() == 1
+",
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel()
+            .arg("--cov")
+            .arg("--cov-report=term")
+            .arg("--status-level=none")
+            .arg("test_partial.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    Name              Stmts   Miss   Cover
+    [LONG-LINE]
+    test_partial.py       6      1     83%
+    [LONG-LINE]
+    TOTAL                 6      1     83%
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
 fn test_cov_skips_docstrings() {
     let context = TestContext::with_file(
         "test_docstrings.py",

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -277,7 +277,7 @@ pub struct SubTestCommand {
     )]
     pub cov: Vec<String>,
 
-    /// Coverage report type. May be passed multiple times.
+    /// Coverage terminal report type.
     ///
     /// `term` (default) prints a compact terminal table.
     /// `term-missing` extends it with a `Missing` column listing the
@@ -286,10 +286,9 @@ pub struct SubTestCommand {
         long = "cov-report",
         value_name = "TYPE",
         value_enum,
-        action = clap::ArgAction::Append,
         help_heading = "Coverage options"
     )]
-    pub cov_report: Vec<CovReport>,
+    pub cov_report: Option<CovReport>,
 
     /// Internal: per-worker coverage data file path.
     ///

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -279,16 +279,17 @@ pub struct SubTestCommand {
 
     /// Coverage report type. May be passed multiple times.
     ///
-    /// Currently supported values are `term` (default, compact terminal
-    /// table) and `term-missing` (terminal table with a `Missing` column
-    /// listing the uncovered line numbers per file).
+    /// `term` (default) prints a compact terminal table.
+    /// `term-missing` extends it with a `Missing` column listing the
+    /// uncovered line numbers per file.
     #[clap(
         long = "cov-report",
         value_name = "TYPE",
+        value_enum,
         action = clap::ArgAction::Append,
         help_heading = "Coverage options"
     )]
-    pub cov_report: Vec<String>,
+    pub cov_report: Vec<CovReport>,
 
     /// Internal: per-worker coverage data file path.
     ///
@@ -370,6 +371,19 @@ impl TestCommand {
     pub fn verbosity(&self) -> &Verbosity {
         &self.sub_command.verbosity
     }
+}
+
+/// Coverage terminal report type.
+#[derive(Copy, Clone, Hash, Debug, PartialEq, Eq, PartialOrd, Ord, Default, clap::ValueEnum)]
+pub enum CovReport {
+    /// Compact terminal table (default).
+    #[default]
+    #[value(name = "term")]
+    Term,
+
+    /// Terminal table with a `Missing` column listing uncovered line numbers.
+    #[value(name = "term-missing")]
+    TermMissing,
 }
 
 /// The diagnostic output format.

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -53,7 +53,7 @@ pub struct Args {
 #[derive(Debug, clap::Subcommand)]
 pub enum Command {
     /// Run tests.
-    Test(Box<TestCommand>),
+    Test(TestCommand),
 
     /// Manage snapshots created by `karva.assert_snapshot()`.
     Snapshot(SnapshotCommand),

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -53,7 +53,7 @@ pub struct Args {
 #[derive(Debug, clap::Subcommand)]
 pub enum Command {
     /// Run tests.
-    Test(TestCommand),
+    Test(Box<TestCommand>),
 
     /// Manage snapshots created by `karva.assert_snapshot()`.
     Snapshot(SnapshotCommand),
@@ -276,6 +276,19 @@ pub struct SubTestCommand {
         help_heading = "Coverage options"
     )]
     pub cov: Vec<String>,
+
+    /// Coverage report type. May be passed multiple times.
+    ///
+    /// Currently supported values are `term` (default, compact terminal
+    /// table) and `term-missing` (terminal table with a `Missing` column
+    /// listing the uncovered line numbers per file).
+    #[clap(
+        long = "cov-report",
+        value_name = "TYPE",
+        action = clap::ArgAction::Append,
+        help_heading = "Coverage options"
+    )]
+    pub cov_report: Vec<String>,
 
     /// Internal: per-worker coverage data file path.
     ///

--- a/crates/karva_coverage/src/report.rs
+++ b/crates/karva_coverage/src/report.rs
@@ -99,6 +99,21 @@ fn combine(data_dir: &Utf8Path) -> Result<BTreeMap<String, CombinedFile>> {
     Ok(combined)
 }
 
+struct Row<'a> {
+    name: &'a str,
+    stmts: &'a str,
+    miss: &'a str,
+    cover: &'a str,
+    missing: &'a str,
+}
+
+struct FileRow {
+    name: String,
+    stmts: u32,
+    miss: u32,
+    missing: String,
+}
+
 fn print_report(
     cwd: &Utf8Path,
     combined: &BTreeMap<String, CombinedFile>,
@@ -107,13 +122,12 @@ fn print_report(
 ) -> Result<()> {
     let cwd_real = std::fs::canonicalize(cwd.as_std_path()).unwrap_or_else(|_| cwd.into());
 
-    let rows: Vec<(String, u32, u32, String)> = combined
+    let rows: Vec<FileRow> = combined
         .iter()
         .map(|(filename, data)| {
-            let display = display_path(filename, &cwd_real);
-            let total = u32::try_from(data.executable.len()).unwrap_or(u32::MAX);
+            let stmts = u32::try_from(data.executable.len()).unwrap_or(u32::MAX);
             let hit = u32::try_from(data.executed.len()).unwrap_or(u32::MAX);
-            let miss = total.saturating_sub(hit);
+            let miss = stmts.saturating_sub(hit);
             let missing = if show_missing {
                 let uncovered: BTreeSet<u32> = data
                     .executable
@@ -124,13 +138,18 @@ fn print_report(
             } else {
                 String::new()
             };
-            (display, total, miss, missing)
+            FileRow {
+                name: display_path(filename, &cwd_real),
+                stmts,
+                miss,
+                missing,
+            }
         })
         .collect();
 
     let name_width = rows
         .iter()
-        .map(|(n, _, _, _)| n.len())
+        .map(|row| row.name.len())
         .max()
         .unwrap_or(0)
         .max("Name".len())
@@ -138,12 +157,14 @@ fn print_report(
 
     let header = format_row(
         name_width,
-        "Name",
-        "Stmts",
-        "Miss",
-        "Cover",
         show_missing,
-        "Missing",
+        &Row {
+            name: "Name",
+            stmts: "Stmts",
+            miss: "Miss",
+            cover: "Cover",
+            missing: "Missing",
+        },
     );
     let rule_len = header.chars().count();
     let rule = "-".repeat(rule_len);
@@ -155,25 +176,27 @@ fn print_report(
     let mut total_stmts: u32 = 0;
     let mut total_miss: u32 = 0;
 
-    for (name, stmts, miss, missing) in &rows {
-        let cover = format_percent(*stmts, *miss);
-        let stmts_str = stmts.to_string();
-        let miss_str = miss.to_string();
+    for row in &rows {
+        let cover = format_percent(row.stmts, row.miss);
+        let stmts_str = row.stmts.to_string();
+        let miss_str = row.miss.to_string();
         writeln!(
             out,
             "{}",
             format_row(
                 name_width,
-                name,
-                &stmts_str,
-                &miss_str,
-                &cover,
                 show_missing,
-                missing
+                &Row {
+                    name: &row.name,
+                    stmts: &stmts_str,
+                    miss: &miss_str,
+                    cover: &cover,
+                    missing: &row.missing,
+                },
             )
         )?;
-        total_stmts = total_stmts.saturating_add(*stmts);
-        total_miss = total_miss.saturating_add(*miss);
+        total_stmts = total_stmts.saturating_add(row.stmts);
+        total_miss = total_miss.saturating_add(row.miss);
     }
 
     writeln!(out, "{rule}")?;
@@ -185,35 +208,33 @@ fn print_report(
         "{}",
         format_row(
             name_width,
-            "TOTAL",
-            &total_stmts_str,
-            &total_miss_str,
-            &total_cover,
             show_missing,
-            "",
+            &Row {
+                name: "TOTAL",
+                stmts: &total_stmts_str,
+                miss: &total_miss_str,
+                cover: &total_cover,
+                missing: "",
+            },
         )
     )?;
 
     Ok(())
 }
 
-fn format_row(
-    name_width: usize,
-    name: &str,
-    stmts: &str,
-    miss: &str,
-    cover: &str,
-    show_missing: bool,
-    missing: &str,
-) -> String {
+fn format_row(name_width: usize, show_missing: bool, row: &Row<'_>) -> String {
     let base = format!(
         "{name:<name_width$}   {stmts:>stmts_w$}   {miss:>miss_w$}   {cover:>cover_w$}",
+        name = row.name,
+        stmts = row.stmts,
+        miss = row.miss,
+        cover = row.cover,
         stmts_w = "Stmts".len(),
         miss_w = "Miss".len(),
         cover_w = "Cover".len(),
     );
-    if show_missing && !missing.is_empty() {
-        format!("{base}   {missing}")
+    if show_missing && !row.missing.is_empty() {
+        format!("{base}   {missing}", missing = row.missing)
     } else {
         base
     }

--- a/crates/karva_coverage/src/report.rs
+++ b/crates/karva_coverage/src/report.rs
@@ -46,12 +46,16 @@ pub fn prepare_data_dir(data_dir: &Utf8Path) -> Result<()> {
 
 /// Combine per-worker data files in `data_dir` and print a terminal report
 /// to stdout. No-ops if there is no data to report.
-pub fn combine_and_report(cwd: &Utf8Path, data_dir: &Utf8Path) -> Result<()> {
+///
+/// When `show_missing` is true, the report includes a final `Missing` column
+/// listing the uncovered line numbers per file (consecutive lines collapsed
+/// into `a-b` ranges).
+pub fn combine_and_report(cwd: &Utf8Path, data_dir: &Utf8Path, show_missing: bool) -> Result<()> {
     let combined = combine(data_dir)?;
     if combined.is_empty() {
         return Ok(());
     }
-    print_report(cwd, &combined, &mut std::io::stdout().lock())?;
+    print_report(cwd, &combined, show_missing, &mut std::io::stdout().lock())?;
     Ok(())
 }
 
@@ -98,30 +102,49 @@ fn combine(data_dir: &Utf8Path) -> Result<BTreeMap<String, CombinedFile>> {
 fn print_report(
     cwd: &Utf8Path,
     combined: &BTreeMap<String, CombinedFile>,
+    show_missing: bool,
     out: &mut dyn Write,
 ) -> Result<()> {
     let cwd_real = std::fs::canonicalize(cwd.as_std_path()).unwrap_or_else(|_| cwd.into());
 
-    let rows: Vec<(String, u32, u32)> = combined
+    let rows: Vec<(String, u32, u32, String)> = combined
         .iter()
         .map(|(filename, data)| {
             let display = display_path(filename, &cwd_real);
             let total = u32::try_from(data.executable.len()).unwrap_or(u32::MAX);
             let hit = u32::try_from(data.executed.len()).unwrap_or(u32::MAX);
             let miss = total.saturating_sub(hit);
-            (display, total, miss)
+            let missing = if show_missing {
+                let uncovered: BTreeSet<u32> = data
+                    .executable
+                    .difference(&data.executed)
+                    .copied()
+                    .collect();
+                collapse_ranges(&uncovered)
+            } else {
+                String::new()
+            };
+            (display, total, miss, missing)
         })
         .collect();
 
     let name_width = rows
         .iter()
-        .map(|(n, _, _)| n.len())
+        .map(|(n, _, _, _)| n.len())
         .max()
         .unwrap_or(0)
         .max("Name".len())
         .max("TOTAL".len());
 
-    let header = format_row(name_width, "Name", "Stmts", "Miss", "Cover");
+    let header = format_row(
+        name_width,
+        "Name",
+        "Stmts",
+        "Miss",
+        "Cover",
+        show_missing,
+        "Missing",
+    );
     let rule_len = header.chars().count();
     let rule = "-".repeat(rule_len);
 
@@ -132,14 +155,22 @@ fn print_report(
     let mut total_stmts: u32 = 0;
     let mut total_miss: u32 = 0;
 
-    for (name, stmts, miss) in &rows {
+    for (name, stmts, miss, missing) in &rows {
         let cover = format_percent(*stmts, *miss);
         let stmts_str = stmts.to_string();
         let miss_str = miss.to_string();
         writeln!(
             out,
             "{}",
-            format_row(name_width, name, &stmts_str, &miss_str, &cover)
+            format_row(
+                name_width,
+                name,
+                &stmts_str,
+                &miss_str,
+                &cover,
+                show_missing,
+                missing
+            )
         )?;
         total_stmts = total_stmts.saturating_add(*stmts);
         total_miss = total_miss.saturating_add(*miss);
@@ -158,19 +189,60 @@ fn print_report(
             &total_stmts_str,
             &total_miss_str,
             &total_cover,
+            show_missing,
+            "",
         )
     )?;
 
     Ok(())
 }
 
-fn format_row(name_width: usize, name: &str, stmts: &str, miss: &str, cover: &str) -> String {
-    format!(
+fn format_row(
+    name_width: usize,
+    name: &str,
+    stmts: &str,
+    miss: &str,
+    cover: &str,
+    show_missing: bool,
+    missing: &str,
+) -> String {
+    let base = format!(
         "{name:<name_width$}   {stmts:>stmts_w$}   {miss:>miss_w$}   {cover:>cover_w$}",
         stmts_w = "Stmts".len(),
         miss_w = "Miss".len(),
         cover_w = "Cover".len(),
-    )
+    );
+    if show_missing && !missing.is_empty() {
+        format!("{base}   {missing}")
+    } else {
+        base
+    }
+}
+
+fn collapse_ranges(lines: &BTreeSet<u32>) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    let mut iter = lines.iter().copied();
+    let Some(mut start) = iter.next() else {
+        return String::new();
+    };
+    let mut end = start;
+    for line in iter {
+        if line != end + 1 {
+            parts.push(format_range(start, end));
+            start = line;
+        }
+        end = line;
+    }
+    parts.push(format_range(start, end));
+    parts.join(", ")
+}
+
+fn format_range(start: u32, end: u32) -> String {
+    if start == end {
+        start.to_string()
+    } else {
+        format!("{start}-{end}")
+    }
 }
 
 fn format_percent(total: u32, miss: u32) -> String {
@@ -223,12 +295,53 @@ mod tests {
         data.insert("/proj/b.py".to_string(), cf(&[1, 2], &[1, 2]));
 
         let mut buf: Vec<u8> = Vec::new();
-        print_report(Utf8Path::new("/proj"), &data, &mut buf).unwrap();
+        print_report(Utf8Path::new("/proj"), &data, false, &mut buf).unwrap();
         let out = String::from_utf8(buf).unwrap();
 
         assert!(out.contains("a.py"));
         assert!(out.contains("b.py"));
         assert!(out.contains("TOTAL"));
         assert!(out.contains("67%"));
+        assert!(!out.contains("Missing"));
+    }
+
+    #[test]
+    fn report_with_missing_shows_uncovered_lines() {
+        let mut data = BTreeMap::new();
+        data.insert(
+            "/proj/a.py".to_string(),
+            cf(&[1, 2, 3, 4, 5, 6, 7, 8, 9], &[1, 5, 9]),
+        );
+
+        let mut buf: Vec<u8> = Vec::new();
+        print_report(Utf8Path::new("/proj"), &data, true, &mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+
+        assert!(out.contains("Missing"));
+        assert!(out.contains("2-4, 6-8"));
+    }
+
+    #[test]
+    fn collapse_empty() {
+        let set: BTreeSet<u32> = BTreeSet::new();
+        assert_eq!(collapse_ranges(&set), "");
+    }
+
+    #[test]
+    fn collapse_singletons() {
+        let set: BTreeSet<u32> = [3, 7, 12].into_iter().collect();
+        assert_eq!(collapse_ranges(&set), "3, 7, 12");
+    }
+
+    #[test]
+    fn collapse_mixed_ranges() {
+        let set: BTreeSet<u32> = [26, 87, 94, 95, 119, 120, 121, 157].into_iter().collect();
+        assert_eq!(collapse_ranges(&set), "26, 87, 94-95, 119-121, 157");
+    }
+
+    #[test]
+    fn collapse_single_contiguous_range() {
+        let set: BTreeSet<u32> = [10, 11, 12, 13].into_iter().collect();
+        assert_eq!(collapse_ranges(&set), "10-13");
     }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,7 +48,7 @@ karva test [OPTIONS] [PATH]...
 <p>While karva configuration can be included in a <code>pyproject.toml</code> file, it is not allowed in this context.</p>
 <p>May also be set with the <code>KARVA_CONFIG_FILE</code> environment variable.</p></dd><dt id="karva-test--cov"><a href="#karva-test--cov"><code>--cov</code></a> <i>source</i></dt><dd><p>Measure code coverage for the given source path.</p>
 <p>May be passed multiple times to measure several sources. Pass without a value (<code>--cov</code>) to measure the current working directory.</p>
-</dd><dt id="karva-test--cov-report"><a href="#karva-test--cov-report"><code>--cov-report</code></a> <i>type</i></dt><dd><p>Coverage report type. May be passed multiple times.</p>
+</dd><dt id="karva-test--cov-report"><a href="#karva-test--cov-report"><code>--cov-report</code></a> <i>type</i></dt><dd><p>Coverage terminal report type.</p>
 <p><code>term</code> (default) prints a compact terminal table. <code>term-missing</code> extends it with a <code>Missing</code> column listing the uncovered line numbers per file.</p>
 <p>Possible values:</p>
 <ul>

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -49,8 +49,12 @@ karva test [OPTIONS] [PATH]...
 <p>May also be set with the <code>KARVA_CONFIG_FILE</code> environment variable.</p></dd><dt id="karva-test--cov"><a href="#karva-test--cov"><code>--cov</code></a> <i>source</i></dt><dd><p>Measure code coverage for the given source path.</p>
 <p>May be passed multiple times to measure several sources. Pass without a value (<code>--cov</code>) to measure the current working directory.</p>
 </dd><dt id="karva-test--cov-report"><a href="#karva-test--cov-report"><code>--cov-report</code></a> <i>type</i></dt><dd><p>Coverage report type. May be passed multiple times.</p>
-<p>Currently supported values are <code>term</code> (default, compact terminal table) and <code>term-missing</code> (terminal table with a <code>Missing</code> column listing the uncovered line numbers per file).</p>
-</dd><dt id="karva-test--durations"><a href="#karva-test--durations"><code>--durations</code></a> <i>n</i></dt><dd><p>Show the N slowest tests after the run completes</p>
+<p><code>term</code> (default) prints a compact terminal table. <code>term-missing</code> extends it with a <code>Missing</code> column listing the uncovered line numbers per file.</p>
+<p>Possible values:</p>
+<ul>
+<li><code>term</code>:  Compact terminal table (default)</li>
+<li><code>term-missing</code>:  Terminal table with a <code>Missing</code> column listing uncovered line numbers</li>
+</ul></dd><dt id="karva-test--durations"><a href="#karva-test--durations"><code>--durations</code></a> <i>n</i></dt><dd><p>Show the N slowest tests after the run completes</p>
 </dd><dt id="karva-test--fail-fast"><a href="#karva-test--fail-fast"><code>--fail-fast</code></a></dt><dd><p>Stop scheduling new tests after the first failure.</p>
 <p>Equivalent to <code>--max-fail=1</code>. Use <code>--no-fail-fast</code> to keep running after failures.</p>
 </dd><dt id="karva-test--filter"><a href="#karva-test--filter"><code>--filter</code></a>, <code>-E</code> <i>filter-expressions</i></dt><dd><p>Filter tests using a filterset expression.</p>

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,6 +48,8 @@ karva test [OPTIONS] [PATH]...
 <p>While karva configuration can be included in a <code>pyproject.toml</code> file, it is not allowed in this context.</p>
 <p>May also be set with the <code>KARVA_CONFIG_FILE</code> environment variable.</p></dd><dt id="karva-test--cov"><a href="#karva-test--cov"><code>--cov</code></a> <i>source</i></dt><dd><p>Measure code coverage for the given source path.</p>
 <p>May be passed multiple times to measure several sources. Pass without a value (<code>--cov</code>) to measure the current working directory.</p>
+</dd><dt id="karva-test--cov-report"><a href="#karva-test--cov-report"><code>--cov-report</code></a> <i>type</i></dt><dd><p>Coverage report type. May be passed multiple times.</p>
+<p>Currently supported values are <code>term</code> (default, compact terminal table) and <code>term-missing</code> (terminal table with a <code>Missing</code> column listing the uncovered line numbers per file).</p>
 </dd><dt id="karva-test--durations"><a href="#karva-test--durations"><code>--durations</code></a> <i>n</i></dt><dd><p>Show the N slowest tests after the run completes</p>
 </dd><dt id="karva-test--fail-fast"><a href="#karva-test--fail-fast"><code>--fail-fast</code></a></dt><dd><p>Stop scheduling new tests after the first failure.</p>
 <p>Equivalent to <code>--max-fail=1</code>. Use <code>--no-fail-fast</code> to keep running after failures.</p>


### PR DESCRIPTION
## Summary

Adds a `--cov-report=<TYPE>` flag with values `term` (default, current compact table) and `term-missing` (table extended with a `Missing` column listing uncovered line numbers per file). Consecutive uncovered lines are collapsed into `a-b` ranges to match pytest-cov's terminal output, so spotting which lines need tests no longer requires opening each file.

```
Name              Stmts   Miss   Cover   Missing
---------------------------------------------------
test_missing.py      10      4     60%   6, 9-11
---------------------------------------------------
TOTAL                10      4     60%
```

The `Missing` column is computed from `executable.difference(executed)` per file — data the coverage runner already produces. The TOTAL row deliberately omits a Missing value to avoid concatenating every file's lines.

Closes #704.

## Test plan

ci