### PR TITLE
Add `--no-cov` to disable coverage for a single run

### DIFF
--- a/crates/karva/tests/it/coverage.rs
+++ b/crates/karva/tests/it/coverage.rs
@@ -560,6 +560,74 @@ def test_add():
 }
 
 #[test]
+fn test_no_cov_overrides_config_sources() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.default.coverage]
+sources = [""]
+"#,
+        ),
+        (
+            "test_simple.py",
+            r"
+def test_one():
+    assert 1 + 1 == 2
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel()
+            .arg("--no-cov")
+            .arg("--status-level=none")
+            .arg("test_simple.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+}
+
+/// `--cov --no-cov` (no-cov last) disables coverage; clap `overrides_with`
+/// makes the later flag win.
+#[test]
+fn test_no_cov_after_cov_disables_coverage() {
+    let context = TestContext::with_file(
+        "test_simple.py",
+        r"
+def test_one():
+    assert 1 + 1 == 2
+",
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel()
+            .arg("--cov")
+            .arg("--no-cov")
+            .arg("--status-level=none")
+            .arg("test_simple.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
 fn test_cov_report_term_missing_from_config() {
     let context = TestContext::with_files([
         (

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -274,9 +274,23 @@ pub struct SubTestCommand {
         num_args = 0..=1,
         default_missing_value = "",
         action = clap::ArgAction::Append,
+        overrides_with = "no_cov",
         help_heading = "Coverage options"
     )]
     pub cov: Vec<String>,
+
+    /// Disable coverage measurement for this run.
+    ///
+    /// Overrides any `--cov` flag and any `[coverage] sources` configured in
+    /// `karva.toml` / `pyproject.toml`. Useful when iterating locally without
+    /// editing config.
+    #[clap(
+        long = "no-cov",
+        action = clap::ArgAction::SetTrue,
+        overrides_with = "cov",
+        help_heading = "Coverage options"
+    )]
+    pub no_cov: bool,
 
     /// Coverage terminal report type.
     ///
@@ -466,6 +480,7 @@ impl SubTestCommand {
             coverage: Some(CoverageOptions {
                 sources: (!self.cov.is_empty()).then(|| self.cov.clone()),
                 report: self.cov_report.map(Into::into),
+                disabled: self.no_cov.then_some(true),
             }),
         }
     }

--- a/crates/karva_metadata/src/options.rs
+++ b/crates/karva_metadata/src/options.rs
@@ -448,12 +448,25 @@ pub struct CoverageOptions {
         "#
     )]
     pub report: Option<CovReport>,
+
+    /// Set by `--no-cov` to disable coverage for a single run, overriding
+    /// any sources configured in `karva.toml`.
+    ///
+    /// Not user-facing: skipped during (de)serialization so it cannot be
+    /// set from a configuration file.
+    #[serde(skip)]
+    pub disabled: Option<bool>,
 }
 
 impl CoverageOptions {
     pub fn to_settings(&self) -> CoverageSettings {
+        let sources = if self.disabled.unwrap_or(false) {
+            Vec::new()
+        } else {
+            self.sources.clone().unwrap_or_default()
+        };
         CoverageSettings {
-            sources: self.sources.clone().unwrap_or_default(),
+            sources,
             report: self.report.unwrap_or_default(),
         }
     }
@@ -958,6 +971,7 @@ report = "term-missing"
                 report: Some(
                     TermMissing,
                 ),
+                disabled: None,
             },
         )
         "#);
@@ -974,6 +988,7 @@ report = "term-missing"
         let file = CoverageOptions {
             sources: Some(vec!["src".to_string()]),
             report: Some(CovReport::TermMissing),
+            ..CoverageOptions::default()
         };
         assert_debug_snapshot!(cli.combine(file), @r#"
         CoverageOptions {
@@ -986,6 +1001,7 @@ report = "term-missing"
             report: Some(
                 TermMissing,
             ),
+            disabled: None,
         }
         "#);
     }
@@ -1006,6 +1022,41 @@ report = "term-missing"
             Term,
         )
         ");
+    }
+
+    /// `--no-cov` (CLI sets `disabled = Some(true)`) overrides any sources
+    /// configured in `karva.toml`.
+    #[test]
+    fn to_settings_disabled_clears_configured_sources() {
+        let cli = CoverageOptions {
+            disabled: Some(true),
+            ..CoverageOptions::default()
+        };
+        let file = CoverageOptions {
+            sources: Some(vec!["src".to_string()]),
+            ..CoverageOptions::default()
+        };
+        let combined = cli.combine(file);
+        assert_debug_snapshot!(combined.to_settings().sources, @"[]");
+    }
+
+    /// `disabled` is CLI-only; `deny_unknown_fields` should reject it from TOML.
+    #[test]
+    fn from_toml_str_rejects_disabled_key() {
+        let toml = r"
+[profile.default.coverage]
+disabled = true
+";
+        assert_snapshot!(
+            Config::from_toml_str(toml).expect_err("unknown field"),
+            @r"
+        TOML parse error at line 3, column 1
+          |
+        3 | disabled = true
+          | ^^^^^^^^
+        unknown field `disabled`, expected `sources` or `report`
+        "
+        );
     }
 
     #[test]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -80,6 +80,8 @@ karva test [OPTIONS] [PATH]...
 </dd><dt id="karva-test--no-cache"><a href="#karva-test--no-cache"><code>--no-cache</code></a></dt><dd><p>Disable reading the karva cache for test duration history</p>
 </dd><dt id="karva-test--no-capture"><a href="#karva-test--no-capture"><code>--no-capture</code></a></dt><dd><p>Disable output capture and run tests serially.</p>
 <p>Lets stdout/stderr from tests flow directly to the terminal, useful when debugging with print statements or interactive debuggers. Implies <code>--show-output</code> and forces a single worker so output from concurrent tests cannot interleave.</p>
+</dd><dt id="karva-test--no-cov"><a href="#karva-test--no-cov"><code>--no-cov</code></a></dt><dd><p>Disable coverage measurement for this run.</p>
+<p>Overrides any <code>--cov</code> flag and any <code>[coverage] sources</code> configured in <code>karva.toml</code> / <code>pyproject.toml</code>. Useful when iterating locally without editing config.</p>
 </dd><dt id="karva-test--no-fail-fast"><a href="#karva-test--no-fail-fast"><code>--no-fail-fast</code></a></dt><dd><p>Run every test regardless of how many fail.</p>
 <p>Clears any <code>fail-fast</code> or <code>max-fail</code> value set in configuration. When <code>--max-fail</code> is provided alongside <code>--no-fail-fast</code>, <code>--max-fail</code> takes precedence.</p>
 </dd><dt id="karva-test--no-ignore"><a href="#karva-test--no-ignore"><code>--no-ignore</code></a></dt><dd><p>When set, .gitignore files will not be respected</p>


### PR DESCRIPTION
## Summary

Pairs with `[coverage]` config (#730): once `sources` can be pinned in `karva.toml`, users need an escape hatch to skip coverage when debugging, profiling, or iterating quickly. `--no-cov` is mutually exclusive with `--cov` (clap `overrides_with`, so the later flag wins) and overrides any configured sources. pytest-cov exposes the same flag for the same reason.

```toml
[profile.default.coverage]
sources = ["src"]
```

```bash
karva test            # measures src
karva test --no-cov   # skips the tracer entirely
```

Implementation adds a CLI-only `disabled` field to `CoverageOptions`. The field is `#[serde(skip)]` so it cannot be set from TOML — `deny_unknown_fields` rejects it with the usual error. When set, `CoverageOptions::to_settings()` returns an empty `sources` vec regardless of what config or CLI accumulated. The runner already keys coverage on `sources.is_empty()`, so the tracer never starts.

Closes #724

## Test Plan

ci