### PR TITLE
Add `--slow-timeout` and SLOW reporting

### DIFF
--- a/crates/karva/src/lib.rs
+++ b/crates/karva/src/lib.rs
@@ -42,7 +42,7 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
     let args = Args::parse_from(args);
 
     match args.command {
-        Command::Test(test_args) => commands::test::test(test_args),
+        Command::Test(test_args) => commands::test::test(*test_args),
         Command::Snapshot(snapshot_args) => commands::snapshot::snapshot(snapshot_args),
         Command::Cache(cache_args) => commands::cache::cache(&cache_args),
         Command::Version => commands::version::version().map(|()| ExitStatus::Success),

--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -2813,3 +2813,105 @@ fn test_test_prefix_requires_value() {
     For more information, try '--help'.
     ");
 }
+
+/// `--slow-timeout` flags tests whose total duration exceeds the threshold.
+/// At `--status-level=slow` the SLOW line precedes the PASS line and the
+/// summary picks up a `1 slow` counter.
+#[test]
+fn test_slow_timeout_emits_slow_line_and_counter() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import time
+
+def test_slow():
+    time.sleep(0.05)
+
+def test_fast():
+    pass
+",
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
+            "--slow-timeout=0.001",
+            "--status-level=slow",
+        ]),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            SLOW [TIME] test::test_slow
+
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed, 0 skipped, 1 slow
+
+    ----- stderr -----
+    "
+    );
+}
+
+/// Below `--status-level=slow` the SLOW line is suppressed, but the slow
+/// counter still appears in the summary so `--final-status-level=slow` users
+/// can elevate the summary independently.
+#[test]
+fn test_slow_timeout_counter_visible_below_slow_status_level() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import time
+
+def test_slow():
+    time.sleep(0.05)
+",
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
+            "--slow-timeout=0.001",
+            "--status-level=fail",
+        ]),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped, 1 slow
+
+    ----- stderr -----
+    "
+    );
+}
+
+/// A test that completes well under the threshold is not reported as slow
+/// and does not bump the counter.
+#[test]
+fn test_slow_timeout_does_not_flag_fast_tests() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+def test_fast(): pass
+",
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
+            "--slow-timeout=60",
+            "--status-level=slow",
+        ]),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+}

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -6,8 +6,8 @@ use clap::builder::Styles;
 use clap::builder::styling::{AnsiColor, Effects};
 use karva_logging::{FinalStatusLevel, StatusLevel, TerminalColor, VerbosityLevel};
 use karva_metadata::{
-    CoverageOptions, MaxFail, NoTestsMode, Options, RunIgnoredMode, SrcOptions, TerminalOptions,
-    TestOptions,
+    CoverageOptions, MaxFail, NoTestsMode, Options, RunIgnoredMode, SlowTimeoutSecs, SrcOptions,
+    TerminalOptions, TestOptions,
 };
 use ruff_db::diagnostic::DiagnosticFormat;
 
@@ -54,7 +54,7 @@ pub struct Args {
 #[derive(Debug, clap::Subcommand)]
 pub enum Command {
     /// Run tests.
-    Test(TestCommand),
+    Test(Box<TestCommand>),
 
     /// Manage snapshots created by `karva.assert_snapshot()`.
     Snapshot(SnapshotCommand),
@@ -230,6 +230,15 @@ pub struct SubTestCommand {
     /// When set, the test will retry failed tests up to this number of times.
     #[clap(long, help_heading = "Runner options")]
     pub retry: Option<u32>,
+
+    /// Threshold in seconds after which a test is flagged as slow.
+    ///
+    /// When a test takes longer than this duration, it is reported with a
+    /// `SLOW` status line (gated on `--status-level=slow` or higher) and
+    /// counted in the run summary. Pass a positive number such as
+    /// `--slow-timeout=60` or `--slow-timeout=0.5`.
+    #[clap(long, value_name = "SECONDS", help_heading = "Runner options")]
+    pub slow_timeout: Option<f64>,
 
     /// Update snapshots directly instead of creating pending `.snap.new` files.
     ///
@@ -462,6 +471,7 @@ impl SubTestCommand {
                 try_import_fixtures: self.try_import_fixtures,
                 retry: self.retry,
                 no_tests: self.no_tests.map(Into::into),
+                slow_timeout: self.slow_timeout.map(SlowTimeoutSecs),
             }),
             coverage: Some(CoverageOptions {
                 sources: (!self.cov.is_empty()).then(|| self.cov.clone()),

--- a/crates/karva_diagnostic/src/reporter.rs
+++ b/crates/karva_diagnostic/src/reporter.rs
@@ -33,12 +33,20 @@ pub trait Reporter: Send + Sync {
     ) {
         let _ = (test_name, attempt, result_kind, duration);
     }
+
+    /// Report that a test exceeded the configured slow-test threshold.
+    ///
+    /// Emitted in addition to (and ahead of) the regular result line. Default
+    /// no-op for reporters that don't surface slow-test detail.
+    fn report_test_slow(&self, test_name: &QualifiedTestName, duration: Duration) {
+        let _ = (test_name, duration);
+    }
 }
 
 fn show_for_status_level(level: StatusLevel, kind: &IndividualTestResultKind) -> bool {
     // Levels are cumulative, like nextest: each level shows itself plus all
-    // earlier levels. Karva does not yet implement a slow-test threshold, so
-    // `Slow` currently behaves like `Retry`.
+    // earlier levels. The `Slow` line is gated separately in
+    // `report_test_slow`, so `Slow` here acts the same as `Retry`.
     match level {
         StatusLevel::None => false,
         StatusLevel::Fail | StatusLevel::Retry | StatusLevel::Slow => {
@@ -118,6 +126,31 @@ impl Reporter for TestCaseReporter {
         writeln!(
             stdout,
             "{padding}{colored_label} {duration_str} {module}::{fn_name}{params}{suffix}"
+        )
+        .ok();
+    }
+
+    fn report_test_slow(&self, test_name: &QualifiedTestName, duration: Duration) {
+        if self.printer.status_level() < StatusLevel::Slow {
+            return;
+        }
+
+        let label = "SLOW";
+        let colored_label = label.yellow().bold().to_string();
+        let padding = " ".repeat(12usize.saturating_sub(label.len()));
+        let duration_str = format_duration_bracketed(duration);
+
+        let module = test_name.function_name().module_path().module_name().cyan();
+        let fn_name = test_name.function_name().function_name().blue().bold();
+        let params = test_name
+            .params()
+            .map(|p| p.blue().bold().to_string())
+            .unwrap_or_default();
+
+        let mut stdout = self.printer.stream_for_test_result().lock();
+        writeln!(
+            stdout,
+            "{padding}{colored_label} {duration_str} {module}::{fn_name}{params}"
         )
         .ok();
     }

--- a/crates/karva_diagnostic/src/result/kind.rs
+++ b/crates/karva_diagnostic/src/result/kind.rs
@@ -13,7 +13,7 @@ pub enum IndividualTestResultKind {
 ///
 /// Unlike [`IndividualTestResultKind`] this is plain, hashable, and copyable
 /// — it drops contextual fields (like skip reasons) and gains the synthetic
-/// `Flaky` marker for tests that passed only after retries.
+/// `Flaky` and `Slow` markers.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
 pub enum TestResultKind {
     Passed,
@@ -23,6 +23,10 @@ pub enum TestResultKind {
     /// (not instead of) `Passed` so the summary can show how many of the
     /// passing tests are flaky.
     Flaky,
+    /// A test whose total duration exceeded the configured `slow-timeout`
+    /// threshold. Tracked alongside the test's actual outcome so the summary
+    /// can show how many tests were slow regardless of pass/fail.
+    Slow,
 }
 
 impl TestResultKind {
@@ -32,6 +36,7 @@ impl TestResultKind {
             Self::Failed => "failed",
             Self::Skipped => "skipped",
             Self::Flaky => "flaky",
+            Self::Slow => "slow",
         }
     }
 
@@ -41,6 +46,7 @@ impl TestResultKind {
             "failed" => Ok(Self::Failed),
             "skipped" => Ok(Self::Skipped),
             "flaky" => Ok(Self::Flaky),
+            "slow" => Ok(Self::Slow),
             _ => Err("invalid TestResultKind"),
         }
     }

--- a/crates/karva_diagnostic/src/result/mod.rs
+++ b/crates/karva_diagnostic/src/result/mod.rs
@@ -140,6 +140,21 @@ impl TestRunResult {
         }
     }
 
+    /// Mark a test as slow: increments the slow counter and emits a `SLOW`
+    /// line through the reporter. The test's actual outcome (pass/fail) is
+    /// registered separately.
+    pub fn register_slow_test(
+        &mut self,
+        test_case_name: &QualifiedTestName,
+        duration: std::time::Duration,
+        reporter: Option<&dyn Reporter>,
+    ) {
+        self.stats.add(TestResultKind::Slow);
+        if let Some(reporter) = reporter {
+            reporter.report_test_slow(test_case_name, duration);
+        }
+    }
+
     #[must_use]
     pub fn into_sorted(mut self) -> Self {
         self.diagnostics.sort_by(Diagnostic::ruff_start_ordering);

--- a/crates/karva_diagnostic/src/result/stats.rs
+++ b/crates/karva_diagnostic/src/result/stats.rs
@@ -54,6 +54,10 @@ impl TestResultStats {
         self.get(TestResultKind::Flaky)
     }
 
+    pub fn slow(&self) -> usize {
+        self.get(TestResultKind::Slow)
+    }
+
     pub fn add(&mut self, kind: TestResultKind) {
         self.inner.entry(kind).and_modify(|v| *v += 1).or_insert(1);
     }
@@ -100,7 +104,10 @@ impl<'de> Deserialize<'de> for TestResultStats {
 
                 while let Some((key, value)) = access.next_entry::<String, usize>()? {
                     let kind = TestResultKind::from_str(&key).map_err(|_| {
-                        de::Error::unknown_field(&key, &["passed", "failed", "skipped", "flaky"])
+                        de::Error::unknown_field(
+                            &key,
+                            &["passed", "failed", "skipped", "flaky", "slow"],
+                        )
                     })?;
                     inner.insert(kind, value);
                 }
@@ -162,6 +169,14 @@ impl fmt::Display for DisplayTestResultStats<'_> {
                 .bold()
                 .to_string(),
         );
+        if self.stats.slow() > 0 {
+            parts.push(
+                format!("{} slow", self.stats.slow())
+                    .yellow()
+                    .bold()
+                    .to_string(),
+            );
+        }
 
         writeln!(
             f,

--- a/crates/karva_metadata/src/lib.rs
+++ b/crates/karva_metadata/src/lib.rs
@@ -15,7 +15,9 @@ pub use options::{
     ProjectOptionsOverrides, SrcOptions, TerminalOptions, TestOptions, UnknownProfile,
 };
 pub use pyproject::{PyProject, PyProjectError};
-pub use settings::{CoverageSettings, NoTestsMode, ProjectSettings, RunIgnoredMode};
+pub use settings::{
+    CoverageSettings, NoTestsMode, ProjectSettings, RunIgnoredMode, SlowTimeoutSecs,
+};
 
 use crate::options::KarvaTomlError;
 

--- a/crates/karva_metadata/src/options.rs
+++ b/crates/karva_metadata/src/options.rs
@@ -11,8 +11,8 @@ use thiserror::Error;
 use crate::filter::FiltersetSet;
 use crate::max_fail::MaxFail;
 use crate::settings::{
-    CoverageSettings, NoTestsMode, ProjectSettings, RunIgnoredMode, SrcSettings, TerminalSettings,
-    TestSettings,
+    CoverageSettings, NoTestsMode, ProjectSettings, RunIgnoredMode, SlowTimeoutSecs, SrcSettings,
+    TerminalSettings, TestSettings,
 };
 
 /// The implicit name of the default profile.
@@ -376,6 +376,24 @@ pub struct TestOptions {
         "#
     )]
     pub no_tests: Option<NoTestsMode>,
+
+    /// Threshold (in seconds) after which a test is flagged as slow.
+    ///
+    /// When set, tests that take longer than this duration are reported with
+    /// a `SLOW` status line and counted in the run summary. The `SLOW` line
+    /// is gated on `--status-level=slow` (or higher); the summary always
+    /// shows the slow count when `--final-status-level=slow` is set.
+    ///
+    /// Defaults to unset, which disables slow-test detection.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"null"#,
+        value_type = "float (seconds)",
+        example = r#"
+            slow-timeout = 60.0
+        "#
+    )]
+    pub slow_timeout: Option<SlowTimeoutSecs>,
 }
 
 impl TestOptions {
@@ -396,6 +414,7 @@ impl TestOptions {
             filter: FiltersetSet::default(),
             run_ignored: RunIgnoredMode::default(),
             no_tests: self.no_tests.unwrap_or_default(),
+            slow_timeout: self.slow_timeout.and_then(SlowTimeoutSecs::as_duration),
         }
     }
 }
@@ -595,7 +614,7 @@ nonsense = 42
           |
         4 | nonsense = 42
           | ^^^^^^^^
-        unknown field `nonsense`, expected one of `test-function-prefix`, `fail-fast`, `max-fail`, `try-import-fixtures`, `retry`, `no-tests`
+        unknown field `nonsense`, expected one of `test-function-prefix`, `fail-fast`, `max-fail`, `try-import-fixtures`, `retry`, `no-tests`, `slow-timeout`
         "
         );
     }
@@ -692,6 +711,7 @@ max-fail = 0
                 5,
             ),
             no_tests: None,
+            slow_timeout: None,
         }
         "#);
     }
@@ -719,6 +739,7 @@ max-fail = 0
                 3,
             ),
             no_tests: None,
+            slow_timeout: None,
         }
         "#);
     }
@@ -779,6 +800,7 @@ retry = 2
                     2,
                 ),
                 no_tests: None,
+                slow_timeout: None,
             },
         )
         "#);
@@ -833,6 +855,7 @@ retry = 5
                     5,
                 ),
                 no_tests: None,
+                slow_timeout: None,
             },
         )
         "#);

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use karva_combine::Combine;
 use karva_logging::{FinalStatusLevel, StatusLevel};
 use serde::{Deserialize, Serialize};
@@ -25,6 +27,38 @@ pub enum NoTestsMode {
 }
 
 impl Combine for NoTestsMode {
+    #[inline(always)]
+    fn combine_with(&mut self, _other: Self) {}
+
+    #[inline]
+    fn combine(self, _other: Self) -> Self {
+        self
+    }
+}
+
+/// A slow-test threshold expressed in seconds.
+///
+/// Wraps `f64` so the surrounding [`crate::options::TestOptions`] can keep
+/// deriving `Eq`/`Combine` without pulling `f64` into those bounds. Bit-wise
+/// equality is used (`NaN` is not a valid value because the option is
+/// validated at parse time).
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SlowTimeoutSecs(pub f64);
+
+impl Eq for SlowTimeoutSecs {}
+
+impl SlowTimeoutSecs {
+    pub fn as_duration(self) -> Option<Duration> {
+        if self.0.is_finite() && self.0 > 0.0 {
+            Some(Duration::from_secs_f64(self.0))
+        } else {
+            None
+        }
+    }
+}
+
+impl Combine for SlowTimeoutSecs {
     #[inline(always)]
     fn combine_with(&mut self, _other: Self) {}
 
@@ -101,4 +135,7 @@ pub struct TestSettings {
     pub filter: FiltersetSet,
     pub run_ignored: RunIgnoredMode,
     pub no_tests: NoTestsMode,
+    /// Threshold after which a test is flagged as slow. `None` disables
+    /// slow-test detection entirely.
+    pub slow_timeout: Option<Duration>,
 }

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -447,6 +447,11 @@ fn inner_cli_args(settings: &ProjectSettings, args: &SubTestCommand) -> Vec<Stri
         cli_args.push(retry.to_string());
     }
 
+    if let Some(threshold) = settings.test().slow_timeout {
+        cli_args.push("--slow-timeout".to_string());
+        cli_args.push(format!("{}", threshold.as_secs_f64()));
+    }
+
     for expr in &args.filter_expressions {
         cli_args.push("--filter".to_string());
         cli_args.push(expr.clone());

--- a/crates/karva_test_semantic/src/context.rs
+++ b/crates/karva_test_semantic/src/context.rs
@@ -112,6 +112,18 @@ impl<'a> Context<'a> {
         );
     }
 
+    /// Mark a test as slow: increments the slow counter and emits the
+    /// `SLOW` reporter line. Called once per test variant whose total
+    /// runtime exceeded the configured `slow-timeout`.
+    pub fn register_slow_test(
+        &self,
+        test_case_name: &QualifiedTestName,
+        duration: std::time::Duration,
+    ) {
+        self.result()
+            .register_slow_test(test_case_name, duration, Some(self.reporter));
+    }
+
     /// Register the final outcome of a retried test. Updates summary stats
     /// (counting the test as flaky if it ultimately passed) without
     /// emitting a duplicate result line — the per-attempt `TRY N STATUS`

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -76,6 +76,21 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             .is_exceeded_by(self.failed_count.get())
     }
 
+    /// If the test exceeded the configured `slow-timeout`, register it as
+    /// slow so the reporter emits a `SLOW` line ahead of the result line and
+    /// the run summary includes a slow counter.
+    fn maybe_register_slow(
+        &self,
+        test_name: &QualifiedTestName,
+        total_duration: std::time::Duration,
+    ) {
+        if let Some(threshold) = self.context.settings().test().slow_timeout
+            && total_duration > threshold
+        {
+            self.context.register_slow_test(test_name, total_duration);
+        }
+    }
+
     /// Record a test variant's outcome for `max-fail` accounting.
     fn record_outcome(&self, passed: bool) {
         if !passed {
@@ -527,6 +542,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             );
 
             let total_duration = start_time.elapsed();
+            self.maybe_register_slow(&qualified_test_name, total_duration);
             self.classify_test_result(py, test_result, fixture_call_errors, &report_ctx, |kind| {
                 self.context.register_retried_result(
                     &qualified_test_name,
@@ -538,6 +554,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             })
         } else {
             let total_duration = start_time.elapsed();
+            self.maybe_register_slow(&qualified_test_name, total_duration);
             self.classify_test_result(py, test_result, fixture_call_errors, &report_ctx, |kind| {
                 self.context
                     .register_test_case_result(&qualified_test_name, kind, total_duration)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -107,6 +107,8 @@ karva test [OPTIONS] [PATH]...
 <li><code>only</code>:  Run only ignored tests</li>
 <li><code>all</code>:  Run both ignored and non-ignored tests</li>
 </ul></dd><dt id="karva-test--show-output"><a href="#karva-test--show-output"><code>--show-output</code></a>, <code>-s</code></dt><dd><p>Show Python stdout during test execution</p>
+</dd><dt id="karva-test--slow-timeout"><a href="#karva-test--slow-timeout"><code>--slow-timeout</code></a> <i>seconds</i></dt><dd><p>Threshold in seconds after which a test is flagged as slow.</p>
+<p>When a test takes longer than this duration, it is reported with a <code>SLOW</code> status line (gated on <code>--status-level=slow</code> or higher) and counted in the run summary. Pass a positive number such as <code>--slow-timeout=60</code> or <code>--slow-timeout=0.5</code>.</p>
 </dd><dt id="karva-test--snapshot-update"><a href="#karva-test--snapshot-update"><code>--snapshot-update</code></a></dt><dd><p>Update snapshots directly instead of creating pending <code>.snap.new</code> files.</p>
 <p>When set, <code>karva.assert_snapshot()</code> will write directly to <code>.snap</code> files, accepting any changes automatically.</p>
 </dd><dt id="karva-test--status-level"><a href="#karva-test--status-level"><code>--status-level</code></a> <i>level</i></dt><dd><p>Test result statuses to display during the run [default: pass]</p>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -266,6 +266,30 @@ retry = 3
 
 ---
 
+### `slow-timeout`
+
+Threshold (in seconds) after which a test is flagged as slow.
+
+When set, tests that take longer than this duration are reported with
+a `SLOW` status line and counted in the run summary. The `SLOW` line
+is gated on `--status-level=slow` (or higher); the summary always
+shows the slow count when `--final-status-level=slow` is set.
+
+Defaults to unset, which disables slow-test detection.
+
+**Default value**: `null`
+
+**Type**: `float (seconds)`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.karva.profile.default.test]
+slow-timeout = 60.0
+```
+
+---
+
 ### `test-function-prefix`
 
 The prefix to use for test functions.


### PR DESCRIPTION
## Summary

Closes #697.

Adds a slow-test threshold so karva can flag tests whose total runtime exceeds a configured duration. The threshold is configurable via `--slow-timeout=SECONDS` on the CLI or as `slow-timeout` under `[test]` in `karva.toml` / `[tool.karva.profile.default.test]` in `pyproject.toml`. When a test's total runtime crosses the threshold, the worker emits a `SLOW` result line ahead of the regular `PASS`/`FAIL` line and bumps a slow counter that the run summary surfaces as `N slow`.

The `SLOW` line is gated on `--status-level=slow` or higher, so users on the default `pass` level keep seeing only `PASS`/`FAIL` output. The summary always includes the slow count when any test was slow, which gives `--final-status-level=slow` something to elevate independently. With this in place, `show_for_status_level` no longer needs the "Slow currently behaves like Retry" workaround introduced by #695 — the SLOW line carries its own gate.

```toml
[tool.karva.profile.default.test]
slow-timeout = 0.5
```

```text
    Starting 2 tests across 1 worker
        SLOW [   0.052s] test::test_slow

────────────
     Summary [   0.063s] 2 tests run: 2 passed, 0 skipped, 1 slow
```

The terminate-after multiplier from nextest is intentionally not in scope here; the issue describes it as optional and it can land separately on top of the existing `TimeoutTag` infrastructure.

## Test Plan

ci