### PR TITLE
Make CoverageTracer thread-safe to fix --cov panic on threaded code

### DIFF
--- a/crates/karva/tests/it/coverage.rs
+++ b/crates/karva/tests/it/coverage.rs
@@ -921,6 +921,62 @@ def test_one():
     );
 }
 
+/// Regression test for <https://github.com/MatthewMckee4/karva/issues/760>.
+///
+/// On Python 3.12+ the `sys.monitoring` LINE callback (and on older versions
+/// the `sys.settrace` callback) can fire on threads other than the one that
+/// installed the tracer. The `PyO3` `#[pyclass]` must therefore be safe to
+/// access cross-thread; otherwise `unsendable` triggers a panic of the form
+/// `CoverageTracer is unsendable, but sent to another thread`.
+#[test]
+fn test_cov_traces_python_threads() {
+    let context = TestContext::with_file(
+        "test_threaded.py",
+        r"
+import threading
+
+def in_thread():
+    x = 1
+    y = x + 1
+    return y
+
+def test_thread_runs():
+    results = []
+    threads = [
+        threading.Thread(target=lambda: results.append(in_thread()))
+        for _ in range(4)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert results == [2, 2, 2, 2]
+",
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel()
+            .arg("--cov")
+            .arg("--status-level=none")
+            .arg("test_threaded.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    Name               Stmts   Miss   Cover
+    [LONG-LINE]
+    test_threaded.py      13      0    100%
+    [LONG-LINE]
+    TOTAL                 13      0    100%
+
+    ----- stderr -----
+    "
+    );
+}
+
 #[test]
 fn test_cov_report_term_missing_from_config() {
     let context = TestContext::with_files([

--- a/crates/karva_coverage/src/tracer.rs
+++ b/crates/karva_coverage/src/tracer.rs
@@ -5,9 +5,9 @@
 //! touched file and writes a per-worker JSON file at
 //! [`CoverageConfig::data_file`].
 
-use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use pyo3::prelude::*;
@@ -57,9 +57,9 @@ impl CoverageSession {
             py,
             CoverageTracer {
                 roots,
-                state: RefCell::new(TracerState::default()),
-                monitoring_tool_id: Cell::new(None),
-                monitoring_disable: RefCell::new(None),
+                state: Mutex::new(TracerState::default()),
+                monitoring_tool_id: OnceLock::new(),
+                monitoring_disable: OnceLock::new(),
             },
         )?;
 
@@ -78,7 +78,7 @@ impl CoverageSession {
     pub fn stop_and_save(self, py: Python<'_>) -> PyResult<()> {
         let Self { tracer, data_file } = self;
         let bound = tracer.bind(py);
-        let tool_id = bound.borrow().monitoring_tool_id.get();
+        let tool_id = bound.borrow().monitoring_tool_id.get().copied();
 
         if let Some(tool_id) = tool_id {
             let mon = py.import("sys")?.getattr("monitoring")?;
@@ -90,8 +90,13 @@ impl CoverageSession {
             py.import("sys")?.call_method1("settrace", (py.None(),))?;
         }
 
-        let executed = std::mem::take(&mut bound.borrow_mut().state.borrow_mut().executed);
-        let roots = bound.borrow().roots.clone();
+        let borrowed = bound.borrow();
+        let executed = match borrowed.state.lock() {
+            Ok(mut state) => std::mem::take(&mut state.executed),
+            Err(poisoned) => std::mem::take(&mut poisoned.into_inner().executed),
+        };
+        let roots = borrowed.roots.clone();
+        drop(borrowed);
         save_data(&data_file, executed, &roots).map_err(|err| {
             pyo3::exceptions::PyOSError::new_err(format!(
                 "failed to write coverage data to {data_file}: {err}"
@@ -109,17 +114,23 @@ struct TracerState {
     track_cache: HashMap<String, Option<PathBuf>>,
 }
 
-#[pyclass(module = "karva_coverage", unsendable)]
+/// Thread-safe because the trace callbacks fire on whichever Python thread
+/// happens to be executing tracked code: `sys.monitoring` LINE events are
+/// global to the registered tool id, and `sys.settrace` propagates to threads
+/// that opt in via `threading.settrace`. Marking the pyclass `unsendable`
+/// panics in `borrow()` as soon as a Python thread other than the installer
+/// invokes a callback (issue #760).
+#[pyclass(module = "karva_coverage")]
 struct CoverageTracer {
     roots: Vec<PathBuf>,
-    state: RefCell<TracerState>,
-    monitoring_tool_id: Cell<Option<u8>>,
+    state: Mutex<TracerState>,
+    monitoring_tool_id: OnceLock<u8>,
     /// Cached `sys.monitoring.DISABLE` sentinel. Populated when the
     /// `sys.monitoring` backend is installed; never accessed for the
     /// `sys.settrace` backend. Caching avoids importing `sys` inside the
     /// hot callback, which can re-enter the import system while `CPython`
     /// is mid-import and surface as `KeyError('__import__')`.
-    monitoring_disable: RefCell<Option<Py<PyAny>>>,
+    monitoring_disable: OnceLock<Py<PyAny>>,
 }
 
 #[pymethods]
@@ -134,19 +145,12 @@ impl CoverageTracer {
         lineno: u32,
     ) -> PyResult<Option<Py<PyAny>>> {
         let filename: String = code.getattr("co_filename")?.extract()?;
-        if let Some(path) = self.tracked_path(&filename) {
-            self.state
-                .borrow_mut()
-                .executed
-                .entry(path)
-                .or_default()
-                .insert(lineno);
+        if let Some(path) = self.tracked_path(&filename)
+            && let Ok(mut state) = self.state.lock()
+        {
+            state.executed.entry(path).or_default().insert(lineno);
         }
-        Ok(self
-            .monitoring_disable
-            .borrow()
-            .as_ref()
-            .map(|d| d.clone_ref(py)))
+        Ok(self.monitoring_disable.get().map(|d| d.clone_ref(py)))
     }
 
     /// `sys.settrace` global trace function. Returns the per-frame
@@ -187,13 +191,9 @@ impl CoverageTracer {
             let path = slf.borrow().tracked_path(&filename);
             if let Some(path) = path {
                 let lineno: u32 = frame.getattr("f_lineno")?.extract()?;
-                slf.borrow()
-                    .state
-                    .borrow_mut()
-                    .executed
-                    .entry(path)
-                    .or_default()
-                    .insert(lineno);
+                if let Ok(mut state) = slf.borrow().state.lock() {
+                    state.executed.entry(path).or_default().insert(lineno);
+                }
             }
         }
         Ok(slf.getattr("local_trace")?.unbind())
@@ -205,14 +205,17 @@ impl CoverageTracer {
     /// path if the file should be tracked, or `None` otherwise. Memoized
     /// per filename string.
     fn tracked_path(&self, filename: &str) -> Option<PathBuf> {
-        if let Some(cached) = self.state.borrow().track_cache.get(filename) {
+        if let Ok(state) = self.state.lock()
+            && let Some(cached) = state.track_cache.get(filename)
+        {
             return cached.clone();
         }
         let resolved = compute_tracked_path(filename, &self.roots);
-        self.state
-            .borrow_mut()
-            .track_cache
-            .insert(filename.to_string(), resolved.clone());
+        if let Ok(mut state) = self.state.lock() {
+            state
+                .track_cache
+                .insert(filename.to_string(), resolved.clone());
+        }
         resolved
     }
 }
@@ -261,8 +264,8 @@ fn install_monitoring(py: Python<'_>, tracer: &Py<CoverageTracer>) -> PyResult<(
     mon.call_method1("set_events", (tool_id, line_event))?;
     {
         let bound = tracer.bind(py).borrow();
-        bound.monitoring_tool_id.set(Some(tool_id));
-        *bound.monitoring_disable.borrow_mut() = Some(disable);
+        let _ = bound.monitoring_tool_id.set(tool_id);
+        let _ = bound.monitoring_disable.set(disable);
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

Fixes #760. `CoverageTracer` was a `#[pyclass(unsendable)]`, so any callback fired from a non-installer thread panicked with `CoverageTracer is unsendable, but sent to another thread` — and `sys.monitoring` LINE events fire on whichever thread is running tracked code, so any test under `--cov` that touched a worker thread crashed and hung the worker.

Dropped `unsendable` and switched the interior-mutability fields to thread-safe equivalents (`Mutex<TracerState>`, `OnceLock` for the install-once monitoring slots).

## Test Plan

Added a regression test that runs four `threading.Thread`s under `--cov` — hangs without the fix, passes with it. Verified end-to-end against `~/dev/requests` (`./.venv/bin/karva test --cov=src --no-parallel`): 165 tests complete in 16s and the full coverage table prints.