### PR TITLE
Set status-level to none for walltime benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,3 +293,4 @@ jobs:
         with:
           run: cargo codspeed run --bench karva_benchmark_walltime
           mode: walltime
+          status-level: none


### PR DESCRIPTION
## Summary

Pass `status-level: none` to the CodSpeed action for the walltime benchmark job so that performance regressions don't fail the CI workflow.

## Test Plan

ci