### PR TITLE
Split karva_metadata::options into submodules

### DIFF
--- a/crates/karva_metadata/src/options/config.rs
+++ b/crates/karva_metadata/src/options/config.rs
@@ -1,0 +1,141 @@
+use std::collections::BTreeMap;
+
+use camino::Utf8PathBuf;
+use karva_combine::Combine;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::Options;
+
+/// The implicit name of the default profile.
+pub const DEFAULT_PROFILE: &str = "default";
+
+/// File-level configuration: a collection of named profiles.
+///
+/// Mirrors nextest: every option group lives inside `[profile.<name>]`. The
+/// implicit `default` profile is always available; other profiles inherit
+/// from it (and can override individual fields).
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct Config {
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub profile: BTreeMap<String, Options>,
+}
+
+impl Config {
+    pub fn from_toml_str(content: &str) -> Result<Self, KarvaTomlError> {
+        let config: Self = toml::from_str(content)?;
+        validate_profile_names(&config.profile)?;
+        Ok(config)
+    }
+
+    pub(crate) fn from_karva_configuration_file(
+        path: &Utf8PathBuf,
+    ) -> Result<Self, KarvaTomlError> {
+        let karva_toml_str =
+            std::fs::read_to_string(path).map_err(|source| KarvaTomlError::FileReadError {
+                source,
+                path: path.clone(),
+            })?;
+
+        Self::from_toml_str(&karva_toml_str)
+    }
+
+    /// Returns true if `name` is defined as a profile in this configuration.
+    /// The implicit `default` profile always exists.
+    pub fn has_profile(&self, name: &str) -> bool {
+        if name == DEFAULT_PROFILE {
+            return true;
+        }
+        self.profile.contains_key(name)
+    }
+
+    /// Resolve a profile by collapsing the `profile` map into a single
+    /// [`Options`] value.
+    ///
+    /// The selected profile is layered on top of any `[profile.default]`
+    /// overrides, which form the base. CLI options can then be combined with
+    /// the result via the usual `Combine` precedence.
+    ///
+    /// Returns [`UnknownProfile`] when `name` refers to a profile that is
+    /// not defined.
+    pub fn resolve_profile(mut self, name: Option<&str>) -> Result<Options, UnknownProfile> {
+        let requested = name.unwrap_or(DEFAULT_PROFILE);
+
+        let default_overrides = self.profile.remove(DEFAULT_PROFILE);
+        let named_overrides = if requested == DEFAULT_PROFILE {
+            None
+        } else if let Some(p) = self.profile.remove(requested) {
+            Some(p)
+        } else {
+            let mut available: Vec<String> = self.profile.into_keys().collect();
+            available.push(DEFAULT_PROFILE.to_string());
+            available.sort();
+            available.dedup();
+            return Err(UnknownProfile {
+                name: requested.to_string(),
+                available,
+            });
+        };
+
+        let mut effective = Options::default();
+        if let Some(default_p) = default_overrides {
+            effective = default_p.combine(effective);
+        }
+        if let Some(named_p) = named_overrides {
+            effective = named_p.combine(effective);
+        }
+        Ok(effective)
+    }
+}
+
+fn validate_profile_names(profiles: &BTreeMap<String, Options>) -> Result<(), KarvaTomlError> {
+    for name in profiles.keys() {
+        if name.is_empty() {
+            return Err(KarvaTomlError::InvalidProfileName {
+                name: name.clone(),
+                reason: "profile name cannot be empty",
+            });
+        }
+        if name != DEFAULT_PROFILE && name.starts_with("default-") {
+            return Err(KarvaTomlError::InvalidProfileName {
+                name: name.clone(),
+                reason: "the `default-` prefix is reserved for built-in profiles",
+            });
+        }
+        if !name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        {
+            return Err(KarvaTomlError::InvalidProfileName {
+                name: name.clone(),
+                reason: "profile names may only contain ASCII letters, digits, `-`, and `_`",
+            });
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Error)]
+#[error(
+    "profile `{name}` is not defined in configuration (available: {})",
+    available.join(", ")
+)]
+pub struct UnknownProfile {
+    pub name: String,
+    pub available: Vec<String>,
+}
+
+#[derive(Error, Debug)]
+pub enum KarvaTomlError {
+    #[error(transparent)]
+    TomlSyntax(#[from] toml::de::Error),
+    #[error("Failed to read `{path}`: {source}")]
+    FileReadError {
+        #[source]
+        source: std::io::Error,
+        path: Utf8PathBuf,
+    },
+    #[error("invalid profile name `{name}`: {reason}")]
+    InvalidProfileName { name: String, reason: &'static str },
+}

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -1,12 +1,14 @@
-use std::collections::BTreeMap;
+mod config;
+mod overrides;
 
-use camino::Utf8PathBuf;
 use karva_combine::Combine;
 use karva_logging::{FinalStatusLevel, StatusLevel};
 use karva_macros::{Combine, OptionsMetadata};
 use ruff_db::diagnostic::DiagnosticFormat;
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
+
+pub use config::{Config, DEFAULT_PROFILE, KarvaTomlError, UnknownProfile};
+pub use overrides::ProjectOptionsOverrides;
 
 use crate::filter::FiltersetSet;
 use crate::max_fail::MaxFail;
@@ -14,125 +16,6 @@ use crate::settings::{
     CovFailUnder, CoverageSettings, NoTestsMode, ProjectSettings, RunIgnoredMode, SlowTimeoutSecs,
     SrcSettings, TerminalSettings, TestSettings,
 };
-
-/// The implicit name of the default profile.
-pub const DEFAULT_PROFILE: &str = "default";
-
-/// File-level configuration: a collection of named profiles.
-///
-/// Mirrors nextest: every option group lives inside `[profile.<name>]`. The
-/// implicit `default` profile is always available; other profiles inherit
-/// from it (and can override individual fields).
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case", deny_unknown_fields)]
-pub struct Config {
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub profile: BTreeMap<String, Options>,
-}
-
-impl Config {
-    pub fn from_toml_str(content: &str) -> Result<Self, KarvaTomlError> {
-        let config: Self = toml::from_str(content)?;
-        validate_profile_names(&config.profile)?;
-        Ok(config)
-    }
-
-    pub(crate) fn from_karva_configuration_file(
-        path: &Utf8PathBuf,
-    ) -> Result<Self, KarvaTomlError> {
-        let karva_toml_str =
-            std::fs::read_to_string(path).map_err(|source| KarvaTomlError::FileReadError {
-                source,
-                path: path.clone(),
-            })?;
-
-        Self::from_toml_str(&karva_toml_str)
-    }
-
-    /// Returns true if `name` is defined as a profile in this configuration.
-    /// The implicit `default` profile always exists.
-    pub fn has_profile(&self, name: &str) -> bool {
-        if name == DEFAULT_PROFILE {
-            return true;
-        }
-        self.profile.contains_key(name)
-    }
-
-    /// Resolve a profile by collapsing the `profile` map into a single
-    /// [`Options`] value.
-    ///
-    /// The selected profile is layered on top of any `[profile.default]`
-    /// overrides, which form the base. CLI options can then be combined with
-    /// the result via the usual `Combine` precedence.
-    ///
-    /// Returns [`UnknownProfile`] when `name` refers to a profile that is
-    /// not defined.
-    pub fn resolve_profile(mut self, name: Option<&str>) -> Result<Options, UnknownProfile> {
-        let requested = name.unwrap_or(DEFAULT_PROFILE);
-
-        let default_overrides = self.profile.remove(DEFAULT_PROFILE);
-        let named_overrides = if requested == DEFAULT_PROFILE {
-            None
-        } else if let Some(p) = self.profile.remove(requested) {
-            Some(p)
-        } else {
-            let mut available: Vec<String> = self.profile.into_keys().collect();
-            available.push(DEFAULT_PROFILE.to_string());
-            available.sort();
-            available.dedup();
-            return Err(UnknownProfile {
-                name: requested.to_string(),
-                available,
-            });
-        };
-
-        let mut effective = Options::default();
-        if let Some(default_p) = default_overrides {
-            effective = default_p.combine(effective);
-        }
-        if let Some(named_p) = named_overrides {
-            effective = named_p.combine(effective);
-        }
-        Ok(effective)
-    }
-}
-
-fn validate_profile_names(profiles: &BTreeMap<String, Options>) -> Result<(), KarvaTomlError> {
-    for name in profiles.keys() {
-        if name.is_empty() {
-            return Err(KarvaTomlError::InvalidProfileName {
-                name: name.clone(),
-                reason: "profile name cannot be empty",
-            });
-        }
-        if name != DEFAULT_PROFILE && name.starts_with("default-") {
-            return Err(KarvaTomlError::InvalidProfileName {
-                name: name.clone(),
-                reason: "the `default-` prefix is reserved for built-in profiles",
-            });
-        }
-        if !name
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-        {
-            return Err(KarvaTomlError::InvalidProfileName {
-                name: name.clone(),
-                reason: "profile names may only contain ASCII letters, digits, `-`, and `_`",
-            });
-        }
-    }
-    Ok(())
-}
-
-#[derive(Debug, Error)]
-#[error(
-    "profile `{name}` is not defined in configuration (available: {})",
-    available.join(", ")
-)]
-pub struct UnknownProfile {
-    pub name: String,
-    pub available: Vec<String>,
-}
 
 #[derive(
     Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, OptionsMetadata, Combine,
@@ -417,20 +300,6 @@ impl TestOptions {
             slow_timeout: self.slow_timeout.and_then(SlowTimeoutSecs::as_duration),
         }
     }
-}
-
-#[derive(Error, Debug)]
-pub enum KarvaTomlError {
-    #[error(transparent)]
-    TomlSyntax(#[from] toml::de::Error),
-    #[error("Failed to read `{path}`: {source}")]
-    FileReadError {
-        #[source]
-        source: std::io::Error,
-        path: Utf8PathBuf,
-    },
-    #[error("invalid profile name `{name}`: {reason}")]
-    InvalidProfileName { name: String, reason: &'static str },
 }
 
 #[derive(
@@ -1118,35 +987,5 @@ nonsense = 1
         unknown field `nonsense`, expected one of `sources`, `report`, `fail-under`
         "
         );
-    }
-}
-
-#[derive(Debug, Default, PartialEq, Eq, Clone)]
-pub struct ProjectOptionsOverrides {
-    pub config_file_override: Option<Utf8PathBuf>,
-    pub profile: Option<String>,
-    pub options: Options,
-}
-
-impl ProjectOptionsOverrides {
-    pub fn new(config_file_override: Option<Utf8PathBuf>, options: Options) -> Self {
-        Self {
-            config_file_override,
-            profile: None,
-            options,
-        }
-    }
-
-    #[must_use]
-    pub fn with_profile(mut self, profile: Option<String>) -> Self {
-        self.profile = profile;
-        self
-    }
-
-    /// Resolve the requested profile from `config` and combine the CLI
-    /// overrides on top.
-    pub fn apply_to(&self, config: Config) -> Result<Options, UnknownProfile> {
-        let resolved = config.resolve_profile(self.profile.as_deref())?;
-        Ok(self.options.clone().combine(resolved))
     }
 }

--- a/crates/karva_metadata/src/options/overrides.rs
+++ b/crates/karva_metadata/src/options/overrides.rs
@@ -1,0 +1,34 @@
+use camino::Utf8PathBuf;
+use karva_combine::Combine;
+
+use super::{Config, Options, UnknownProfile};
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct ProjectOptionsOverrides {
+    pub config_file_override: Option<Utf8PathBuf>,
+    pub profile: Option<String>,
+    pub options: Options,
+}
+
+impl ProjectOptionsOverrides {
+    pub fn new(config_file_override: Option<Utf8PathBuf>, options: Options) -> Self {
+        Self {
+            config_file_override,
+            profile: None,
+            options,
+        }
+    }
+
+    #[must_use]
+    pub fn with_profile(mut self, profile: Option<String>) -> Self {
+        self.profile = profile;
+        self
+    }
+
+    /// Resolve the requested profile from `config` and combine the CLI
+    /// overrides on top.
+    pub fn apply_to(&self, config: Config) -> Result<Options, UnknownProfile> {
+        let resolved = config.resolve_profile(self.profile.as_deref())?;
+        Ok(self.options.clone().combine(resolved))
+    }
+}


### PR DESCRIPTION
## Summary

The `options.rs` module in `karva_metadata` had grown to ~1150 lines, mixing the `Options` aggregate, four large option-group structs (`SrcOptions`, `TerminalOptions`, `TestOptions`, `CoverageOptions`), the `Config` profile-resolution machinery, the `KarvaTomlError`/`UnknownProfile` types, the `ProjectOptionsOverrides` builder, two small format enums, and a 540-line `tests` module sitting in the middle of the file before `ProjectOptionsOverrides` was even defined. This made the file awkward to navigate.

The file is now an `options/` directory: `options/mod.rs` keeps the option groups, the `Options` struct, and the `OutputFormat`/`CovReport` enums (they live next to the option groups that use them); `options/config.rs` owns `Config`, profile resolution, profile-name validation, `KarvaTomlError`, and `UnknownProfile`; `options/overrides.rs` owns `ProjectOptionsOverrides`. Public API is unchanged — the existing `pub use` re-exports in `lib.rs` keep every external import path stable, so no call sites were touched.

## Test Plan

ci