### PR TITLE
Fix zensical build warnings and bump zensical to 0.0.38

### DIFF
--- a/crates/karva_dev/src/generate_cli_reference.rs
+++ b/crates/karva_dev/src/generate_cli_reference.rs
@@ -12,6 +12,12 @@ use crate::{Mode, REGENERATE_ALL_COMMAND, ROOT_DIR};
 
 const SHOW_HIDDEN_COMMANDS: &[&str] = &["generate-shell-completion"];
 
+fn render_html(markdown_text: &str) -> String {
+    markdown::to_html(markdown_text)
+        .replace('[', "&#91;")
+        .replace(']', "&#93;")
+}
+
 #[derive(clap::Args)]
 pub(crate) struct Args {
     #[arg(long, default_value_t, value_enum)]
@@ -152,10 +158,7 @@ fn generate_command<'a>(output: &mut String, command: &'a Command, parents: &mut
                 subcommand_name.replace(' ', "-")
             ));
             if let Some(about) = subcommand.get_about() {
-                output.push_str(&format!(
-                    "<dd>{}</dd>\n",
-                    markdown::to_html(&about.to_string())
-                ));
+                output.push_str(&format!("<dd>{}</dd>\n", render_html(&about.to_string())));
             }
         }
 
@@ -186,7 +189,7 @@ fn generate_command<'a>(output: &mut String, command: &'a Command, parents: &mut
                 output.push_str("</dt>");
                 if let Some(help) = arg.get_long_help().or_else(|| arg.get_help()) {
                     output.push_str("<dd>");
-                    output.push_str(&format!("{}\n", markdown::to_html(&help.to_string())));
+                    output.push_str(&format!("{}\n", render_html(&help.to_string())));
                     output.push_str("</dd>");
                 }
             }
@@ -238,7 +241,7 @@ fn generate_command<'a>(output: &mut String, command: &'a Command, parents: &mut
                 output.push_str("</dt>");
                 if let Some(help) = opt.get_long_help().or_else(|| opt.get_help()) {
                     output.push_str("<dd>");
-                    output.push_str(&format!("{}\n", markdown::to_html(&help.to_string())));
+                    output.push_str(&format!("{}\n", render_html(&help.to_string())));
                     emit_env_option(opt, output);
                     emit_default_option(opt, output);
                     emit_possible_options(opt, output);
@@ -267,7 +270,7 @@ fn emit_env_option(opt: &clap::Arg, output: &mut String) {
         return;
     }
     if let Some(env) = opt.get_env() {
-        output.push_str(&markdown::to_html(&format!(
+        output.push_str(&render_html(&format!(
             "May also be set with the `{}` environment variable.",
             env.to_string_lossy()
         )));
@@ -293,7 +296,7 @@ fn emit_default_option(opt: &clap::Arg, output: &mut String) {
                 .map(|s| s.to_string_lossy())
                 .join(",")
         );
-        output.push_str(&markdown::to_html(&value));
+        output.push_str(&render_html(&value));
     }
 }
 
@@ -319,7 +322,7 @@ fn emit_possible_options(opt: &clap::Arg, output: &mut String) {
                 .collect_vec()
                 .join("\n"),
         );
-        output.push_str(&markdown::to_html(&value));
+        output.push_str(&render_html(&value));
     }
 }
 

--- a/crates/karva_metadata/src/options.rs
+++ b/crates/karva_metadata/src/options.rs
@@ -260,7 +260,7 @@ pub struct TerminalOptions {
     /// Test summary information to display at the end of the run.
     ///
     /// Modeled after `cargo-nextest`'s `--final-status-level`. Levels are
-    /// cumulative in the same way as [`status_level`](#terminal_status-level).
+    /// cumulative in the same way as [`status_level`](#status-level).
     ///
     /// Defaults to `pass`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -305,7 +305,7 @@ pub struct TestOptions {
 
     /// Whether to stop at the first test failure.
     ///
-    /// This is a legacy alias for [`max_fail`](#test_max-fail): `true`
+    /// This is a legacy alias for [`max_fail`](#max-fail): `true`
     /// corresponds to `max-fail = 1` and `false` leaves the limit unset.
     /// When both are set, `max-fail` takes precedence.
     ///
@@ -326,7 +326,7 @@ pub struct TestOptions {
     /// every test run regardless of how many fail. Setting `max-fail = 1`
     /// is equivalent to the legacy `fail-fast = true`.
     ///
-    /// When both [`fail_fast`](#test_fail-fast) and `max-fail` are set,
+    /// When both [`fail_fast`](#fail-fast) and `max-fail` are set,
     /// `max-fail` takes precedence.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[option(

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -122,7 +122,7 @@ respect-ignore-files = false
 Test summary information to display at the end of the run.
 
 Modeled after `cargo-nextest`'s `--final-status-level`. Levels are
-cumulative in the same way as [`status_level`](#terminal_status-level).
+cumulative in the same way as [`status_level`](#status-level).
 
 Defaults to `pass`.
 
@@ -207,7 +207,7 @@ status-level = "fail"
 
 Whether to stop at the first test failure.
 
-This is a legacy alias for [`max_fail`](#test_max-fail): `true`
+This is a legacy alias for [`max_fail`](#max-fail): `true`
 corresponds to `max-fail = 1` and `false` leaves the limit unset.
 When both are set, `max-fail` takes precedence.
 
@@ -234,7 +234,7 @@ Accepts a positive integer. Omitting the field (the default) lets
 every test run regardless of how many fail. Setting `max-fail = 1`
 is equivalent to the legacy `fail-fast = true`.
 
-When both [`fail_fast`](#test_fail-fast) and `max-fail` are set,
+When both [`fail_fast`](#fail-fast) and `max-fail` are set,
 `max-fail` takes precedence.
 
 **Default value**: `unlimited`

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -33,7 +33,7 @@ karva test [OPTIONS] [PATH]...
 
 <h3 class="cli-reference">Arguments</h3>
 
-<dl class="cli-reference"><dt id="karva-test--paths"><a href="#karva-test--paths"><code>PATHS</code></a></dt><dd><p>List of files, directories, or test functions to test [default: the project root]</p>
+<dl class="cli-reference"><dt id="karva-test--paths"><a href="#karva-test--paths"><code>PATHS</code></a></dt><dd><p>List of files, directories, or test functions to test &#91;default: the project root&#93;</p>
 </dd></dl>
 
 <h3 class="cli-reference">Options</h3>
@@ -65,7 +65,7 @@ karva test [OPTIONS] [PATH]...
 <p>Operators: <code>&amp;</code> / <code>and</code>, <code>|</code> / <code>or</code>, <code>not</code> / <code>!</code>, and <code>-</code> as shorthand for &quot;and not&quot;. Use parentheses for grouping. <code>and</code> binds tighter than <code>or</code>.</p>
 <p>When specified multiple times, a test runs if it matches any of the expressions (OR semantics across flags).</p>
 <p>Examples: <code>-E 'tag(slow)'</code>, <code>-E 'test(/^mod::test_login$/)'</code>, <code>-E 'tag(slow) &amp; test(~login)'</code>, <code>-E '(tag(fast) | tag(unit)) - tag(flaky)'</code>.</p>
-</dd><dt id="karva-test--final-status-level"><a href="#karva-test--final-status-level"><code>--final-status-level</code></a> <i>level</i></dt><dd><p>Test summary information to display at the end of the run [default: pass]</p>
+</dd><dt id="karva-test--final-status-level"><a href="#karva-test--final-status-level"><code>--final-status-level</code></a> <i>level</i></dt><dd><p>Test summary information to display at the end of the run &#91;default: pass&#93;</p>
 <p>May also be set with the <code>KARVA_FINAL_STATUS_LEVEL</code> environment variable.</p><p>Possible values:</p>
 <ul>
 <li><code>none</code>:  Don't display the summary line or any diagnostic blocks</li>
@@ -83,12 +83,12 @@ karva test [OPTIONS] [PATH]...
 </dd><dt id="karva-test--no-capture"><a href="#karva-test--no-capture"><code>--no-capture</code></a></dt><dd><p>Disable output capture and run tests serially.</p>
 <p>Lets stdout/stderr from tests flow directly to the terminal, useful when debugging with print statements or interactive debuggers. Implies <code>--show-output</code> and forces a single worker so output from concurrent tests cannot interleave.</p>
 </dd><dt id="karva-test--no-cov"><a href="#karva-test--no-cov"><code>--no-cov</code></a></dt><dd><p>Disable coverage measurement for this run.</p>
-<p>Overrides any <code>--cov</code> flag and any <code>[coverage] sources</code> configured in <code>karva.toml</code> / <code>pyproject.toml</code>. Useful when iterating locally without editing config.</p>
+<p>Overrides any <code>--cov</code> flag and any <code>&#91;coverage&#93; sources</code> configured in <code>karva.toml</code> / <code>pyproject.toml</code>. Useful when iterating locally without editing config.</p>
 </dd><dt id="karva-test--no-fail-fast"><a href="#karva-test--no-fail-fast"><code>--no-fail-fast</code></a></dt><dd><p>Run every test regardless of how many fail.</p>
 <p>Clears any <code>fail-fast</code> or <code>max-fail</code> value set in configuration. When <code>--max-fail</code> is provided alongside <code>--no-fail-fast</code>, <code>--max-fail</code> takes precedence.</p>
 </dd><dt id="karva-test--no-ignore"><a href="#karva-test--no-ignore"><code>--no-ignore</code></a></dt><dd><p>When set, .gitignore files will not be respected</p>
 </dd><dt id="karva-test--no-parallel"><a href="#karva-test--no-parallel"><code>--no-parallel</code></a></dt><dd><p>Disable parallel execution (equivalent to <code>--num-workers 1</code>)</p>
-</dd><dt id="karva-test--no-tests"><a href="#karva-test--no-tests"><code>--no-tests</code></a> <i>action</i></dt><dd><p>Behavior when no tests are found to run [default: auto]</p>
+</dd><dt id="karva-test--no-tests"><a href="#karva-test--no-tests"><code>--no-tests</code></a> <i>action</i></dt><dd><p>Behavior when no tests are found to run &#91;default: auto&#93;</p>
 <p>May also be set with the <code>KARVA_NO_TESTS</code> environment variable.</p><p>Possible values:</p>
 <ul>
 <li><code>auto</code>:  Automatically determine behavior: fail if no filter expressions were given, pass silently if filters were given</li>
@@ -102,7 +102,7 @@ karva test [OPTIONS] [PATH]...
 <li><code>full</code>:  Print diagnostics verbosely, with context and helpful hints (default)</li>
 <li><code>concise</code>:  Print diagnostics concisely, one per line</li>
 </ul></dd><dt id="karva-test--profile"><a href="#karva-test--profile"><code>--profile</code></a>, <code>-P</code> <i>name</i></dt><dd><p>Configuration profile to use.</p>
-<p>Profiles are defined as <code>[profile.&lt;name&gt;]</code> sections in <code>karva.toml</code> (or <code>[tool.karva.profile.&lt;name&gt;]</code> in <code>pyproject.toml</code>) and may override any of the <code>[src]</code>, <code>[terminal]</code>, and <code>[test]</code> settings. The selected profile is layered on top of any <code>[profile.default]</code> overrides, which themselves layer on top of the top-level options.</p>
+<p>Profiles are defined as <code>&#91;profile.&lt;name&gt;&#93;</code> sections in <code>karva.toml</code> (or <code>&#91;tool.karva.profile.&lt;name&gt;&#93;</code> in <code>pyproject.toml</code>) and may override any of the <code>&#91;src&#93;</code>, <code>&#91;terminal&#93;</code>, and <code>&#91;test&#93;</code> settings. The selected profile is layered on top of any <code>&#91;profile.default&#93;</code> overrides, which themselves layer on top of the top-level options.</p>
 <p>Defaults to <code>default</code>.</p>
 <p>May also be set with the <code>KARVA_PROFILE</code> environment variable.</p></dd><dt id="karva-test--retry"><a href="#karva-test--retry"><code>--retry</code></a> <i>retry</i></dt><dd><p>When set, the test will retry failed tests up to this number of times</p>
 </dd><dt id="karva-test--run-ignored"><a href="#karva-test--run-ignored"><code>--run-ignored</code></a> <i>run-ignored</i></dt><dd><p>Run ignored tests</p>
@@ -115,7 +115,7 @@ karva test [OPTIONS] [PATH]...
 <p>When a test takes longer than this duration, it is reported with a <code>SLOW</code> status line (gated on <code>--status-level=slow</code> or higher) and counted in the run summary. Pass a positive number such as <code>--slow-timeout=60</code> or <code>--slow-timeout=0.5</code>.</p>
 </dd><dt id="karva-test--snapshot-update"><a href="#karva-test--snapshot-update"><code>--snapshot-update</code></a></dt><dd><p>Update snapshots directly instead of creating pending <code>.snap.new</code> files.</p>
 <p>When set, <code>karva.assert_snapshot()</code> will write directly to <code>.snap</code> files, accepting any changes automatically.</p>
-</dd><dt id="karva-test--status-level"><a href="#karva-test--status-level"><code>--status-level</code></a> <i>level</i></dt><dd><p>Test result statuses to display during the run [default: pass]</p>
+</dd><dt id="karva-test--status-level"><a href="#karva-test--status-level"><code>--status-level</code></a> <i>level</i></dt><dd><p>Test result statuses to display during the run &#91;default: pass&#93;</p>
 <p>May also be set with the <code>KARVA_STATUS_LEVEL</code> environment variable.</p><p>Possible values:</p>
 <ul>
 <li><code>none</code>:  Don't display any test result lines (or the &quot;Starting&quot; header)</li>

--- a/docs/usage/running-tests/filtering.md
+++ b/docs/usage/running-tests/filtering.md
@@ -153,7 +153,7 @@ metacharacters round-trip without double-backslashing:
 - Bare identifiers have no escape syntax at all — if your tag or test
   name needs characters the identifier rules don't allow, quote it.
 - For literal glob metacharacters, use the bracket escape from
-  [globset]: `#[*]` matches a literal `*` character, `#[?]` matches a
+  [globset] — `#[*]` matches a literal `*` character, `#[?]` matches a
   literal `?`, and so on.
 
 ## Migration from `-t` and `-m`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ karva-worker = "karva._karva:karva_worker_run"
 
 [dependency-groups]
 dev = ["ruff", "ty"]
-docs = ["zensical==0.0.10"]
+docs = ["zensical==0.0.38"]
 release = ["tbump"]
 
 [project.urls]


### PR DESCRIPTION
## Summary

Bumps zensical to 0.0.38 and clears the 16 warnings that `zensical build` was emitting.

The CLI reference generator now routes its `markdown::to_html` output through a small `render_html` helper that escapes `[` and `]` to `&#91;` / `&#93;`. Without this, fragments such as `<p>...[default: pass]...</p>` and `<code>[profile.&lt;name&gt;]</code>` in the rendered HTML get re-parsed by zensical's markdown layer as link references and warned as unresolved.

Three intra-page anchors in `karva_metadata::options` were stale — they referenced `#terminal_status-level`, `#test_max-fail`, and `#test_fail-fast` which were never the slugs zensical generates. They now point at `#status-level`, `#max-fail`, and `#fail-fast`.

In `docs/usage/running-tests/filtering.md` the line `[globset]: #[*] matches a literal *...` was being read as a duplicate link definition that shadowed the canonical one at the bottom of the file. Replacing the colon with an em dash keeps the prose link intact.

## Test Plan

ci