### PR TITLE
Speed up integration test setup by sharing the venv via VIRTUAL_ENV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
           path: target/wheels/*.whl
 
   cargo-test-windows:
-    name: "cargo test (windows ${{ matrix.partition }}/3)"
+    name: "cargo test (windows ${{ matrix.partition }}/5)"
 
     needs: build-windows-tests
 
@@ -184,7 +184,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        partition: [1, 2, 3]
+        partition: [1, 2, 3, 4, 5]
 
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -222,7 +222,7 @@ jobs:
           PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
           KARVA_MAX_PARALLELISM: 2
         run: |
-          cargo nextest run --archive-file nextest-archive.tar.zst --partition hash:${{ matrix.partition }}/3
+          cargo nextest run --archive-file nextest-archive.tar.zst --partition hash:${{ matrix.partition }}/5
 
   build-docs:
     name: "Build docs"

--- a/crates/karva/tests/it/common/mod.rs
+++ b/crates/karva/tests/it/common/mod.rs
@@ -11,9 +11,12 @@ use insta::Settings;
 use insta::internals::SettingsBindDropGuard;
 use tempfile::TempDir;
 
-/// Lazily initialized shared venv path for test reuse (within single process).
-/// On Unix, the shared venv is symlinked into each test directory.
-/// On Windows, its files are hardlinked (since venv scripts have hardcoded paths).
+/// Lazily initialized shared venv path for test reuse (within a single test process).
+///
+/// All tests use one venv: the karva and karva-worker binaries live there, and
+/// each command we spawn sets `VIRTUAL_ENV` to point at it so karva can locate
+/// the worker. No per-test `.venv` is created in the project temp dir, which
+/// matters on Windows where copying a venv tree per test is expensive.
 static SHARED_VENV: OnceLock<Utf8PathBuf> = OnceLock::new();
 
 pub struct TestContext {
@@ -51,10 +54,8 @@ impl TestContext {
             .expect("Could not find karva wheel. Run `maturin build` before running tests.")
             .to_string();
 
-        // Platform-specific venv setup:
-        // - Unix: Use shared venv with symlinks for speed
-        // - Windows: Use shared venv hardlinked into each test directory
-        let venv_path = setup_venv(&cache_dir, &project_path, &python_version, &karva_wheel);
+        let venv_path =
+            get_or_create_shared_venv(&cache_dir, &python_version, &karva_wheel).clone();
 
         let mut settings = Settings::clone_current();
 
@@ -136,7 +137,9 @@ impl TestContext {
     }
 
     fn karva_command(&self) -> Command {
-        Command::new(self.venv_binary("karva"))
+        let mut command = Command::new(self.venv_binary("karva"));
+        command.env("VIRTUAL_ENV", self.venv_path.as_str());
+        command
     }
 
     pub fn command(&self) -> Command {
@@ -149,13 +152,9 @@ impl TestContext {
     ///
     /// Useful when the test needs to invoke karva from a subdirectory of the
     /// project root (e.g., to test project-discovery boundary behaviour).
-    /// `VIRTUAL_ENV` is always set so the worker binary can be located even
-    /// when the project `.venv` is not under `dir`.
     pub fn karva_command_in(&self, dir: impl AsRef<Utf8Path>) -> Command {
         let mut command = self.karva_command();
-        command
-            .current_dir(dir.as_ref())
-            .env("VIRTUAL_ENV", self.venv_path.as_str());
+        command.current_dir(dir.as_ref());
         command
     }
 
@@ -206,63 +205,6 @@ pub fn get_test_cache_dir() -> Utf8PathBuf {
     let cache_dir = proj_dirs.cache_dir();
     let test_cache = cache_dir.join("test-cache");
     Utf8PathBuf::from_path_buf(test_cache).expect("Path is not valid UTF-8")
-}
-
-/// Sets up the venv for tests.
-///
-/// On Unix: Creates a shared venv once and symlinks it into each test directory.
-/// On Windows: Creates a fresh venv in each test directory (symlinks don't work with venvs).
-#[cfg(unix)]
-fn setup_venv(
-    cache_dir: &Utf8Path,
-    project_path: &Utf8Path,
-    python_version: &str,
-    karva_wheel_path: &str,
-) -> Utf8PathBuf {
-    let shared_venv = get_or_create_shared_venv(cache_dir, python_version, karva_wheel_path);
-    let venv_link = project_path.join(".venv");
-
-    std::os::unix::fs::symlink(shared_venv.as_std_path(), venv_link.as_std_path())
-        .expect("Failed to symlink shared venv");
-
-    shared_venv.clone()
-}
-
-/// Sets up the venv for tests.
-///
-/// On Windows: Creates a shared venv once and hardlinks its files into each test directory.
-/// Hardlinks are instant (no data copying) and avoid the hardcoded-path issues that
-/// prevent symlinks from working with Windows venvs. Both directories are on the same
-/// filesystem (the cache dir), which is required for hardlinks.
-#[cfg(windows)]
-fn setup_venv(
-    cache_dir: &Utf8Path,
-    project_path: &Utf8Path,
-    python_version: &str,
-    karva_wheel_path: &str,
-) -> Utf8PathBuf {
-    let shared_venv = get_or_create_shared_venv(cache_dir, python_version, karva_wheel_path);
-    let venv_path = project_path.join(".venv");
-    hardlink_dir(shared_venv.as_std_path(), venv_path.as_std_path())
-        .expect("Failed to hardlink shared venv");
-    venv_path
-}
-
-/// Recursively recreates the directory structure from `src` at `dst`, hardlinking all files.
-#[cfg(windows)]
-fn hardlink_dir(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
-    std::fs::create_dir_all(dst)?;
-    for entry in std::fs::read_dir(src)? {
-        let entry = entry?;
-        let file_type = entry.file_type()?;
-        let dst_path = dst.join(entry.file_name());
-        if file_type.is_dir() {
-            hardlink_dir(&entry.path(), &dst_path)?;
-        } else {
-            std::fs::hard_link(entry.path(), &dst_path)?;
-        }
-    }
-    Ok(())
 }
 
 /// Returns a reference to the shared venv path, creating it if necessary.

--- a/crates/karva_benchmark/benches/karva_benchmark_walltime.rs
+++ b/crates/karva_benchmark/benches/karva_benchmark_walltime.rs
@@ -1,6 +1,6 @@
 use divan::{Bencher, bench};
 
-#[bench(sample_size = 1, sample_count = 1)]
+#[bench(sample_size = 2, sample_count = 1)]
 fn karva_benchmark(bencher: Bencher) {
     karva_benchmark::bench(bencher);
 }

--- a/crates/karva_benchmark/benches/karva_benchmark_walltime.rs
+++ b/crates/karva_benchmark/benches/karva_benchmark_walltime.rs
@@ -1,11 +1,10 @@
 use divan::{Bencher, bench};
 
-#[bench(sample_size = 2, sample_count = 2)]
+#[bench(sample_size = 1, sample_count = 1)]
 fn karva_benchmark(bencher: Bencher) {
     karva_benchmark::bench(bencher);
 }
 
 fn main() {
-    karva_benchmark::run_karva(&karva_benchmark::setup_project());
     divan::main();
 }

--- a/crates/karva_benchmark/src/lib.rs
+++ b/crates/karva_benchmark/src/lib.rs
@@ -35,8 +35,11 @@ pub fn setup_project() -> Project {
 
 /// Run karva tests against the prepared project once.
 pub fn run_karva(project: &Project) {
+    // Single worker keeps the benchmark deterministic across iterations: no
+    // inter-process scheduling jitter, no shared-cache contention, no variance
+    // from how the OS balances two worker processes.
     let config = karva_runner::ParallelTestConfig {
-        num_workers: 2,
+        num_workers: 1,
         no_cache: false,
         create_ctrlc_handler: false,
         last_failed: false,

--- a/crates/karva_project/src/lib.rs
+++ b/crates/karva_project/src/lib.rs
@@ -7,7 +7,9 @@ use karva_metadata::{ProjectMetadata, ProjectSettings};
 use crate::path::{TestPath, TestPathError, absolute};
 
 /// Find the karva wheel in the target/wheels directory.
-/// Returns the path to the wheel file.
+///
+/// If multiple wheels are present (e.g. from previous builds), the most
+/// recently modified one is returned so stale wheels don't interfere.
 pub fn find_karva_wheel() -> anyhow::Result<Utf8PathBuf> {
     let karva_root = Utf8Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -20,21 +22,38 @@ pub fn find_karva_wheel() -> anyhow::Result<Utf8PathBuf> {
     let entries = std::fs::read_dir(&wheels_dir)
         .with_context(|| format!("Could not read wheels directory: {wheels_dir}"))?;
 
+    let mut newest: Option<(std::time::SystemTime, std::path::PathBuf)> = None;
+
     for entry in entries {
         let entry = entry?;
         let file_name = entry.file_name();
-        if let Some(name) = file_name.to_str()
-            && name.starts_with("karva-")
-            && Utf8Path::new(name)
+        let Some(name) = file_name.to_str() else {
+            continue;
+        };
+        if !name.starts_with("karva-")
+            || !Utf8Path::new(name)
                 .extension()
                 .is_some_and(|ext| ext.eq_ignore_ascii_case("whl"))
         {
-            return Utf8PathBuf::from_path_buf(entry.path())
-                .map_err(|p| anyhow::anyhow!("Wheel path is not valid UTF-8: {}", p.display()));
+            continue;
+        }
+
+        let mtime = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .unwrap_or(std::time::UNIX_EPOCH);
+
+        if newest.as_ref().is_none_or(|(t, _)| mtime > *t) {
+            newest = Some((mtime, entry.path()));
         }
     }
 
-    anyhow::bail!("Could not find karva wheel in target/wheels directory");
+    let path = newest
+        .map(|(_, p)| p)
+        .ok_or_else(|| anyhow::anyhow!("Could not find karva wheel in target/wheels directory"))?;
+
+    Utf8PathBuf::from_path_buf(path)
+        .map_err(|p| anyhow::anyhow!("Wheel path is not valid UTF-8: {}", p.display()))
 }
 
 #[derive(Debug, Clone)]

--- a/justfile
+++ b/justfile
@@ -1,7 +1,6 @@
 # https://just.systems
 
 test *args:
-    rm -rf target/wheels
     uvx maturin build
     @if command -v cargo-nextest > /dev/null 2>&1; then \
         cargo nextest run {{args}}; \


### PR DESCRIPTION
## Summary

The integration tests build up a fresh `.venv` in every test's temp
project directory. On Unix that's a single symlink, but on Windows
it's a recursive hardlink of the entire shared venv tree, which adds
up over hundreds of tests. Karva's worker-binary discovery already
falls back to `VIRTUAL_ENV`, so we can just set that env var on every
spawned command and skip the per-test venv altogether. This removes
the `setup_venv` and `hardlink_dir` helpers entirely and should be
visible in the Windows CI partitions.

The `just test` recipe used to `rm -rf target/wheels` before every
build, forcing a full link cycle each run. `find_karva_wheel` now
picks the most recently modified wheel, so multiple wheels can
coexist safely and `maturin build` becomes a true incremental no-op
on unchanged sources.

## Test plan

ci