### PR TITLE
Expose coverage configuration via `[coverage]`

### DIFF
--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -6,10 +6,10 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context as _, Result};
 use karva_cache::{AggregatedResults, DisplayFlakyTests};
-use karva_cli::{CovReport, OutputFormat, TestCommand};
+use karva_cli::{OutputFormat, TestCommand};
 use karva_logging::{Printer, Stdout, set_colored_override, setup_tracing};
 use karva_metadata::filter::FiltersetSet;
-use karva_metadata::{NoTestsMode, ProjectMetadata, ProjectOptionsOverrides};
+use karva_metadata::{CovReport, NoTestsMode, ProjectMetadata, ProjectOptionsOverrides};
 use karva_project::Project;
 use karva_project::path::absolute;
 use karva_python_semantic::current_python_version;
@@ -94,10 +94,10 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
         durations,
     )?;
 
-    if !sub_command.cov.is_empty() {
+    if !project.settings().coverage().sources.is_empty() {
         let cache_dir = project.cwd().join(karva_cache::CACHE_DIR);
         let coverage_dir = karva_runner::coverage_data_dir(&cache_dir);
-        let show_missing = matches!(sub_command.cov_report, Some(CovReport::TermMissing));
+        let show_missing = matches!(project.settings().coverage().report, CovReport::TermMissing);
         if let Err(err) =
             karva_coverage::combine_and_report(project.cwd(), &coverage_dir, show_missing)
         {

--- a/crates/karva/tests/it/coverage.rs
+++ b/crates/karva/tests/it/coverage.rs
@@ -505,3 +505,105 @@ def test_add():
     "
     );
 }
+
+#[test]
+fn test_cov_sources_from_config() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.default.coverage]
+sources = ["src"]
+"#,
+        ),
+        (
+            "src/mymod.py",
+            r"
+def add(a, b):
+    return a + b
+",
+        ),
+        (
+            "test_mymod.py",
+            r"
+import sys, os
+sys.path.insert(0, os.path.dirname(__file__))
+from src.mymod import add
+
+def test_add():
+    assert add(2, 3) == 5
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel()
+            .arg("--status-level=none")
+            .arg("test_mymod.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    Name           Stmts   Miss   Cover
+    [LONG-LINE]
+    src/mymod.py       2      0    100%
+    [LONG-LINE]
+    TOTAL              2      0    100%
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
+fn test_cov_report_term_missing_from_config() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.default.coverage]
+sources = [""]
+report = "term-missing"
+"#,
+        ),
+        (
+            "test_missing.py",
+            r"
+def covered():
+    return 1
+
+def uncovered():
+    return 2
+
+def test_only_covered():
+    assert covered() == 1
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel()
+            .arg("--status-level=none")
+            .arg("test_missing.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    Name              Stmts   Miss   Cover   Missing
+    [LONG-LINE]
+    test_missing.py       6      1     83%   6
+    [LONG-LINE]
+    TOTAL                 6      1     83%
+
+    ----- stderr -----
+    "
+    );
+}

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -6,7 +6,8 @@ use clap::builder::Styles;
 use clap::builder::styling::{AnsiColor, Effects};
 use karva_logging::{FinalStatusLevel, StatusLevel, TerminalColor, VerbosityLevel};
 use karva_metadata::{
-    MaxFail, NoTestsMode, Options, RunIgnoredMode, SrcOptions, TerminalOptions, TestOptions,
+    CoverageOptions, MaxFail, NoTestsMode, Options, RunIgnoredMode, SrcOptions, TerminalOptions,
+    TestOptions,
 };
 use ruff_db::diagnostic::DiagnosticFormat;
 
@@ -416,6 +417,15 @@ impl From<OutputFormat> for karva_metadata::OutputFormat {
     }
 }
 
+impl From<CovReport> for karva_metadata::CovReport {
+    fn from(value: CovReport) -> Self {
+        match value {
+            CovReport::Term => Self::Term,
+            CovReport::TermMissing => Self::TermMissing,
+        }
+    }
+}
+
 impl SubTestCommand {
     pub fn into_options(self) -> Options {
         // `--no-fail-fast` forces `fail_fast = false` and clears any
@@ -452,6 +462,10 @@ impl SubTestCommand {
                 try_import_fixtures: self.try_import_fixtures,
                 retry: self.retry,
                 no_tests: self.no_tests.map(Into::into),
+            }),
+            coverage: Some(CoverageOptions {
+                sources: (!self.cov.is_empty()).then(|| self.cov.clone()),
+                report: self.cov_report.map(Into::into),
             }),
         }
     }

--- a/crates/karva_metadata/src/lib.rs
+++ b/crates/karva_metadata/src/lib.rs
@@ -11,11 +11,11 @@ mod settings;
 
 pub use max_fail::MaxFail;
 pub use options::{
-    Config, DEFAULT_PROFILE, Options, OutputFormat, ProjectOptionsOverrides, SrcOptions,
-    TerminalOptions, TestOptions, UnknownProfile,
+    Config, CovReport, CoverageOptions, DEFAULT_PROFILE, Options, OutputFormat,
+    ProjectOptionsOverrides, SrcOptions, TerminalOptions, TestOptions, UnknownProfile,
 };
 pub use pyproject::{PyProject, PyProjectError};
-pub use settings::{NoTestsMode, ProjectSettings, RunIgnoredMode};
+pub use settings::{CoverageSettings, NoTestsMode, ProjectSettings, RunIgnoredMode};
 
 use crate::options::KarvaTomlError;
 

--- a/crates/karva_metadata/src/options.rs
+++ b/crates/karva_metadata/src/options.rs
@@ -11,7 +11,8 @@ use thiserror::Error;
 use crate::filter::FiltersetSet;
 use crate::max_fail::MaxFail;
 use crate::settings::{
-    NoTestsMode, ProjectSettings, RunIgnoredMode, SrcSettings, TerminalSettings, TestSettings,
+    CoverageSettings, NoTestsMode, ProjectSettings, RunIgnoredMode, SrcSettings, TerminalSettings,
+    TestSettings,
 };
 
 /// The implicit name of the default profile.
@@ -147,6 +148,9 @@ pub struct Options {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[option_group]
     pub test: Option<TestOptions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option_group]
+    pub coverage: Option<CoverageOptions>,
 }
 
 impl Options {
@@ -155,6 +159,7 @@ impl Options {
             terminal: self.terminal.clone().unwrap_or_default().to_settings(),
             src: self.src.clone().unwrap_or_default().to_settings(),
             test: self.test.clone().unwrap_or_default().to_settings(),
+            coverage: self.coverage.clone().unwrap_or_default().to_settings(),
         }
     }
 }
@@ -407,6 +412,73 @@ pub enum KarvaTomlError {
     },
     #[error("invalid profile name `{name}`: {reason}")]
     InvalidProfileName { name: String, reason: &'static str },
+}
+
+#[derive(
+    Debug, Default, Clone, Eq, PartialEq, Combine, Serialize, Deserialize, OptionsMetadata,
+)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct CoverageOptions {
+    /// Source paths to measure coverage for.
+    ///
+    /// Equivalent to passing `--cov=<path>` on the command line; may be
+    /// listed multiple times. An empty entry (`""`) measures the current
+    /// working directory, matching pytest-cov's bare `--cov`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"null"#,
+        value_type = r#"list[str]"#,
+        example = r#"
+            sources = ["src"]
+        "#
+    )]
+    pub sources: Option<Vec<String>>,
+
+    /// Coverage terminal report type.
+    ///
+    /// `term` (default) prints a compact terminal table.
+    /// `term-missing` extends it with a `Missing` column listing the
+    /// uncovered line numbers per file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"term"#,
+        value_type = "term | term-missing",
+        example = r#"
+            report = "term-missing"
+        "#
+    )]
+    pub report: Option<CovReport>,
+}
+
+impl CoverageOptions {
+    pub fn to_settings(&self) -> CoverageSettings {
+        CoverageSettings {
+            sources: self.sources.clone().unwrap_or_default(),
+            report: self.report.unwrap_or_default(),
+        }
+    }
+}
+
+/// Coverage terminal report type.
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub enum CovReport {
+    /// Compact terminal table (default).
+    #[default]
+    Term,
+
+    /// Terminal table with a `Missing` column listing uncovered line numbers.
+    TermMissing,
+}
+
+impl Combine for CovReport {
+    #[inline(always)]
+    fn combine_with(&mut self, _other: Self) {}
+
+    #[inline]
+    fn combine(self, _other: Self) -> Self {
+        self
+    }
 }
 
 /// The diagnostic output format.
@@ -861,6 +933,98 @@ retry = 5
             99,
         )
         ");
+    }
+
+    #[test]
+    fn parse_coverage_section() {
+        let toml = r#"
+[profile.default.coverage]
+sources = ["src", "tests"]
+report = "term-missing"
+"#;
+        let resolved = Config::from_toml_str(toml)
+            .expect("parse")
+            .resolve_profile(None)
+            .expect("resolves");
+        assert_debug_snapshot!(resolved.coverage, @r#"
+        Some(
+            CoverageOptions {
+                sources: Some(
+                    [
+                        "src",
+                        "tests",
+                    ],
+                ),
+                report: Some(
+                    TermMissing,
+                ),
+            },
+        )
+        "#);
+    }
+
+    /// CLI `--cov` sources accumulate with file sources at the tail (matching
+    /// the existing `include` behavior).
+    #[test]
+    fn combine_appends_cli_coverage_sources_after_file() {
+        let cli = CoverageOptions {
+            sources: Some(vec!["tests".to_string()]),
+            ..CoverageOptions::default()
+        };
+        let file = CoverageOptions {
+            sources: Some(vec!["src".to_string()]),
+            report: Some(CovReport::TermMissing),
+        };
+        assert_debug_snapshot!(cli.combine(file), @r#"
+        CoverageOptions {
+            sources: Some(
+                [
+                    "src",
+                    "tests",
+                ],
+            ),
+            report: Some(
+                TermMissing,
+            ),
+        }
+        "#);
+    }
+
+    /// CLI `--cov-report` overrides the configured value (scalar `Combine`).
+    #[test]
+    fn combine_cli_coverage_report_wins_over_file() {
+        let cli = CoverageOptions {
+            report: Some(CovReport::Term),
+            ..CoverageOptions::default()
+        };
+        let file = CoverageOptions {
+            report: Some(CovReport::TermMissing),
+            ..CoverageOptions::default()
+        };
+        assert_debug_snapshot!(cli.combine(file).report, @r"
+        Some(
+            Term,
+        )
+        ");
+    }
+
+    #[test]
+    fn from_toml_str_rejects_unknown_coverage_key() {
+        let toml = r#"
+[profile.default.coverage]
+sources = ["src"]
+nonsense = 1
+"#;
+        assert_snapshot!(
+            Config::from_toml_str(toml).expect_err("unknown field"),
+            @r"
+        TOML parse error at line 4, column 1
+          |
+        4 | nonsense = 1
+          | ^^^^^^^^
+        unknown field `nonsense`, expected `sources` or `report`
+        "
+        );
     }
 }
 

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::filter::FiltersetSet;
 use crate::max_fail::MaxFail;
-use crate::options::OutputFormat;
+use crate::options::{CovReport, OutputFormat};
 
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RunIgnoredMode {
@@ -39,6 +39,7 @@ pub struct ProjectSettings {
     pub(crate) terminal: TerminalSettings,
     pub(crate) src: SrcSettings,
     pub(crate) test: TestSettings,
+    pub(crate) coverage: CoverageSettings,
 }
 
 impl ProjectSettings {
@@ -52,6 +53,10 @@ impl ProjectSettings {
 
     pub fn test(&self) -> &TestSettings {
         &self.test
+    }
+
+    pub fn coverage(&self) -> &CoverageSettings {
+        &self.coverage
     }
 
     pub fn max_fail(&self) -> MaxFail {
@@ -79,6 +84,12 @@ pub struct TerminalSettings {
 pub struct SrcSettings {
     pub respect_ignore_files: bool,
     pub include_paths: Vec<String>,
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct CoverageSettings {
+    pub sources: Vec<String>,
+    pub report: CovReport,
 }
 
 #[derive(Default, Debug, Clone)]

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -187,7 +187,7 @@ fn spawn_workers(
 
         cmd.args(inner_cli_args(project.settings(), args));
 
-        if !args.cov.is_empty() {
+        if !project.settings().coverage().sources.is_empty() {
             let data_file = karva_coverage::worker_data_file(&coverage_dir, worker_id);
             cmd.arg("--cov-data-file").arg(data_file.as_str());
         }
@@ -319,7 +319,7 @@ pub fn run_parallel_tests(
 
     let run_hash = RunHash::current_time();
 
-    if !args.cov.is_empty() {
+    if !project.settings().coverage().sources.is_empty() {
         let coverage_dir = coverage_data_dir(&cache_dir);
         karva_coverage::prepare_data_dir(&coverage_dir)?;
     }
@@ -451,7 +451,7 @@ fn inner_cli_args(settings: &ProjectSettings, args: &SubTestCommand) -> Vec<Stri
         cli_args.push(mode.as_str().to_string());
     }
 
-    for source in &args.cov {
+    for source in &settings.coverage().sources {
         cli_args.push(format!("--cov={source}"));
     }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,6 +6,50 @@ Karva is configured through `karva.toml` (or the `[tool.karva]` table in `pyproj
 
 The reference below documents every field supported inside a profile. Examples target the implicit `default` profile.
 
+## `coverage`
+
+### `report`
+
+Coverage terminal report type.
+
+`term` (default) prints a compact terminal table.
+`term-missing` extends it with a `Missing` column listing the
+uncovered line numbers per file.
+
+**Default value**: `term`
+
+**Type**: `term | term-missing`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.karva.profile.default.coverage]
+report = "term-missing"
+```
+
+---
+
+### `sources`
+
+Source paths to measure coverage for.
+
+Equivalent to passing `--cov=<path>` on the command line; may be
+listed multiple times. An empty entry (`""`) measures the current
+working directory, matching pytest-cov's bare `--cov`.
+
+**Default value**: `null`
+
+**Type**: `list[str]`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.karva.profile.default.coverage]
+sources = ["src"]
+```
+
+---
+
 ## `src`
 
 ### `include`


### PR DESCRIPTION
## Summary

Adds a `coverage` option group alongside the existing `src`, `terminal`, and `test` groups so projects can pin coverage defaults in `karva.toml` or `pyproject.toml`. The new section accepts `sources` (equivalent to repeated `--cov=<path>`) and `report` (`term` or `term-missing`).

```toml
[profile.default.coverage]
sources = ["src"]
report = "term-missing"
```

CLI flags layer on top via the usual `Combine` precedence: `--cov` entries append to file sources, and `--cov-report` overrides the configured report scalar. `CovReport` moves to `karva_metadata` so it can be reached from settings and from the runner; `karva_cli::CovReport` keeps its clap derives and gains a `From` conversion. The main process and runner both read coverage state from `project.settings().coverage()` instead of `SubTestCommand`, so configuration alone now suffices to enable coverage measurement and reporting.

This is the prerequisite refactor called out in #722; subsequent coverage features (`--no-cov`, `--cov-fail-under`, `omit`/`include` globs, branch coverage) can each add a single field rather than re-doing the plumbing.

Closes #722

## Test Plan

ci