### PR TITLE
Tidy karva_project error handling and function-spec parsing

### DIFF
--- a/crates/karva_project/src/lib.rs
+++ b/crates/karva_project/src/lib.rs
@@ -23,16 +23,14 @@ pub fn find_karva_wheel() -> anyhow::Result<Utf8PathBuf> {
     for entry in entries {
         let entry = entry?;
         let file_name = entry.file_name();
-        if let Some(name) = file_name.to_str() {
-            if name.starts_with("karva-")
-                && Utf8Path::new(name)
-                    .extension()
-                    .is_some_and(|ext| ext.eq_ignore_ascii_case("whl"))
-            {
-                return Ok(
-                    Utf8PathBuf::from_path_buf(entry.path()).expect("Path is not valid UTF-8")
-                );
-            }
+        if let Some(name) = file_name.to_str()
+            && name.starts_with("karva-")
+            && Utf8Path::new(name)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("whl"))
+        {
+            return Utf8PathBuf::from_path_buf(entry.path())
+                .map_err(|p| anyhow::anyhow!("Wheel path is not valid UTF-8: {}", p.display()));
         }
     }
 

--- a/crates/karva_project/src/path/test_path.rs
+++ b/crates/karva_project/src/path/test_path.rs
@@ -26,39 +26,39 @@ pub struct TestPathFunction {
     pub function_name: String,
 }
 
-impl TryFrom<&str> for TestPathFunction {
-    type Error = Option<TestPathError>;
+/// Parse a `path::function` specification.
+///
+/// Returns `Ok(None)` when `value` does not contain a `::` separator (callers
+/// can then fall back to file/directory parsing). Any other failure—including
+/// an empty function name or a non-Python target file—is returned as `Err`.
+fn parse_function_spec(value: &str) -> Result<Option<TestPathFunction>, TestPathError> {
+    let Some(separator_pos) = value.rfind("::") else {
+        return Ok(None);
+    };
 
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        if let Some(separator_pos) = value.rfind("::") {
-            let file_part = &value[..separator_pos];
-            let function_name = &value[separator_pos + 2..];
+    let file_part = &value[..separator_pos];
+    let function_name = &value[separator_pos + 2..];
 
-            if function_name.is_empty() {
-                return Err(Some(TestPathError::MissingFunctionName(Utf8PathBuf::from(
-                    file_part,
-                ))));
-            }
-
-            let file_path = Utf8PathBuf::from(file_part);
-            let path = try_convert_to_py_path(&file_path)?;
-
-            if !path.is_file() {
-                return Err(Some(TestPathError::InvalidUtf8Path(path)));
-            }
-
-            if !is_python_file(&path) {
-                return Err(Some(TestPathError::WrongFileExtension(path)));
-            }
-
-            Ok(Self {
-                path,
-                function_name: function_name.to_string(),
-            })
-        } else {
-            Err(None)
-        }
+    if function_name.is_empty() {
+        return Err(TestPathError::MissingFunctionName(Utf8PathBuf::from(
+            file_part,
+        )));
     }
+
+    let path = try_convert_to_py_path(&Utf8PathBuf::from(file_part))?;
+
+    if !path.is_file() {
+        return Err(TestPathError::InvalidUtf8Path(path));
+    }
+
+    if !is_python_file(&path) {
+        return Err(TestPathError::WrongFileExtension(path));
+    }
+
+    Ok(Some(TestPathFunction {
+        path,
+        function_name: function_name.to_string(),
+    }))
 }
 
 #[derive(Eq, PartialEq, Clone, Hash, PartialOrd, Ord, Debug)]
@@ -86,12 +86,8 @@ pub enum TestPath {
 
 impl TestPath {
     pub fn new(value: &str) -> Result<Self, TestPathError> {
-        let try_function = TestPathFunction::try_from(value);
-
-        match try_function {
-            Ok(function) => return Ok(Self::Function(function)),
-            Err(Some(error)) => return Err(error),
-            Err(None) => {}
+        if let Some(function) = parse_function_spec(value)? {
+            return Ok(Self::Function(function));
         }
 
         let value = Utf8PathBuf::from(value);


### PR DESCRIPTION
## Summary

Two small cleanups inside `karva_project`. `find_karva_wheel` no longer panics on a non-UTF-8 wheel path; the `from_path_buf` failure is converted into an `anyhow::Error` so callers see a normal error path. The `TryFrom<&str> for TestPathFunction` impl, whose `Option<TestPathError>` error type conflated "this isn't a function spec" with "this is a malformed function spec", is replaced by a private `parse_function_spec` returning `Result<Option<TestPathFunction>, TestPathError>`. `TestPath::new` then becomes a single `if let Some(function) = parse_function_spec(value)?` branch, which is easier to follow than the previous `match` over a nested option.

No behavior or public API changes; `TestPathFunction` is still public and the `TryFrom` impl had no external callers.

## Test Plan

ci