### PR TITLE
Add Coverage section to seal.toml changelog labels

### DIFF
--- a/seal.toml
+++ b/seal.toml
@@ -26,6 +26,7 @@ confirm = true
 "Property Testing" = ["property-testing"]
 "Diagnostics" = ["diagnostics"]
 "Configuration" = ["configuration"]
+"Coverage" = ["coverage"]
 "CLI" = ["cli"]
 "Pytest Compatibility" = ["pytest", "migration"]
 "Documentation" = ["documentation"]


### PR DESCRIPTION
## Summary

Adds a `Coverage` heading to `[changelog.section-labels]` in `seal.toml` so PRs tagged with the new `coverage` GitHub label land in their own changelog section instead of being grouped under `Test Running` or dropped. Slots in next to `Configuration` to keep related testing-output sections grouped, mirroring the pattern from #714.

## Test Plan

ci