### PR TITLE
Expose KARVA_PROFILE, KARVA_TEST_THREADS, and KARVA_VERSION to tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,6 +1308,7 @@ dependencies = [
  "karva_metadata",
  "karva_project",
  "karva_static",
+ "karva_version",
  "tracing",
  "uuid",
  "which",

--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -55,8 +55,8 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
     };
 
     let profile = args.profile.clone();
-    let project_options_overrides =
-        ProjectOptionsOverrides::new(config_file, args.into_options()).with_profile(profile);
+    let project_options_overrides = ProjectOptionsOverrides::new(config_file, args.into_options())
+        .with_profile(profile.clone());
     project_metadata
         .apply_overrides(&project_options_overrides)
         .map_err(|err| anyhow::anyhow!("{err}"))?;
@@ -75,6 +75,7 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
         no_cache,
         create_ctrlc_handler: true,
         last_failed,
+        profile,
     };
 
     if watch {

--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -2339,10 +2339,11 @@ def test_always_fails(): assert False
     );
 }
 
-/// `KARVA`, `KARVA_WORKER_ID`, `KARVA_RUN_ID`, and `KARVA_WORKSPACE_ROOT` are
-/// exposed to the test process. The values come from the worker spawn (not
-/// from the test's own `os.environ` writes), so a single passing test is
-/// enough to exercise all four.
+/// `KARVA`, `KARVA_WORKER_ID`, `KARVA_RUN_ID`, `KARVA_WORKSPACE_ROOT`,
+/// `KARVA_PROFILE`, `KARVA_TEST_THREADS`, and `KARVA_VERSION` are exposed to
+/// the test process. The values come from the worker spawn (not from the
+/// test's own `os.environ` writes), so a single passing test is enough to
+/// exercise all of them.
 #[test]
 fn test_karva_static_env_vars() {
     let context = TestContext::with_file(
@@ -2359,6 +2360,10 @@ def test_static_env():
         os.environ["KARVA_RUN_ID"],
     ), os.environ["KARVA_RUN_ID"]
     assert os.environ["KARVA_WORKSPACE_ROOT"] == os.getcwd()
+    assert os.environ["KARVA_PROFILE"] == "default"
+    assert os.environ["KARVA_TEST_THREADS"] == "1"
+    assert re.fullmatch(r"\d+\.\d+\.\d+(-[A-Za-z0-9.]+)?", os.environ["KARVA_VERSION"]), \
+        os.environ["KARVA_VERSION"]
         "#,
     );
 
@@ -2368,6 +2373,42 @@ def test_static_env():
     ----- stdout -----
         Starting 1 test across 1 worker
             PASS [TIME] test::test_static_env
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+/// `KARVA_PROFILE` reflects the active profile when `--profile` is passed,
+/// rather than always being `"default"`.
+#[test]
+fn test_karva_profile_env_reflects_active_profile() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r"
+[profile.fast.test]
+",
+        ),
+        (
+            "test.py",
+            r#"
+import os
+
+def test_profile_env():
+    assert os.environ["KARVA_PROFILE"] == "fast"
+        "#,
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--profile=fast"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_profile_env
 
     ────────────
          Summary [TIME] 1 test run: 1 passed, 0 skipped

--- a/crates/karva_benchmark/src/lib.rs
+++ b/crates/karva_benchmark/src/lib.rs
@@ -40,6 +40,7 @@ pub fn run_karva(project: &Project) {
         no_cache: false,
         create_ctrlc_handler: false,
         last_failed: false,
+        profile: None,
     };
 
     let args = SubTestCommand {

--- a/crates/karva_runner/Cargo.toml
+++ b/crates/karva_runner/Cargo.toml
@@ -19,6 +19,7 @@ karva_logging = { workspace = true }
 karva_metadata = { workspace = true }
 karva_project = { workspace = true }
 karva_static = { workspace = true }
+karva_version = { workspace = true }
 
 anyhow = { workspace = true }
 camino = { workspace = true }

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -156,25 +156,66 @@ pub struct ParallelTestConfig {
     pub profile: Option<String>,
 }
 
+/// Inputs shared by every worker spawned in a single run.
+struct WorkerSpawn<'a> {
+    project: &'a Project,
+    cache_dir: &'a Utf8PathBuf,
+    cache: &'a RunCache,
+    run_hash: &'a RunHash,
+    args: &'a SubTestCommand,
+    num_workers: usize,
+    profile: &'a str,
+    run_id: &'a str,
+    worker_binary: &'a Utf8PathBuf,
+    coverage_enabled: bool,
+}
+
+/// Build the `Command` for a single worker.
+fn worker_command(spawn: &WorkerSpawn, worker_id: usize, partition: &Partition) -> Command {
+    let mut cmd = Command::new(spawn.worker_binary);
+    cmd.arg("--cache-dir")
+        .arg(spawn.cache_dir)
+        .arg("--run-hash")
+        .arg(spawn.run_hash.inner())
+        .arg("--worker-id")
+        .arg(worker_id.to_string())
+        .current_dir(spawn.project.cwd())
+        // Ensure python does not buffer output
+        .env("PYTHONUNBUFFERED", "1")
+        .env(WorkerEnvVars::KARVA, "1")
+        .env(WorkerEnvVars::KARVA_WORKER_ID, worker_id.to_string())
+        .env(WorkerEnvVars::KARVA_RUN_ID, spawn.run_id)
+        .env(
+            WorkerEnvVars::KARVA_WORKSPACE_ROOT,
+            spawn.project.cwd().as_str(),
+        )
+        .env(WorkerEnvVars::KARVA_PROFILE, spawn.profile)
+        .env(
+            WorkerEnvVars::KARVA_TEST_THREADS,
+            spawn.num_workers.to_string(),
+        )
+        .env(WorkerEnvVars::KARVA_VERSION, karva_version::version());
+
+    for path in partition.tests() {
+        cmd.arg(path);
+    }
+
+    cmd.args(inner_cli_args(spawn.project.settings(), spawn.args));
+
+    if spawn.coverage_enabled {
+        let data_file = spawn.cache.coverage_data_file(worker_id);
+        cmd.arg("--cov-data-file").arg(data_file.as_str());
+    }
+
+    cmd
+}
+
 /// Spawn worker processes for each partition
 ///
 /// Creates a worker process for each non-empty partition, passing the appropriate
 /// subset of tests and command-line arguments to each worker.
-fn spawn_workers(
-    project: &Project,
-    partitions: &[Partition],
-    cache_dir: &Utf8PathBuf,
-    cache: &RunCache,
-    run_hash: &RunHash,
-    args: &SubTestCommand,
-    num_workers: usize,
-    profile: &str,
-) -> Result<WorkerManager> {
-    let core_binary = find_karva_worker_binary(project.cwd())?;
+fn spawn_workers(spawn: &WorkerSpawn, partitions: &[Partition]) -> Result<WorkerManager> {
     let mut worker_manager = WorkerManager::default();
-
-    let run_id = uuid::Uuid::new_v4().to_string();
-    let coverage_enabled = !project.settings().coverage().sources.is_empty();
 
     for (worker_id, partition) in partitions.iter().enumerate() {
         if partition.tests().is_empty() {
@@ -182,36 +223,7 @@ fn spawn_workers(
             continue;
         }
 
-        let mut cmd = Command::new(&core_binary);
-        cmd.arg("--cache-dir")
-            .arg(cache_dir)
-            .arg("--run-hash")
-            .arg(run_hash.inner())
-            .arg("--worker-id")
-            .arg(worker_id.to_string())
-            .current_dir(project.cwd())
-            // Ensure python does not buffer output
-            .env("PYTHONUNBUFFERED", "1")
-            .env(WorkerEnvVars::KARVA, "1")
-            .env(WorkerEnvVars::KARVA_WORKER_ID, worker_id.to_string())
-            .env(WorkerEnvVars::KARVA_RUN_ID, &run_id)
-            .env(WorkerEnvVars::KARVA_WORKSPACE_ROOT, project.cwd().as_str())
-            .env(WorkerEnvVars::KARVA_PROFILE, profile)
-            .env(WorkerEnvVars::KARVA_TEST_THREADS, num_workers.to_string())
-            .env(WorkerEnvVars::KARVA_VERSION, karva_version::version());
-
-        for path in partition.tests() {
-            cmd.arg(path);
-        }
-
-        cmd.args(inner_cli_args(project.settings(), args));
-
-        if coverage_enabled {
-            let data_file = cache.coverage_data_file(worker_id);
-            cmd.arg("--cov-data-file").arg(data_file.as_str());
-        }
-
-        let child = cmd
+        let child = worker_command(spawn, worker_id, partition)
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .spawn()
@@ -352,17 +364,20 @@ pub fn run_parallel_tests(
 
     tracing::info!("Spawning {} workers", partitions.len());
 
-    let profile = config.profile.as_deref().unwrap_or("default");
-    let mut worker_manager = spawn_workers(
+    let worker_binary = find_karva_worker_binary(project.cwd())?;
+    let spawn = WorkerSpawn {
         project,
-        &partitions,
-        &cache_dir,
-        &cache,
-        &run_hash,
+        cache_dir: &cache_dir,
+        cache: &cache,
+        run_hash: &run_hash,
         args,
         num_workers,
-        profile,
-    )?;
+        profile: config.profile.as_deref().unwrap_or("default"),
+        run_id: &uuid::Uuid::new_v4().to_string(),
+        worker_binary: &worker_binary,
+        coverage_enabled: !project.settings().coverage().sources.is_empty(),
+    };
+    let mut worker_manager = spawn_workers(&spawn, &partitions)?;
 
     let shutdown_rx = if config.create_ctrlc_handler {
         Some(shutdown_receiver())

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -151,6 +151,9 @@ pub struct ParallelTestConfig {
     pub create_ctrlc_handler: bool,
     /// When `true`, only tests that failed in the previous run will be executed.
     pub last_failed: bool,
+    /// Active configuration profile name. Propagated to workers as
+    /// `KARVA_PROFILE`; falls back to `"default"` when `None`.
+    pub profile: Option<String>,
 }
 
 /// Spawn worker processes for each partition
@@ -164,6 +167,8 @@ fn spawn_workers(
     cache: &RunCache,
     run_hash: &RunHash,
     args: &SubTestCommand,
+    num_workers: usize,
+    profile: &str,
 ) -> Result<WorkerManager> {
     let core_binary = find_karva_worker_binary(project.cwd())?;
     let mut worker_manager = WorkerManager::default();
@@ -190,7 +195,10 @@ fn spawn_workers(
             .env(WorkerEnvVars::KARVA, "1")
             .env(WorkerEnvVars::KARVA_WORKER_ID, worker_id.to_string())
             .env(WorkerEnvVars::KARVA_RUN_ID, &run_id)
-            .env(WorkerEnvVars::KARVA_WORKSPACE_ROOT, project.cwd().as_str());
+            .env(WorkerEnvVars::KARVA_WORKSPACE_ROOT, project.cwd().as_str())
+            .env(WorkerEnvVars::KARVA_PROFILE, profile)
+            .env(WorkerEnvVars::KARVA_TEST_THREADS, num_workers.to_string())
+            .env(WorkerEnvVars::KARVA_VERSION, karva_version::version());
 
         for path in partition.tests() {
             cmd.arg(path);
@@ -344,8 +352,17 @@ pub fn run_parallel_tests(
 
     tracing::info!("Spawning {} workers", partitions.len());
 
-    let mut worker_manager =
-        spawn_workers(project, &partitions, &cache_dir, &cache, &run_hash, args)?;
+    let profile = config.profile.as_deref().unwrap_or("default");
+    let mut worker_manager = spawn_workers(
+        project,
+        &partitions,
+        &cache_dir,
+        &cache,
+        &run_hash,
+        args,
+        num_workers,
+        profile,
+    )?;
 
     let shutdown_rx = if config.create_ctrlc_handler {
         Some(shutdown_receiver())

--- a/crates/karva_static/src/lib.rs
+++ b/crates/karva_static/src/lib.rs
@@ -107,7 +107,7 @@ env_vars! {
         /// `--num-workers` (capped to the number of useful workers).
         pub const KARVA_TEST_THREADS: &'static str = "KARVA_TEST_THREADS";
 
-        /// Version of the running karva CLI, e.g. `"0.0.1-alpha.5"`.
+        /// Version of the running karva CLI.
         pub const KARVA_VERSION: &'static str = "KARVA_VERSION";
     }
 }

--- a/crates/karva_static/src/lib.rs
+++ b/crates/karva_static/src/lib.rs
@@ -98,6 +98,17 @@ env_vars! {
         /// The total number of attempts allowed for the currently running test
         /// (`retries + 1`). Always set.
         pub const KARVA_TOTAL_ATTEMPTS: &'static str = "KARVA_TOTAL_ATTEMPTS";
+
+        /// Name of the active configuration profile, e.g. `"default"` or
+        /// whatever was passed to `--profile` / `KARVA_PROFILE`.
+        pub const KARVA_PROFILE: &'static str = "KARVA_PROFILE";
+
+        /// Configured number of worker processes for this run. Mirrors
+        /// `--num-workers` (capped to the number of useful workers).
+        pub const KARVA_TEST_THREADS: &'static str = "KARVA_TEST_THREADS";
+
+        /// Version of the running karva CLI, e.g. `"0.0.1-alpha.5"`.
+        pub const KARVA_VERSION: &'static str = "KARVA_VERSION";
     }
 }
 

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -68,3 +68,17 @@ set; `"1"` when no retries are configured.
 The total number of attempts allowed for the currently running test
 (`retries + 1`). Always set.
 
+### `KARVA_PROFILE`
+
+Name of the active configuration profile, e.g. `"default"` or
+whatever was passed to `--profile` / `KARVA_PROFILE`.
+
+### `KARVA_TEST_THREADS`
+
+Configured number of worker processes for this run. Mirrors
+`--num-workers` (capped to the number of useful workers).
+
+### `KARVA_VERSION`
+
+Version of the running karva CLI, e.g. `"0.0.1-alpha.5"`.
+

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -80,5 +80,5 @@ Configured number of worker processes for this run. Mirrors
 
 ### `KARVA_VERSION`
 
-Version of the running karva CLI, e.g. `"0.0.1-alpha.5"`.
+Version of the running karva CLI.
 


### PR DESCRIPTION
## Summary

Closes the remaining gap in #594 by propagating three more variables to the worker process: `KARVA_PROFILE` (the active profile name, defaulting to `default`), `KARVA_TEST_THREADS` (the configured worker count after capping), and `KARVA_VERSION` (the karva CLI version). The values are set alongside the existing `KARVA_RUN_ID` / `KARVA_WORKSPACE_ROOT` writes in `spawn_workers`, with the profile name plumbed through `ParallelTestConfig` from the `test` command. `karva_runner` picks up a dependency on `karva_version` so the version string comes from the same source as `karva --version`.

## Test plan

ci