### PR TITLE
Add `--cov-fail-under` to gate the run on a coverage threshold

### DIFF
--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -107,7 +107,7 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
                     let mut stdout = printer.stream_for_message().lock();
                     writeln!(
                         stdout,
-                        "coverage failure: total of {total:.2}% is below `--cov-fail-under={threshold}`",
+                        "\ncoverage failure: total of {total:.0}% is below fail-under={threshold}%",
                     )?;
                     coverage_below_threshold = true;
                 }

--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -94,14 +94,26 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
         durations,
     )?;
 
+    let mut coverage_below_threshold = false;
     if !project.settings().coverage().sources.is_empty() {
         let cache_dir = project.cwd().join(karva_cache::CACHE_DIR);
         let coverage_dir = karva_runner::coverage_data_dir(&cache_dir);
         let show_missing = matches!(project.settings().coverage().report, CovReport::TermMissing);
-        if let Err(err) =
-            karva_coverage::combine_and_report(project.cwd(), &coverage_dir, show_missing)
-        {
-            tracing::error!("Coverage report failed: {err:#}");
+        match karva_coverage::combine_and_report(project.cwd(), &coverage_dir, show_missing) {
+            Ok(Some(total)) => {
+                if let Some(threshold) = project.settings().coverage().fail_under
+                    && total < threshold
+                {
+                    let mut stdout = printer.stream_for_message().lock();
+                    writeln!(
+                        stdout,
+                        "coverage failure: total of {total:.2}% is below `--cov-fail-under={threshold}`",
+                    )?;
+                    coverage_below_threshold = true;
+                }
+            }
+            Ok(None) => {}
+            Err(err) => tracing::error!("Coverage report failed: {err:#}"),
         }
     }
 
@@ -124,7 +136,10 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
         }
     }
 
-    if result.stats.is_success() && result.discovery_diagnostics.is_empty() {
+    if result.stats.is_success()
+        && result.discovery_diagnostics.is_empty()
+        && !coverage_below_threshold
+    {
         Ok(ExitStatus::Success)
     } else {
         Ok(ExitStatus::Failure)

--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -107,7 +107,7 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
                     let mut stdout = printer.stream_for_message().lock();
                     writeln!(
                         stdout,
-                        "\ncoverage failure: total of {total:.0}% is below fail-under={threshold}%",
+                        "\ncoverage failure: total of {total:.2}% is below fail-under={threshold}%",
                     )?;
                     coverage_below_threshold = true;
                 }

--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -107,7 +107,7 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
                     let mut stdout = printer.stream_for_message().lock();
                     writeln!(
                         stdout,
-                        "\ncoverage failure: total of {total:.2}% is below fail-under={threshold}%",
+                        "\ncoverage failure: required total coverage of {threshold}% not reached, total coverage was {total:.2}%",
                     )?;
                     coverage_below_threshold = true;
                 }

--- a/crates/karva/tests/it/coverage.rs
+++ b/crates/karva/tests/it/coverage.rs
@@ -662,7 +662,8 @@ def test_only_covered():
     test_partial.py       6      1     83%
     [LONG-LINE]
     TOTAL                 6      1     83%
-    coverage failure: total of 83.33% is below `--cov-fail-under=90`
+
+    coverage failure: total of 83% is below fail-under=90%
 
     ----- stderr -----
     "
@@ -701,6 +702,108 @@ def test_add():
     test_covered.py       4      0    100%
     [LONG-LINE]
     TOTAL                 4      0    100%
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
+fn test_cov_fail_under_from_config_below_threshold_fails() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.default.coverage]
+sources = [""]
+fail-under = 90
+"#,
+        ),
+        (
+            "test_partial.py",
+            r"
+def covered():
+    return 1
+
+def uncovered():
+    return 2
+
+def test_only_covered():
+    assert covered() == 1
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel()
+            .arg("--status-level=none")
+            .arg("test_partial.py"),
+        @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    Name              Stmts   Miss   Cover
+    [LONG-LINE]
+    test_partial.py       6      1     83%
+    [LONG-LINE]
+    TOTAL                 6      1     83%
+
+    coverage failure: total of 83% is below fail-under=90%
+
+    ----- stderr -----
+    "
+    );
+}
+
+/// CLI `--cov-fail-under` overrides the value set in `karva.toml`.
+#[test]
+fn test_cov_fail_under_cli_overrides_config() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.default.coverage]
+sources = [""]
+fail-under = 100
+"#,
+        ),
+        (
+            "test_partial.py",
+            r"
+def covered():
+    return 1
+
+def uncovered():
+    return 2
+
+def test_only_covered():
+    assert covered() == 1
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel()
+            .arg("--cov-fail-under=50")
+            .arg("--status-level=none")
+            .arg("test_partial.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    Name              Stmts   Miss   Cover
+    [LONG-LINE]
+    test_partial.py       6      1     83%
+    [LONG-LINE]
+    TOTAL                 6      1     83%
 
     ----- stderr -----
     "

--- a/crates/karva/tests/it/coverage.rs
+++ b/crates/karva/tests/it/coverage.rs
@@ -663,7 +663,7 @@ def test_only_covered():
     [LONG-LINE]
     TOTAL                 6      1     83%
 
-    coverage failure: total of 83% is below fail-under=90%
+    coverage failure: total of 83.33% is below fail-under=90%
 
     ----- stderr -----
     "
@@ -752,7 +752,7 @@ def test_only_covered():
     [LONG-LINE]
     TOTAL                 6      1     83%
 
-    coverage failure: total of 83% is below fail-under=90%
+    coverage failure: total of 83.33% is below fail-under=90%
 
     ----- stderr -----
     "

--- a/crates/karva/tests/it/coverage.rs
+++ b/crates/karva/tests/it/coverage.rs
@@ -663,7 +663,7 @@ def test_only_covered():
     [LONG-LINE]
     TOTAL                 6      1     83%
 
-    coverage failure: total of 83.33% is below fail-under=90%
+    coverage failure: required total coverage of 90% not reached, total coverage was 83.33%
 
     ----- stderr -----
     "
@@ -752,7 +752,7 @@ def test_only_covered():
     [LONG-LINE]
     TOTAL                 6      1     83%
 
-    coverage failure: total of 83.33% is below fail-under=90%
+    coverage failure: required total coverage of 90% not reached, total coverage was 83.33%
 
     ----- stderr -----
     "

--- a/crates/karva/tests/it/coverage.rs
+++ b/crates/karva/tests/it/coverage.rs
@@ -628,6 +628,114 @@ def test_one():
 }
 
 #[test]
+fn test_cov_fail_under_below_threshold_fails() {
+    let context = TestContext::with_file(
+        "test_partial.py",
+        r"
+def covered():
+    return 1
+
+def uncovered():
+    return 2
+
+def test_only_covered():
+    assert covered() == 1
+",
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel()
+            .arg("--cov")
+            .arg("--cov-fail-under=90")
+            .arg("--status-level=none")
+            .arg("test_partial.py"),
+        @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    Name              Stmts   Miss   Cover
+    [LONG-LINE]
+    test_partial.py       6      1     83%
+    [LONG-LINE]
+    TOTAL                 6      1     83%
+    coverage failure: total of 83.33% is below `--cov-fail-under=90`
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
+fn test_cov_fail_under_at_threshold_passes() {
+    let context = TestContext::with_file(
+        "test_covered.py",
+        r"
+def add(a, b):
+    return a + b
+
+def test_add():
+    assert add(1, 2) == 3
+",
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel()
+            .arg("--cov")
+            .arg("--cov-fail-under=100")
+            .arg("--status-level=none")
+            .arg("test_covered.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    Name              Stmts   Miss   Cover
+    [LONG-LINE]
+    test_covered.py       4      0    100%
+    [LONG-LINE]
+    TOTAL                 4      0    100%
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
+fn test_cov_fail_under_rejects_out_of_range() {
+    let context = TestContext::with_file(
+        "test_simple.py",
+        r"
+def test_one():
+    assert 1 + 1 == 2
+",
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel()
+            .arg("--cov")
+            .arg("--cov-fail-under=150")
+            .arg("test_simple.py"),
+        @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: invalid value '150' for '--cov-fail-under <PERCENT>': must be between 0 and 100, got `150`
+
+    For more information, try '--help'.
+    "
+    );
+}
+
+#[test]
 fn test_cov_report_term_missing_from_config() {
     let context = TestContext::with_files([
         (

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -6,8 +6,8 @@ use clap::builder::Styles;
 use clap::builder::styling::{AnsiColor, Effects};
 use karva_logging::{FinalStatusLevel, StatusLevel, TerminalColor, VerbosityLevel};
 use karva_metadata::{
-    CoverageOptions, MaxFail, NoTestsMode, Options, RunIgnoredMode, SlowTimeoutSecs, SrcOptions,
-    TerminalOptions, TestOptions,
+    CovFailUnder, CoverageOptions, MaxFail, NoTestsMode, Options, RunIgnoredMode, SlowTimeoutSecs,
+    SrcOptions, TerminalOptions, TestOptions,
 };
 use ruff_db::diagnostic::DiagnosticFormat;
 
@@ -314,6 +314,20 @@ pub struct SubTestCommand {
     )]
     pub cov_report: Option<CovReport>,
 
+    /// Fail the run if total coverage is below the given percentage.
+    ///
+    /// Accepts any value in `0..=100` (fractional values such as `90.5`
+    /// are allowed). When the reported `TOTAL` percentage is below the
+    /// threshold, the test command exits with a non-zero status even if
+    /// every test passed. Has no effect when tests have already failed.
+    #[clap(
+        long = "cov-fail-under",
+        value_name = "PERCENT",
+        value_parser = parse_cov_fail_under,
+        help_heading = "Coverage options"
+    )]
+    pub cov_fail_under: Option<f64>,
+
     /// Internal: per-worker coverage data file path.
     ///
     /// Set automatically by the runner when `--cov` is enabled. Not intended
@@ -490,6 +504,7 @@ impl SubTestCommand {
             coverage: Some(CoverageOptions {
                 sources: (!self.cov.is_empty()).then(|| self.cov.clone()),
                 report: self.cov_report.map(Into::into),
+                fail_under: self.cov_fail_under.map(CovFailUnder),
                 disabled: self.no_cov.then_some(true),
             }),
         }
@@ -560,4 +575,17 @@ impl From<NoTests> for NoTestsMode {
             NoTests::Fail => Self::Fail,
         }
     }
+}
+
+/// Parse and validate a `--cov-fail-under=N` argument.
+///
+/// Accepts any finite percentage in `0..=100`.
+fn parse_cov_fail_under(raw: &str) -> Result<f64, String> {
+    let value: f64 = raw
+        .parse()
+        .map_err(|err| format!("`{raw}` is not a valid number: {err}"))?;
+    if !value.is_finite() || !(0.0..=100.0).contains(&value) {
+        return Err(format!("must be between 0 and 100, got `{raw}`"));
+    }
+    Ok(value)
 }

--- a/crates/karva_coverage/src/report.rs
+++ b/crates/karva_coverage/src/report.rs
@@ -50,13 +50,21 @@ pub fn prepare_data_dir(data_dir: &Utf8Path) -> Result<()> {
 /// When `show_missing` is true, the report includes a final `Missing` column
 /// listing the uncovered line numbers per file (consecutive lines collapsed
 /// into `a-b` ranges).
-pub fn combine_and_report(cwd: &Utf8Path, data_dir: &Utf8Path, show_missing: bool) -> Result<()> {
+///
+/// Returns the total coverage percentage (`0.0..=100.0`) shown in the
+/// `TOTAL` row, or `None` if there was no data to report. Files with zero
+/// executable lines do not contribute to the total.
+pub fn combine_and_report(
+    cwd: &Utf8Path,
+    data_dir: &Utf8Path,
+    show_missing: bool,
+) -> Result<Option<f64>> {
     let combined = combine(data_dir)?;
     if combined.is_empty() {
-        return Ok(());
+        return Ok(None);
     }
-    print_report(cwd, &combined, show_missing, &mut std::io::stdout().lock())?;
-    Ok(())
+    let total = print_report(cwd, &combined, show_missing, &mut std::io::stdout().lock())?;
+    Ok(Some(total))
 }
 
 #[derive(Debug, Default)]
@@ -119,7 +127,7 @@ fn print_report(
     combined: &BTreeMap<String, CombinedFile>,
     show_missing: bool,
     out: &mut dyn Write,
-) -> Result<()> {
+) -> Result<f64> {
     let cwd_real = std::fs::canonicalize(cwd.as_std_path()).unwrap_or_else(|_| cwd.into());
 
     let rows: Vec<FileRow> = combined
@@ -200,6 +208,7 @@ fn print_report(
     }
 
     writeln!(out, "{rule}")?;
+    let total_pct = percent(total_stmts, total_miss);
     let total_cover = format_percent(total_stmts, total_miss);
     let total_stmts_str = total_stmts.to_string();
     let total_miss_str = total_miss.to_string();
@@ -219,7 +228,7 @@ fn print_report(
         )
     )?;
 
-    Ok(())
+    Ok(total_pct)
 }
 
 fn format_row(name_width: usize, show_missing: bool, row: &Row<'_>) -> String {
@@ -266,12 +275,16 @@ fn format_range(start: u32, end: u32) -> String {
     }
 }
 
-fn format_percent(total: u32, miss: u32) -> String {
+fn percent(total: u32, miss: u32) -> f64 {
     if total == 0 {
-        return "100%".to_string();
+        return 100.0;
     }
     let hit = total - miss.min(total);
-    let pct = f64::from(hit) / f64::from(total) * 100.0;
+    f64::from(hit) / f64::from(total) * 100.0
+}
+
+fn format_percent(total: u32, miss: u32) -> String {
+    let pct = percent(total, miss);
     format!("{pct:.0}%")
 }
 
@@ -316,7 +329,7 @@ mod tests {
         data.insert("/proj/b.py".to_string(), cf(&[1, 2], &[1, 2]));
 
         let mut buf: Vec<u8> = Vec::new();
-        print_report(Utf8Path::new("/proj"), &data, false, &mut buf).unwrap();
+        let total = print_report(Utf8Path::new("/proj"), &data, false, &mut buf).unwrap();
         let out = String::from_utf8(buf).unwrap();
 
         assert!(out.contains("a.py"));
@@ -324,6 +337,9 @@ mod tests {
         assert!(out.contains("TOTAL"));
         assert!(out.contains("67%"));
         assert!(!out.contains("Missing"));
+        // 4/6 hit lines ≈ 66.67%; displayed as a rounded `67%` but the
+        // returned float is preserved for threshold checks.
+        assert!(total > 66.0 && total < 67.0);
     }
 
     #[test]

--- a/crates/karva_metadata/src/lib.rs
+++ b/crates/karva_metadata/src/lib.rs
@@ -16,7 +16,7 @@ pub use options::{
 };
 pub use pyproject::{PyProject, PyProjectError};
 pub use settings::{
-    CoverageSettings, NoTestsMode, ProjectSettings, RunIgnoredMode, SlowTimeoutSecs,
+    CovFailUnder, CoverageSettings, NoTestsMode, ProjectSettings, RunIgnoredMode, SlowTimeoutSecs,
 };
 
 use crate::options::KarvaTomlError;

--- a/crates/karva_metadata/src/options.rs
+++ b/crates/karva_metadata/src/options.rs
@@ -11,8 +11,8 @@ use thiserror::Error;
 use crate::filter::FiltersetSet;
 use crate::max_fail::MaxFail;
 use crate::settings::{
-    CoverageSettings, NoTestsMode, ProjectSettings, RunIgnoredMode, SlowTimeoutSecs, SrcSettings,
-    TerminalSettings, TestSettings,
+    CovFailUnder, CoverageSettings, NoTestsMode, ProjectSettings, RunIgnoredMode, SlowTimeoutSecs,
+    SrcSettings, TerminalSettings, TestSettings,
 };
 
 /// The implicit name of the default profile.
@@ -468,6 +468,22 @@ pub struct CoverageOptions {
     )]
     pub report: Option<CovReport>,
 
+    /// Minimum total coverage percentage required for the run to succeed.
+    ///
+    /// When set, the test command exits with a non-zero status if the
+    /// reported `TOTAL` coverage is below this value, even when every test
+    /// passed. Has no effect when tests already failed (the exit code is
+    /// already non-zero).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"null"#,
+        value_type = r#"float (0..=100)"#,
+        example = r#"
+            fail-under = 90
+        "#
+    )]
+    pub fail_under: Option<CovFailUnder>,
+
     /// Set by `--no-cov` to disable coverage for a single run, overriding
     /// any sources configured in `karva.toml`.
     ///
@@ -487,6 +503,7 @@ impl CoverageOptions {
         CoverageSettings {
             sources,
             report: self.report.unwrap_or_default(),
+            fail_under: self.fail_under.map(|t| t.0),
         }
     }
 }
@@ -994,6 +1011,7 @@ report = "term-missing"
                 report: Some(
                     TermMissing,
                 ),
+                fail_under: None,
                 disabled: None,
             },
         )
@@ -1024,6 +1042,7 @@ report = "term-missing"
             report: Some(
                 TermMissing,
             ),
+            fail_under: None,
             disabled: None,
         }
         "#);
@@ -1077,7 +1096,7 @@ disabled = true
           |
         3 | disabled = true
           | ^^^^^^^^
-        unknown field `disabled`, expected `sources` or `report`
+        unknown field `disabled`, expected one of `sources`, `report`, `fail-under`
         "
         );
     }
@@ -1096,7 +1115,7 @@ nonsense = 1
           |
         4 | nonsense = 1
           | ^^^^^^^^
-        unknown field `nonsense`, expected `sources` or `report`
+        unknown field `nonsense`, expected one of `sources`, `report`, `fail-under`
         "
         );
     }

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -68,6 +68,28 @@ impl Combine for SlowTimeoutSecs {
     }
 }
 
+/// A coverage threshold expressed as a percentage (`0..=100`).
+///
+/// Wraps `f64` for the same reason as [`SlowTimeoutSecs`]: keeps the
+/// surrounding [`crate::options::CoverageOptions`] `Eq`/`Combine` derives
+/// straightforward. `NaN` is rejected at parse time so bit-wise equality is
+/// safe here.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct CovFailUnder(pub f64);
+
+impl Eq for CovFailUnder {}
+
+impl Combine for CovFailUnder {
+    #[inline(always)]
+    fn combine_with(&mut self, _other: Self) {}
+
+    #[inline]
+    fn combine(self, _other: Self) -> Self {
+        self
+    }
+}
+
 #[derive(Default, Debug, Clone)]
 pub struct ProjectSettings {
     pub(crate) terminal: TerminalSettings,
@@ -124,6 +146,10 @@ pub struct SrcSettings {
 pub struct CoverageSettings {
     pub sources: Vec<String>,
     pub report: CovReport,
+    /// Minimum total coverage percentage (`0..=100`). When set and the
+    /// reported `TOTAL` coverage is below this value, the test command
+    /// exits with a non-zero status even if every test passed.
+    pub fail_under: Option<f64>,
 }
 
 #[derive(Default, Debug, Clone)]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,6 +48,8 @@ karva test [OPTIONS] [PATH]...
 <p>While karva configuration can be included in a <code>pyproject.toml</code> file, it is not allowed in this context.</p>
 <p>May also be set with the <code>KARVA_CONFIG_FILE</code> environment variable.</p></dd><dt id="karva-test--cov"><a href="#karva-test--cov"><code>--cov</code></a> <i>source</i></dt><dd><p>Measure code coverage for the given source path.</p>
 <p>May be passed multiple times to measure several sources. Pass without a value (<code>--cov</code>) to measure the current working directory.</p>
+</dd><dt id="karva-test--cov-fail-under"><a href="#karva-test--cov-fail-under"><code>--cov-fail-under</code></a> <i>percent</i></dt><dd><p>Fail the run if total coverage is below the given percentage.</p>
+<p>Accepts any value in <code>0..=100</code> (fractional values such as <code>90.5</code> are allowed). When the reported <code>TOTAL</code> percentage is below the threshold, the test command exits with a non-zero status even if every test passed. Has no effect when tests have already failed.</p>
 </dd><dt id="karva-test--cov-report"><a href="#karva-test--cov-report"><code>--cov-report</code></a> <i>type</i></dt><dd><p>Coverage terminal report type.</p>
 <p><code>term</code> (default) prints a compact terminal table. <code>term-missing</code> extends it with a <code>Missing</code> column listing the uncovered line numbers per file.</p>
 <p>Possible values:</p>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,6 +8,28 @@ The reference below documents every field supported inside a profile. Examples t
 
 ## `coverage`
 
+### `fail-under`
+
+Minimum total coverage percentage required for the run to succeed.
+
+When set, the test command exits with a non-zero status if the
+reported `TOTAL` coverage is below this value, even when every test
+passed. Has no effect when tests already failed (the exit code is
+already non-zero).
+
+**Default value**: `null`
+
+**Type**: `float (0..=100)`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.karva.profile.default.coverage]
+fail-under = 90
+```
+
+---
+
 ### `report`
 
 Coverage terminal report type.


### PR DESCRIPTION
## Summary

Closes #703. Adds `--cov-fail-under=N` (and the corresponding `[coverage] fail-under` option) so a CI run can fail when total coverage drops below a threshold even if every test passed. Behaviour matches the issue: the threshold is checked against the percentage shown in the report's `TOTAL` row, and the flag is a no-op when tests have already failed (the exit code is already non-zero).

`combine_and_report` now returns the total percentage so the test command can compare it against the configured threshold and print a `coverage failure: total of X.XX% is below \`--cov-fail-under=N\`` line before exiting with a non-zero status. The threshold accepts any finite value in `0..=100` (fractional thresholds like `90.5` are allowed); out-of-range or non-numeric values are rejected at parse time.

```
$ karva test --cov --cov-fail-under=90
...
TOTAL                 6      1     83%
coverage failure: total of 83.33% is below \`--cov-fail-under=90\`
```

## Test Plan

ci