### PR TITLE
Expose `KARVA`, `KARVA_WORKER_ID`, `KARVA_RUN_ID`, `KARVA_WORKSPACE_ROOT`, and `KARVA_TEST_NAME` to tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1309,6 +1309,7 @@ dependencies = [
  "karva_project",
  "karva_static",
  "tracing",
+ "uuid",
  "which",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ tracing-subscriber = { version = "0.3.23", default-features = false, features = 
     "fmt",
 ] }
 tracing-tree = { version = "0.4.1" }
+uuid = { version = "1.21", features = ["v4"] }
 which = { version = "8.0" }
 wild = { version = "2" }
 

--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -2339,6 +2339,78 @@ def test_always_fails(): assert False
     );
 }
 
+/// `KARVA`, `KARVA_WORKER_ID`, `KARVA_RUN_ID`, and `KARVA_WORKSPACE_ROOT` are
+/// exposed to the test process. The values come from the worker spawn (not
+/// from the test's own `os.environ` writes), so a single passing test is
+/// enough to exercise all four.
+#[test]
+fn test_karva_static_env_vars() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import os
+import re
+
+def test_static_env():
+    assert os.environ["KARVA"] == "1"
+    assert os.environ["KARVA_WORKER_ID"] == "0"
+    assert re.fullmatch(
+        r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}",
+        os.environ["KARVA_RUN_ID"],
+    ), os.environ["KARVA_RUN_ID"]
+    assert os.environ["KARVA_WORKSPACE_ROOT"] == os.getcwd()
+        "#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_static_env
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+/// `KARVA_TEST_NAME` is set to the qualified test name before each attempt,
+/// including the parametrize-arg suffix.
+#[test]
+fn test_karva_test_name_env() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import os
+import karva
+
+def test_plain():
+    assert os.environ["KARVA_TEST_NAME"] == "test::test_plain"
+
+@karva.tags.parametrize("value", [1, 2])
+def test_param(value):
+    assert os.environ["KARVA_TEST_NAME"] == f"test::test_param(value={value})"
+        "#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            PASS [TIME] test::test_plain
+            PASS [TIME] test::test_param(value=1)
+            PASS [TIME] test::test_param(value=2)
+
+    ────────────
+         Summary [TIME] 3 tests run: 3 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
 /// `KARVA_ATTEMPT` and `KARVA_TOTAL_ATTEMPTS` are exposed to the test process.
 /// Without `--retry`, both are `"1"`.
 #[test]

--- a/crates/karva_dev/src/generate_env_vars.rs
+++ b/crates/karva_dev/src/generate_env_vars.rs
@@ -67,8 +67,8 @@ fn generate() -> String {
     emit_section(
         &mut output,
         "Set by the worker on tests",
-        "Variables the Karva worker writes into the test process before each \
-         attempt, so running test code can introspect its own retry state.",
+        "Variables the Karva worker writes into the test process so running \
+         test code can introspect the run, the worker, and its own attempt.",
         WorkerEnvVars::METADATA,
     );
 

--- a/crates/karva_runner/Cargo.toml
+++ b/crates/karva_runner/Cargo.toml
@@ -28,6 +28,7 @@ ctrlc = { workspace = true }
 fastrand = { workspace = true }
 ignore = { workspace = true }
 tracing = { workspace = true }
+uuid = { workspace = true }
 which = { workspace = true }
 
 [lints]

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -19,9 +19,37 @@ use karva_logging::Printer;
 use karva_logging::time::format_duration;
 use karva_metadata::ProjectSettings;
 use karva_project::Project;
+use karva_static::WorkerEnvVars;
 
 use crate::collection::ParallelCollector;
 use crate::partition::{Partition, partition_collected_tests};
+
+/// Generate a UUID v4 string identifying a single `karva test` invocation.
+fn generate_run_id() -> String {
+    let mut bytes = [0u8; 16];
+    fastrand::fill(&mut bytes);
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    format!(
+        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        bytes[0],
+        bytes[1],
+        bytes[2],
+        bytes[3],
+        bytes[4],
+        bytes[5],
+        bytes[6],
+        bytes[7],
+        bytes[8],
+        bytes[9],
+        bytes[10],
+        bytes[11],
+        bytes[12],
+        bytes[13],
+        bytes[14],
+        bytes[15],
+    )
+}
 
 #[derive(Debug)]
 struct Worker {
@@ -163,6 +191,7 @@ fn spawn_workers(
     let mut worker_manager = WorkerManager::default();
 
     let coverage_dir = coverage_data_dir(cache_dir);
+    let run_id = generate_run_id();
 
     for (worker_id, partition) in partitions.iter().enumerate() {
         if partition.tests().is_empty() {
@@ -179,7 +208,11 @@ fn spawn_workers(
             .arg(worker_id.to_string())
             .current_dir(project.cwd())
             // Ensure python does not buffer output
-            .env("PYTHONUNBUFFERED", "1");
+            .env("PYTHONUNBUFFERED", "1")
+            .env(WorkerEnvVars::KARVA, "1")
+            .env(WorkerEnvVars::KARVA_WORKER_ID, worker_id.to_string())
+            .env(WorkerEnvVars::KARVA_RUN_ID, &run_id)
+            .env(WorkerEnvVars::KARVA_WORKSPACE_ROOT, project.cwd().as_str());
 
         for path in partition.tests() {
             cmd.arg(path);

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -24,33 +24,6 @@ use karva_static::WorkerEnvVars;
 use crate::collection::ParallelCollector;
 use crate::partition::{Partition, partition_collected_tests};
 
-/// Generate a UUID v4 string identifying a single `karva test` invocation.
-fn generate_run_id() -> String {
-    let mut bytes = [0u8; 16];
-    fastrand::fill(&mut bytes);
-    bytes[6] = (bytes[6] & 0x0f) | 0x40;
-    bytes[8] = (bytes[8] & 0x3f) | 0x80;
-    format!(
-        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
-        bytes[0],
-        bytes[1],
-        bytes[2],
-        bytes[3],
-        bytes[4],
-        bytes[5],
-        bytes[6],
-        bytes[7],
-        bytes[8],
-        bytes[9],
-        bytes[10],
-        bytes[11],
-        bytes[12],
-        bytes[13],
-        bytes[14],
-        bytes[15],
-    )
-}
-
 #[derive(Debug)]
 struct Worker {
     id: usize,
@@ -191,7 +164,7 @@ fn spawn_workers(
     let mut worker_manager = WorkerManager::default();
 
     let coverage_dir = coverage_data_dir(cache_dir);
-    let run_id = generate_run_id();
+    let run_id = uuid::Uuid::new_v4().to_string();
 
     for (worker_id, partition) in partitions.iter().enumerate() {
         if partition.tests().is_empty() {

--- a/crates/karva_static/src/lib.rs
+++ b/crates/karva_static/src/lib.rs
@@ -67,6 +67,30 @@ env_vars! {
     /// Environment variables that the Karva worker sets on the test process so
     /// running tests can read them at runtime.
     pub struct WorkerEnvVars {
+        /// Always set to `"1"`. The cheapest signal that test code is running
+        /// under Karva, useful for fixtures and helpers that want to detect
+        /// the runner without heavier introspection.
+        pub const KARVA: &'static str = "KARVA";
+
+        /// 0-indexed worker number. The canonical way to partition shared
+        /// resources (database names, ports, scratch directories) across
+        /// parallel workers without coordination.
+        pub const KARVA_WORKER_ID: &'static str = "KARVA_WORKER_ID";
+
+        /// Unique identifier (UUID) for a single `karva test` invocation,
+        /// shared by every worker. Useful for correlating logs and external
+        /// artifacts produced across multiple worker processes.
+        pub const KARVA_RUN_ID: &'static str = "KARVA_RUN_ID";
+
+        /// Absolute path to the directory Karva resolved as the project root.
+        /// Saves tests from re-deriving the root via `__file__` walking or
+        /// `os.getcwd()` heuristics.
+        pub const KARVA_WORKSPACE_ROOT: &'static str = "KARVA_WORKSPACE_ROOT";
+
+        /// Qualified name of the currently running test, e.g.
+        /// `pkg.module::test_foo(value=1)`. Updated before each attempt.
+        pub const KARVA_TEST_NAME: &'static str = "KARVA_TEST_NAME";
+
         /// The 1-indexed attempt number for the currently running test. Always
         /// set; `"1"` when no retries are configured.
         pub const KARVA_ATTEMPT: &'static str = "KARVA_ATTEMPT";

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -30,7 +30,8 @@ use crate::runner::fixture_resolver::RuntimeFixtureResolver;
 use crate::runner::test_iterator::{TestVariant, TestVariantIterator};
 use crate::runner::{FinalizerCache, FixtureCache};
 use crate::utils::{
-    full_test_name, run_coroutine, run_test_with_timeout, set_attempt_env, source_file,
+    full_test_name, run_coroutine, run_test_with_timeout, set_attempt_env, set_test_name_env,
+    source_file,
 };
 
 /// Executes discovered tests within a package hierarchy.
@@ -417,6 +418,8 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             QualifiedTestName::new(name.clone(), Some(computed_full_test_name));
 
         tracing::debug!("Running test `{}`", qualified_test_name);
+
+        let _ = set_test_name_env(py, &qualified_test_name.to_string());
 
         // Set snapshot context so `karva.assert_snapshot()` can determine the current test.
         // Use `function_name()` (not `qualified_test_name`) to avoid doubling the module prefix,

--- a/crates/karva_test_semantic/src/utils.rs
+++ b/crates/karva_test_semantic/src/utils.rs
@@ -195,6 +195,14 @@ pub(crate) fn set_attempt_env(py: Python<'_>, attempt: u32, total_attempts: u32)
     Ok(())
 }
 
+/// Sets `KARVA_TEST_NAME` on Python's `os.environ` to the qualified name of
+/// the currently running test variant.
+pub(crate) fn set_test_name_env(py: Python<'_>, qualified_name: &str) -> PyResult<()> {
+    let environ = py.import("os")?.getattr("environ")?;
+    environ.set_item(WorkerEnvVars::KARVA_TEST_NAME, qualified_name)?;
+    Ok(())
+}
+
 /// Adds a directory path to Python's sys.path at the specified index.
 pub(crate) fn add_to_sys_path(py: Python<'_>, path: &Utf8Path, index: isize) -> PyResult<()> {
     let sys_module = py.import("sys")?;

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -27,7 +27,36 @@ instead of creating `.snap.new` pending files.
 
 ## Set by the worker on tests
 
-Variables the Karva worker writes into the test process before each attempt, so running test code can introspect its own retry state.
+Variables the Karva worker writes into the test process so running test code can introspect the run, the worker, and its own attempt.
+
+### `KARVA`
+
+Always set to `"1"`. The cheapest signal that test code is running
+under Karva, useful for fixtures and helpers that want to detect
+the runner without heavier introspection.
+
+### `KARVA_WORKER_ID`
+
+0-indexed worker number. The canonical way to partition shared
+resources (database names, ports, scratch directories) across
+parallel workers without coordination.
+
+### `KARVA_RUN_ID`
+
+Unique identifier (UUID) for a single `karva test` invocation,
+shared by every worker. Useful for correlating logs and external
+artifacts produced across multiple worker processes.
+
+### `KARVA_WORKSPACE_ROOT`
+
+Absolute path to the directory Karva resolved as the project root.
+Saves tests from re-deriving the root via `__file__` walking or
+`os.getcwd()` heuristics.
+
+### `KARVA_TEST_NAME`
+
+Qualified name of the currently running test, e.g.
+`pkg.module::test_foo(value=1)`. Updated before each attempt.
 
 ### `KARVA_ATTEMPT`
 


### PR DESCRIPTION
## Summary

Closes #717, #718, #719, #720, #721. Builds on #715 (`KARVA_ATTEMPT` / `KARVA_TOTAL_ATTEMPTS`) by exposing five more environment variables to the test process, mirroring nextest's `NEXTEST_*` set (and `pytest-xdist`'s `PYTEST_XDIST_WORKER` for the worker-id case). `KARVA=1` is a sentinel for runner detection, `KARVA_WORKER_ID` partitions shared resources across parallel workers, `KARVA_RUN_ID` is a UUID v4 generated once per `karva test` invocation and shared by every worker, `KARVA_WORKSPACE_ROOT` is the resolved project root, and `KARVA_TEST_NAME` is the qualified name of the currently running variant including parametrize args.

The four static vars are set on each worker `Command` in the runner, so Python inherits them via `os.environ` at interpreter startup. `KARVA_TEST_NAME` is updated per variant via `os.environ` before the first attempt, alongside the existing `set_attempt_env` call.

```python
import os

def test_uses_env(database):
    if os.environ.get("KARVA") == "1":
        worker = os.environ["KARVA_WORKER_ID"]
        database.use_schema(f"test_{worker}")
```

## Test Plan

ci