### PR TITLE
Add `[test-groups]` configuration for concurrency control

### DIFF
--- a/crates/karva/tests/it/configuration/mod.rs
+++ b/crates/karva/tests/it/configuration/mod.rs
@@ -1,4 +1,5 @@
 mod profile;
+mod test_groups;
 
 use insta_cmd::assert_cmd_snapshot;
 

--- a/crates/karva/tests/it/configuration/profile.rs
+++ b/crates/karva/tests/it/configuration/profile.rs
@@ -338,13 +338,13 @@ test-function-prefix = "check"
       |
     2 | [test]
       |  ^^^^
-    unknown field `test`, expected `profile`
+    unknown field `test`, expected `profile` or `test-groups`
 
       Cause: TOML parse error at line 2, column 2
       |
     2 | [test]
       |  ^^^^
-    unknown field `test`, expected `profile`
+    unknown field `test`, expected `profile` or `test-groups`
     ");
 }
 

--- a/crates/karva/tests/it/configuration/test_groups.rs
+++ b/crates/karva/tests/it/configuration/test_groups.rs
@@ -1,0 +1,194 @@
+use insta_cmd::assert_cmd_snapshot;
+
+use crate::common::TestContext;
+
+#[test]
+fn group_filter_matches_tests_assigned_via_override() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[test-groups.database]
+max-threads = 4
+
+[[profile.default.overrides]]
+filter = "tag(database)"
+test-group = "database"
+"#,
+        ),
+        (
+            "test.py",
+            r"
+import karva
+
+@karva.tags.database
+def test_db():
+    assert True
+
+def test_other():
+    assert True
+        ",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().arg("-E").arg("group(database)"),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            PASS [TIME] test::test_db
+
+    ────────────
+         Summary [TIME] 2 tests run: 1 passed, 1 skipped
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
+fn override_referencing_unknown_group_errors() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[test-groups.database]
+max-threads = 2
+
+[[profile.default.overrides]]
+filter = "tag(slow)"
+test-group = "missing"
+"#,
+        ),
+        ("test.py", "def test_x(): assert True\n"),
+    ]);
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+        Starting 1 test across 1 worker
+
+    ----- stderr -----
+    Karva failed
+      Cause: invalid test-groups configuration: override #0 references unknown test-group `missing` (defined groups: database)
+    ");
+}
+
+#[test]
+fn override_with_group_predicate_in_filter_rejected() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[test-groups.database]
+max-threads = 2
+
+[[profile.default.overrides]]
+filter = "group(database)"
+test-group = "database"
+"#,
+        ),
+        ("test.py", "def test_x(): assert True\n"),
+    ]);
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+        Starting 1 test across 1 worker
+
+    ----- stderr -----
+    Karva failed
+      Cause: invalid test-groups configuration: override #0 filter `group(database)` uses `group(...)`; overrides cannot reference test-groups in their own filter
+    ");
+}
+
+#[test]
+fn test_groups_zero_max_threads_rejected_at_parse() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r"
+[test-groups.serial]
+max-threads = 0
+",
+        ),
+        ("test.py", "def test_x(): assert True\n"),
+    ]);
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Karva failed
+      Cause: <temp_dir>/karva.toml is not a valid `karva.toml`: TOML parse error at line 3, column 15
+      |
+    3 | max-threads = 0
+      |               ^
+    invalid value: integer `0`, expected a nonzero usize
+
+      Cause: TOML parse error at line 3, column 15
+      |
+    3 | max-threads = 0
+      |               ^
+    invalid value: integer `0`, expected a nonzero usize
+    ");
+}
+
+#[test]
+fn serial_group_runs_when_filtered_to_group() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[test-groups.serial]
+max-threads = 1
+
+[[profile.default.overrides]]
+filter = "tag(exclusive)"
+test-group = "serial"
+"#,
+        ),
+        (
+            "test_serial.py",
+            r"
+import karva
+
+@karva.tags.exclusive
+def test_one():
+    assert True
+
+@karva.tags.exclusive
+def test_two():
+    assert True
+
+@karva.tags.exclusive
+def test_three():
+    assert True
+        ",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().arg("-E").arg("group(serial)"),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 3 tests across 1 worker
+            PASS [TIME] test_serial::test_one
+            PASS [TIME] test_serial::test_two
+            PASS [TIME] test_serial::test_three
+
+    ────────────
+         Summary [TIME] 3 tests run: 3 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+}

--- a/crates/karva/tests/it/filterset.rs
+++ b/crates/karva/tests/it/filterset.rs
@@ -1089,7 +1089,7 @@ fn filterset_unknown_predicate() {
     ----- stderr -----
     Karva failed
       Cause: invalid `--filter` expression
-      Cause: unknown predicate `package` in filter expression `package(foo)` (expected `test` or `tag`)
+      Cause: unknown predicate `package` in filter expression `package(foo)` (expected `test`, `tag`, or `group`)
     "
     );
 }
@@ -1126,6 +1126,69 @@ fn filterset_empty_matcher_body() {
     Karva failed
       Cause: invalid `--filter` expression
       Cause: expected a matcher body in filter expression `tag()`
+    "
+    );
+}
+
+/// `group(...)` matches the test's resolved test-group. Tests not assigned to
+/// any group never match, so without test-groups configured this filter skips
+/// every test. The inverse `not group(...)` matches everything.
+#[test]
+fn filterset_group_unassigned_tests_skipped() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+def test_x():
+    assert True
+
+def test_y():
+    assert True
+        ",
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().arg("-E").arg("group(database)"),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+
+    ────────────
+         Summary [TIME] 2 tests run: 0 passed, 2 skipped
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
+fn filterset_not_group_matches_unassigned_tests() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+def test_x():
+    assert True
+
+def test_y():
+    assert True
+        ",
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().arg("-E").arg("not group(database)"),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            PASS [TIME] test::test_x
+            PASS [TIME] test::test_y
+
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+
+    ----- stderr -----
     "
     );
 }

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -320,6 +320,13 @@ pub struct SubTestCommand {
     /// for direct use.
     #[clap(long, hide = true, value_name = "PATH")]
     pub cov_data_file: Option<Utf8PathBuf>,
+
+    /// Internal: TOML-encoded list of profile overrides forwarded from the
+    /// main process so workers can resolve `group(...)` predicates against
+    /// the same group assignments the partitioner used. Not intended for
+    /// direct use.
+    #[clap(long, hide = true, value_name = "TOML")]
+    pub group_overrides: Option<String>,
 }
 
 #[derive(Debug, Parser)]
@@ -492,6 +499,7 @@ impl SubTestCommand {
                 report: self.cov_report.map(Into::into),
                 disabled: self.no_cov.then_some(true),
             }),
+            overrides: None,
         }
     }
 }

--- a/crates/karva_metadata/src/filter.rs
+++ b/crates/karva_metadata/src/filter.rs
@@ -36,13 +36,19 @@ pub enum Predicate {
     Test(Matcher),
     /// Evaluated against each custom tag on the test; matches if any tag matches.
     Tag(Matcher),
+    /// Evaluated against the test's resolved test-group name; matches if the
+    /// test belongs to a group whose name matches.
+    Group(Matcher),
 }
 
 /// The value a [`Filterset`] is evaluated against.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct EvalContext<'a> {
     pub test_name: &'a str,
     pub tags: &'a [&'a str],
+    /// The name of the test-group this test was assigned to, if any.
+    /// `group(...)` predicates evaluate against this value.
+    pub group: Option<&'a str>,
 }
 
 #[derive(Debug, Clone)]
@@ -60,9 +66,23 @@ impl Expr {
             Self::Predicate(Predicate::Tag(matcher)) => {
                 ctx.tags.iter().any(|tag| matcher.matches(tag))
             }
+            Self::Predicate(Predicate::Group(matcher)) => {
+                ctx.group.is_some_and(|name| matcher.matches(name))
+            }
             Self::Not(inner) => !inner.matches(ctx),
             Self::And(lhs, rhs) => lhs.matches(ctx) && rhs.matches(ctx),
             Self::Or(lhs, rhs) => lhs.matches(ctx) || rhs.matches(ctx),
+        }
+    }
+
+    fn uses_group_predicate(&self) -> bool {
+        match self {
+            Self::Predicate(Predicate::Group(_)) => true,
+            Self::Predicate(_) => false,
+            Self::Not(inner) => inner.uses_group_predicate(),
+            Self::And(lhs, rhs) | Self::Or(lhs, rhs) => {
+                lhs.uses_group_predicate() || rhs.uses_group_predicate()
+            }
         }
     }
 }
@@ -89,6 +109,14 @@ impl Filterset {
 
     pub fn matches(&self, ctx: &EvalContext<'_>) -> bool {
         self.expr.matches(ctx)
+    }
+
+    /// Returns `true` if this expression contains a `group(...)` predicate
+    /// anywhere in its tree. Used to reject `group(...)` inside override
+    /// filters, where it would create a circular dependency: a test's group
+    /// would depend on a filter that depends on the test's group.
+    pub fn uses_group_predicate(&self) -> bool {
+        self.expr.uses_group_predicate()
     }
 }
 
@@ -146,7 +174,7 @@ pub enum FilterError {
         expression: String,
     },
     #[error(
-        "unknown predicate `{name}` in filter expression `{expression}` (expected `test` or `tag`)"
+        "unknown predicate `{name}` in filter expression `{expression}` (expected `test`, `tag`, or `group`)"
     )]
     UnknownPredicate { name: String, expression: String },
     #[error("expected `(` after predicate in filter expression `{expression}`")]
@@ -159,6 +187,7 @@ pub enum FilterError {
 enum PredicateKind {
     Test,
     Tag,
+    Group,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -418,6 +447,7 @@ impl<'a> Parser<'a> {
                 let kind = match name.as_str() {
                     "test" => PredicateKind::Test,
                     "tag" => PredicateKind::Tag,
+                    "group" => PredicateKind::Group,
                     _ => {
                         return Err(FilterError::UnknownPredicate {
                             name,
@@ -442,6 +472,7 @@ impl<'a> Parser<'a> {
                 let predicate = match kind {
                     PredicateKind::Test => Predicate::Test(matcher),
                     PredicateKind::Tag => Predicate::Tag(matcher),
+                    PredicateKind::Group => Predicate::Group(matcher),
                 };
                 Ok(Expr::Predicate(predicate))
             }
@@ -495,7 +526,7 @@ impl<'a> Parser<'a> {
                 let body = self.parse_matcher_body()?;
                 Ok(match kind {
                     PredicateKind::Test => Matcher::Substring(body),
-                    PredicateKind::Tag => Matcher::Exact(body),
+                    PredicateKind::Tag | PredicateKind::Group => Matcher::Exact(body),
                 })
             }
             _ => Err(FilterError::ExpectedMatcher {
@@ -531,6 +562,19 @@ mod tests {
         EvalContext {
             test_name,
             tags: tag_list,
+            group: None,
+        }
+    }
+
+    fn ctx_with_group<'a>(
+        test_name: &'a str,
+        tag_list: &'a [&'a str],
+        group: &'a str,
+    ) -> EvalContext<'a> {
+        EvalContext {
+            test_name,
+            tags: tag_list,
+            group: Some(group),
         }
     }
 
@@ -609,6 +653,37 @@ mod tests {
         assert!(f.matches(&ctx("mod::test_login", &[])));
         assert!(f.matches(&ctx("mod::test_logout_and_login", &[])));
         assert!(!f.matches(&ctx("mod::test_logout", &[])));
+    }
+
+    #[test]
+    fn group_default_exact() {
+        let f = Filterset::new("group(database)").expect("parse");
+        assert!(f.matches(&ctx_with_group("x", &[], "database")));
+        assert!(!f.matches(&ctx_with_group("x", &[], "databases")));
+        assert!(!f.matches(&ctx("x", &[])));
+    }
+
+    #[test]
+    fn group_substring_explicit() {
+        let f = Filterset::new("group(~db)").expect("parse");
+        assert!(f.matches(&ctx_with_group("x", &[], "db_writes")));
+        assert!(f.matches(&ctx_with_group("x", &[], "shared_db")));
+        assert!(!f.matches(&ctx_with_group("x", &[], "cache")));
+    }
+
+    #[test]
+    fn group_glob() {
+        let f = Filterset::new("group(#db_*)").expect("parse");
+        assert!(f.matches(&ctx_with_group("x", &[], "db_writes")));
+        assert!(!f.matches(&ctx_with_group("x", &[], "cache")));
+    }
+
+    #[test]
+    fn group_combines_with_other_predicates() {
+        let f = Filterset::new("group(database) & tag(slow)").expect("parse");
+        assert!(f.matches(&ctx_with_group("x", &["slow"], "database")));
+        assert!(!f.matches(&ctx_with_group("x", &[], "database")));
+        assert!(!f.matches(&ctx("x", &["slow"])));
     }
 
     #[test]

--- a/crates/karva_metadata/src/lib.rs
+++ b/crates/karva_metadata/src/lib.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use camino::{Utf8Path, Utf8PathBuf};
 use karva_combine::Combine;
 use ruff_python_ast::PythonVersion;
@@ -8,6 +10,7 @@ mod max_fail;
 mod options;
 mod pyproject;
 mod settings;
+pub mod test_groups;
 
 pub use max_fail::MaxFail;
 pub use options::{
@@ -17,6 +20,9 @@ pub use options::{
 pub use pyproject::{PyProject, PyProjectError};
 pub use settings::{
     CoverageSettings, NoTestsMode, ProjectSettings, RunIgnoredMode, SlowTimeoutSecs,
+};
+pub use test_groups::{
+    OverrideOptions, OverridesList, TestGroupOptions, TestGroupResolver, TestGroupsError,
 };
 
 use crate::options::KarvaTomlError;
@@ -35,6 +41,10 @@ pub struct ProjectMetadata {
     pub config: Config,
 
     pub options: Options,
+
+    /// Snapshot of `[test-groups]` taken at `apply_overrides` time so the
+    /// table survives `std::mem::take(&mut self.config)`.
+    pub test_groups: BTreeMap<String, TestGroupOptions>,
 }
 
 impl ProjectMetadata {
@@ -45,6 +55,7 @@ impl ProjectMetadata {
             python_version,
             config: Config::default(),
             options: Options::default(),
+            test_groups: BTreeMap::new(),
         }
     }
 
@@ -67,6 +78,7 @@ impl ProjectMetadata {
             python_version,
             config,
             options: Options::default(),
+            test_groups: BTreeMap::new(),
         })
     }
 
@@ -93,6 +105,7 @@ impl ProjectMetadata {
             python_version,
             config,
             options: Options::default(),
+            test_groups: BTreeMap::new(),
         }
     }
 
@@ -201,9 +214,34 @@ impl ProjectMetadata {
         &mut self,
         overrides: &ProjectOptionsOverrides,
     ) -> Result<(), UnknownProfile> {
-        let config = std::mem::take(&mut self.config);
+        let mut config = std::mem::take(&mut self.config);
+        self.test_groups = std::mem::take(&mut config.test_groups);
         self.options = overrides.apply_to(config)?;
         Ok(())
+    }
+
+    /// Build a [`TestGroupResolver`] from the resolved overrides and
+    /// configured `[test-groups]` table.
+    pub fn build_test_group_resolver(&self) -> Result<TestGroupResolver, TestGroupsError> {
+        let overrides = self
+            .options
+            .overrides
+            .as_ref()
+            .map(|list| list.0.as_slice())
+            .unwrap_or(&[]);
+        TestGroupResolver::new(overrides, &self.test_groups)
+    }
+
+    pub fn test_groups(&self) -> &BTreeMap<String, TestGroupOptions> {
+        &self.test_groups
+    }
+
+    pub fn resolved_overrides(&self) -> &[OverrideOptions] {
+        self.options
+            .overrides
+            .as_ref()
+            .map(|list| list.0.as_slice())
+            .unwrap_or(&[])
     }
 
     /// Combine the project options with the CLI options where the CLI options take precedence.

--- a/crates/karva_metadata/src/options.rs
+++ b/crates/karva_metadata/src/options.rs
@@ -14,6 +14,7 @@ use crate::settings::{
     CoverageSettings, NoTestsMode, ProjectSettings, RunIgnoredMode, SlowTimeoutSecs, SrcSettings,
     TerminalSettings, TestSettings,
 };
+use crate::test_groups::{OverridesList, TestGroupOptions, TestGroupsError};
 
 /// The implicit name of the default profile.
 pub const DEFAULT_PROFILE: &str = "default";
@@ -28,13 +29,25 @@ pub const DEFAULT_PROFILE: &str = "default";
 pub struct Config {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub profile: BTreeMap<String, Options>,
+
+    /// Named test-groups that limit how many workers may run tests from the
+    /// group at once. See [nextest's docs](https://nexte.st/docs/configuration/test-groups/).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub test_groups: BTreeMap<String, TestGroupOptions>,
 }
 
 impl Config {
     pub fn from_toml_str(content: &str) -> Result<Self, KarvaTomlError> {
         let config: Self = toml::from_str(content)?;
         validate_profile_names(&config.profile)?;
+        crate::test_groups::validate_group_names(&config.test_groups)
+            .map_err(KarvaTomlError::InvalidTestGroups)?;
         Ok(config)
+    }
+
+    /// Borrow the configured `[test-groups]` table.
+    pub fn test_groups(&self) -> &BTreeMap<String, TestGroupOptions> {
+        &self.test_groups
     }
 
     pub(crate) fn from_karva_configuration_file(
@@ -151,6 +164,11 @@ pub struct Options {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[option_group]
     pub coverage: Option<CoverageOptions>,
+
+    /// Per-profile filter→test-group assignments. Evaluated top-down per
+    /// test; the first matching override wins.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub overrides: Option<OverridesList>,
 }
 
 impl Options {
@@ -415,6 +433,7 @@ impl TestOptions {
             run_ignored: RunIgnoredMode::default(),
             no_tests: self.no_tests.unwrap_or_default(),
             slow_timeout: self.slow_timeout.and_then(SlowTimeoutSecs::as_duration),
+            group_resolver: crate::test_groups::TestGroupResolver::default(),
         }
     }
 }
@@ -431,6 +450,8 @@ pub enum KarvaTomlError {
     },
     #[error("invalid profile name `{name}`: {reason}")]
     InvalidProfileName { name: String, reason: &'static str },
+    #[error(transparent)]
+    InvalidTestGroups(TestGroupsError),
 }
 
 #[derive(
@@ -645,7 +666,7 @@ foo = 1
           |
         2 | [bogus]
           |  ^^^^^
-        unknown field `bogus`, expected `profile`
+        unknown field `bogus`, expected `profile` or `test-groups`
         "
         );
     }
@@ -663,7 +684,7 @@ test-function-prefix = "test"
           |
         2 | [test]
           |  ^^^^
-        unknown field `test`, expected `profile`
+        unknown field `test`, expected `profile` or `test-groups`
         "
         );
     }
@@ -673,6 +694,7 @@ test-function-prefix = "test"
         assert_debug_snapshot!(Config::from_toml_str("").expect("parse"), @"
         Config {
             profile: {},
+            test_groups: {},
         }
         ");
     }
@@ -944,6 +966,95 @@ retry = 1
         assert_snapshot!(
             Config::from_toml_str(toml).expect_err("invalid"),
             @"invalid profile name `ci/fast`: profile names may only contain ASCII letters, digits, `-`, and `_`"
+        );
+    }
+
+    #[test]
+    fn parse_test_groups_table() {
+        let toml = r"
+[test-groups.database]
+max-threads = 4
+
+[test-groups.serial]
+max-threads = 1
+";
+        let config = Config::from_toml_str(toml).expect("parse");
+        assert_eq!(config.test_groups().len(), 2);
+        assert_eq!(
+            config
+                .test_groups()
+                .get("database")
+                .expect("database group")
+                .max_threads
+                .get(),
+            4
+        );
+    }
+
+    #[test]
+    fn parse_overrides_inside_profile() {
+        let toml = r#"
+[test-groups.serial]
+max-threads = 1
+
+[[profile.default.overrides]]
+filter = "tag(exclusive)"
+test-group = "serial"
+
+[[profile.default.overrides]]
+filter = "tag(slow)"
+"#;
+        let config = Config::from_toml_str(toml).expect("parse");
+        let resolved = config.resolve_profile(None).expect("resolves");
+        let overrides = resolved.overrides.expect("has overrides").0;
+        assert_eq!(overrides.len(), 2);
+        assert_eq!(overrides[0].filter, "tag(exclusive)");
+        assert_eq!(overrides[0].test_group.as_deref(), Some("serial"));
+        assert_eq!(overrides[1].test_group, None);
+    }
+
+    #[test]
+    fn resolve_profile_orders_named_overrides_before_default() {
+        let toml = r#"
+[test-groups.serial]
+max-threads = 1
+
+[test-groups.database]
+max-threads = 4
+
+[[profile.default.overrides]]
+filter = "tag(slow)"
+test-group = "database"
+
+[[profile.ci.overrides]]
+filter = "tag(exclusive)"
+test-group = "serial"
+"#;
+        let config = Config::from_toml_str(toml).expect("parse");
+        let resolved = config.resolve_profile(Some("ci")).expect("resolves");
+        let overrides = resolved.overrides.expect("has overrides").0;
+        let filters: Vec<&str> = overrides.iter().map(|o| o.filter.as_str()).collect();
+        assert_eq!(filters, vec!["tag(exclusive)", "tag(slow)"]);
+    }
+
+    #[test]
+    fn from_toml_str_rejects_zero_max_threads() {
+        let toml = r"
+[test-groups.serial]
+max-threads = 0
+";
+        assert!(Config::from_toml_str(toml).is_err());
+    }
+
+    #[test]
+    fn from_toml_str_rejects_at_prefix_group_name() {
+        let toml = r#"
+[test-groups."@global"]
+max-threads = 1
+"#;
+        assert_snapshot!(
+            Config::from_toml_str(toml).expect_err("reserved"),
+            @"invalid test-group name `@global`: the `@` prefix is reserved for built-in test-groups"
         );
     }
 

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::filter::FiltersetSet;
 use crate::max_fail::MaxFail;
 use crate::options::{CovReport, OutputFormat};
+use crate::test_groups::TestGroupResolver;
 
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RunIgnoredMode {
@@ -104,6 +105,10 @@ impl ProjectSettings {
     pub fn set_run_ignored(&mut self, mode: RunIgnoredMode) {
         self.test.run_ignored = mode;
     }
+
+    pub fn set_group_resolver(&mut self, resolver: TestGroupResolver) {
+        self.test.group_resolver = resolver;
+    }
 }
 
 #[derive(Default, Debug, Clone)]
@@ -138,4 +143,5 @@ pub struct TestSettings {
     /// Threshold after which a test is flagged as slow. `None` disables
     /// slow-test detection entirely.
     pub slow_timeout: Option<Duration>,
+    pub group_resolver: TestGroupResolver,
 }

--- a/crates/karva_metadata/src/test_groups.rs
+++ b/crates/karva_metadata/src/test_groups.rs
@@ -1,0 +1,446 @@
+use std::collections::BTreeMap;
+use std::num::NonZeroUsize;
+
+use karva_combine::Combine;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::filter::{EvalContext, FilterError, Filterset};
+
+/// Per-group concurrency configuration.
+///
+/// Modeled after [nextest's test groups](https://nexte.st/docs/configuration/test-groups/).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct TestGroupOptions {
+    /// Maximum number of workers that may run tests from this group at once.
+    ///
+    /// `1` enforces serial execution within the group; tests in other groups
+    /// (or in no group) continue to run in parallel.
+    pub max_threads: NonZeroUsize,
+}
+
+/// A profile-level override that assigns matching tests to a `test-group`.
+///
+/// Overrides are evaluated in order; the first one whose `filter` matches a
+/// given test *and* sets `test-group` wins. Filter expressions use the same
+/// DSL as the `--filter` CLI flag, except that the `group(...)` predicate is
+/// rejected here to avoid circular references (a test's group cannot depend
+/// on a filter that itself depends on the test's group).
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct OverrideOptions {
+    pub filter: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub test_group: Option<String>,
+}
+
+/// A list of overrides with prepend-on-combine semantics.
+///
+/// Prepending makes higher-priority profile overrides (named profile)
+/// evaluate before lower-priority ones (default profile) under
+/// first-match-wins semantics.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct OverridesList(pub Vec<OverrideOptions>);
+
+/// Wrapper used purely for the TOML encoding, which cannot represent a
+/// top-level array of tables.
+#[derive(Debug, Serialize, Deserialize)]
+struct OverridesEnvelope {
+    #[serde(default)]
+    overrides: Vec<OverrideOptions>,
+}
+
+impl OverridesList {
+    /// Serialize to TOML for forwarding from the main process to workers via
+    /// the `--group-overrides` CLI argument. TOML is used in preference to
+    /// JSON because `karva_metadata` already depends on `toml`; using it
+    /// avoids pulling `serde_json` into the dependency graph.
+    pub fn to_toml_string(&self) -> Result<String, toml::ser::Error> {
+        toml::to_string(&OverridesEnvelope {
+            overrides: self.0.clone(),
+        })
+    }
+
+    /// Deserialize from the TOML form produced by [`Self::to_toml_string`].
+    pub fn from_toml_str(input: &str) -> Result<Vec<OverrideOptions>, toml::de::Error> {
+        Ok(toml::from_str::<OverridesEnvelope>(input)?.overrides)
+    }
+}
+
+impl Combine for OverridesList {
+    fn combine_with(&mut self, other: Self) {
+        let mut merged = std::mem::take(&mut self.0);
+        merged.extend(other.0);
+        self.0 = merged;
+    }
+}
+
+/// Errors raised when validating `[test-groups]` and `[[profile.*.overrides]]`.
+#[derive(Debug, Error)]
+pub enum TestGroupsError {
+    #[error("invalid test-group name `{name}`: {reason}")]
+    InvalidGroupName { name: String, reason: &'static str },
+    #[error(
+        "override #{index} references unknown test-group `{group}` (defined groups: {available})"
+    )]
+    UnknownGroup {
+        index: usize,
+        group: String,
+        available: String,
+    },
+    #[error("override #{index} has invalid filter `{filter}`: {source}")]
+    InvalidFilter {
+        index: usize,
+        filter: String,
+        #[source]
+        source: Box<FilterError>,
+    },
+    #[error(
+        "override #{index} filter `{filter}` uses `group(...)`; overrides cannot reference test-groups in their own filter"
+    )]
+    GroupPredicateInOverride { index: usize, filter: String },
+}
+
+pub(crate) fn validate_group_names(
+    groups: &BTreeMap<String, TestGroupOptions>,
+) -> Result<(), TestGroupsError> {
+    for name in groups.keys() {
+        validate_group_name(name)?;
+    }
+    Ok(())
+}
+
+fn validate_group_name(name: &str) -> Result<(), TestGroupsError> {
+    if name.is_empty() {
+        return Err(TestGroupsError::InvalidGroupName {
+            name: name.to_string(),
+            reason: "test-group name cannot be empty",
+        });
+    }
+    if name.starts_with('@') {
+        return Err(TestGroupsError::InvalidGroupName {
+            name: name.to_string(),
+            reason: "the `@` prefix is reserved for built-in test-groups",
+        });
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(TestGroupsError::InvalidGroupName {
+            name: name.to_string(),
+            reason: "test-group names may only contain ASCII letters, digits, `-`, and `_`",
+        });
+    }
+    Ok(())
+}
+
+/// Compiled override + group lookup.
+///
+/// Maps a test (by name + tags) to its resolved group, if any. Built once
+/// per run and shared between the main process (for partitioning) and
+/// workers (for `group(...)` filter eval).
+#[derive(Debug, Default, Clone)]
+pub struct TestGroupResolver {
+    compiled: Vec<CompiledOverride>,
+}
+
+#[derive(Debug, Clone)]
+struct CompiledOverride {
+    filterset: Filterset,
+    /// `None` for overrides that match tests but do not assign a group; such
+    /// overrides are skipped during group resolution rather than terminating
+    /// the search, so a later override can still set the group.
+    group: Option<String>,
+}
+
+impl TestGroupResolver {
+    /// Build a resolver from already-validated overrides without re-checking
+    /// that referenced groups exist. Used by workers, which receive overrides
+    /// as JSON from the main process — group existence has already been
+    /// validated there.
+    pub fn from_validated_overrides(
+        overrides: &[OverrideOptions],
+    ) -> Result<Self, TestGroupsError> {
+        Self::build(overrides, None)
+    }
+
+    /// Build a resolver from overrides + the configured `[test-groups]` table.
+    /// Errors if any override references a group not present in `groups`, has
+    /// an unparsable filter, or uses the `group(...)` predicate in its filter.
+    pub fn new(
+        overrides: &[OverrideOptions],
+        groups: &BTreeMap<String, TestGroupOptions>,
+    ) -> Result<Self, TestGroupsError> {
+        Self::build(overrides, Some(groups))
+    }
+
+    fn build(
+        overrides: &[OverrideOptions],
+        groups: Option<&BTreeMap<String, TestGroupOptions>>,
+    ) -> Result<Self, TestGroupsError> {
+        let mut compiled = Vec::with_capacity(overrides.len());
+        for (index, ov) in overrides.iter().enumerate() {
+            if let (Some(groups), Some(group)) = (groups, ov.test_group.as_deref())
+                && !groups.contains_key(group)
+            {
+                let mut available: Vec<&str> = groups.keys().map(String::as_str).collect();
+                available.sort_unstable();
+                return Err(TestGroupsError::UnknownGroup {
+                    index,
+                    group: group.to_string(),
+                    available: available.join(", "),
+                });
+            }
+            let filterset =
+                Filterset::new(&ov.filter).map_err(|source| TestGroupsError::InvalidFilter {
+                    index,
+                    filter: ov.filter.clone(),
+                    source: Box::new(source),
+                })?;
+            if filterset.uses_group_predicate() {
+                return Err(TestGroupsError::GroupPredicateInOverride {
+                    index,
+                    filter: ov.filter.clone(),
+                });
+            }
+            compiled.push(CompiledOverride {
+                filterset,
+                group: ov.test_group.clone(),
+            });
+        }
+        Ok(Self { compiled })
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.compiled.is_empty()
+    }
+
+    /// Returns the test-group assigned to a test by the first override that
+    /// both matches and sets a `test-group`. Overrides that match but do not
+    /// set a group are skipped, so they cannot accidentally shadow later
+    /// assignments — mirroring nextest's per-setting first-match-wins model.
+    pub fn resolve(&self, test_name: &str, tags: &[&str]) -> Option<&str> {
+        let ctx = EvalContext {
+            test_name,
+            tags,
+            group: None,
+        };
+        self.compiled
+            .iter()
+            .filter(|ov| ov.group.is_some() && ov.filterset.matches(&ctx))
+            .find_map(|ov| ov.group.as_deref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn group_opts(max: usize) -> TestGroupOptions {
+        TestGroupOptions {
+            max_threads: NonZeroUsize::new(max).expect("non-zero"),
+        }
+    }
+
+    #[test]
+    fn resolver_first_match_wins() {
+        let mut groups = BTreeMap::new();
+        groups.insert("database".to_string(), group_opts(4));
+        groups.insert("serial".to_string(), group_opts(1));
+
+        let overrides = vec![
+            OverrideOptions {
+                filter: "tag(serial)".to_string(),
+                test_group: Some("serial".to_string()),
+            },
+            OverrideOptions {
+                filter: "tag(db)".to_string(),
+                test_group: Some("database".to_string()),
+            },
+        ];
+        let resolver = TestGroupResolver::new(&overrides, &groups).expect("build");
+        assert_eq!(resolver.resolve("x", &["serial", "db"]), Some("serial"));
+        assert_eq!(resolver.resolve("x", &["db"]), Some("database"));
+        assert_eq!(resolver.resolve("x", &[]), None);
+    }
+
+    #[test]
+    fn resolver_skips_overrides_without_test_group() {
+        let mut groups = BTreeMap::new();
+        groups.insert("database".to_string(), group_opts(4));
+
+        // An override that matches but assigns no group should NOT shadow
+        // the later override that does assign one.
+        let overrides = vec![
+            OverrideOptions {
+                filter: "tag(slow)".to_string(),
+                test_group: None,
+            },
+            OverrideOptions {
+                filter: "tag(slow)".to_string(),
+                test_group: Some("database".to_string()),
+            },
+        ];
+        let resolver = TestGroupResolver::new(&overrides, &groups).expect("build");
+        assert_eq!(resolver.resolve("x", &["slow"]), Some("database"));
+    }
+
+    #[test]
+    fn resolver_rejects_unknown_group() {
+        let groups = BTreeMap::new();
+        let overrides = vec![OverrideOptions {
+            filter: "tag(slow)".to_string(),
+            test_group: Some("missing".to_string()),
+        }];
+        let err = TestGroupResolver::new(&overrides, &groups).expect_err("unknown");
+        assert!(matches!(err, TestGroupsError::UnknownGroup { .. }));
+    }
+
+    #[test]
+    fn resolver_rejects_group_predicate_in_override() {
+        let mut groups = BTreeMap::new();
+        groups.insert("a".to_string(), group_opts(2));
+        let overrides = vec![OverrideOptions {
+            filter: "group(a)".to_string(),
+            test_group: Some("a".to_string()),
+        }];
+        let err = TestGroupResolver::new(&overrides, &groups).expect_err("circular");
+        assert!(matches!(
+            err,
+            TestGroupsError::GroupPredicateInOverride { .. }
+        ));
+    }
+
+    /// `group` appearing inside a string or regex literal must not be
+    /// confused with a `group(...)` predicate. The check walks the parsed
+    /// AST instead of doing a lexical scan precisely so these cases work.
+    #[test]
+    fn resolver_accepts_literal_group_inside_other_predicates() {
+        let mut groups = BTreeMap::new();
+        groups.insert("a".to_string(), group_opts(2));
+        for filter in [
+            "tag(/group(.*)/)",
+            "test(\"group(slow)\")",
+            "tag(my_group)",
+            "tag(grouped)",
+            "test(=group)",
+        ] {
+            let overrides = vec![OverrideOptions {
+                filter: filter.to_string(),
+                test_group: Some("a".to_string()),
+            }];
+            TestGroupResolver::new(&overrides, &groups)
+                .unwrap_or_else(|err| panic!("filter `{filter}` rejected: {err}"));
+        }
+    }
+
+    #[test]
+    fn resolver_rejects_filter_with_group_predicate() {
+        let mut groups = BTreeMap::new();
+        groups.insert("a".to_string(), group_opts(2));
+        for filter in [
+            "group(a)",
+            " group ( a ) ",
+            "tag(a) & group(b)",
+            "not group(a)",
+        ] {
+            let overrides = vec![OverrideOptions {
+                filter: filter.to_string(),
+                test_group: Some("a".to_string()),
+            }];
+            let err = TestGroupResolver::new(&overrides, &groups)
+                .err()
+                .unwrap_or_else(|| panic!("filter `{filter}` accepted"));
+            assert!(
+                matches!(err, TestGroupsError::GroupPredicateInOverride { .. }),
+                "filter `{filter}` produced unexpected error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn resolver_rejects_invalid_filter_syntax() {
+        let groups = BTreeMap::new();
+        let overrides = vec![OverrideOptions {
+            filter: "tag(".to_string(),
+            test_group: None,
+        }];
+        let err = TestGroupResolver::new(&overrides, &groups).expect_err("invalid filter");
+        assert!(matches!(err, TestGroupsError::InvalidFilter { .. }));
+    }
+
+    #[test]
+    fn from_validated_overrides_skips_existence_check() {
+        let overrides = vec![OverrideOptions {
+            filter: "tag(slow)".to_string(),
+            test_group: Some("anything".to_string()),
+        }];
+        let resolver = TestGroupResolver::from_validated_overrides(&overrides).expect("build");
+        assert_eq!(resolver.resolve("x", &["slow"]), Some("anything"));
+    }
+
+    #[test]
+    fn overrides_list_combine_prepends_self() {
+        let high = OverridesList(vec![OverrideOptions {
+            filter: "tag(a)".to_string(),
+            test_group: Some("g".to_string()),
+        }]);
+        let low = OverridesList(vec![OverrideOptions {
+            filter: "tag(b)".to_string(),
+            test_group: Some("g".to_string()),
+        }]);
+        let merged = high.combine(low);
+        let names: Vec<&str> = merged.0.iter().map(|o| o.filter.as_str()).collect();
+        assert_eq!(names, vec!["tag(a)", "tag(b)"]);
+    }
+
+    #[test]
+    fn overrides_list_toml_round_trip() {
+        let overrides = OverridesList(vec![
+            OverrideOptions {
+                filter: "tag(slow)".to_string(),
+                test_group: Some("serial".to_string()),
+            },
+            OverrideOptions {
+                filter: "tag(db)".to_string(),
+                test_group: None,
+            },
+        ]);
+        let encoded = overrides.to_toml_string().expect("serialize");
+        let parsed = OverridesList::from_toml_str(&encoded).expect("parse");
+        assert_eq!(parsed, overrides.0);
+    }
+
+    #[test]
+    fn overrides_list_from_empty_string_yields_empty_list() {
+        let parsed = OverridesList::from_toml_str("").expect("parse empty");
+        assert!(parsed.is_empty());
+    }
+
+    #[test]
+    fn validate_group_names_rejects_at_prefix() {
+        let mut groups = BTreeMap::new();
+        groups.insert("@global".to_string(), group_opts(1));
+        let err = validate_group_names(&groups).expect_err("reserved");
+        assert!(matches!(err, TestGroupsError::InvalidGroupName { .. }));
+    }
+
+    #[test]
+    fn validate_group_names_rejects_empty() {
+        let mut groups = BTreeMap::new();
+        groups.insert(String::new(), group_opts(1));
+        let err = validate_group_names(&groups).expect_err("empty");
+        assert!(matches!(err, TestGroupsError::InvalidGroupName { .. }));
+    }
+
+    #[test]
+    fn validate_group_names_rejects_invalid_chars() {
+        let mut groups = BTreeMap::new();
+        groups.insert("with space".to_string(), group_opts(1));
+        let err = validate_group_names(&groups).expect_err("invalid");
+        assert!(matches!(err, TestGroupsError::InvalidGroupName { .. }));
+    }
+}

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -17,7 +17,7 @@ use karva_cli::SubTestCommand;
 use karva_collector::{CollectedPackage, CollectionSettings};
 use karva_logging::Printer;
 use karva_logging::time::format_duration;
-use karva_metadata::ProjectSettings;
+use karva_metadata::{OverridesList, ProjectSettings};
 use karva_project::Project;
 use karva_static::WorkerEnvVars;
 
@@ -192,6 +192,9 @@ fn spawn_workers(
         }
 
         cmd.args(inner_cli_args(project.settings(), args));
+        if let Some(toml) = encode_group_overrides(project.metadata().resolved_overrides()) {
+            cmd.arg("--group-overrides").arg(toml);
+        }
 
         if !project.settings().coverage().sources.is_empty() {
             let data_file = karva_coverage::worker_data_file(&coverage_dir, worker_id);
@@ -315,6 +318,15 @@ pub fn run_parallel_tests(
     } else {
         HashSet::new()
     };
+
+    // Validate `[[profile.*.overrides]]` against `[test-groups]` up front so
+    // misconfigurations are rejected before any worker spawns. Workers only
+    // see the resolved override list (forwarded via `--group-overrides`),
+    // so they don't redo this check.
+    project
+        .metadata()
+        .build_test_group_resolver()
+        .map_err(|err| anyhow::anyhow!("invalid test-groups configuration: {err}"))?;
 
     let partitions = partition_collected_tests(
         &collected,
@@ -471,4 +483,27 @@ fn inner_cli_args(settings: &ProjectSettings, args: &SubTestCommand) -> Vec<Stri
 
 pub fn coverage_data_dir(cache_dir: &Utf8PathBuf) -> Utf8PathBuf {
     cache_dir.join("coverage")
+}
+
+/// Serialize the resolved override list as TOML for forwarding to workers.
+///
+/// Workers rebuild a `TestGroupResolver` from the same data so `group(...)`
+/// filter predicates evaluate consistently on both sides. Returns `None`
+/// when there are no overrides to forward, so the `--group-overrides` flag
+/// is omitted entirely rather than passed with an empty value.
+fn encode_group_overrides(overrides: &[karva_metadata::OverrideOptions]) -> Option<String> {
+    if overrides.is_empty() {
+        return None;
+    }
+    let list = OverridesList(overrides.to_vec());
+    match list.to_toml_string() {
+        Ok(toml) => Some(toml),
+        Err(err) => {
+            tracing::warn!(
+                ?err,
+                "failed to serialize group overrides; workers will not resolve groups"
+            );
+            None
+        }
+    }
 }

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -231,15 +231,21 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
     ) -> Option<bool> {
         let filter = &self.context.settings().test().filter;
         let run_ignored = self.context.settings().test().run_ignored;
+        let group_resolver = &self.context.settings().test().group_resolver;
 
         if !filter.is_empty() {
             let qualified = QualifiedTestName::new(name.clone(), None);
             let display_name = qualified.to_string();
             let custom_names = tags.custom_tag_names();
+            let group = if group_resolver.is_empty() {
+                None
+            } else {
+                group_resolver.resolve(&display_name, &custom_names)
+            };
             let ctx = EvalContext {
                 test_name: &display_name,
                 tags: &custom_names,
-                group: None,
+                group,
             };
             if !filter.matches(&ctx) {
                 return Some(self.context.register_test_case_result(

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -239,6 +239,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             let ctx = EvalContext {
                 test_name: &display_name,
                 tags: &custom_names,
+                group: None,
             };
             if !filter.matches(&ctx) {
                 return Some(self.context.register_test_case_result(

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -10,8 +10,8 @@ use karva_cache::{Cache, RunHash};
 use karva_cli::{SubTestCommand, Verbosity};
 use karva_diagnostic::{DummyReporter, Reporter, TestCaseReporter};
 use karva_logging::{Printer, StatusLevel, set_colored_override, setup_tracing};
-use karva_metadata::RunIgnoredMode;
 use karva_metadata::filter::FiltersetSet;
+use karva_metadata::{OverridesList, RunIgnoredMode, TestGroupResolver};
 use karva_project::path::{TestPath, TestPathError, absolute};
 use karva_python_semantic::current_python_version;
 use karva_static::EnvVars;
@@ -141,6 +141,19 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
     let filter = FiltersetSet::new(&args.sub_command.filter_expressions)
         .context("invalid `--filter` expression")?;
 
+    let group_resolver = match args.sub_command.group_overrides.as_deref() {
+        Some(toml) if !toml.is_empty() => {
+            let overrides = OverridesList::from_toml_str(toml)
+                .context("failed to parse `--group-overrides` (forwarded by main process)")?;
+            // The main process already validated overrides against `[test-groups]`,
+            // so the worker only needs the list to compute group assignments
+            // at filter-eval time.
+            TestGroupResolver::from_validated_overrides(&overrides)
+                .context("failed to build group resolver from overrides")?
+        }
+        _ => TestGroupResolver::default(),
+    };
+
     let run_ignored = args
         .sub_command
         .run_ignored
@@ -161,6 +174,7 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
     let mut settings = args.sub_command.into_options().to_settings();
     settings.set_filter(filter);
     settings.set_run_ignored(run_ignored);
+    settings.set_group_resolver(group_resolver);
 
     let run_hash = RunHash::from_existing(&args.run_hash);
 


### PR DESCRIPTION
## Summary

Adds nextest-style [test groups](https://nexte.st/docs/configuration/test-groups/) (#563, #564) to karva, in two commits: the `group(...)` filter predicate first, then the surrounding configuration.

The `[test-groups.<name>]` table declares groups, and per-profile `[[profile.*.overrides]]` entries assign matching tests to a group via filter expressions:

```toml
[test-groups.database]
max-threads = 4

[[profile.default.overrides]]
filter = "tag(database)"
test-group = "database"
```

The new `group(...)` predicate then targets the resolved group, so `-E 'group(database)'` runs only database-tagged tests and `-E 'not group(database)'` excludes them.

Group resolution happens worker-side at filter-eval time, using the runtime tags the worker already extracts via the existing extension machinery. The main process forwards the resolved override list as TOML through a hidden `--group-overrides` CLI argument; no new dependencies are needed because `karva_metadata` already pulls in `toml`. Validation that every override references a declared group (and that override filters do not themselves use `group(...)` to avoid circular references) happens in the main process before any worker spawns.

`max-threads` is intentionally not enforced by the partitioner in this PR. Honouring it requires either a coordinator-based scheduler or a two-pass discovery phase, both of which are larger architectural changes that are best landed separately. The schema and runtime predicate are useful on their own — `--group-overrides` gives users a way to filter by group today, and a follow-up PR can add scheduling without changing the user-facing surface.

Profile inheritance preserves first-match-wins: a named profile's overrides are evaluated before the default profile's, and within a profile, top-down. Overrides that match but do not set a `test-group` are skipped during group resolution rather than terminating the search, mirroring nextest's per-setting first-match-wins model.

## Test Plan

ci