### PR TITLE
Partition parametrize cases across workers

### DIFF
--- a/crates/karva_collector/src/lib.rs
+++ b/crates/karva_collector/src/lib.rs
@@ -6,8 +6,10 @@ use karva_python_semantic::ModulePath;
 use karva_python_semantic::is_fixture_function;
 
 mod models;
+mod parametrize;
 
 pub use models::{CollectedModule, CollectedPackage, ModuleType};
+pub use parametrize::count_parametrize_cases;
 
 /// Settings that control how test files are collected and parsed.
 pub struct CollectionSettings<'a> {

--- a/crates/karva_collector/src/parametrize.rs
+++ b/crates/karva_collector/src/parametrize.rs
@@ -1,0 +1,180 @@
+use ruff_python_ast::{Expr, StmtFunctionDef};
+
+/// Statically count the number of test cases a function will expand to once
+/// its `@parametrize` decorators are applied.
+///
+/// Returns `Some(n)` for `n >= 1` when every parametrize-shaped decorator can
+/// be counted from the AST alone (`argvalues` is a literal list or tuple).
+/// Returns `None` when at least one parametrize decorator has a non-literal
+/// `argvalues`; callers should treat the function as a single opaque unit.
+///
+/// A function with no parametrize decorators returns `Some(1)`.
+pub fn count_parametrize_cases(stmt: &StmtFunctionDef) -> Option<usize> {
+    let mut total: usize = 1;
+
+    for decorator in &stmt.decorator_list {
+        let Expr::Call(call) = &decorator.expression else {
+            continue;
+        };
+
+        if !is_parametrize_call(call.func.as_ref()) {
+            continue;
+        }
+
+        let argvalues = argvalues_arg(call)?;
+        let count = literal_sequence_len(argvalues)?;
+
+        total = total.checked_mul(count)?;
+    }
+
+    Some(total)
+}
+
+/// Returns true if `func` resolves to a parametrize reference.
+///
+/// Matches bare `parametrize`, attribute accesses ending in `parametrize`
+/// (`pytest.mark.parametrize`, `karva.tags.parametrize`), and any chained
+/// attribute on those.
+fn is_parametrize_call(func: &Expr) -> bool {
+    match func {
+        Expr::Name(name) => name.id == "parametrize",
+        Expr::Attribute(attr) => attr.attr.id == "parametrize",
+        _ => false,
+    }
+}
+
+/// Extract the `argvalues` argument from a parametrize call.
+///
+/// Accepts both `parametrize("x", [1, 2])` (positional) and
+/// `parametrize(argnames="x", argvalues=[1, 2])` (keyword).
+fn argvalues_arg(call: &ruff_python_ast::ExprCall) -> Option<&Expr> {
+    if let Some(expr) = call.arguments.args.get(1) {
+        return Some(expr);
+    }
+    call.arguments
+        .keywords
+        .iter()
+        .find(|kw| kw.arg.as_ref().is_some_and(|id| id.as_str() == "argvalues"))
+        .map(|kw| &kw.value)
+}
+
+/// Returns the element count of a list or tuple literal, or `None` if the
+/// expression isn't a literal sequence we can count statically.
+fn literal_sequence_len(expr: &Expr) -> Option<usize> {
+    match expr {
+        Expr::List(list) => Some(list.elts.len()),
+        Expr::Tuple(tuple) => Some(tuple.elts.len()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_python_ast::{Mod, Stmt};
+    use ruff_python_parser::{Mode, ParseOptions, parse_unchecked};
+
+    use super::*;
+
+    fn parse_function(source: &str) -> StmtFunctionDef {
+        let parsed = parse_unchecked(source, ParseOptions::from(Mode::Module))
+            .try_into_module()
+            .expect("parse")
+            .into_syntax();
+        let Mod::Module(module) = Mod::Module(parsed) else {
+            unreachable!()
+        };
+        module
+            .body
+            .into_iter()
+            .find_map(|stmt| match stmt {
+                Stmt::FunctionDef(f) => Some(f),
+                _ => None,
+            })
+            .expect("function def")
+    }
+
+    #[test]
+    fn no_decorators_returns_one() {
+        let f = parse_function("def test_x(): pass\n");
+        assert_eq!(count_parametrize_cases(&f), Some(1));
+    }
+
+    #[test]
+    fn unrelated_decorator_returns_one() {
+        let f = parse_function("@my_decorator\ndef test_x(): pass\n");
+        assert_eq!(count_parametrize_cases(&f), Some(1));
+    }
+
+    #[test]
+    fn pytest_mark_parametrize_list() {
+        let f = parse_function("@pytest.mark.parametrize('x', [1, 2, 3])\ndef test_x(x): pass\n");
+        assert_eq!(count_parametrize_cases(&f), Some(3));
+    }
+
+    #[test]
+    fn karva_tags_parametrize_list_of_tuples() {
+        let f = parse_function(
+            "@karva.tags.parametrize('a, b', [(1, 2), (3, 4)])\ndef test_x(a, b): pass\n",
+        );
+        assert_eq!(count_parametrize_cases(&f), Some(2));
+    }
+
+    #[test]
+    fn bare_parametrize_name() {
+        let f = parse_function("@parametrize('x', [1, 2])\ndef test_x(x): pass\n");
+        assert_eq!(count_parametrize_cases(&f), Some(2));
+    }
+
+    #[test]
+    fn keyword_argvalues() {
+        let f = parse_function(
+            "@pytest.mark.parametrize(argnames='x', argvalues=[1, 2, 3, 4])\ndef test_x(x): pass\n",
+        );
+        assert_eq!(count_parametrize_cases(&f), Some(4));
+    }
+
+    #[test]
+    fn stacked_decorators_multiply() {
+        let f = parse_function(
+            "@pytest.mark.parametrize('a', [1, 2, 3])\n\
+             @pytest.mark.parametrize('b', [4, 5])\n\
+             def test_x(a, b): pass\n",
+        );
+        assert_eq!(count_parametrize_cases(&f), Some(6));
+    }
+
+    #[test]
+    fn tuple_argvalues_counts_outer_elements() {
+        let f =
+            parse_function("@parametrize('x', ((1, 2), (3, 4), (5, 6)))\ndef test_x(x): pass\n");
+        assert_eq!(count_parametrize_cases(&f), Some(3));
+    }
+
+    #[test]
+    fn dynamic_argvalues_returns_none() {
+        let f = parse_function("@parametrize('x', load_cases())\ndef test_x(x): pass\n");
+        assert_eq!(count_parametrize_cases(&f), None);
+    }
+
+    #[test]
+    fn list_comprehension_argvalues_returns_none() {
+        let f = parse_function("@parametrize('x', [v for v in values()])\ndef test_x(x): pass\n");
+        assert_eq!(count_parametrize_cases(&f), None);
+    }
+
+    #[test]
+    fn missing_argvalues_returns_none() {
+        let f = parse_function("@parametrize('x')\ndef test_x(x): pass\n");
+        assert_eq!(count_parametrize_cases(&f), None);
+    }
+
+    #[test]
+    fn dynamic_decorator_propagates_none() {
+        let f = parse_function(
+            "@parametrize('a', [1, 2])\n\
+             @parametrize('b', dynamic_values())\n\
+             def test_x(a, b): pass\n",
+        );
+        assert_eq!(count_parametrize_cases(&f), None);
+    }
+}

--- a/crates/karva_diagnostic/src/result/mod.rs
+++ b/crates/karva_diagnostic/src/result/mod.rs
@@ -4,7 +4,7 @@ mod stats;
 
 use std::collections::HashMap;
 
-use karva_python_semantic::{QualifiedFunctionName, QualifiedTestName};
+use karva_python_semantic::QualifiedTestName;
 use ruff_db::diagnostic::Diagnostic;
 
 use crate::reporter::Reporter;
@@ -27,11 +27,14 @@ pub struct TestRunResult {
     /// Stats generated during test execution.
     stats: TestResultStats,
 
-    /// The duration of each test function.
-    durations: HashMap<QualifiedFunctionName, std::time::Duration>,
+    /// The duration of each test, keyed by [`QualifiedTestName::cache_key`]
+    /// (e.g., `module::test_name` or `module::test_name[3]`). Per-case
+    /// keys let the partitioner schedule individual parametrize cases.
+    durations: HashMap<String, std::time::Duration>,
 
-    /// Names of tests that failed during this run.
-    failed_tests: Vec<QualifiedFunctionName>,
+    /// Names of tests that failed during this run, in the same per-case
+    /// cache key format as `durations`.
+    failed_tests: Vec<String>,
 
     /// Tests that passed only after at least one retry.
     flaky_tests: Vec<FlakyTest>,
@@ -67,10 +70,10 @@ impl TestRunResult {
     ) {
         self.stats.add(result.clone().into());
 
-        let function_name = test_case_name.function_name().clone();
+        let cache_key = test_case_name.cache_key();
 
         if matches!(result, IndividualTestResultKind::Failed) {
-            self.failed_tests.push(function_name.clone());
+            self.failed_tests.push(cache_key.clone());
         }
 
         if let Some(reporter) = reporter {
@@ -78,7 +81,7 @@ impl TestRunResult {
         }
 
         self.durations
-            .entry(function_name)
+            .entry(cache_key)
             .and_modify(|existing_duration| *existing_duration += duration)
             .or_insert(duration);
     }
@@ -104,10 +107,10 @@ impl TestRunResult {
     ) {
         self.stats.add(result.clone().into());
 
-        let function_name = test_case_name.function_name().clone();
+        let cache_key = test_case_name.cache_key();
 
         if matches!(result, IndividualTestResultKind::Failed) {
-            self.failed_tests.push(function_name.clone());
+            self.failed_tests.push(cache_key.clone());
         } else if matches!(result, IndividualTestResultKind::Passed) {
             self.stats.add(TestResultKind::Flaky);
             self.flaky_tests.push(FlakyTest::from_qualified_name(
@@ -119,7 +122,7 @@ impl TestRunResult {
         }
 
         self.durations
-            .entry(function_name)
+            .entry(cache_key)
             .and_modify(|existing_duration| *existing_duration += duration)
             .or_insert(duration);
     }
@@ -161,11 +164,11 @@ impl TestRunResult {
         self
     }
 
-    pub fn durations(&self) -> &HashMap<QualifiedFunctionName, std::time::Duration> {
+    pub fn durations(&self) -> &HashMap<String, std::time::Duration> {
         &self.durations
     }
 
-    pub fn failed_tests(&self) -> &[QualifiedFunctionName] {
+    pub fn failed_tests(&self) -> &[String] {
         &self.failed_tests
     }
 

--- a/crates/karva_project/src/path/test_path.rs
+++ b/crates/karva_project/src/path/test_path.rs
@@ -24,6 +24,32 @@ fn try_convert_to_py_path(path: &Utf8Path) -> Result<Utf8PathBuf, TestPathError>
 pub struct TestPathFunction {
     pub path: Utf8PathBuf,
     pub function_name: String,
+    /// Restrict execution to specific parametrize case indices (when `Some`),
+    /// or run all cases (when `None`). The partitioner emits one entry per
+    /// case so the worker can run a subset of a parametrized test.
+    pub parametrize_indices: Option<Vec<usize>>,
+}
+
+/// Parse a trailing `[idx]` suffix on a function name into `(name, index)`.
+///
+/// Returns `(name, None)` if no suffix is present; returns `Err` if the
+/// brackets are malformed (missing `]`, non-numeric content, or empty).
+fn parse_parametrize_suffix(value: &str) -> Result<(&str, Option<usize>), TestPathError> {
+    let Some(open) = value.rfind('[') else {
+        return Ok((value, None));
+    };
+    let Some(close_rel) = value[open..].find(']') else {
+        return Err(TestPathError::MalformedCaseIndex(value.to_string()));
+    };
+    let close = open + close_rel;
+    if close + 1 != value.len() {
+        return Err(TestPathError::MalformedCaseIndex(value.to_string()));
+    }
+    let inner = &value[open + 1..close];
+    let index = inner
+        .parse::<usize>()
+        .map_err(|_| TestPathError::MalformedCaseIndex(value.to_string()))?;
+    Ok((&value[..open], Some(index)))
 }
 
 impl TryFrom<&str> for TestPathFunction {
@@ -32,13 +58,15 @@ impl TryFrom<&str> for TestPathFunction {
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         if let Some(separator_pos) = value.rfind("::") {
             let file_part = &value[..separator_pos];
-            let function_name = &value[separator_pos + 2..];
+            let function_part = &value[separator_pos + 2..];
 
-            if function_name.is_empty() {
+            if function_part.is_empty() {
                 return Err(Some(TestPathError::MissingFunctionName(Utf8PathBuf::from(
                     file_part,
                 ))));
             }
+
+            let (function_name, case_index) = parse_parametrize_suffix(function_part)?;
 
             let file_path = Utf8PathBuf::from(file_part);
             let path = try_convert_to_py_path(&file_path)?;
@@ -54,6 +82,7 @@ impl TryFrom<&str> for TestPathFunction {
             Ok(Self {
                 path,
                 function_name: function_name.to_string(),
+                parametrize_indices: case_index.map(|idx| vec![idx]),
             })
         } else {
             Err(None)
@@ -129,6 +158,8 @@ pub enum TestPathError {
     InvalidUtf8Path(Utf8PathBuf),
     #[error("path `{0}` is missing a function name")]
     MissingFunctionName(Utf8PathBuf),
+    #[error("function selector `{0}` has a malformed parametrize index")]
+    MalformedCaseIndex(String),
 }
 
 impl TestPathError {
@@ -138,6 +169,10 @@ impl TestPathError {
             | Self::WrongFileExtension(path)
             | Self::InvalidUtf8Path(path)
             | Self::MissingFunctionName(path) => path,
+            Self::MalformedCaseIndex(_) => {
+                static EMPTY: std::sync::OnceLock<Utf8PathBuf> = std::sync::OnceLock::new();
+                EMPTY.get_or_init(Utf8PathBuf::new)
+            }
         }
     }
 }
@@ -284,10 +319,12 @@ mod tests {
         if let Ok(TestPath::Function(TestPathFunction {
             path: result_path,
             function_name,
+            parametrize_indices,
         })) = result
         {
             assert_eq!(result_path, path);
             assert_eq!(function_name, "test_function");
+            assert_eq!(parametrize_indices, None);
         } else {
             panic!("Expected Ok(TestUtf8Path::Function), got {result:?}");
         }
@@ -306,6 +343,38 @@ mod tests {
         if let Ok(TestPath::Function(TestPathFunction { function_name, .. })) = result {
             assert_eq!(function_name, "test_function");
         }
+    }
+
+    #[test]
+    fn test_function_specification_with_parametrize_index() {
+        let env = TestEnv::new();
+        let path = env.create_file("test.py", "def test_function(): pass");
+
+        let function_spec = format!("{path}::test_function[3]");
+        let result = TestPath::new(&function_spec);
+
+        if let Ok(TestPath::Function(TestPathFunction {
+            function_name,
+            parametrize_indices,
+            ..
+        })) = result
+        {
+            assert_eq!(function_name, "test_function");
+            assert_eq!(parametrize_indices, Some(vec![3]));
+        } else {
+            panic!("Expected Ok(TestPath::Function), got {result:?}");
+        }
+    }
+
+    #[test]
+    fn test_function_specification_malformed_case_index() {
+        let env = TestEnv::new();
+        let path = env.create_file("test.py", "def test_function(): pass");
+
+        let function_spec = format!("{path}::test_function[oops]");
+        let result = TestPath::new(&function_spec);
+
+        assert!(matches!(result, Err(TestPathError::MalformedCaseIndex(_))));
     }
 
     #[test]

--- a/crates/karva_python_semantic/src/name.rs
+++ b/crates/karva_python_semantic/src/name.rs
@@ -55,6 +55,7 @@ impl Serialize for QualifiedFunctionName {
 pub struct QualifiedTestName {
     function_name: QualifiedFunctionName,
     full_name: Option<String>,
+    case_index: Option<usize>,
 }
 
 impl QualifiedTestName {
@@ -63,7 +64,16 @@ impl QualifiedTestName {
         Self {
             function_name,
             full_name,
+            case_index: None,
         }
+    }
+
+    /// Attach a parametrize case index. Used for stable cache/duration keys
+    /// that survive renaming of parameter values across runs.
+    #[must_use]
+    pub fn with_case_index(mut self, case_index: Option<usize>) -> Self {
+        self.case_index = case_index;
+        self
     }
 
     /// Return the underlying qualified function name.
@@ -71,11 +81,28 @@ impl QualifiedTestName {
         &self.function_name
     }
 
+    /// Return the parametrize case index if this name refers to a specific case.
+    pub fn case_index(&self) -> Option<usize> {
+        self.case_index
+    }
+
     /// Return the parameter portion of the test name (e.g., `"(a=1, b=2)"`), if any.
     pub fn params(&self) -> Option<&str> {
         let full_name = self.full_name.as_deref()?;
         let base = self.function_name.to_string();
         full_name.strip_prefix(&base)
+    }
+
+    /// Stable string identifier for cache and partitioning, of the form
+    /// `module::test_name` (no parametrize) or `module::test_name[idx]`.
+    ///
+    /// Distinct from `Display`, which renders the human-facing name with
+    /// parameter values.
+    pub fn cache_key(&self) -> String {
+        match self.case_index {
+            Some(idx) => format!("{}[{idx}]", self.function_name),
+            None => self.function_name.to_string(),
+        }
     }
 }
 

--- a/crates/karva_runner/src/collection.rs
+++ b/crates/karva_runner/src/collection.rs
@@ -95,6 +95,7 @@ impl<'a> ParallelCollector<'a> {
                 TestPath::Function(TestPathFunction {
                     path: file_path,
                     function_name,
+                    parametrize_indices: _,
                 }) => {
                     if let Some(module) =
                         collect_file(&file_path, self.cwd, &self.settings, &[function_name])

--- a/crates/karva_runner/src/partition.rs
+++ b/crates/karva_runner/src/partition.rs
@@ -10,6 +10,10 @@ struct TestInfo {
     path: String,
     /// Actual runtime from previous test run (if available)
     duration: Option<Duration>,
+    /// Qualified name without any `[idx]` suffix. Cases of the same
+    /// parametrized function share this key so they can be shuffled and
+    /// reasoned about as a single unit.
+    function_root: String,
 }
 
 /// Calculate the weight of a test for partitioning.
@@ -199,28 +203,50 @@ fn compare_test_weights(a: &TestInfo, b: &TestInfo) -> std::cmp::Ordering {
     }
 }
 
-/// Shuffles only the tests that have no historical duration data.
+/// Shuffles tests that have no historical duration data, treating cases of
+/// the same parametrized function as a single unit.
 ///
-/// This ensures tests without timing info are randomly distributed across partitions
-/// rather than always landing in the same order.
-fn shuffle_tests_without_durations(test_infos: &mut [TestInfo]) {
-    let no_duration_indices: Vec<usize> = test_infos
+/// Without this grouping, parametrize cases for one function would be
+/// reordered relative to one another, making test output order
+/// non-deterministic in the common single-worker case.
+fn shuffle_tests_without_durations(test_infos: &mut Vec<TestInfo>) {
+    let mut groups: Vec<Vec<TestInfo>> = Vec::new();
+    let mut group_index: HashMap<String, usize> = HashMap::new();
+
+    for info in test_infos.drain(..) {
+        if let Some(idx) = group_index.get(&info.function_root) {
+            groups[*idx].push(info);
+        } else {
+            group_index.insert(info.function_root.clone(), groups.len());
+            groups.push(vec![info]);
+        }
+    }
+
+    let no_duration_groups: Vec<usize> = groups
         .iter()
         .enumerate()
-        .filter(|(_, t)| t.duration.is_none())
+        .filter(|(_, g)| g.iter().any(|t| t.duration.is_none()))
         .map(|(i, _)| i)
         .collect();
 
-    // Fisher-Yates shuffle on the indices
-    for i in (1..no_duration_indices.len()).rev() {
+    for i in (1..no_duration_groups.len()).rev() {
         let j = fastrand::usize(..=i);
-        let idx_a = no_duration_indices[i];
-        let idx_b = no_duration_indices[j];
-        test_infos.swap(idx_a, idx_b);
+        let idx_a = no_duration_groups[i];
+        let idx_b = no_duration_groups[j];
+        groups.swap(idx_a, idx_b);
+    }
+
+    for group in groups {
+        test_infos.extend(group);
     }
 }
 
-/// Recursively collects test information from a package and all its subpackages
+/// Recursively collects test information from a package and all its subpackages.
+///
+/// For each test function whose `@parametrize` decorators can be statically
+/// counted, emits one `TestInfo` per case so that the partitioner can split
+/// individual cases across workers. Cases of the same function share a
+/// `function_root` key so they can be reordered as a unit.
 fn collect_test_paths_recursive(
     package: &karva_collector::CollectedPackage,
     test_infos: &mut Vec<TestInfo>,
@@ -228,15 +254,34 @@ fn collect_test_paths_recursive(
 ) {
     for module in package.modules.values() {
         for test_fn_def in &module.test_function_defs {
-            let qualified_name = format!("{}::{}", module.path.module_name(), test_fn_def.name);
-            let duration = previous_durations.get(&qualified_name).copied();
+            let module_name = module.path.module_name();
+            let module_path = module.path.path();
+            let function_name = test_fn_def.name.as_str();
+            let function_root = format!("{module_name}::{function_name}");
+            let case_count = karva_collector::count_parametrize_cases(test_fn_def).unwrap_or(1);
 
-            test_infos.push(TestInfo {
-                module_name: module.path.module_name().to_string(),
-                qualified_name,
-                path: format!("{}::{}", module.path.path(), test_fn_def.name),
-                duration,
-            });
+            if case_count <= 1 {
+                let duration = previous_durations.get(&function_root).copied();
+                test_infos.push(TestInfo {
+                    module_name: module_name.to_string(),
+                    qualified_name: function_root.clone(),
+                    path: format!("{module_path}::{function_name}"),
+                    duration,
+                    function_root,
+                });
+            } else {
+                for idx in 0..case_count {
+                    let qualified_name = format!("{function_root}[{idx}]");
+                    let duration = previous_durations.get(&qualified_name).copied();
+                    test_infos.push(TestInfo {
+                        module_name: module_name.to_string(),
+                        qualified_name,
+                        path: format!("{module_path}::{function_name}[{idx}]"),
+                        duration,
+                        function_root: function_root.clone(),
+                    });
+                }
+            }
         }
     }
 

--- a/crates/karva_test_semantic/src/discovery/discoverer.rs
+++ b/crates/karva_test_semantic/src/discovery/discoverer.rs
@@ -1,9 +1,10 @@
+use std::collections::HashMap;
 use std::path::Path;
 use std::rc::Rc;
 
-use camino::Utf8Path;
+use camino::{Utf8Path, Utf8PathBuf};
 use karva_collector::{CollectedModule, CollectedPackage};
-use karva_project::path::{TestPath, TestPathError};
+use karva_project::path::{TestPath, TestPathError, TestPathFunction};
 use karva_python_semantic::ModulePath;
 use pyo3::prelude::*;
 use ruff_python_ast::{PythonVersion, Stmt};
@@ -15,6 +16,13 @@ use crate::discovery::visitor::{discover, is_generator};
 use crate::discovery::{DiscoveredModule, DiscoveredPackage};
 use crate::extensions::fixtures::DiscoveredFixture;
 use crate::utils::add_to_sys_path;
+
+/// Maps `(file path, function name)` to the parametrize indices the worker
+/// should run for that function.
+///
+/// `None` means the function appeared without an `[idx]` suffix at least once,
+/// so every case should run. `Some(indices)` means only those indices.
+type CaseFilterMap = HashMap<(Utf8PathBuf, String), Option<Vec<usize>>>;
 
 /// Discovers test functions and fixtures from Python source files.
 ///
@@ -41,7 +49,7 @@ impl<'ctx, 'a> StandardDiscoverer<'ctx, 'a> {
             return DiscoveredPackage::new(cwd.to_path_buf());
         }
 
-        let test_paths = test_paths
+        let test_paths: Vec<TestPathFunction> = test_paths
             .into_iter()
             .filter_map(|path| match path {
                 Ok(path) => match path {
@@ -52,12 +60,14 @@ impl<'ctx, 'a> StandardDiscoverer<'ctx, 'a> {
             })
             .collect();
 
+        let case_filter = build_case_filter(&test_paths);
+
         let collector =
             TestFunctionCollector::new(self.context.cwd(), self.context.collection_settings());
 
         let collected_package = collector.collect_all(test_paths);
 
-        let mut session_package = self.convert_package(py, collected_package);
+        let mut session_package = self.convert_package(py, collected_package, &case_filter);
 
         session_package.shrink();
 
@@ -75,6 +85,7 @@ impl<'ctx, 'a> StandardDiscoverer<'ctx, 'a> {
         &self,
         py: Python,
         collected_package: CollectedPackage,
+        case_filter: &CaseFilterMap,
     ) -> DiscoveredPackage {
         let CollectedPackage {
             path,
@@ -86,23 +97,38 @@ impl<'ctx, 'a> StandardDiscoverer<'ctx, 'a> {
         let mut discovered_package = DiscoveredPackage::new(path);
 
         if let Some(collected_module) = configuration_module {
-            discovered_package
-                .set_configuration_module(Some(self.convert_module(py, collected_module)));
+            discovered_package.set_configuration_module(Some(self.convert_module(
+                py,
+                collected_module,
+                case_filter,
+            )));
         }
 
         for collected_module in modules.into_values() {
-            discovered_package.add_direct_module(self.convert_module(py, collected_module));
+            discovered_package.add_direct_module(self.convert_module(
+                py,
+                collected_module,
+                case_filter,
+            ));
         }
 
         for collected_subpackage in packages.into_values() {
-            discovered_package
-                .add_direct_subpackage(self.convert_package(py, collected_subpackage));
+            discovered_package.add_direct_subpackage(self.convert_package(
+                py,
+                collected_subpackage,
+                case_filter,
+            ));
         }
 
         discovered_package
     }
 
-    fn convert_module(&self, py: Python, collected_module: CollectedModule) -> DiscoveredModule {
+    fn convert_module(
+        &self,
+        py: Python,
+        collected_module: CollectedModule,
+        case_filter: &CaseFilterMap,
+    ) -> DiscoveredModule {
         let CollectedModule {
             path,
             module_type: _,
@@ -111,7 +137,17 @@ impl<'ctx, 'a> StandardDiscoverer<'ctx, 'a> {
             fixture_function_defs,
         } = collected_module;
 
+        let module_file_path = path.path().clone();
         let mut module = DiscoveredModule::new_with_source(path, source_text);
+
+        let test_function_defs: Vec<_> = test_function_defs
+            .into_iter()
+            .map(|def| {
+                let key = (module_file_path.clone(), def.name.to_string());
+                let filter = case_filter.get(&key).cloned().unwrap_or(None);
+                (def, filter)
+            })
+            .collect();
 
         discover(
             self.context,
@@ -123,6 +159,32 @@ impl<'ctx, 'a> StandardDiscoverer<'ctx, 'a> {
 
         module
     }
+}
+
+/// Build a `(file path, function name) -> Option<Vec<usize>>` map from the
+/// resolved test path selectors. `None` means "run every parametrize case",
+/// `Some(indices)` means "run only these case indices."
+///
+/// Multiple selectors for the same function are unioned: any bare selector
+/// (no `[idx]`) wins and yields `None`; otherwise the indices are merged.
+fn build_case_filter(test_paths: &[TestPathFunction]) -> CaseFilterMap {
+    let mut filter: CaseFilterMap = HashMap::new();
+
+    for tpf in test_paths {
+        let key = (tpf.path.clone(), tpf.function_name.clone());
+        match filter.get_mut(&key) {
+            Some(existing) => match (existing.as_mut(), tpf.parametrize_indices.as_ref()) {
+                (None, _) => {} // already "all"
+                (_, None) => *existing = None,
+                (Some(acc), Some(new)) => acc.extend(new.iter().copied()),
+            },
+            None => {
+                filter.insert(key, tpf.parametrize_indices.clone());
+            }
+        }
+    }
+
+    filter
 }
 
 /// Discovers all fixtures defined in `karva._builtins` by importing the module at

--- a/crates/karva_test_semantic/src/discovery/models/function.rs
+++ b/crates/karva_test_semantic/src/discovery/models/function.rs
@@ -25,6 +25,11 @@ pub struct DiscoveredTestFunction {
 
     /// Decorator tags like parametrize, skip, xfail, etc.
     pub(crate) tags: Tags,
+
+    /// Restrict execution to these parametrize case indices when `Some`,
+    /// or run every case when `None`. Set by the worker CLI when the user
+    /// (or partitioner) requested a subset like `file::test[3]`.
+    pub(crate) case_filter: Option<Vec<usize>>,
 }
 
 impl DiscoveredTestFunction {
@@ -33,6 +38,7 @@ impl DiscoveredTestFunction {
         module: &DiscoveredModule,
         stmt_function_def: Rc<StmtFunctionDef>,
         py_function: Py<PyAny>,
+        case_filter: Option<Vec<usize>>,
     ) -> Self {
         let name = QualifiedFunctionName::new(
             stmt_function_def.name.to_string(),
@@ -46,6 +52,7 @@ impl DiscoveredTestFunction {
             stmt_function_def,
             py_function,
             tags,
+            case_filter,
         }
     }
 }

--- a/crates/karva_test_semantic/src/discovery/visitor.rs
+++ b/crates/karva_test_semantic/src/discovery/visitor.rs
@@ -106,7 +106,11 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
         }
     }
 
-    fn process_test_function(&mut self, stmt_function_def: StmtFunctionDef) {
+    fn process_test_function(
+        &mut self,
+        stmt_function_def: StmtFunctionDef,
+        case_filter: Option<Vec<usize>>,
+    ) {
         self.try_import_module();
 
         let Some(py_module) = self.py_module.as_ref() else {
@@ -119,6 +123,7 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
                 self.module,
                 Rc::new(stmt_function_def),
                 py_function.unbind(),
+                case_filter,
             ));
         }
     }
@@ -239,7 +244,7 @@ pub fn discover(
     context: &Context,
     py: Python,
     module: &mut DiscoveredModule,
-    test_function_defs: Vec<StmtFunctionDef>,
+    test_function_defs: Vec<(StmtFunctionDef, Option<Vec<usize>>)>,
     fixture_function_defs: Vec<StmtFunctionDef>,
 ) {
     let is_conftest = module
@@ -249,8 +254,8 @@ pub fn discover(
 
     let mut visitor = FunctionDefinitionVisitor::new(py, context, module);
 
-    for test_function_def in test_function_defs {
-        visitor.process_test_function(test_function_def);
+    for (test_function_def, case_filter) in test_function_defs {
+        visitor.process_test_function(test_function_def, case_filter);
     }
 
     for fixture_function_def in fixture_function_defs {

--- a/crates/karva_test_semantic/src/extensions/tags/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/mod.rs
@@ -229,6 +229,13 @@ impl Tags {
         Some(Self { inner: tags })
     }
 
+    /// True if any decorator on the test is a parametrize tag.
+    pub(crate) fn has_parametrize(&self) -> bool {
+        self.inner
+            .iter()
+            .any(|tag| matches!(tag, Tag::Parametrize(_)))
+    }
+
     /// Return all parametrizations
     ///
     /// This function ensures that if we have multiple parametrize tags, we combine them together.

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -406,6 +406,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             use_fixture_dependencies,
             auto_use_fixtures,
             tags: _variant_tags,
+            case_index,
         } = variant;
 
         let name = test.name.clone();
@@ -430,7 +431,8 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         let computed_full_test_name = full_test_name(py, name.to_string(), &function_arguments);
 
         let qualified_test_name =
-            QualifiedTestName::new(name.clone(), Some(computed_full_test_name));
+            QualifiedTestName::new(name.clone(), Some(computed_full_test_name))
+                .with_case_index(case_index);
 
         tracing::debug!("Running test `{}`", qualified_test_name);
 

--- a/crates/karva_test_semantic/src/runner/test_iterator.rs
+++ b/crates/karva_test_semantic/src/runner/test_iterator.rs
@@ -41,6 +41,11 @@ pub(super) struct TestVariant<'a> {
 
     /// Combined tags from the test and its parameter set.
     pub tags: Tags,
+
+    /// Original parametrize index in the test's full case list (`None` for
+    /// non-parametrized tests). Used to form a stable per-case cache key
+    /// even when the worker only ran a filtered subset of cases.
+    pub case_index: Option<usize>,
 }
 
 impl TestVariant<'_> {
@@ -77,9 +82,10 @@ impl TestVariant<'_> {
 /// producing N variants costs N refcount bumps rather than N deep clones.
 pub(super) struct TestVariantIterator<'a> {
     test: &'a DiscoveredTestFunction,
-    /// Consumed as we iterate, so `values` and `tags` on each
-    /// `ParametrizationArgs` are moved into the emitted variant (not cloned).
-    param_args: std::vec::IntoIter<ParametrizationArgs>,
+    /// Consumed as we iterate. Each item is `(original case index, args)`.
+    /// `original case index` is `None` for non-parametrized tests; otherwise
+    /// it is the index in the full pre-filter parametrize expansion.
+    param_args: std::vec::IntoIter<(Option<usize>, ParametrizationArgs)>,
     fixture_dependencies: Rc<[Rc<NormalizedFixture>]>,
     use_fixture_dependencies: Rc<[Rc<NormalizedFixture>]>,
     auto_use_fixtures: Rc<[Rc<NormalizedFixture>]>,
@@ -116,10 +122,28 @@ impl<'a> TestVariantIterator<'a> {
         let use_fixture_names = test.tags.required_fixtures_names();
         let use_fixture_dependencies = resolver.resolve_use_fixtures(py, &use_fixture_names);
 
-        let param_args = if test_params.is_empty() {
-            vec![ParametrizationArgs::default()]
+        let is_parametrized = test.tags.has_parametrize();
+
+        let param_args: Vec<(Option<usize>, ParametrizationArgs)> = if !is_parametrized {
+            vec![(None, ParametrizationArgs::default())]
+        } else if let Some(allowed_indices) = test.case_filter.as_ref() {
+            // The worker was told to run only specific parametrize case indices
+            // (the partitioner split a parametrized test across workers).
+            // Indices outside the actual case range silently drop — they would
+            // have come from a stale plan, not real tests.
+            let total = test_params.len();
+            allowed_indices
+                .iter()
+                .copied()
+                .filter(|idx| *idx < total)
+                .filter_map(|idx| test_params.get(idx).cloned().map(|args| (Some(idx), args)))
+                .collect()
         } else {
             test_params
+                .into_iter()
+                .enumerate()
+                .map(|(idx, args)| (Some(idx), args))
+                .collect()
         };
 
         Self {
@@ -136,7 +160,7 @@ impl<'a> Iterator for TestVariantIterator<'a> {
     type Item = TestVariant<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let param_args = self.param_args.next()?;
+        let (case_index, param_args) = self.param_args.next()?;
 
         let mut tags = self.test.tags.clone();
         tags.extend(&param_args.tags);
@@ -148,6 +172,7 @@ impl<'a> Iterator for TestVariantIterator<'a> {
             use_fixture_dependencies: Rc::clone(&self.use_fixture_dependencies),
             auto_use_fixtures: Rc::clone(&self.auto_use_fixtures),
             tags,
+            case_index,
         })
     }
 


### PR DESCRIPTION
## Summary

Cases of a parametrized test now partition across workers instead of riding together as one unit. The collector parses `@parametrize` decorators statically, counts literal `argvalues`, and the partitioner emits one `TestInfo` per case with paths of the form `file.py::test_name[idx]`. Workers parse the `[idx]` suffix into `TestPathFunction.parametrize_indices`, the discoverer threads a per-`(file, function)` filter map into `DiscoveredTestFunction.case_filter`, and `TestVariantIterator` slices `parametrize_args()` to the requested indices while preserving the original case index for cache and reporter use.

Per-case scheduling needs a per-case duration cache. `QualifiedTestName` gained a `case_index` field and a `cache_key()` method (`module::test_name` or `module::test_name[3]`) that is distinct from `Display` (which still renders the human-facing `module::test_name(a=1)`). `TestRunResult.durations` and `failed_tests` rekey on `cache_key()`, so `--last-failed` now re-runs only the failing cases and the partitioner's per-case weights actually persist across runs.

Dynamic `argvalues` (function calls, comprehensions, name references) can't be counted from the AST and fall back to whole-function units. The shuffle that distributes tests-without-history across workers now operates at the function level, so cases of one function stay adjacent and in index order — keeping single-worker output deterministic.

## Test Plan

ci