### PR TITLE
Extract shared mode dispatch helper in karva_dev

### DIFF
--- a/crates/karva_dev/src/generate_cli_reference.rs
+++ b/crates/karva_dev/src/generate_cli_reference.rs
@@ -1,14 +1,12 @@
 //! Generate a Markdown-compatible reference for the karva command-line interface.
 use std::cmp::max;
 
-use anyhow::{Result, bail};
-use camino::Utf8PathBuf;
+use anyhow::Result;
 use clap::{Command, CommandFactory};
 use itertools::Itertools;
 use karva_cli::Args as Cli;
-use pretty_assertions::StrComparison;
 
-use crate::{Mode, REGENERATE_ALL_COMMAND, ROOT_DIR};
+use crate::{Mode, apply_mode};
 
 const SHOW_HIDDEN_COMMANDS: &[&str] = &["generate-shell-completion"];
 
@@ -25,54 +23,7 @@ pub(crate) struct Args {
 }
 
 pub(crate) fn main(args: &Args) -> Result<()> {
-    let reference_string = generate();
-    let filename = "docs/reference/cli.md";
-    let reference_path = Utf8PathBuf::from(ROOT_DIR).join(filename);
-
-    match args.mode {
-        Mode::DryRun => {
-            println!("{reference_string}");
-        }
-        Mode::Check => match std::fs::read_to_string(reference_path) {
-            Ok(current) => {
-                if current == reference_string {
-                    println!("Up-to-date: {filename}");
-                } else {
-                    let comparison = StrComparison::new(&current, &reference_string);
-                    bail!(
-                        "{filename} changed, please run `{REGENERATE_ALL_COMMAND}`:\n{comparison}"
-                    );
-                }
-            }
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                bail!("{filename} not found, please run `{REGENERATE_ALL_COMMAND}`");
-            }
-            Err(err) => {
-                bail!("{filename} changed, please run `{REGENERATE_ALL_COMMAND}`:\n{err}");
-            }
-        },
-        Mode::Write => match std::fs::read_to_string(&reference_path) {
-            Ok(current) => {
-                if current == reference_string {
-                    println!("Up-to-date: {filename}");
-                } else {
-                    println!("Updating: {filename}");
-                    std::fs::write(reference_path, reference_string.as_bytes())?;
-                }
-            }
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                println!("Updating: {filename}");
-                std::fs::write(reference_path, reference_string.as_bytes())?;
-            }
-            Err(err) => {
-                bail!(
-                    "{filename} changed, please run `cargo run -p karva_dev generate-cli-reference`:\n{err}"
-                );
-            }
-        },
-    }
-
-    Ok(())
+    apply_mode(args.mode, "docs/reference/cli.md", &generate())
 }
 
 fn generate() -> String {

--- a/crates/karva_dev/src/generate_env_vars.rs
+++ b/crates/karva_dev/src/generate_env_vars.rs
@@ -2,13 +2,10 @@
 //! produced by Karva.
 
 use std::fmt::Write;
-use std::path::PathBuf;
 
-use anyhow::bail;
 use karva_static::{EnvVarDoc, EnvVars, WorkerEnvVars};
-use pretty_assertions::StrComparison;
 
-use crate::{Mode, REGENERATE_ALL_COMMAND, ROOT_DIR};
+use crate::{Mode, apply_mode};
 
 #[derive(clap::Args)]
 pub(crate) struct Args {
@@ -23,34 +20,7 @@ const HEADER: &str = "<!-- WARNING: This file is auto-generated (cargo run -p ka
 environment, plus the variables the worker exposes to running tests.\n\n";
 
 pub(crate) fn main(args: &Args) -> anyhow::Result<()> {
-    let output = generate();
-    let markdown_path = PathBuf::from(ROOT_DIR).join(FILE_NAME);
-
-    match args.mode {
-        Mode::DryRun => {
-            println!("{output}");
-        }
-        Mode::Check => {
-            let current = std::fs::read_to_string(&markdown_path)?;
-            if output == current {
-                println!("Up-to-date: {FILE_NAME}");
-            } else {
-                let comparison = StrComparison::new(&current, &output);
-                bail!("{FILE_NAME} changed, please run `{REGENERATE_ALL_COMMAND}`:\n{comparison}");
-            }
-        }
-        Mode::Write => {
-            let current = std::fs::read_to_string(&markdown_path).unwrap_or_default();
-            if current == output {
-                println!("Up-to-date: {FILE_NAME}");
-            } else {
-                println!("Updating: {FILE_NAME}");
-                std::fs::write(markdown_path, output.as_bytes())?;
-            }
-        }
-    }
-
-    Ok(())
+    apply_mode(args.mode, FILE_NAME, &generate())
 }
 
 fn generate() -> String {

--- a/crates/karva_dev/src/generate_options.rs
+++ b/crates/karva_dev/src/generate_options.rs
@@ -1,15 +1,12 @@
 //! Generate a Markdown-compatible listing of configuration options for `pyproject.toml`.
 
 use std::fmt::Write;
-use std::path::PathBuf;
 
-use anyhow::bail;
 use itertools::Itertools;
 use karva_metadata::Options;
-use pretty_assertions::StrComparison;
 use ruff_options_metadata::{OptionField, OptionSet, OptionsMetadata, Visit};
 
-use crate::{Mode, REGENERATE_ALL_COMMAND, ROOT_DIR};
+use crate::{Mode, apply_mode};
 
 #[derive(clap::Args)]
 pub(crate) struct Args {
@@ -20,12 +17,6 @@ pub(crate) struct Args {
 
 pub(crate) fn main(args: &Args) -> anyhow::Result<()> {
     let mut output = String::new();
-    let file_name = "docs/configuration/configuration.md";
-    let markdown_path = PathBuf::from(ROOT_DIR).join(file_name);
-
-    if !markdown_path.exists() {
-        std::fs::File::create(&markdown_path)?;
-    }
 
     output.push_str(
         "<!-- WARNING: This file is auto-generated (cargo dev generate-all). Update the doc comments on the 'Options' struct in 'crates/karva_project/src/metadata/options.rs' if you want to change anything here. -->\n\n",
@@ -37,31 +28,7 @@ pub(crate) fn main(args: &Args) -> anyhow::Result<()> {
         &mut Vec::new(),
     );
 
-    match args.mode {
-        Mode::DryRun => {
-            println!("{output}");
-        }
-        Mode::Check => {
-            let current = std::fs::read_to_string(&markdown_path)?;
-            if output == current {
-                println!("Up-to-date: {file_name}",);
-            } else {
-                let comparison = StrComparison::new(&current, &output);
-                bail!("{file_name} changed, please run `{REGENERATE_ALL_COMMAND}`:\n{comparison}",);
-            }
-        }
-        Mode::Write => {
-            let current = std::fs::read_to_string(&markdown_path)?;
-            if current == output {
-                println!("Up-to-date: {file_name}",);
-            } else {
-                println!("Updating: {file_name}",);
-                std::fs::write(markdown_path, output.as_bytes())?;
-            }
-        }
-    }
-
-    Ok(())
+    apply_mode(args.mode, "docs/configuration/configuration.md", &output)
 }
 
 fn generate_set(output: &mut String, set: Set, parents: &mut Vec<Set>) {

--- a/crates/karva_dev/src/main.rs
+++ b/crates/karva_dev/src/main.rs
@@ -6,8 +6,10 @@
 
 use std::process::ExitCode;
 
-use anyhow::Result;
+use anyhow::{Result, bail};
+use camino::Utf8PathBuf;
 use clap::{Parser, Subcommand};
+use pretty_assertions::StrComparison;
 
 mod generate_cli_reference;
 mod generate_env_vars;
@@ -15,7 +17,7 @@ mod generate_options;
 
 const ROOT_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../");
 
-pub const REGENERATE_ALL_COMMAND: &str = "cargo run -p karva_dev generate-all";
+const REGENERATE_ALL_COMMAND: &str = "cargo run -p karva_dev generate-all";
 
 #[derive(Copy, Clone, PartialEq, Eq, clap::ValueEnum, Default)]
 pub(crate) enum Mode {
@@ -28,6 +30,46 @@ pub(crate) enum Mode {
 
     /// Write the generated help to stdout.
     DryRun,
+}
+
+/// Apply `mode` against the file at `relative_path` (relative to `ROOT_DIR`),
+/// using `generated` as the desired contents.
+pub(crate) fn apply_mode(mode: Mode, relative_path: &str, generated: &str) -> Result<()> {
+    let path = Utf8PathBuf::from(ROOT_DIR).join(relative_path);
+
+    match mode {
+        Mode::DryRun => {
+            println!("{generated}");
+        }
+        Mode::Check => match std::fs::read_to_string(&path) {
+            Ok(current) if current == generated => {
+                println!("Up-to-date: {relative_path}");
+            }
+            Ok(current) => {
+                let comparison = StrComparison::new(&current, generated);
+                bail!(
+                    "{relative_path} changed, please run `{REGENERATE_ALL_COMMAND}`:\n{comparison}"
+                );
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                bail!("{relative_path} not found, please run `{REGENERATE_ALL_COMMAND}`");
+            }
+            Err(err) => {
+                bail!("{relative_path} changed, please run `{REGENERATE_ALL_COMMAND}`:\n{err}");
+            }
+        },
+        Mode::Write => match std::fs::read_to_string(&path) {
+            Ok(current) if current == generated => {
+                println!("Up-to-date: {relative_path}");
+            }
+            Ok(_) | Err(_) => {
+                println!("Updating: {relative_path}");
+                std::fs::write(&path, generated.as_bytes())?;
+            }
+        },
+    }
+
+    Ok(())
 }
 
 #[derive(Parser)]


### PR DESCRIPTION
## Summary

The three doc generators in `karva_dev` (`generate_cli_reference`, `generate_env_vars`, `generate_options`) each carried an almost-identical `match Mode { DryRun, Check, Write }` block that read the file, compared it to the freshly generated string, and either printed `Up-to-date`, wrote the file, or bailed with a diff. This commit pulls that dispatch into a single `apply_mode(mode, relative_path, generated)` helper in `main.rs`, so each generator's `main` function shrinks to one line. Behavior is unchanged for the existing-file paths exercised by `generate-all`; the regenerated `cli.md`, `env-vars.md`, and `configuration.md` are byte-identical. Net effect is roughly 70 fewer lines and a single place to evolve mode handling.

## Test Plan

ci