### PR TITLE
Centralize cache artifact catalogue in karva_cache

### DIFF
--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -136,10 +136,7 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
         }
     }
 
-    if result.stats.is_success()
-        && result.discovery_diagnostics.is_empty()
-        && !coverage_below_threshold
-    {
+    if result.stats.is_success() && result.diagnostics.is_empty() && !coverage_below_threshold {
         Ok(ExitStatus::Success)
     } else {
         Ok(ExitStatus::Failure)
@@ -147,9 +144,7 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
 }
 
 fn no_tests_collected(result: &AggregatedResults) -> bool {
-    result.stats.total() == 0
-        && result.discovery_diagnostics.is_empty()
-        && result.diagnostics.is_empty()
+    result.stats.total() == 0 && result.diagnostics.is_empty()
 }
 
 /// Print test output: diagnostics, durations, and result summary.
@@ -163,8 +158,7 @@ pub fn print_test_output(
     let mut details = printer.stream_for_details().lock();
     let is_concise = matches!(output_format, Some(OutputFormat::Concise));
 
-    let has_diagnostics =
-        !result.diagnostics.is_empty() || !result.discovery_diagnostics.is_empty();
+    let has_diagnostics = !result.diagnostics.is_empty();
     let has_durations = durations.is_some_and(|n| n > 0) && !result.durations.is_empty();
     let has_preceding_test_lines = result.stats.total() > 0;
 
@@ -209,7 +203,7 @@ fn write_diagnostics_block(
     is_concise: bool,
     needs_leading_blank: bool,
 ) -> Result<()> {
-    if result.discovery_diagnostics.is_empty() && result.diagnostics.is_empty() {
+    if result.diagnostics.is_empty() {
         return Ok(());
     }
 
@@ -218,13 +212,7 @@ fn write_diagnostics_block(
     }
     writeln!(stdout, "diagnostics:")?;
     writeln!(stdout)?;
-
-    if !result.discovery_diagnostics.is_empty() {
-        write!(stdout, "{}", result.discovery_diagnostics)?;
-    }
-    if !result.diagnostics.is_empty() {
-        write!(stdout, "{}", result.diagnostics)?;
-    }
+    write!(stdout, "{}", result.diagnostics)?;
     // Non-concise diagnostic content ends with a trailing blank line of its
     // own; concise mode needs an explicit one to match.
     if is_concise {

--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -259,7 +259,7 @@ fn test_fail_concise_output() {
 
     diagnostics:
 
-    test_fail.py:5:5: warning[invalid-fixture-finalizer] Discovered an invalid fixture finalizer `fixture_1`
+    test_fail.py:5:5: error[invalid-fixture-finalizer] Discovered an invalid fixture finalizer `fixture_1`
     test_fail.py:9:5: error[test-failure] Test `test_1` failed
     test_fail.py:16:5: error[missing-fixtures] Test `test_2` has missing fixtures: `fixture_2`
     test_fail.py:19:5: error[test-failure] Test `test_3` failed
@@ -610,15 +610,15 @@ fn test_fixture_generator_two_yields_passing_test() {
     );
 
     assert_cmd_snapshot!(context.command(), @"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
             PASS [TIME] test::test_fixture_generator(fixture_generator=1)
 
     diagnostics:
 
-    warning[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `fixture_generator`
+    error[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `fixture_generator`
      --> test.py:5:5
       |
     4 | @karva.fixture
@@ -662,7 +662,7 @@ fn test_fixture_generator_two_yields_failing_test() {
 
     diagnostics:
 
-    warning[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `fixture_generator`
+    error[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `fixture_generator`
      --> test.py:5:5
       |
     4 | @karva.fixture
@@ -717,15 +717,15 @@ fn test_fixture_generator_fail_in_teardown() {
     );
 
     assert_cmd_snapshot!(context.command(), @r#"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
             PASS [TIME] test::test_fixture_generator(fixture_generator=1)
 
     diagnostics:
 
-    warning[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `fixture_generator`
+    error[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `fixture_generator`
      --> test.py:5:5
       |
     4 | @karva.fixture

--- a/crates/karva/tests/it/extensions/fixtures/autouse.rs
+++ b/crates/karva/tests/it/extensions/fixtures/autouse.rs
@@ -249,15 +249,15 @@ def test_something():
     );
 
     assert_cmd_snapshot!(context.command_no_parallel(), @r#"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
             PASS [TIME] test::test_something
 
     diagnostics:
 
-    warning[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `failing_teardown_fixture`
+    error[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `failing_teardown_fixture`
      --> test.py:5:5
       |
     4 | @karva.fixture(auto_use=True)
@@ -329,8 +329,8 @@ def test_second():
     );
 
     assert_cmd_snapshot!(context.command_no_parallel(), @r#"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
         Starting 2 tests across 1 worker
             PASS [TIME] test::test_first

--- a/crates/karva/tests/it/extensions/fixtures/generators.rs
+++ b/crates/karva/tests/it/extensions/fixtures/generators.rs
@@ -119,15 +119,15 @@ async def test_bad(bad_fixture):
     );
 
     assert_cmd_snapshot!(test_context.command(), @"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
             PASS [TIME] test::test_bad(bad_fixture=1)
 
     diagnostics:
 
-    warning[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `bad_fixture`
+    error[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `bad_fixture`
      --> test.py:4:11
       |
     3 | @karva.fixture
@@ -162,15 +162,15 @@ async def test_error(error_fixture):
     );
 
     assert_cmd_snapshot!(test_context.command(), @r#"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
             PASS [TIME] test::test_error(error_fixture=1)
 
     diagnostics:
 
-    warning[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `error_fixture`
+    error[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `error_fixture`
      --> test.py:4:11
       |
     3 | @karva.fixture

--- a/crates/karva/tests/it/extensions/fixtures/invalid.rs
+++ b/crates/karva/tests/it/extensions/fixtures/invalid.rs
@@ -366,15 +366,15 @@ fn test_fixture_generator_two_yields() {
     );
 
     assert_cmd_snapshot!(context.command(), @"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
             PASS [TIME] test::test_fixture_generator(fixture_generator=1)
 
     diagnostics:
 
-    warning[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `fixture_generator`
+    error[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `fixture_generator`
      --> test.py:5:5
       |
     4 | @karva.fixture
@@ -410,15 +410,15 @@ fn test_fixture_generator_fail_in_teardown() {
     );
 
     assert_cmd_snapshot!(context.command(), @r#"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
             PASS [TIME] test::test_fixture_generator(fixture_generator=1)
 
     diagnostics:
 
-    warning[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `fixture_generator`
+    error[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `fixture_generator`
      --> test.py:5:5
       |
     4 | @karva.fixture

--- a/crates/karva_cache/src/artifact.rs
+++ b/crates/karva_cache/src/artifact.rs
@@ -1,26 +1,10 @@
 //! Cache artifact catalogue.
 //!
-//! The cache directory hierarchy contains a small, fixed set of files. Each
-//! file lives at a known path and has a known on-disk format (pretty-printed
-//! JSON or plain text). Centralising those pairings here means adding a new
-//! artifact requires changing exactly one file, and the read/write helpers
-//! cannot accidentally mismatch a filename with the wrong serializer.
-//!
-//! The hierarchy is:
-//!
-//! ```text
-//! .karva_cache/
-//! ├── last-failed.json                     <- LastFailed
-//! └── run-<hash>/
-//!     ├── fail-fast                        <- FailFastSignal
-//!     └── worker-<id>/
-//!         ├── stats.json                   <- Stats
-//!         ├── diagnostics.txt              <- Diagnostics
-//!         ├── discover_diagnostics.txt     <- DiscoveryDiagnostics
-//!         ├── durations.json               <- Durations
-//!         ├── failed_tests.json            <- FailedTests
-//!         └── flaky_tests.json             <- FlakyTests
-//! ```
+//! The cache hierarchy has three levels — cache root, per-run directory, and
+//! per-worker directory — and a small fixed set of files at each level. Each
+//! file has a known on-disk format (pretty-printed JSON or plain text), so
+//! pairing the filename with its serializer in one place means adding a new
+//! artifact is a single-place change and read/write helpers can't drift.
 
 use std::fs;
 

--- a/crates/karva_cache/src/artifact.rs
+++ b/crates/karva_cache/src/artifact.rs
@@ -18,10 +18,8 @@ use serde::de::DeserializeOwned;
 pub enum CacheFile {
     /// Per-worker JSON: aggregated `TestResultStats`.
     Stats,
-    /// Per-worker text: rendered diagnostics from test execution.
+    /// Per-worker text: rendered diagnostics from discovery, collection, and execution.
     Diagnostics,
-    /// Per-worker text: rendered diagnostics from collection/discovery.
-    DiscoveryDiagnostics,
     /// Per-worker JSON: map of test id to wall-clock duration.
     Durations,
     /// Per-worker JSON: list of failed test names.
@@ -40,7 +38,6 @@ impl CacheFile {
         match self {
             Self::Stats => "stats.json",
             Self::Diagnostics => "diagnostics.txt",
-            Self::DiscoveryDiagnostics => "discover_diagnostics.txt",
             Self::Durations => "durations.json",
             Self::FailedTests => "failed_tests.json",
             Self::FlakyTests => "flaky_tests.json",

--- a/crates/karva_cache/src/artifact.rs
+++ b/crates/karva_cache/src/artifact.rs
@@ -1,0 +1,113 @@
+//! Cache artifact catalogue.
+//!
+//! The cache directory hierarchy contains a small, fixed set of files. Each
+//! file lives at a known path and has a known on-disk format (pretty-printed
+//! JSON or plain text). Centralising those pairings here means adding a new
+//! artifact requires changing exactly one file, and the read/write helpers
+//! cannot accidentally mismatch a filename with the wrong serializer.
+//!
+//! The hierarchy is:
+//!
+//! ```text
+//! .karva_cache/
+//! ├── last-failed.json                     <- LastFailed
+//! └── run-<hash>/
+//!     ├── fail-fast                        <- FailFastSignal
+//!     └── worker-<id>/
+//!         ├── stats.json                   <- Stats
+//!         ├── diagnostics.txt              <- Diagnostics
+//!         ├── discover_diagnostics.txt     <- DiscoveryDiagnostics
+//!         ├── durations.json               <- Durations
+//!         ├── failed_tests.json            <- FailedTests
+//!         └── flaky_tests.json             <- FlakyTests
+//! ```
+
+use std::fs;
+
+use anyhow::Result;
+use camino::{Utf8Path, Utf8PathBuf};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+/// One of the well-known files in the cache directory hierarchy.
+#[derive(Clone, Copy)]
+pub enum CacheFile {
+    /// Per-worker JSON: aggregated `TestResultStats`.
+    Stats,
+    /// Per-worker text: rendered diagnostics from test execution.
+    Diagnostics,
+    /// Per-worker text: rendered diagnostics from collection/discovery.
+    DiscoveryDiagnostics,
+    /// Per-worker JSON: map of test id to wall-clock duration.
+    Durations,
+    /// Per-worker JSON: list of failed test names.
+    FailedTests,
+    /// Per-worker JSON: list of `FlakyTest` records.
+    FlakyTests,
+    /// Per-run empty sentinel marking that fail-fast was triggered.
+    FailFastSignal,
+    /// Cache-root JSON: list of last-run failed test names.
+    LastFailed,
+}
+
+impl CacheFile {
+    /// Returns the on-disk filename for this artifact.
+    pub const fn filename(self) -> &'static str {
+        match self {
+            Self::Stats => "stats.json",
+            Self::Diagnostics => "diagnostics.txt",
+            Self::DiscoveryDiagnostics => "discover_diagnostics.txt",
+            Self::Durations => "durations.json",
+            Self::FailedTests => "failed_tests.json",
+            Self::FlakyTests => "flaky_tests.json",
+            Self::FailFastSignal => "fail-fast",
+            Self::LastFailed => "last-failed.json",
+        }
+    }
+
+    /// Joins this artifact's filename onto `dir`.
+    pub fn path_in(self, dir: &Utf8Path) -> Utf8PathBuf {
+        dir.join(self.filename())
+    }
+}
+
+/// Pretty-prints `value` as JSON and writes it to `dir/<file>`.
+pub fn write_json<T: Serialize>(dir: &Utf8Path, file: CacheFile, value: &T) -> Result<()> {
+    let json = serde_json::to_string_pretty(value)?;
+    fs::write(file.path_in(dir), json)?;
+    Ok(())
+}
+
+/// Like [`write_json`], but skips writing entirely when `items` is empty.
+///
+/// Used for artifacts where an empty list carries no information and the file
+/// is treated as absent by readers.
+pub fn write_json_if_nonempty<T: Serialize>(
+    dir: &Utf8Path,
+    file: CacheFile,
+    items: &[T],
+) -> Result<()> {
+    if items.is_empty() {
+        return Ok(());
+    }
+    write_json(dir, file, &items)
+}
+
+/// Reads `dir/<file>` as JSON, or returns `Ok(None)` when the file does not exist.
+pub fn read_json<T: DeserializeOwned>(dir: &Utf8Path, file: CacheFile) -> Result<Option<T>> {
+    let path = file.path_in(dir);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = fs::read_to_string(&path)?;
+    Ok(Some(serde_json::from_str(&content)?))
+}
+
+/// Reads `dir/<file>` as raw text, or returns `Ok(None)` when the file does not exist.
+pub fn read_text(dir: &Utf8Path, file: CacheFile) -> Result<Option<String>> {
+    let path = file.path_in(dir);
+    if !path.exists() {
+        return Ok(None);
+    }
+    Ok(Some(fs::read_to_string(&path)?))
+}

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -6,12 +6,10 @@ use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
 use karva_diagnostic::{FlakyTest, TestResultStats, TestRunResult};
 use ruff_db::diagnostic::{DisplayDiagnosticConfig, DisplayDiagnostics, FileResolver};
-use serde::de::DeserializeOwned;
 
-use crate::{
-    DIAGNOSTICS_FILE, DISCOVER_DIAGNOSTICS_FILE, DURATIONS_FILE, FAIL_FAST_SIGNAL_FILE,
-    FAILED_TESTS_FILE, FLAKY_TESTS_FILE, LAST_FAILED_FILE, RunHash, STATS_FILE, worker_folder,
-};
+use crate::RunHash;
+use crate::artifact::{CacheFile, read_json, read_text, write_json, write_json_if_nonempty};
+use crate::worker_folder;
 
 /// Aggregated test results collected from all worker processes.
 #[derive(Default)]
@@ -39,14 +37,13 @@ impl Cache {
     /// Writes a fail-fast signal file to indicate a worker encountered a test failure.
     pub fn write_fail_fast_signal(&self) -> Result<()> {
         fs::create_dir_all(&self.run_dir)?;
-        let signal_path = self.run_dir.join(FAIL_FAST_SIGNAL_FILE);
-        fs::write(signal_path, "")?;
+        fs::write(CacheFile::FailFastSignal.path_in(&self.run_dir), "")?;
         Ok(())
     }
 
     /// Checks whether any worker has written a fail-fast signal file.
     pub fn has_fail_fast_signal(&self) -> bool {
-        self.run_dir.join(FAIL_FAST_SIGNAL_FILE).exists()
+        CacheFile::FailFastSignal.path_in(&self.run_dir).exists()
     }
 
     /// Reads and merges test results from all worker directories for this run.
@@ -91,16 +88,26 @@ impl Cache {
         fs::create_dir_all(&worker_dir)?;
 
         write_diagnostics(&worker_dir, result, resolver, config)?;
-        write_stats(&worker_dir, result.stats())?;
-        write_durations(&worker_dir, result.durations())?;
-        write_failed_tests(&worker_dir, result.failed_tests())?;
-        write_flaky_tests(&worker_dir, result.flaky_tests())?;
+        write_json(&worker_dir, CacheFile::Stats, result.stats())?;
+        write_json(&worker_dir, CacheFile::Durations, result.durations())?;
+
+        let failed_names: Vec<String> = result
+            .failed_tests()
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+        write_json_if_nonempty(&worker_dir, CacheFile::FailedTests, &failed_names)?;
+        write_json_if_nonempty(&worker_dir, CacheFile::FlakyTests, result.flaky_tests())?;
 
         Ok(())
     }
 }
 
-/// Formats and writes test diagnostics and discovery diagnostics to files.
+/// Renders test and discovery diagnostics into the worker directory.
+///
+/// Diagnostics use the ruff `DisplayDiagnostics` formatter rather than JSON,
+/// so they don't share the [`write_json`] path; both files are skipped when
+/// their respective diagnostic lists are empty.
 fn write_diagnostics(
     worker_dir: &Utf8Path,
     result: &TestRunResult,
@@ -109,13 +116,16 @@ fn write_diagnostics(
 ) -> Result<()> {
     if !result.diagnostics().is_empty() {
         let output = DisplayDiagnostics::new(resolver, config, result.diagnostics());
-        fs::write(worker_dir.join(DIAGNOSTICS_FILE), output.to_string())?;
+        fs::write(
+            CacheFile::Diagnostics.path_in(worker_dir),
+            output.to_string(),
+        )?;
     }
 
     if !result.discovery_diagnostics().is_empty() {
         let output = DisplayDiagnostics::new(resolver, config, result.discovery_diagnostics());
         fs::write(
-            worker_dir.join(DISCOVER_DIAGNOSTICS_FILE),
+            CacheFile::DiscoveryDiagnostics.path_in(worker_dir),
             output.to_string(),
         )?;
     }
@@ -123,87 +133,30 @@ fn write_diagnostics(
     Ok(())
 }
 
-/// Writes test result stats as JSON.
-fn write_stats(worker_dir: &Utf8Path, stats: &TestResultStats) -> Result<()> {
-    let json = serde_json::to_string_pretty(stats)?;
-    fs::write(worker_dir.join(STATS_FILE), json)?;
-    Ok(())
-}
-
-/// Writes test durations as JSON.
-fn write_durations<K: serde::Serialize, V: serde::Serialize>(
-    worker_dir: &Utf8Path,
-    durations: &HashMap<K, V>,
-) -> Result<()> {
-    let json = serde_json::to_string_pretty(durations)?;
-    fs::write(worker_dir.join(DURATIONS_FILE), json)?;
-    Ok(())
-}
-
-/// Writes the list of failed test names as JSON, skipping if empty.
-fn write_failed_tests(worker_dir: &Utf8Path, failed_tests: &[impl ToString]) -> Result<()> {
-    if !failed_tests.is_empty() {
-        let names: Vec<String> = failed_tests.iter().map(ToString::to_string).collect();
-        let json = serde_json::to_string_pretty(&names)?;
-        fs::write(worker_dir.join(FAILED_TESTS_FILE), json)?;
-    }
-    Ok(())
-}
-
-/// Writes the list of flaky tests as JSON, skipping if empty.
-fn write_flaky_tests(worker_dir: &Utf8Path, flaky_tests: &[FlakyTest]) -> Result<()> {
-    if !flaky_tests.is_empty() {
-        let json = serde_json::to_string_pretty(flaky_tests)?;
-        fs::write(worker_dir.join(FLAKY_TESTS_FILE), json)?;
-    }
-    Ok(())
-}
-
-/// Reads a JSON file from a directory and deserializes it, returning `None` if the file
-/// does not exist.
-fn read_and_parse<T: DeserializeOwned>(dir: &Utf8Path, filename: &str) -> Result<Option<T>> {
-    let path = dir.join(filename);
-    if !path.exists() {
-        return Ok(None);
-    }
-    let content = fs::read_to_string(&path)?;
-    let value = serde_json::from_str(&content)?;
-    Ok(Some(value))
-}
-
-/// Reads a text file from a directory, returning `None` if the file does not exist.
-fn read_text(dir: &Utf8Path, filename: &str) -> Result<Option<String>> {
-    let path = dir.join(filename);
-    if !path.exists() {
-        return Ok(None);
-    }
-    Ok(Some(fs::read_to_string(&path)?))
-}
-
-/// Read results from a single worker directory into the accumulator.
+/// Reads results from a single worker directory into the accumulator.
 fn read_worker_results(worker_dir: &Utf8Path, results: &mut AggregatedResults) -> Result<()> {
-    if let Some(stats) = read_and_parse::<TestResultStats>(worker_dir, STATS_FILE)? {
+    if let Some(stats) = read_json::<TestResultStats>(worker_dir, CacheFile::Stats)? {
         results.stats.merge(&stats);
     }
 
-    if let Some(content) = read_text(worker_dir, DIAGNOSTICS_FILE)? {
+    if let Some(content) = read_text(worker_dir, CacheFile::Diagnostics)? {
         results.diagnostics.push_str(&content);
     }
 
-    if let Some(content) = read_text(worker_dir, DISCOVER_DIAGNOSTICS_FILE)? {
+    if let Some(content) = read_text(worker_dir, CacheFile::DiscoveryDiagnostics)? {
         results.discovery_diagnostics.push_str(&content);
     }
 
-    if let Some(failed) = read_and_parse::<Vec<String>>(worker_dir, FAILED_TESTS_FILE)? {
+    if let Some(failed) = read_json::<Vec<String>>(worker_dir, CacheFile::FailedTests)? {
         results.failed_tests.extend(failed);
     }
 
-    if let Some(flaky) = read_and_parse::<Vec<FlakyTest>>(worker_dir, FLAKY_TESTS_FILE)? {
+    if let Some(flaky) = read_json::<Vec<FlakyTest>>(worker_dir, CacheFile::FlakyTests)? {
         results.flaky_tests.extend(flaky);
     }
 
     if let Some(durations) =
-        read_and_parse::<HashMap<String, Duration>>(worker_dir, DURATIONS_FILE)?
+        read_json::<HashMap<String, Duration>>(worker_dir, CacheFile::Durations)?
     {
         results.durations.extend(durations);
     }
@@ -216,23 +169,14 @@ fn read_worker_results(worker_dir: &Utf8Path, results: &mut AggregatedResults) -
 /// This overwrites any previous last-failed list.
 pub fn write_last_failed(cache_dir: &Utf8Path, failed_tests: &[String]) -> Result<()> {
     fs::create_dir_all(cache_dir)?;
-    let path = cache_dir.join(LAST_FAILED_FILE);
-    let json = serde_json::to_string_pretty(failed_tests)?;
-    fs::write(path, json)?;
-    Ok(())
+    write_json(cache_dir, CacheFile::LastFailed, &failed_tests)
 }
 
 /// Reads the list of previously failed tests from the cache directory root.
 ///
 /// Returns an empty list if the file does not exist.
 pub fn read_last_failed(cache_dir: &Utf8Path) -> Result<Vec<String>> {
-    let path = cache_dir.join(LAST_FAILED_FILE);
-    if !path.exists() {
-        return Ok(Vec::new());
-    }
-    let content = fs::read_to_string(&path)?;
-    let failed_tests: Vec<String> = serde_json::from_str(&content)?;
-    Ok(failed_tests)
+    Ok(read_json::<Vec<String>>(cache_dir, CacheFile::LastFailed)?.unwrap_or_default())
 }
 
 /// Collects sorted `run-*` directory names from the cache directory.
@@ -280,7 +224,7 @@ pub fn read_recent_durations(cache_dir: &Utf8PathBuf) -> Result<HashMap<String, 
         }
 
         if let Some(durations) =
-            read_and_parse::<HashMap<String, Duration>>(&worker_path, DURATIONS_FILE)?
+            read_json::<HashMap<String, Duration>>(&worker_path, CacheFile::Durations)?
         {
             aggregated_durations.extend(durations);
         }
@@ -347,7 +291,7 @@ mod tests {
         let worker_dir = dir.join(run_name).join(format!("worker-{worker_id}"));
         fs::create_dir_all(&worker_dir).unwrap();
         let json = serde_json::to_string(durations).unwrap();
-        fs::write(worker_dir.join(DURATIONS_FILE), json).unwrap();
+        fs::write(worker_dir.join(CacheFile::Durations.filename()), json).unwrap();
     }
 
     fn create_cache_with_stats(
@@ -358,7 +302,7 @@ mod tests {
     ) {
         let worker_dir = dir.join(run_name).join(format!("worker-{worker_id}"));
         fs::create_dir_all(&worker_dir).unwrap();
-        fs::write(worker_dir.join(STATS_FILE), stats_json).unwrap();
+        fs::write(worker_dir.join(CacheFile::Stats.filename()), stats_json).unwrap();
     }
 
     #[test]
@@ -583,20 +527,28 @@ mod tests {
         fs::create_dir_all(&worker0).unwrap();
         fs::create_dir_all(&worker1).unwrap();
 
-        fs::write(worker0.join(FAILED_TESTS_FILE), r#"["mod::test_a"]"#).unwrap();
-        fs::write(worker1.join(FAILED_TESTS_FILE), r#"["mod::test_b"]"#).unwrap();
+        fs::write(
+            worker0.join(CacheFile::FailedTests.filename()),
+            r#"["mod::test_a"]"#,
+        )
+        .unwrap();
+        fs::write(
+            worker1.join(CacheFile::FailedTests.filename()),
+            r#"["mod::test_b"]"#,
+        )
+        .unwrap();
 
         let mut d0 = HashMap::new();
         d0.insert("mod::test_a".to_string(), Duration::from_millis(10));
         let mut d1 = HashMap::new();
         d1.insert("mod::test_b".to_string(), Duration::from_millis(20));
         fs::write(
-            worker0.join(DURATIONS_FILE),
+            worker0.join(CacheFile::Durations.filename()),
             serde_json::to_string(&d0).unwrap(),
         )
         .unwrap();
         fs::write(
-            worker1.join(DURATIONS_FILE),
+            worker1.join(CacheFile::Durations.filename()),
             serde_json::to_string(&d1).unwrap(),
         )
         .unwrap();

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -7,29 +7,27 @@ use camino::{Utf8Path, Utf8PathBuf};
 use karva_diagnostic::{FlakyTest, TestResultStats, TestRunResult};
 use ruff_db::diagnostic::{DisplayDiagnosticConfig, DisplayDiagnostics, FileResolver};
 
-use crate::RunHash;
 use crate::artifact::{CacheFile, read_json, read_text, write_json, write_json_if_nonempty};
-use crate::worker_folder;
+use crate::{RUN_PREFIX, RunHash, WORKER_PREFIX, worker_folder};
 
 /// Aggregated test results collected from all worker processes.
 #[derive(Default)]
 pub struct AggregatedResults {
     pub stats: TestResultStats,
     pub diagnostics: String,
-    pub discovery_diagnostics: String,
     pub failed_tests: Vec<String>,
     pub flaky_tests: Vec<FlakyTest>,
     pub durations: HashMap<String, Duration>,
 }
 
 /// Reads and writes test results in the cache directory for a specific run.
-pub struct Cache {
+pub struct RunCache {
     run_dir: Utf8PathBuf,
 }
 
-impl Cache {
+impl RunCache {
     /// Constructs a cache handle for a specific run within the cache directory.
-    pub fn new(cache_dir: &Utf8PathBuf, run_hash: &RunHash) -> Self {
+    pub fn new(cache_dir: &Utf8Path, run_hash: &RunHash) -> Self {
         let run_dir = cache_dir.join(run_hash.to_string());
         Self { run_dir }
     }
@@ -50,27 +48,8 @@ impl Cache {
     pub fn aggregate_results(&self) -> Result<AggregatedResults> {
         let mut results = AggregatedResults::default();
 
-        if self.run_dir.exists() {
-            let mut worker_dirs: Vec<Utf8PathBuf> = fs::read_dir(&self.run_dir)?
-                .filter_map(|entry| {
-                    let entry = entry.ok()?;
-                    let path = Utf8PathBuf::try_from(entry.path()).ok()?;
-                    if path.is_dir()
-                        && path
-                            .file_name()
-                            .is_some_and(|name| name.starts_with("worker-"))
-                    {
-                        Some(path)
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-            worker_dirs.sort();
-
-            for worker_dir in &worker_dirs {
-                read_worker_results(worker_dir, &mut results)?;
-            }
+        for worker_dir in list_worker_dirs(&self.run_dir)? {
+            read_worker_results(&worker_dir, &mut results)?;
         }
 
         Ok(results)
@@ -103,33 +82,25 @@ impl Cache {
     }
 }
 
-/// Renders test and discovery diagnostics into the worker directory.
+/// Renders diagnostics into the worker directory.
 ///
 /// Diagnostics use the ruff `DisplayDiagnostics` formatter rather than JSON,
-/// so they don't share the [`write_json`] path; both files are skipped when
-/// their respective diagnostic lists are empty.
+/// so they don't share the [`write_json`] path; the file is skipped entirely
+/// when there are no diagnostics.
 fn write_diagnostics(
     worker_dir: &Utf8Path,
     result: &TestRunResult,
     resolver: &dyn FileResolver,
     config: &DisplayDiagnosticConfig,
 ) -> Result<()> {
-    if !result.diagnostics().is_empty() {
-        let output = DisplayDiagnostics::new(resolver, config, result.diagnostics());
-        fs::write(
-            CacheFile::Diagnostics.path_in(worker_dir),
-            output.to_string(),
-        )?;
+    if result.diagnostics().is_empty() {
+        return Ok(());
     }
-
-    if !result.discovery_diagnostics().is_empty() {
-        let output = DisplayDiagnostics::new(resolver, config, result.discovery_diagnostics());
-        fs::write(
-            CacheFile::DiscoveryDiagnostics.path_in(worker_dir),
-            output.to_string(),
-        )?;
-    }
-
+    let output = DisplayDiagnostics::new(resolver, config, result.diagnostics());
+    fs::write(
+        CacheFile::Diagnostics.path_in(worker_dir),
+        output.to_string(),
+    )?;
     Ok(())
 }
 
@@ -141,10 +112,6 @@ fn read_worker_results(worker_dir: &Utf8Path, results: &mut AggregatedResults) -
 
     if let Some(content) = read_text(worker_dir, CacheFile::Diagnostics)? {
         results.diagnostics.push_str(&content);
-    }
-
-    if let Some(content) = read_text(worker_dir, CacheFile::DiscoveryDiagnostics)? {
-        results.discovery_diagnostics.push_str(&content);
     }
 
     if let Some(failed) = read_json::<Vec<String>>(worker_dir, CacheFile::FailedTests)? {
@@ -179,22 +146,45 @@ pub fn read_last_failed(cache_dir: &Utf8Path) -> Result<Vec<String>> {
     Ok(read_json::<Vec<String>>(cache_dir, CacheFile::LastFailed)?.unwrap_or_default())
 }
 
-/// Collects sorted `run-*` directory names from the cache directory.
-fn collect_run_dirs(cache_dir: &Utf8Path) -> Result<Vec<String>> {
-    let mut run_dirs = Vec::new();
-
-    for entry in fs::read_dir(cache_dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.is_dir() {
-            if let Some(dir_name) = path.file_name().and_then(|n| n.to_str()) {
-                if dir_name.starts_with("run-") {
-                    run_dirs.push(dir_name.to_string());
-                }
-            }
-        }
+/// Lists subdirectories of `parent` whose name starts with `prefix`.
+///
+/// Returns an empty vec if `parent` does not exist. Non-UTF-8 entries and
+/// non-directory entries are silently skipped.
+fn list_subdirs_with_prefix(parent: &Utf8Path, prefix: &str) -> Result<Vec<Utf8PathBuf>> {
+    if !parent.exists() {
+        return Ok(Vec::new());
     }
 
+    let mut dirs = Vec::new();
+    for entry in fs::read_dir(parent)? {
+        let entry = entry?;
+        let Ok(path) = Utf8PathBuf::try_from(entry.path()) else {
+            continue;
+        };
+        if path.is_dir()
+            && path
+                .file_name()
+                .is_some_and(|name| name.starts_with(prefix))
+        {
+            dirs.push(path);
+        }
+    }
+    Ok(dirs)
+}
+
+/// Returns sorted `worker-*` directories within a run directory.
+fn list_worker_dirs(run_dir: &Utf8Path) -> Result<Vec<Utf8PathBuf>> {
+    let mut dirs = list_subdirs_with_prefix(run_dir, WORKER_PREFIX)?;
+    dirs.sort();
+    Ok(dirs)
+}
+
+/// Returns `run-*` directory names sorted chronologically by their parsed timestamp.
+fn collect_run_dirs(cache_dir: &Utf8Path) -> Result<Vec<String>> {
+    let mut run_dirs: Vec<String> = list_subdirs_with_prefix(cache_dir, RUN_PREFIX)?
+        .into_iter()
+        .filter_map(|p| p.file_name().map(str::to_string))
+        .collect();
     run_dirs.sort_by_key(|hash| RunHash::from_existing(hash).sort_key());
     Ok(run_dirs)
 }
@@ -203,33 +193,21 @@ fn collect_run_dirs(cache_dir: &Utf8Path) -> Result<Vec<String>> {
 ///
 /// Finds the most recent `run-{timestamp}` directory, then aggregates
 /// all durations from all worker directories within it.
-pub fn read_recent_durations(cache_dir: &Utf8PathBuf) -> Result<HashMap<String, Duration>> {
+pub fn read_recent_durations(cache_dir: &Utf8Path) -> Result<HashMap<String, Duration>> {
     let run_dirs = collect_run_dirs(cache_dir)?;
-
     let most_recent = run_dirs
         .last()
         .ok_or_else(|| anyhow::anyhow!("No run directories found"))?;
-
     let run_dir = cache_dir.join(most_recent);
 
     let mut aggregated_durations = HashMap::new();
-
-    for entry in fs::read_dir(&run_dir)? {
-        let entry = entry?;
-        let worker_path = Utf8PathBuf::try_from(entry.path())
-            .map_err(|e| anyhow::anyhow!("Invalid UTF-8 path: {e}"))?;
-
-        if !worker_path.is_dir() {
-            continue;
-        }
-
+    for worker_dir in list_worker_dirs(&run_dir)? {
         if let Some(durations) =
-            read_json::<HashMap<String, Duration>>(&worker_path, CacheFile::Durations)?
+            read_json::<HashMap<String, Duration>>(&worker_dir, CacheFile::Durations)?
         {
             aggregated_durations.extend(durations);
         }
     }
-
     Ok(aggregated_durations)
 }
 
@@ -342,7 +320,7 @@ mod tests {
         create_cache_with_stats(tmp.path(), "run-500", 0, r#"{"passed": 3, "failed": 1}"#);
         create_cache_with_stats(tmp.path(), "run-500", 1, r#"{"passed": 2, "skipped": 1}"#);
 
-        let cache = Cache::new(&cache_dir, &run_hash);
+        let cache = RunCache::new(&cache_dir, &run_hash);
         let results = cache.aggregate_results().unwrap();
 
         assert_eq!(results.stats.passed(), 5);
@@ -359,7 +337,7 @@ mod tests {
         let run_dir = tmp.path().join("run-600");
         fs::create_dir_all(&run_dir).unwrap();
 
-        let cache = Cache::new(&cache_dir, &run_hash);
+        let cache = RunCache::new(&cache_dir, &run_hash);
         let results = cache.aggregate_results().unwrap();
 
         assert_eq!(results.stats.total(), 0);
@@ -553,7 +531,7 @@ mod tests {
         )
         .unwrap();
 
-        let cache = Cache::new(&cache_dir, &run_hash);
+        let cache = RunCache::new(&cache_dir, &run_hash);
         let results = cache.aggregate_results().unwrap();
 
         let mut failed = results.failed_tests.clone();
@@ -586,7 +564,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let cache_dir = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
         let run_hash = RunHash::from_existing("run-800");
-        let cache = Cache::new(&cache_dir, &run_hash);
+        let cache = RunCache::new(&cache_dir, &run_hash);
 
         assert!(!cache.has_fail_fast_signal());
         cache.write_fail_fast_signal().unwrap();

--- a/crates/karva_cache/src/hash.rs
+++ b/crates/karva_cache/src/hash.rs
@@ -3,6 +3,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
+use crate::RUN_PREFIX;
+
 /// A unique identifier for a test run based on a millisecond timestamp.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct RunHash {
@@ -25,7 +27,7 @@ impl RunHash {
     /// Falls back to timestamp `0` if the input cannot be parsed.
     pub fn from_existing(hash: &str) -> Self {
         let timestamp = hash
-            .strip_prefix("run-")
+            .strip_prefix(RUN_PREFIX)
             .unwrap_or(hash)
             .parse()
             .unwrap_or(0);
@@ -34,7 +36,7 @@ impl RunHash {
 
     /// Returns the string representation used as a directory name (e.g. `run-1234`).
     pub fn inner(&self) -> String {
-        format!("run-{}", self.timestamp)
+        format!("{RUN_PREFIX}{}", self.timestamp)
     }
 
     /// Returns the underlying timestamp, used for ordering runs chronologically.

--- a/crates/karva_cache/src/lib.rs
+++ b/crates/karva_cache/src/lib.rs
@@ -3,7 +3,7 @@ pub(crate) mod cache;
 pub(crate) mod hash;
 
 pub use cache::{
-    AggregatedResults, Cache, PruneResult, clean_cache, prune_cache, read_last_failed,
+    AggregatedResults, PruneResult, RunCache, clean_cache, prune_cache, read_last_failed,
     read_recent_durations, write_last_failed,
 };
 pub use hash::RunHash;
@@ -12,7 +12,13 @@ pub use karva_diagnostic::{DisplayFlakyTests, FlakyTest};
 /// The directory name used for the cache, relative to the project root.
 pub const CACHE_DIR: &str = ".karva_cache";
 
+/// Filename prefix for per-run sub-directories of the cache.
+pub(crate) const RUN_PREFIX: &str = "run-";
+
+/// Filename prefix for per-worker sub-directories of a run directory.
+pub(crate) const WORKER_PREFIX: &str = "worker-";
+
 /// Returns the conventional sub-directory name for a worker within a run directory.
 pub(crate) fn worker_folder(worker_id: usize) -> String {
-    format!("worker-{worker_id}")
+    format!("{WORKER_PREFIX}{worker_id}")
 }

--- a/crates/karva_cache/src/lib.rs
+++ b/crates/karva_cache/src/lib.rs
@@ -1,3 +1,4 @@
+pub(crate) mod artifact;
 pub(crate) mod cache;
 pub(crate) mod hash;
 
@@ -8,16 +9,10 @@ pub use cache::{
 pub use hash::RunHash;
 pub use karva_diagnostic::{DisplayFlakyTests, FlakyTest};
 
+/// The directory name used for the cache, relative to the project root.
 pub const CACHE_DIR: &str = ".karva_cache";
-pub(crate) const STATS_FILE: &str = "stats.json";
-pub(crate) const DIAGNOSTICS_FILE: &str = "diagnostics.txt";
-pub(crate) const DISCOVER_DIAGNOSTICS_FILE: &str = "discover_diagnostics.txt";
-pub(crate) const DURATIONS_FILE: &str = "durations.json";
-pub(crate) const FAILED_TESTS_FILE: &str = "failed_tests.json";
-pub(crate) const FLAKY_TESTS_FILE: &str = "flaky_tests.json";
-const FAIL_FAST_SIGNAL_FILE: &str = "fail-fast";
-const LAST_FAILED_FILE: &str = "last-failed.json";
 
+/// Returns the conventional sub-directory name for a worker within a run directory.
 pub(crate) fn worker_folder(worker_id: usize) -> String {
     format!("worker-{worker_id}")
 }

--- a/crates/karva_diagnostic/src/result/mod.rs
+++ b/crates/karva_diagnostic/src/result/mod.rs
@@ -18,10 +18,8 @@ pub use stats::TestResultStats;
 /// This is held in the test context and updated throughout the test run.
 #[derive(Debug, Clone, Default)]
 pub struct TestRunResult {
-    /// Diagnostics generated during test discovery.
-    discovery_diagnostics: Vec<Diagnostic>,
-
-    /// Diagnostics generated during test collection and  execution.
+    /// Diagnostics generated during test discovery, collection, and execution,
+    /// in the order they were emitted.
     diagnostics: Vec<Diagnostic>,
 
     /// Stats generated during test execution.
@@ -40,14 +38,6 @@ pub struct TestRunResult {
 impl TestRunResult {
     pub fn diagnostics(&self) -> &[Diagnostic] {
         &self.diagnostics
-    }
-
-    pub fn discovery_diagnostics(&self) -> &[Diagnostic] {
-        &self.discovery_diagnostics
-    }
-
-    pub fn add_discovery_diagnostic(&mut self, diagnostic: Diagnostic) {
-        self.discovery_diagnostics.push(diagnostic);
     }
 
     pub fn add_diagnostic(&mut self, diagnostic: Diagnostic) {

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -10,7 +10,7 @@ use crossbeam_channel::{Receiver, TryRecvError};
 
 use crate::shutdown::shutdown_receiver;
 use karva_cache::{
-    AggregatedResults, CACHE_DIR, Cache, RunHash, read_last_failed, read_recent_durations,
+    AggregatedResults, CACHE_DIR, RunCache, RunHash, read_last_failed, read_recent_durations,
     write_last_failed,
 };
 use karva_cli::SubTestCommand;
@@ -58,7 +58,11 @@ impl WorkerManager {
     /// Wait for all workers to complete.
     /// Returns early if a message is received on `shutdown_rx` or if the cache
     /// contains a fail-fast signal indicating a worker encountered a test failure.
-    fn wait_for_completion(&mut self, shutdown_rx: Option<&Receiver<()>>, cache: Option<&Cache>) {
+    fn wait_for_completion(
+        &mut self,
+        shutdown_rx: Option<&Receiver<()>>,
+        cache: Option<&RunCache>,
+    ) {
         if self.workers.is_empty() {
             return;
         }
@@ -340,7 +344,7 @@ pub fn run_parallel_tests(
         None
     };
 
-    let cache = Cache::new(&cache_dir, &run_hash);
+    let cache = RunCache::new(&cache_dir, &run_hash);
 
     let max_fail_cache = project.settings().max_fail().has_limit().then_some(&cache);
 

--- a/crates/karva_test_semantic/src/context.rs
+++ b/crates/karva_test_semantic/src/context.rs
@@ -155,14 +155,7 @@ impl<'a> Context<'a> {
         &'ctx self,
         rule: &'static DiagnosticType,
     ) -> DiagnosticGuardBuilder<'ctx, 'a> {
-        DiagnosticGuardBuilder::new(self, rule, false)
-    }
-
-    pub(crate) fn report_discovery_diagnostic<'ctx>(
-        &'ctx self,
-        rule: &'static DiagnosticType,
-    ) -> DiagnosticGuardBuilder<'ctx, 'a> {
-        DiagnosticGuardBuilder::new(self, rule, true)
+        DiagnosticGuardBuilder::new(self, rule)
     }
 
     pub fn python_version(&self) -> PythonVersion {

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -26,9 +26,11 @@ use crate::{Context, declare_diagnostic_type};
 declare_diagnostic_type! {
     /// ## Failed to import module
     ///
-    /// This comes from when we try to import tests or fixtures.
-    /// If we try to import a module and it fails, we will raise this warning.
-    /// Tests that were successfully collected still run and determine the exit code.
+    /// Raised when karva tries to import a test module or fixture file and the
+    /// import itself fails (e.g. a syntax error, an unresolved import, an
+    /// exception at top level). Any tests inside the module are not discovered;
+    /// successfully-collected tests in other modules still run, but the run
+    /// exits non-zero.
     pub static FAILED_TO_IMPORT_MODULE = {
         summary: "Failed to import python module",
         severity: Severity::Error,
@@ -53,7 +55,7 @@ declare_diagnostic_type! {
     /// If a finalizer tries to yield another value, we will raise this error.
     pub static INVALID_FIXTURE_FINALIZER = {
         summary: "Tried to run an invalid fixture finalizer",
-        severity: Severity::Warning,
+        severity: Severity::Error,
     }
 }
 
@@ -137,7 +139,7 @@ fn report_dependency_chain(
 }
 
 pub fn report_failed_to_import_module(context: &Context, module_name: &str, error: &str) {
-    let builder = context.report_discovery_diagnostic(&FAILED_TO_IMPORT_MODULE);
+    let builder = context.report_diagnostic(&FAILED_TO_IMPORT_MODULE);
 
     builder.into_diagnostic(format!(
         "Failed to import python module `{module_name}`: {error}"

--- a/crates/karva_test_semantic/src/diagnostic/metadata.rs
+++ b/crates/karva_test_semantic/src/diagnostic/metadata.rs
@@ -50,22 +50,17 @@ pub struct DiagnosticGuardBuilder<'ctx, 'a> {
 
     /// Severity level for this diagnostic.
     severity: Severity,
-
-    /// Whether this diagnostic occurred during test discovery.
-    is_discovery: bool,
 }
 
 impl<'ctx, 'a> DiagnosticGuardBuilder<'ctx, 'a> {
     pub(crate) fn new(
         context: &'ctx Context<'a>,
         diagnostic_type: &'static DiagnosticType,
-        is_discovery: bool,
     ) -> Self {
         DiagnosticGuardBuilder {
             context,
             id: DiagnosticId::Lint(diagnostic_type.name),
             severity: diagnostic_type.severity,
-            is_discovery,
         }
     }
 
@@ -77,7 +72,6 @@ impl<'ctx, 'a> DiagnosticGuardBuilder<'ctx, 'a> {
         DiagnosticGuard {
             context: self.context,
             diag: Some(Diagnostic::new(self.id, self.severity, message)),
-            is_discovery: self.is_discovery,
         }
     }
 }
@@ -92,9 +86,6 @@ pub struct DiagnosticGuard<'ctx, 'a> {
 
     /// The diagnostic being built, wrapped in Option for take-on-drop.
     diag: Option<Diagnostic>,
-
-    /// Whether this diagnostic occurred during test discovery.
-    is_discovery: bool,
 }
 
 /// Return a immutable borrow of the diagnostic in this guard.
@@ -116,11 +107,6 @@ impl std::ops::DerefMut for DiagnosticGuard<'_, '_> {
 impl Drop for DiagnosticGuard<'_, '_> {
     fn drop(&mut self) {
         let diag = self.diag.take().unwrap();
-
-        if self.is_discovery {
-            self.context.result().add_discovery_diagnostic(diag);
-        } else {
-            self.context.result().add_diagnostic(diag);
-        }
+        self.context.result().add_diagnostic(diag);
     }
 }

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -6,7 +6,7 @@ use anyhow::Context as _;
 use camino::Utf8PathBuf;
 use clap::Parser;
 use colored::Colorize;
-use karva_cache::{Cache, RunHash};
+use karva_cache::{RunCache, RunHash};
 use karva_cli::{SubTestCommand, Verbosity};
 use karva_diagnostic::{DummyReporter, Reporter, TestCaseReporter};
 use karva_logging::{Printer, StatusLevel, set_colored_override, setup_tracing};
@@ -164,7 +164,7 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
 
     let run_hash = RunHash::from_existing(&args.run_hash);
 
-    let cache = Cache::new(&args.cache_dir, &run_hash);
+    let cache = RunCache::new(&args.cache_dir, &run_hash);
 
     let reporter: Box<dyn Reporter> = if matches!(printer.status_level(), StatusLevel::None) {
         Box::new(DummyReporter)


### PR DESCRIPTION
## Summary

Three coupled cleanups in `karva_cache` and the diagnostic pipeline.

The first wave centralises the cache artifact catalogue. The cache directory hierarchy is a small fixed set of files, but each filename used to live as a free `const` in `lib.rs` and each artifact had its own hand-rolled writer that knew which constant to pair with which serializer. There was no compile-time link between the three. A new `CacheFile` enum names every file in the hierarchy, and a small set of generic helpers (`write_json`, `write_json_if_nonempty`, `read_json`, `read_text`) take a `CacheFile` instead of a bare filename string. The four near-identical per-artifact write helpers collapse into direct calls against the generics. Adding a new artifact is now a single-place change.

The second wave is a name-and-shape pass. The struct named `Cache` was actually a handle to a single run's directory, not the cache as a whole — renamed to `RunCache` so the type matches the responsibility. The `run-` and `worker-` prefix strings move into module-level constants. The two near-duplicate filtered `fs::read_dir` loops in `aggregate_results` and `read_recent_durations` collapse into one `list_worker_dirs` helper, which also fixes a latent inconsistency (the second loop didn't filter to `worker-` directories). Public APIs that previously took `&Utf8PathBuf` now take `&Utf8Path`.

The third wave merges discovery diagnostics into a single diagnostics stream. `TestRunResult` kept two separate `Vec<Diagnostic>` for discovery vs. execution-phase diagnostics, with two cache files, two `String` fields on `AggregatedResults`, two render branches in the consumer, and an `is_discovery` flag plumbed through `DiagnosticGuardBuilder`. The split was a leak of producer-side structure into the on-disk format and the consumer — the consumer only ever rendered them in a fixed order through the same formatter. Collapsed to one stream end-to-end: dropped `CacheFile::DiscoveryDiagnostics`, `AggregatedResults::discovery_diagnostics`, the `is_discovery` flag on the diagnostic guard, and the `discovery_diagnostic` builder on `Context`. To preserve the existing exit-code semantics with a single stream, `INVALID_FIXTURE_FINALIZER` is promoted from `Warning` to `Error` (its docstring already calls it an error), so the consumer model becomes "any diagnostic fails the run" without needing a per-severity signal.

## Test Plan

ci