### PR TITLE
Simplify Stdout state and Printer stream selection in karva_logging

### DIFF
--- a/crates/karva_logging/src/printer.rs
+++ b/crates/karva_logging/src/printer.rs
@@ -28,11 +28,7 @@ impl Printer {
     ///
     /// The reporter additionally filters individual results by [`StatusLevel`].
     pub fn stream_for_test_result(self) -> Stdout {
-        if matches!(self.status_level, StatusLevel::None) {
-            Stdout::disabled()
-        } else {
-            Stdout::enabled()
-        }
+        Stdout::new(self.status_level != StatusLevel::None)
     }
 
     /// Stream for the end-of-run summary line.
@@ -41,115 +37,79 @@ impl Printer {
     /// least one test was retried; it elevates `final-status-level=retry` (or
     /// higher) to show the summary even when all tests eventually passed.
     pub fn stream_for_summary(self, success: bool, had_retries: bool) -> Stdout {
-        match self.final_status_level {
-            FinalStatusLevel::None => Stdout::disabled(),
-            FinalStatusLevel::Fail if success => Stdout::disabled(),
-            FinalStatusLevel::Retry | FinalStatusLevel::Slow if success && !had_retries => {
-                Stdout::disabled()
-            }
-            FinalStatusLevel::Fail
-            | FinalStatusLevel::Retry
-            | FinalStatusLevel::Slow
-            | FinalStatusLevel::Pass
-            | FinalStatusLevel::Skip
-            | FinalStatusLevel::All => Stdout::enabled(),
-        }
+        let enabled = match self.final_status_level {
+            FinalStatusLevel::None => false,
+            FinalStatusLevel::Fail => !success,
+            FinalStatusLevel::Retry | FinalStatusLevel::Slow => !success || had_retries,
+            FinalStatusLevel::Pass | FinalStatusLevel::Skip | FinalStatusLevel::All => true,
+        };
+        Stdout::new(enabled)
     }
 
     /// Stream for the diagnostic block (tracebacks, durations) at the end of the run.
     pub fn stream_for_details(self) -> Stdout {
-        match self.final_status_level {
-            FinalStatusLevel::None => Stdout::disabled(),
-            FinalStatusLevel::Fail
-            | FinalStatusLevel::Retry
-            | FinalStatusLevel::Slow
-            | FinalStatusLevel::Pass
-            | FinalStatusLevel::Skip
-            | FinalStatusLevel::All => Stdout::enabled(),
-        }
+        Stdout::new(self.final_status_level != FinalStatusLevel::None)
     }
 
     /// Stream for messages explicitly requested by the user, such as
     /// `warning: no tests to run`. Suppressed only when both status levels are `none`.
     pub fn stream_for_message(self) -> Stdout {
-        if matches!(self.status_level, StatusLevel::None)
-            && matches!(self.final_status_level, FinalStatusLevel::None)
-        {
-            Stdout::disabled()
-        } else {
-            Stdout::enabled()
-        }
+        let both_none = self.status_level == StatusLevel::None
+            && self.final_status_level == FinalStatusLevel::None;
+        Stdout::new(!both_none)
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum StreamStatus {
-    Enabled,
-    Disabled,
 }
 
 #[derive(Debug)]
 pub struct Stdout {
-    status: StreamStatus,
+    enabled: bool,
     lock: Option<StdoutLock<'static>>,
 }
 
 impl Stdout {
-    fn enabled() -> Self {
+    fn new(enabled: bool) -> Self {
         Self {
-            status: StreamStatus::Enabled,
-            lock: None,
-        }
-    }
-
-    fn disabled() -> Self {
-        Self {
-            status: StreamStatus::Disabled,
+            enabled,
             lock: None,
         }
     }
 
     #[must_use]
     pub fn lock(mut self) -> Self {
-        match self.status {
-            StreamStatus::Enabled => {
-                self.lock.take();
-                self.lock = Some(std::io::stdout().lock());
-            }
-            StreamStatus::Disabled => self.lock = None,
+        if self.enabled {
+            self.lock = Some(std::io::stdout().lock());
         }
         self
     }
 
     fn handle(&mut self) -> Box<dyn std::io::Write + '_> {
-        match self.lock.as_mut() {
-            Some(lock) => Box::new(lock),
-            None => Box::new(std::io::stdout()),
+        if let Some(lock) = self.lock.as_mut() {
+            Box::new(lock)
+        } else {
+            Box::new(std::io::stdout())
         }
     }
 
     pub fn is_enabled(&self) -> bool {
-        matches!(self.status, StreamStatus::Enabled)
+        self.enabled
     }
 }
 
 impl std::fmt::Write for Stdout {
     fn write_str(&mut self, s: &str) -> std::fmt::Result {
-        match self.status {
-            StreamStatus::Enabled => {
-                let _ = write!(self.handle(), "{s}");
-                Ok(())
-            }
-            StreamStatus::Disabled => Ok(()),
+        if self.enabled {
+            let _ = write!(self.handle(), "{s}");
         }
+        Ok(())
     }
 }
 
 impl From<Stdout> for std::process::Stdio {
     fn from(val: Stdout) -> Self {
-        match val.status {
-            StreamStatus::Enabled => Self::inherit(),
-            StreamStatus::Disabled => Self::null(),
+        if val.enabled {
+            Self::inherit()
+        } else {
+            Self::null()
         }
     }
 }


### PR DESCRIPTION
## Summary

Refactors `karva_logging::printer` to drop the redundant `StreamStatus` enum and the verbose enumeration of every `FinalStatusLevel` variant in `stream_for_summary` and `stream_for_details`. `Stdout` now stores a single `enabled: bool` alongside the optional lock, the four `stream_for_*` methods on `Printer` flow through a small `Stdout::new(enabled)` constructor, and a stale `self.lock.take()` immediately followed by an overwrite is removed. No public API changes and no behavior changes — `Stdout`, `Printer`, and the `Write`/`Stdio` impls keep their existing shapes; `StreamStatus` was already private to the module.

## Test Plan

ci