### PR TITLE
Move per-worker coverage data under the run directory

### DIFF
--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -84,7 +84,10 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
 
     let start_time = Instant::now();
 
-    let result = karva_runner::run_parallel_tests(&project, &config, &sub_command, printer)?;
+    let karva_runner::RunOutput {
+        results: result,
+        coverage_files,
+    } = karva_runner::run_parallel_tests(&project, &config, &sub_command, printer)?;
 
     print_test_output(
         printer,
@@ -94,28 +97,32 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
         durations,
     )?;
 
-    let mut coverage_below_threshold = false;
-    if !project.settings().coverage().sources.is_empty() {
-        let cache_dir = project.cwd().join(karva_cache::CACHE_DIR);
-        let coverage_dir = karva_runner::coverage_data_dir(&cache_dir);
+    let coverage_total = if coverage_files.is_empty() {
+        None
+    } else {
         let show_missing = matches!(project.settings().coverage().report, CovReport::TermMissing);
-        match karva_coverage::combine_and_report(project.cwd(), &coverage_dir, show_missing) {
-            Ok(Some(total)) => {
-                if let Some(threshold) = project.settings().coverage().fail_under
-                    && total < threshold
-                {
-                    let mut stdout = printer.stream_for_message().lock();
-                    writeln!(
-                        stdout,
-                        "\ncoverage failure: required total coverage of {threshold}% not reached, total coverage was {total:.2}%",
-                    )?;
-                    coverage_below_threshold = true;
-                }
+        match karva_coverage::combine_and_report(project.cwd(), &coverage_files, show_missing) {
+            Ok(total) => total,
+            Err(err) => {
+                tracing::error!("Coverage report failed: {err:#}");
+                None
             }
-            Ok(None) => {}
-            Err(err) => tracing::error!("Coverage report failed: {err:#}"),
         }
-    }
+    };
+
+    let coverage_below_threshold = if let Some(total) = coverage_total
+        && let Some(threshold) = project.settings().coverage().fail_under
+        && total < threshold
+    {
+        let mut stdout = printer.stream_for_message().lock();
+        writeln!(
+            stdout,
+            "\ncoverage failure: required total coverage of {threshold}% not reached, total coverage was {total:.2}%",
+        )?;
+        true
+    } else {
+        false
+    };
 
     if no_tests_collected(&result) {
         let has_filters = !sub_command.filter_expressions.is_empty();

--- a/crates/karva/src/commands/test/watch.rs
+++ b/crates/karva/src/commands/test/watch.rs
@@ -24,11 +24,11 @@ fn run_and_print(
 ) {
     let start_time = Instant::now();
     match karva_runner::run_parallel_tests(project, config, sub_command, printer) {
-        Ok(result) => {
+        Ok(output) => {
             if let Err(err) = print_test_output(
                 printer,
                 start_time,
-                &result,
+                &output.results,
                 sub_command.output_format.as_ref(),
                 durations,
             ) {

--- a/crates/karva_benchmark/src/lib.rs
+++ b/crates/karva_benchmark/src/lib.rs
@@ -51,9 +51,9 @@ pub fn run_karva(project: &Project) {
     };
 
     let printer = Printer::new(StatusLevel::None, FinalStatusLevel::None);
-    let result = karva_runner::run_parallel_tests(project, &config, &args, printer).unwrap();
+    let output = karva_runner::run_parallel_tests(project, &config, &args, printer).unwrap();
 
-    assert!(result.stats.total() > 0);
+    assert!(output.results.stats.total() > 0);
 }
 
 /// Divan bencher entry point: re-creates the project for each iteration so the

--- a/crates/karva_cache/src/artifact.rs
+++ b/crates/karva_cache/src/artifact.rs
@@ -26,6 +26,8 @@ pub enum CacheFile {
     FailedTests,
     /// Per-worker JSON: list of `FlakyTest` records.
     FlakyTests,
+    /// Per-worker JSON: line-coverage data for sources tracked during the run.
+    Coverage,
     /// Per-run empty sentinel marking that fail-fast was triggered.
     FailFastSignal,
     /// Cache-root JSON: list of last-run failed test names.
@@ -41,6 +43,7 @@ impl CacheFile {
             Self::Durations => "durations.json",
             Self::FailedTests => "failed_tests.json",
             Self::FlakyTests => "flaky_tests.json",
+            Self::Coverage => "coverage.json",
             Self::FailFastSignal => "fail-fast",
             Self::LastFailed => "last-failed.json",
         }

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -55,6 +55,31 @@ impl RunCache {
         Ok(results)
     }
 
+    /// Path to the directory for a specific worker. Does not create it.
+    pub fn worker_dir(&self, worker_id: usize) -> Utf8PathBuf {
+        self.run_dir.join(worker_folder(worker_id))
+    }
+
+    /// Path to the per-worker coverage data file. The main process passes this
+    /// to a worker via `--cov-data-file`; the worker writes the file when its
+    /// coverage session ends.
+    pub fn coverage_data_file(&self, worker_id: usize) -> Utf8PathBuf {
+        CacheFile::Coverage.path_in(&self.worker_dir(worker_id))
+    }
+
+    /// Returns paths to every per-worker coverage file that exists for this
+    /// run, sorted by worker directory. Used to feed the coverage report.
+    pub fn coverage_files(&self) -> Result<Vec<Utf8PathBuf>> {
+        let mut files = Vec::new();
+        for worker_dir in list_worker_dirs(&self.run_dir)? {
+            let path = CacheFile::Coverage.path_in(&worker_dir);
+            if path.exists() {
+                files.push(path);
+            }
+        }
+        Ok(files)
+    }
+
     /// Persists a test run result (stats, diagnostics, durations, and failed tests) to disk.
     pub fn write_result(
         &self,
@@ -63,7 +88,7 @@ impl RunCache {
         resolver: &dyn FileResolver,
         config: &DisplayDiagnosticConfig,
     ) -> Result<()> {
-        let worker_dir = self.run_dir.join(worker_folder(worker_id));
+        let worker_dir = self.worker_dir(worker_id);
         fs::create_dir_all(&worker_dir)?;
 
         write_diagnostics(&worker_dir, result, resolver, config)?;

--- a/crates/karva_coverage/src/data.rs
+++ b/crates/karva_coverage/src/data.rs
@@ -5,9 +5,6 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-pub const WORKER_FILE_PREFIX: &str = "karva-coverage.";
-pub const WORKER_FILE_SUFFIX: &str = ".json";
-
 #[derive(Debug, Serialize, Deserialize)]
 pub struct WorkerFile {
     pub files: BTreeMap<String, FileEntry>,

--- a/crates/karva_coverage/src/lib.rs
+++ b/crates/karva_coverage/src/lib.rs
@@ -18,5 +18,5 @@ pub mod executable;
 pub mod report;
 pub mod tracer;
 
-pub use report::{combine_and_report, prepare_data_dir, worker_data_file};
+pub use report::combine_and_report;
 pub use tracer::{CoverageConfig, CoverageSession};

--- a/crates/karva_coverage/src/report.rs
+++ b/crates/karva_coverage/src/report.rs
@@ -1,51 +1,25 @@
 //! Combine per-worker JSON files and produce a terminal report.
 //!
-//! Pure Rust — runs in the main process, never touches Python. Reads the
-//! `karva-coverage.<worker_id>.json` files written by the [`tracer`](crate::tracer),
-//! unions the per-file line sets, and prints a `Name / Stmts / Miss / Cover`
-//! table sorted alphabetically with a `TOTAL` row.
+//! Pure Rust — runs in the main process, never touches Python. Reads each
+//! per-worker JSON file written by the [`tracer`](crate::tracer), unions the
+//! per-file line sets, and prints a `Name / Stmts / Miss / Cover` table
+//! sorted alphabetically with a `TOTAL` row.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::Write;
 
 use anyhow::{Context, Result};
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::Utf8Path;
 use colored::Colorize;
 
-use crate::data::{WORKER_FILE_PREFIX, WORKER_FILE_SUFFIX, WorkerFile};
+use crate::data::WorkerFile;
 
-/// The data file path a worker should write to.
-pub fn worker_data_file(data_dir: &Utf8Path, worker_id: usize) -> Utf8PathBuf {
-    data_dir.join(format!(
-        "{WORKER_FILE_PREFIX}{worker_id}{WORKER_FILE_SUFFIX}"
-    ))
-}
-
-/// Prepare the coverage data directory by creating it (if missing) and
-/// removing any stale per-worker files left from a previous run.
-pub fn prepare_data_dir(data_dir: &Utf8Path) -> Result<()> {
-    if data_dir.exists() {
-        for entry in std::fs::read_dir(data_dir.as_std_path())
-            .with_context(|| format!("failed to read coverage dir {data_dir}"))?
-        {
-            let entry = entry?;
-            let path = entry.path();
-            if let Some(name) = path.file_name().and_then(|n| n.to_str())
-                && name.starts_with(WORKER_FILE_PREFIX)
-                && name.ends_with(WORKER_FILE_SUFFIX)
-            {
-                let _ = std::fs::remove_file(&path);
-            }
-        }
-    } else {
-        std::fs::create_dir_all(data_dir.as_std_path())
-            .with_context(|| format!("failed to create coverage dir {data_dir}"))?;
-    }
-    Ok(())
-}
-
-/// Combine per-worker data files in `data_dir` and print a terminal report
+/// Combine the per-worker data files in `files` and print a terminal report
 /// to stdout. No-ops if there is no data to report.
+///
+/// `files` is the list of per-worker `coverage.json` paths to merge. The
+/// caller (typically [`karva_cache::RunCache::coverage_files`]) is responsible
+/// for resolving the paths; this function only reads them.
 ///
 /// When `show_missing` is true, the report includes a final `Missing` column
 /// listing the uncovered line numbers per file (consecutive lines collapsed
@@ -56,10 +30,10 @@ pub fn prepare_data_dir(data_dir: &Utf8Path) -> Result<()> {
 /// executable lines do not contribute to the total.
 pub fn combine_and_report(
     cwd: &Utf8Path,
-    data_dir: &Utf8Path,
+    files: &[impl AsRef<Utf8Path>],
     show_missing: bool,
 ) -> Result<Option<f64>> {
-    let combined = combine(data_dir)?;
+    let combined = combine(files)?;
     if combined.is_empty() {
         return Ok(None);
     }
@@ -73,29 +47,15 @@ struct CombinedFile {
     executed: BTreeSet<u32>,
 }
 
-fn combine(data_dir: &Utf8Path) -> Result<BTreeMap<String, CombinedFile>> {
+fn combine(files: &[impl AsRef<Utf8Path>]) -> Result<BTreeMap<String, CombinedFile>> {
     let mut combined: BTreeMap<String, CombinedFile> = BTreeMap::new();
 
-    if !data_dir.exists() {
-        return Ok(combined);
-    }
-
-    for entry in std::fs::read_dir(data_dir.as_std_path())
-        .with_context(|| format!("failed to read coverage dir {data_dir}"))?
-    {
-        let entry = entry?;
-        let path = entry.path();
-        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
-            continue;
-        };
-        if !name.starts_with(WORKER_FILE_PREFIX) || !name.ends_with(WORKER_FILE_SUFFIX) {
-            continue;
-        }
-
-        let bytes = std::fs::read(&path)
-            .with_context(|| format!("failed to read coverage file {}", path.display()))?;
+    for path in files {
+        let path = path.as_ref();
+        let bytes = std::fs::read(path.as_std_path())
+            .with_context(|| format!("failed to read coverage file {path}"))?;
         let parsed: WorkerFile = serde_json::from_slice(&bytes)
-            .with_context(|| format!("failed to parse coverage file {}", path.display()))?;
+            .with_context(|| format!("failed to parse coverage file {path}"))?;
 
         for (filename, file_entry) in parsed.files {
             let bucket = combined.entry(filename).or_default();

--- a/crates/karva_runner/src/lib.rs
+++ b/crates/karva_runner/src/lib.rs
@@ -3,5 +3,5 @@ mod orchestration;
 mod partition;
 mod shutdown;
 
-pub use orchestration::{ParallelTestConfig, coverage_data_dir, run_parallel_tests};
+pub use orchestration::{ParallelTestConfig, RunOutput, run_parallel_tests};
 pub use shutdown::shutdown_receiver;

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -161,14 +161,15 @@ fn spawn_workers(
     project: &Project,
     partitions: &[Partition],
     cache_dir: &Utf8PathBuf,
+    cache: &RunCache,
     run_hash: &RunHash,
     args: &SubTestCommand,
 ) -> Result<WorkerManager> {
     let core_binary = find_karva_worker_binary(project.cwd())?;
     let mut worker_manager = WorkerManager::default();
 
-    let coverage_dir = coverage_data_dir(cache_dir);
     let run_id = uuid::Uuid::new_v4().to_string();
+    let coverage_enabled = !project.settings().coverage().sources.is_empty();
 
     for (worker_id, partition) in partitions.iter().enumerate() {
         if partition.tests().is_empty() {
@@ -197,8 +198,8 @@ fn spawn_workers(
 
         cmd.args(inner_cli_args(project.settings(), args));
 
-        if !project.settings().coverage().sources.is_empty() {
-            let data_file = karva_coverage::worker_data_file(&coverage_dir, worker_id);
+        if coverage_enabled {
+            let data_file = cache.coverage_data_file(worker_id);
             cmd.arg("--cov-data-file").arg(data_file.as_str());
         }
 
@@ -254,12 +255,23 @@ pub fn collect_tests(project: &Project) -> Result<CollectedPackage> {
     Ok(collected)
 }
 
+/// Aggregated outputs of a parallel test run.
+pub struct RunOutput {
+    /// Test results merged across all workers.
+    pub results: AggregatedResults,
+    /// Paths to per-worker coverage files written during the run. Empty when
+    /// coverage was disabled. The caller hands this to
+    /// [`karva_coverage::combine_and_report`] to render the coverage table at
+    /// the right point in its output sequence (after the test summary).
+    pub coverage_files: Vec<Utf8PathBuf>,
+}
+
 pub fn run_parallel_tests(
     project: &Project,
     config: &ParallelTestConfig,
     args: &SubTestCommand,
     printer: Printer,
-) -> Result<AggregatedResults> {
+) -> Result<RunOutput> {
     let collected = collect_tests(project)?;
 
     let total_tests = collected.test_count();
@@ -328,15 +340,12 @@ pub fn run_parallel_tests(
     );
 
     let run_hash = RunHash::current_time();
-
-    if !project.settings().coverage().sources.is_empty() {
-        let coverage_dir = coverage_data_dir(&cache_dir);
-        karva_coverage::prepare_data_dir(&coverage_dir)?;
-    }
+    let cache = RunCache::new(&cache_dir, &run_hash);
 
     tracing::info!("Spawning {} workers", partitions.len());
 
-    let mut worker_manager = spawn_workers(project, &partitions, &cache_dir, &run_hash, args)?;
+    let mut worker_manager =
+        spawn_workers(project, &partitions, &cache_dir, &cache, &run_hash, args)?;
 
     let shutdown_rx = if config.create_ctrlc_handler {
         Some(shutdown_receiver())
@@ -344,20 +353,27 @@ pub fn run_parallel_tests(
         None
     };
 
-    let cache = RunCache::new(&cache_dir, &run_hash);
-
     let max_fail_cache = project.settings().max_fail().has_limit().then_some(&cache);
 
     worker_manager.wait_for_completion(shutdown_rx, max_fail_cache);
     worker_manager.kill_remaining();
 
-    let result = cache.aggregate_results()?;
+    let results = cache.aggregate_results()?;
 
     if !config.no_cache {
-        let _ = write_last_failed(&cache_dir, &result.failed_tests);
+        let _ = write_last_failed(&cache_dir, &results.failed_tests);
     }
 
-    Ok(result)
+    let coverage_files = if project.settings().coverage().sources.is_empty() {
+        Vec::new()
+    } else {
+        cache.coverage_files()?
+    };
+
+    Ok(RunOutput {
+        results,
+        coverage_files,
+    })
 }
 
 /// Construct a platform-specific binary path within a virtual environment root directory.
@@ -471,8 +487,4 @@ fn inner_cli_args(settings: &ProjectSettings, args: &SubTestCommand) -> Vec<Stri
     }
 
     cli_args
-}
-
-pub fn coverage_data_dir(cache_dir: &Utf8PathBuf) -> Utf8PathBuf {
-    cache_dir.join("coverage")
 }


### PR DESCRIPTION
Closes #740.

Coverage data used to live at `.karva_cache/coverage/karva-coverage.<worker_id>.json` — a flat sibling of the run/worker hierarchy with its own ad-hoc lifecycle. `karva_coverage::prepare_data_dir` ran at the start of every coverage-enabled run to remove stale per-worker files, and `karva_coverage::worker_data_file` knew the filename prefix/suffix. It was the only artifact not owned by `RunCache` and the only reason `prepare_data_dir` existed.

Per-worker coverage now lives at `.karva_cache/run-<hash>/worker-<id>/coverage.json`, registered as `CacheFile::Coverage`. Coverage inherits the regular per-run lifecycle (auto-pruned by `prune_cache`, auto-cleaned by `clean_cache`) and the per-worker directory is already created by the rest of the artifact-writing path. Three new methods on `RunCache` keep callers out of the layout: `worker_dir(worker_id)`, `coverage_data_file(worker_id)` (the path the main process passes to a worker via `--cov-data-file`), and `coverage_files()` (paths to every existing coverage file across workers).

`karva_coverage` drops `worker_data_file`, `prepare_data_dir`, and the `WORKER_FILE_PREFIX`/`WORKER_FILE_SUFFIX` constants. `combine_and_report` now takes a slice of paths instead of walking a directory, removing a second place that knew about the layout. `karva_runner` exposes a new `RunOutput { results, coverage_files }` so the caller renders the coverage table at the right point in its output sequence (after the test summary, where it always was), and the obsolete `coverage_data_dir` helper is gone.

There is no on-disk migration — the cache is per-run and gets recreated on each `karva test`. An old `.karva_cache/coverage/` directory left over from a previous build will sit unused until the user runs `karva cache clean`.

## Test Plan

ci