### PR TITLE
Include never-imported source files at 0% in coverage report

### DIFF
--- a/crates/karva/tests/it/coverage.rs
+++ b/crates/karva/tests/it/coverage.rs
@@ -628,6 +628,65 @@ def test_one():
 }
 
 #[test]
+fn test_cov_includes_unimported_files_at_zero_percent() {
+    let context = TestContext::with_files([
+        ("src/__init__.py", ""),
+        (
+            "src/imported.py",
+            r"
+def used():
+    return 1
+",
+        ),
+        (
+            "src/unimported.py",
+            r"
+def lonely():
+    return 2
+
+def other():
+    return 3
+",
+        ),
+        (
+            "test_partial.py",
+            r"
+import sys, os
+sys.path.insert(0, os.path.dirname(__file__))
+from src.imported import used
+
+def test_used():
+    assert used() == 1
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel()
+            .arg("--cov=src")
+            .arg("--status-level=none")
+            .arg("test_partial.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    Name                Stmts   Miss   Cover
+    [LONG-LINE]
+    src/imported.py         2      0    100%
+    src/unimported.py       4      4      0%
+    [LONG-LINE]
+    TOTAL                   6      4     33%
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
 fn test_cov_report_term_missing_from_config() {
     let context = TestContext::with_files([
         (

--- a/crates/karva_coverage/src/tracer.rs
+++ b/crates/karva_coverage/src/tracer.rs
@@ -7,7 +7,7 @@
 
 use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use pyo3::prelude::*;
@@ -91,7 +91,8 @@ impl CoverageSession {
         }
 
         let executed = std::mem::take(&mut bound.borrow_mut().state.borrow_mut().executed);
-        save_data(&data_file, executed).map_err(|err| {
+        let roots = bound.borrow().roots.clone();
+        save_data(&data_file, executed, &roots).map_err(|err| {
             pyo3::exceptions::PyOSError::new_err(format!(
                 "failed to write coverage data to {data_file}: {err}"
             ))
@@ -272,10 +273,68 @@ fn install_settrace(py: Python<'_>, tracer: &Py<CoverageTracer>) -> PyResult<()>
     Ok(())
 }
 
+/// Walk source roots collecting `.py` files so that files which were never
+/// imported during the run still appear in the report at 0% coverage.
+/// Skips directories matching [`PATH_EXCLUDES`] and never follows symlinks
+/// (avoids descending into a symlinked `.venv`).
+fn walk_source_files(roots: &[PathBuf]) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut seen: HashSet<PathBuf> = HashSet::new();
+    for root in roots {
+        let Ok(metadata) = std::fs::symlink_metadata(root) else {
+            continue;
+        };
+        if metadata.file_type().is_symlink() {
+            continue;
+        }
+        if metadata.is_file() {
+            if is_python_source(root) && seen.insert(root.clone()) {
+                out.push(root.clone());
+            }
+        } else if metadata.is_dir() {
+            walk_dir(root, &mut out, &mut seen);
+        }
+    }
+    out
+}
+
+fn walk_dir(dir: &Path, out: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_symlink() {
+            continue;
+        }
+        let path = entry.path();
+        if file_type.is_dir() {
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            if PATH_EXCLUDES.contains(&name) {
+                continue;
+            }
+            walk_dir(&path, out, seen);
+        } else if file_type.is_file() && is_python_source(&path) && seen.insert(path.clone()) {
+            out.push(path);
+        }
+    }
+}
+
+fn is_python_source(path: &Path) -> bool {
+    path.extension().and_then(|e| e.to_str()) == Some("py")
+}
+
 fn save_data(
     data_file: &Utf8Path,
-    executed: HashMap<PathBuf, HashSet<u32>>,
+    mut executed: HashMap<PathBuf, HashSet<u32>>,
+    roots: &[PathBuf],
 ) -> std::io::Result<()> {
+    for path in walk_source_files(roots) {
+        executed.entry(path).or_default();
+    }
+
     let mut files = BTreeMap::new();
     for (path, hits) in executed {
         let executable = executable_lines(&path);


### PR DESCRIPTION
## Summary

Closes #705. Coverage previously omitted source files that were never imported during the run, silently understating uncovered code: a brand-new module nobody imports had zero coverage but nothing in the report told you it existed.

The worker now walks the configured `--cov` source roots on stop and adds any `.py` file not already in the executed map with an empty hit set. The existing `save_data` path then computes its executable lines via the AST and the file shows up at 0% in the combined report. The walker reuses the tracer's `PATH_EXCLUDES` (`site-packages`, `dist-packages`, `.venv`, `.tox`) and never follows symlinks, so a symlinked `.venv` (as used in the test harness) is naturally skipped.

## Test Plan

ci