### PR TITLE
Extract shared pending-snapshot setup into a helper

### DIFF
--- a/crates/karva/src/commands/snapshot/accept.rs
+++ b/crates/karva/src/commands/snapshot/accept.rs
@@ -6,8 +6,7 @@ use super::pending_setup;
 use crate::ExitStatus;
 
 pub fn accept(filter_paths: &[String]) -> Result<ExitStatus> {
-    let Some((mut stdout, filtered)) = pending_setup(filter_paths, "No pending snapshots found.")?
-    else {
+    let Some((mut stdout, filtered)) = pending_setup(filter_paths)? else {
         return Ok(ExitStatus::Success);
     };
     let refs: Vec<_> = filtered.iter().collect();

--- a/crates/karva/src/commands/snapshot/accept.rs
+++ b/crates/karva/src/commands/snapshot/accept.rs
@@ -2,23 +2,16 @@ use std::fmt::Write;
 
 use anyhow::Result;
 
-use super::{filter_or_empty, snapshot_setup};
+use super::pending_setup;
 use crate::ExitStatus;
 
 pub fn accept(filter_paths: &[String]) -> Result<ExitStatus> {
-    let (mut stdout, cwd, resolved) = snapshot_setup(filter_paths)?;
-    let pending = karva_snapshot::storage::find_pending_snapshots(&cwd);
-    let Some(filtered) = filter_or_empty(
-        &pending,
-        &resolved,
-        |i| &i.pending_path,
-        "No pending snapshots found.",
-        &mut stdout,
-    )?
+    let Some((mut stdout, filtered)) = pending_setup(filter_paths, "No pending snapshots found.")?
     else {
         return Ok(ExitStatus::Success);
     };
-    karva_snapshot::storage::accept_pending_batch(&filtered)?;
+    let refs: Vec<_> = filtered.iter().collect();
+    karva_snapshot::storage::accept_pending_batch(&refs)?;
     for info in &filtered {
         writeln!(stdout, "Accepted: {}", info.pending_path)?;
     }

--- a/crates/karva/src/commands/snapshot/mod.rs
+++ b/crates/karva/src/commands/snapshot/mod.rs
@@ -43,12 +43,9 @@ fn snapshot_setup(filter_paths: &[String]) -> Result<(Stdout, Utf8PathBuf, Vec<U
 /// Setup for snapshot commands that operate on the set of pending snapshots
 /// (`accept`, `reject`, `pending`).
 ///
-/// Returns `Ok(None)` (after writing `empty_message`) when no pending
+/// Returns `Ok(None)` (after writing the empty-state message) when no pending
 /// snapshots match the filter, otherwise `Ok(Some((stdout, filtered)))`.
-fn pending_setup(
-    filter_paths: &[String],
-    empty_message: &str,
-) -> Result<Option<(Stdout, Vec<PendingSnapshotInfo>)>> {
+fn pending_setup(filter_paths: &[String]) -> Result<Option<(Stdout, Vec<PendingSnapshotInfo>)>> {
     let (mut stdout, cwd, resolved) = snapshot_setup(filter_paths)?;
     let pending = find_pending_snapshots(&cwd);
     let filtered: Vec<_> = pending
@@ -56,7 +53,7 @@ fn pending_setup(
         .filter(|info| matches_filter(&info.pending_path, &resolved))
         .collect();
     if filtered.is_empty() {
-        writeln!(stdout, "{empty_message}")?;
+        writeln!(stdout, "No pending snapshots found.")?;
         return Ok(None);
     }
     Ok(Some((stdout, filtered)))

--- a/crates/karva/src/commands/snapshot/mod.rs
+++ b/crates/karva/src/commands/snapshot/mod.rs
@@ -12,6 +12,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use karva_cli::{SnapshotAction, SnapshotCommand};
 use karva_logging::{Printer, Stdout};
 use karva_project::path::absolute;
+use karva_snapshot::storage::{PendingSnapshotInfo, find_pending_snapshots};
 
 use crate::ExitStatus;
 use crate::utils::cwd;
@@ -37,6 +38,28 @@ fn snapshot_setup(filter_paths: &[String]) -> Result<(Stdout, Utf8PathBuf, Vec<U
     let stdout = printer.stream_for_message().lock();
     let resolved = resolve_filter_paths(filter_paths, &cwd);
     Ok((stdout, cwd, resolved))
+}
+
+/// Setup for snapshot commands that operate on the set of pending snapshots
+/// (`accept`, `reject`, `pending`).
+///
+/// Returns `Ok(None)` (after writing `empty_message`) when no pending
+/// snapshots match the filter, otherwise `Ok(Some((stdout, filtered)))`.
+fn pending_setup(
+    filter_paths: &[String],
+    empty_message: &str,
+) -> Result<Option<(Stdout, Vec<PendingSnapshotInfo>)>> {
+    let (mut stdout, cwd, resolved) = snapshot_setup(filter_paths)?;
+    let pending = find_pending_snapshots(&cwd);
+    let filtered: Vec<_> = pending
+        .into_iter()
+        .filter(|info| matches_filter(&info.pending_path, &resolved))
+        .collect();
+    if filtered.is_empty() {
+        writeln!(stdout, "{empty_message}")?;
+        return Ok(None);
+    }
+    Ok(Some((stdout, filtered)))
 }
 
 /// Filters items by resolved path prefixes and handles the empty case.

--- a/crates/karva/src/commands/snapshot/pending.rs
+++ b/crates/karva/src/commands/snapshot/pending.rs
@@ -6,7 +6,7 @@ use super::pending_setup;
 use crate::ExitStatus;
 
 pub fn pending(filter_paths: &[String]) -> Result<ExitStatus> {
-    let Some((mut stdout, filtered)) = pending_setup(filter_paths, "No pending snapshots.")? else {
+    let Some((mut stdout, filtered)) = pending_setup(filter_paths)? else {
         return Ok(ExitStatus::Success);
     };
     for info in &filtered {

--- a/crates/karva/src/commands/snapshot/pending.rs
+++ b/crates/karva/src/commands/snapshot/pending.rs
@@ -2,20 +2,11 @@ use std::fmt::Write;
 
 use anyhow::Result;
 
-use super::{filter_or_empty, snapshot_setup};
+use super::pending_setup;
 use crate::ExitStatus;
 
 pub fn pending(filter_paths: &[String]) -> Result<ExitStatus> {
-    let (mut stdout, cwd, resolved) = snapshot_setup(filter_paths)?;
-    let pending = karva_snapshot::storage::find_pending_snapshots(&cwd);
-    let Some(filtered) = filter_or_empty(
-        &pending,
-        &resolved,
-        |i| &i.pending_path,
-        "No pending snapshots.",
-        &mut stdout,
-    )?
-    else {
+    let Some((mut stdout, filtered)) = pending_setup(filter_paths, "No pending snapshots.")? else {
         return Ok(ExitStatus::Success);
     };
     for info in &filtered {

--- a/crates/karva/src/commands/snapshot/reject.rs
+++ b/crates/karva/src/commands/snapshot/reject.rs
@@ -6,8 +6,7 @@ use super::pending_setup;
 use crate::ExitStatus;
 
 pub fn reject(filter_paths: &[String]) -> Result<ExitStatus> {
-    let Some((mut stdout, filtered)) = pending_setup(filter_paths, "No pending snapshots found.")?
-    else {
+    let Some((mut stdout, filtered)) = pending_setup(filter_paths)? else {
         return Ok(ExitStatus::Success);
     };
     for info in &filtered {

--- a/crates/karva/src/commands/snapshot/reject.rs
+++ b/crates/karva/src/commands/snapshot/reject.rs
@@ -2,19 +2,11 @@ use std::fmt::Write;
 
 use anyhow::Result;
 
-use super::{filter_or_empty, snapshot_setup};
+use super::pending_setup;
 use crate::ExitStatus;
 
 pub fn reject(filter_paths: &[String]) -> Result<ExitStatus> {
-    let (mut stdout, cwd, resolved) = snapshot_setup(filter_paths)?;
-    let pending = karva_snapshot::storage::find_pending_snapshots(&cwd);
-    let Some(filtered) = filter_or_empty(
-        &pending,
-        &resolved,
-        |i| &i.pending_path,
-        "No pending snapshots found.",
-        &mut stdout,
-    )?
+    let Some((mut stdout, filtered)) = pending_setup(filter_paths, "No pending snapshots found.")?
     else {
         return Ok(ExitStatus::Success);
     };

--- a/crates/karva/tests/it/extensions/snapshot/commands.rs
+++ b/crates/karva/tests/it/extensions/snapshot/commands.rs
@@ -256,7 +256,7 @@ def test_pass():
     success: true
     exit_code: 0
     ----- stdout -----
-    No pending snapshots.
+    No pending snapshots found.
 
     ----- stderr -----
     ");


### PR DESCRIPTION
## Summary

The `accept`, `reject`, and `pending` snapshot subcommands all performed the same three-step prelude: resolve the cwd and filter paths via `snapshot_setup`, call `find_pending_snapshots`, then route the result through `filter_or_empty` keyed on `pending_path`. With three identical instances this hits the rule of three, so the prelude moves into a new `pending_setup` helper in `commands/snapshot/mod.rs` that returns either an early-exit `None` (after writing the empty message) or the locked `Stdout` and the owned filtered `Vec<PendingSnapshotInfo>`. Each caller now expresses only the bit that actually differs: the empty message, the per-item action, and the summary line. Behavior, output, and exit codes are unchanged; `filter_or_empty` is still used by the `delete` and `prune` subcommands which key on different paths.

## Test Plan

ci