### PR TITLE
Print nextest-style cancellation banner on Ctrl+C

### DIFF
--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -2717,7 +2717,7 @@ fn test_slow_timeout_emits_slow_line_and_counter() {
 import time
 
 def test_slow():
-    time.sleep(0.05)
+    time.sleep(0.3)
 
 def test_fast():
     pass
@@ -2726,7 +2726,7 @@ def test_fast():
 
     assert_cmd_snapshot!(
         context.command_no_parallel().args([
-            "--slow-timeout=0.001",
+            "--slow-timeout=0.1",
             "--status-level=slow",
         ]),
         @"
@@ -2754,13 +2754,13 @@ fn test_slow_timeout_counter_visible_below_slow_status_level() {
 import time
 
 def test_slow():
-    time.sleep(0.05)
+    time.sleep(0.3)
 ",
     );
 
     assert_cmd_snapshot!(
         context.command_no_parallel().args([
-            "--slow-timeout=0.001",
+            "--slow-timeout=0.1",
             "--status-level=fail",
         ]),
         @"

--- a/crates/karva/tests/it/cancel.rs
+++ b/crates/karva/tests/it/cancel.rs
@@ -57,6 +57,13 @@ def test_slow_e(): time.sleep(60)
         .expect("Failed to wait on karva process");
 
     let mut stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    // Which two of the five slow tests are in flight when SIGINT arrives
+    // depends on partitioning and timing, so collapse the suffix to keep
+    // the snapshot stable across runs.
+    stdout = regex::Regex::new(r"test_slow_[a-e]")
+        .unwrap()
+        .replace_all(&stdout, "test_slow_X")
+        .into_owned();
     // Worker scheduling means PASS and SIGINT lines can appear in any
     // order. Sort each block independently for a deterministic snapshot.
     // The ordering of every other line (Starting / Cancelling / summary
@@ -72,8 +79,8 @@ def test_slow_e(): time.sleep(60)
             PASS [TIME] test_mixed::test_fast_d
             PASS [TIME] test_mixed::test_fast_e
       Cancelling due to interrupt: 10 tests still running
-          SIGINT [TIME] test_mixed::test_slow_a
-          SIGINT [TIME] test_mixed::test_slow_b
+          SIGINT [TIME] test_mixed::test_slow_X
+          SIGINT [TIME] test_mixed::test_slow_X
     ────────────
          Summary [TIME] 0 tests run: 0 passed, 0 skipped
     error: no tests to run

--- a/crates/karva/tests/it/cancel.rs
+++ b/crates/karva/tests/it/cancel.rs
@@ -3,6 +3,8 @@
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
+use insta::assert_snapshot;
+
 use crate::common::TestContext;
 
 #[test]
@@ -19,6 +21,7 @@ def test_slow():
 
     let child = context
         .command()
+        .arg("--no-parallel")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
@@ -26,7 +29,7 @@ def test_slow():
 
     let pid = child.id();
 
-    // Wait long enough for karva to launch its workers and reach the
+    // Wait long enough for karva to launch its worker and reach the
     // wait-for-completion loop. The slow test sleeps for 60s so karva will
     // still be running when we send the signal.
     std::thread::sleep(Duration::from_secs(5));
@@ -43,12 +46,13 @@ def test_slow():
 
     let stdout = String::from_utf8_lossy(&output.stdout);
 
-    assert!(
-        stdout.contains("Cancelling due to interrupt"),
-        "expected cancellation banner in stdout, got:\n{stdout}"
-    );
-    assert!(
-        stdout.contains("SIGINT"),
-        "expected SIGINT line in stdout, got:\n{stdout}"
-    );
+    assert_snapshot!(stdout, @r"
+        Starting 1 test across 1 worker
+      Cancelling due to interrupt: 1 tests still running
+          SIGINT [TIME] worker 0 (1 test)
+    ────────────
+         Summary [TIME] 0 tests run: 0 passed, 0 skipped
+    error: no tests to run
+    (hint: use `--no-tests` to customize)
+    ");
 }

--- a/crates/karva/tests/it/cancel.rs
+++ b/crates/karva/tests/it/cancel.rs
@@ -1,0 +1,54 @@
+#![cfg(unix)]
+
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use crate::common::TestContext;
+
+#[test]
+fn test_ctrlc_emits_cancellation_banner() {
+    let context = TestContext::with_file(
+        "test_slow.py",
+        r"
+import time
+
+def test_slow():
+    time.sleep(60)
+",
+    );
+
+    let child = context
+        .command()
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn karva");
+
+    let pid = child.id();
+
+    // Wait long enough for karva to launch its workers and reach the
+    // wait-for-completion loop. The slow test sleeps for 60s so karva will
+    // still be running when we send the signal.
+    std::thread::sleep(Duration::from_secs(5));
+
+    let status = Command::new("kill")
+        .args(["-s", "INT", &pid.to_string()])
+        .status()
+        .expect("Failed to invoke kill");
+    assert!(status.success(), "kill -s INT {pid} failed");
+
+    let output = child
+        .wait_with_output()
+        .expect("Failed to wait on karva process");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        stdout.contains("Cancelling due to interrupt"),
+        "expected cancellation banner in stdout, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("SIGINT"),
+        "expected SIGINT line in stdout, got:\n{stdout}"
+    );
+}

--- a/crates/karva/tests/it/cancel.rs
+++ b/crates/karva/tests/it/cancel.rs
@@ -57,11 +57,12 @@ def test_slow_e(): time.sleep(60)
         .expect("Failed to wait on karva process");
 
     let mut stdout = String::from_utf8_lossy(&output.stdout).into_owned();
-    // The five fast tests can complete in any order across the two
-    // workers, so sort the PASS lines for a deterministic snapshot. The
-    // ordering of every other line (Starting / Cancelling / SIGINT /
-    // summary / error) is deterministic.
-    sort_pass_lines(&mut stdout);
+    // Worker scheduling means PASS and SIGINT lines can appear in any
+    // order. Sort each block independently for a deterministic snapshot.
+    // The ordering of every other line (Starting / Cancelling / summary
+    // / error) is deterministic.
+    sort_block_starting_with(&mut stdout, "PASS");
+    sort_block_starting_with(&mut stdout, "SIGINT");
 
     assert_snapshot!(stdout, @r"
         Starting 10 tests across 2 workers
@@ -71,8 +72,8 @@ def test_slow_e(): time.sleep(60)
             PASS [TIME] test_mixed::test_fast_d
             PASS [TIME] test_mixed::test_fast_e
       Cancelling due to interrupt: 10 tests still running
-          SIGINT [TIME] worker 0 (5 tests)
-          SIGINT [TIME] worker 1 (5 tests)
+          SIGINT [TIME] test_mixed::test_slow_a
+          SIGINT [TIME] test_mixed::test_slow_b
     ────────────
          Summary [TIME] 0 tests run: 0 passed, 0 skipped
     error: no tests to run
@@ -80,20 +81,18 @@ def test_slow_e(): time.sleep(60)
     ");
 }
 
-/// Sort the contiguous block of `PASS` lines in `stdout` so the snapshot
-/// is deterministic. Workers run in parallel so the PASS-line ordering
-/// is racy, but every other line is emitted by the orchestrator in a
-/// fixed order.
-fn sort_pass_lines(stdout: &mut String) {
+/// Sort the contiguous block of lines whose first token is `label` so
+/// the snapshot is deterministic. Workers run in parallel so PASS- and
+/// SIGINT-line ordering is racy, but every other line is emitted by
+/// the orchestrator in a fixed order.
+fn sort_block_starting_with(stdout: &mut String, label: &str) {
     let lines: Vec<&str> = stdout.lines().collect();
-    let first_pass = lines
-        .iter()
-        .position(|l| l.trim_start().starts_with("PASS"));
-    let Some(start) = first_pass else { return };
+    let first = lines.iter().position(|l| l.trim_start().starts_with(label));
+    let Some(start) = first else { return };
     let end = start
         + lines[start..]
             .iter()
-            .take_while(|l| l.trim_start().starts_with("PASS"))
+            .take_while(|l| l.trim_start().starts_with(label))
             .count();
     let mut sorted: Vec<String> = lines[start..end].iter().map(ToString::to_string).collect();
     sorted.sort();

--- a/crates/karva/tests/it/cancel.rs
+++ b/crates/karva/tests/it/cancel.rs
@@ -9,19 +9,30 @@ use crate::common::TestContext;
 
 #[test]
 fn test_ctrlc_emits_cancellation_banner() {
+    // Mix of fast tests (which complete and print PASS lines) and slow
+    // tests (which keep workers busy when SIGINT arrives) so the snapshot
+    // exercises both code paths and shows non-trivial output.
     let context = TestContext::with_file(
-        "test_slow.py",
+        "test_mixed.py",
         r"
 import time
 
-def test_slow():
-    time.sleep(60)
+def test_fast_a(): pass
+def test_fast_b(): pass
+def test_fast_c(): pass
+def test_fast_d(): pass
+def test_fast_e(): pass
+def test_slow_a(): time.sleep(60)
+def test_slow_b(): time.sleep(60)
+def test_slow_c(): time.sleep(60)
+def test_slow_d(): time.sleep(60)
+def test_slow_e(): time.sleep(60)
 ",
     );
 
     let child = context
         .command()
-        .arg("--no-parallel")
+        .args(["--num-workers", "2"])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
@@ -29,9 +40,10 @@ def test_slow():
 
     let pid = child.id();
 
-    // Wait long enough for karva to launch its worker and reach the
-    // wait-for-completion loop. The slow test sleeps for 60s so karva will
-    // still be running when we send the signal.
+    // Wait long enough for karva to launch its workers, run the fast
+    // tests, and reach the wait-for-completion loop blocked on the slow
+    // tests. The slow tests sleep for 60s so karva will still be running
+    // when we send the signal.
     std::thread::sleep(Duration::from_secs(5));
 
     let status = Command::new("kill")
@@ -44,15 +56,56 @@ def test_slow():
         .wait_with_output()
         .expect("Failed to wait on karva process");
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    // The five fast tests can complete in any order across the two
+    // workers, so sort the PASS lines for a deterministic snapshot. The
+    // ordering of every other line (Starting / Cancelling / SIGINT /
+    // summary / error) is deterministic.
+    sort_pass_lines(&mut stdout);
 
     assert_snapshot!(stdout, @r"
-        Starting 1 test across 1 worker
-      Cancelling due to interrupt: 1 tests still running
-          SIGINT [TIME] worker 0 (1 test)
+        Starting 10 tests across 2 workers
+            PASS [TIME] test_mixed::test_fast_a
+            PASS [TIME] test_mixed::test_fast_b
+            PASS [TIME] test_mixed::test_fast_c
+            PASS [TIME] test_mixed::test_fast_d
+            PASS [TIME] test_mixed::test_fast_e
+      Cancelling due to interrupt: 10 tests still running
+          SIGINT [TIME] worker 0 (5 tests)
+          SIGINT [TIME] worker 1 (5 tests)
     ────────────
          Summary [TIME] 0 tests run: 0 passed, 0 skipped
     error: no tests to run
     (hint: use `--no-tests` to customize)
     ");
+}
+
+/// Sort the contiguous block of `PASS` lines in `stdout` so the snapshot
+/// is deterministic. Workers run in parallel so the PASS-line ordering
+/// is racy, but every other line is emitted by the orchestrator in a
+/// fixed order.
+fn sort_pass_lines(stdout: &mut String) {
+    let lines: Vec<&str> = stdout.lines().collect();
+    let first_pass = lines
+        .iter()
+        .position(|l| l.trim_start().starts_with("PASS"));
+    let Some(start) = first_pass else { return };
+    let end = start
+        + lines[start..]
+            .iter()
+            .take_while(|l| l.trim_start().starts_with("PASS"))
+            .count();
+    let mut sorted: Vec<String> = lines[start..end].iter().map(ToString::to_string).collect();
+    sorted.sort();
+    let mut rebuilt = lines[..start].join("\n");
+    if !rebuilt.is_empty() {
+        rebuilt.push('\n');
+    }
+    rebuilt.push_str(&sorted.join("\n"));
+    rebuilt.push('\n');
+    rebuilt.push_str(&lines[end..].join("\n"));
+    if stdout.ends_with('\n') {
+        rebuilt.push('\n');
+    }
+    *stdout = rebuilt;
 }

--- a/crates/karva/tests/it/cancel.rs
+++ b/crates/karva/tests/it/cancel.rs
@@ -65,11 +65,11 @@ def test_slow_e(): time.sleep(60)
         .replace_all(&stdout, "test_slow_X")
         .into_owned();
     // Worker scheduling means PASS and SIGINT lines can appear in any
-    // order. Sort each block independently for a deterministic snapshot.
-    // The ordering of every other line (Starting / Cancelling / summary
-    // / error) is deterministic.
-    sort_block_starting_with(&mut stdout, "PASS");
-    sort_block_starting_with(&mut stdout, "SIGINT");
+    // order. Sort each status independently for a deterministic snapshot.
+    // The ordering of every other line (Starting / Cancelling / summary)
+    // is deterministic.
+    sort_lines_starting_with(&mut stdout, "PASS");
+    sort_lines_starting_with(&mut stdout, "SIGINT");
 
     assert_snapshot!(stdout, @r"
         Starting 10 tests across 2 workers
@@ -78,38 +78,33 @@ def test_slow_e(): time.sleep(60)
             PASS [TIME] test_mixed::test_fast_c
             PASS [TIME] test_mixed::test_fast_d
             PASS [TIME] test_mixed::test_fast_e
-      Cancelling due to interrupt: 10 tests still running
+      Cancelling due to interrupt: 2 tests still running
           SIGINT [TIME] test_mixed::test_slow_X
           SIGINT [TIME] test_mixed::test_slow_X
     ────────────
-         Summary [TIME] 0 tests run: 0 passed, 0 skipped
-    error: no tests to run
-    (hint: use `--no-tests` to customize)
+         Summary [TIME] 2 tests run: 0 passed, 2 failed, 0 skipped
     ");
 }
 
-/// Sort the contiguous block of lines whose first token is `label` so
-/// the snapshot is deterministic. Workers run in parallel so PASS- and
-/// SIGINT-line ordering is racy, but every other line is emitted by
-/// the orchestrator in a fixed order.
-fn sort_block_starting_with(stdout: &mut String, label: &str) {
-    let lines: Vec<&str> = stdout.lines().collect();
-    let first = lines.iter().position(|l| l.trim_start().starts_with(label));
-    let Some(start) = first else { return };
-    let end = start
-        + lines[start..]
-            .iter()
-            .take_while(|l| l.trim_start().starts_with(label))
-            .count();
-    let mut sorted: Vec<String> = lines[start..end].iter().map(ToString::to_string).collect();
+/// Sort all lines whose first token is `label` so the snapshot is deterministic.
+fn sort_lines_starting_with(stdout: &mut String, label: &str) {
+    let mut lines: Vec<String> = stdout.lines().map(ToString::to_string).collect();
+    let positions: Vec<usize> = lines
+        .iter()
+        .enumerate()
+        .filter_map(|(index, line)| line.trim_start().starts_with(label).then_some(index))
+        .collect();
+    let mut sorted: Vec<String> = positions
+        .iter()
+        .map(|index| lines[*index].clone())
+        .collect();
     sorted.sort();
-    let mut rebuilt = lines[..start].join("\n");
-    if !rebuilt.is_empty() {
-        rebuilt.push('\n');
+
+    for (position, line) in positions.into_iter().zip(sorted) {
+        lines[position] = line;
     }
-    rebuilt.push_str(&sorted.join("\n"));
-    rebuilt.push('\n');
-    rebuilt.push_str(&lines[end..].join("\n"));
+
+    let mut rebuilt = lines.join("\n");
     if stdout.ends_with('\n') {
         rebuilt.push('\n');
     }

--- a/crates/karva/tests/it/main.rs
+++ b/crates/karva/tests/it/main.rs
@@ -3,6 +3,7 @@ pub(crate) mod common;
 mod r#async;
 mod basic;
 mod cache;
+mod cancel;
 mod configuration;
 mod coverage;
 mod discovery;

--- a/crates/karva_cache/src/artifact.rs
+++ b/crates/karva_cache/src/artifact.rs
@@ -32,6 +32,10 @@ pub enum CacheFile {
     FailFastSignal,
     /// Cache-root JSON: list of last-run failed test names.
     LastFailed,
+    /// Per-worker JSON: name + start time of the test currently executing,
+    /// or absent when the worker is between tests. Used by the orchestrator
+    /// to render per-test `SIGINT` lines on Ctrl+C.
+    CurrentTest,
 }
 
 impl CacheFile {
@@ -46,6 +50,7 @@ impl CacheFile {
             Self::Coverage => "coverage.json",
             Self::FailFastSignal => "fail-fast",
             Self::LastFailed => "last-failed.json",
+            Self::CurrentTest => "current_test.json",
         }
     }
 

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -6,9 +6,23 @@ use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
 use karva_diagnostic::{FlakyTest, TestResultStats, TestRunResult};
 use ruff_db::diagnostic::{DisplayDiagnosticConfig, DisplayDiagnostics, FileResolver};
+use serde::{Deserialize, Serialize};
 
 use crate::artifact::{CacheFile, read_json, read_text, write_json, write_json_if_nonempty};
 use crate::{RUN_PREFIX, RunHash, WORKER_PREFIX, worker_folder};
+
+/// Snapshot of the test a worker is currently executing.
+///
+/// Workers update this file at the start of each test and remove it on
+/// completion; the orchestrator reads it on Ctrl+C to render per-test
+/// `SIGINT` lines.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CurrentTest {
+    /// Fully qualified test name (`module::function[params]`).
+    pub name: String,
+    /// Wall-clock start of the test, milliseconds since the Unix epoch.
+    pub start_unix_ms: u64,
+}
 
 /// Aggregated test results collected from all worker processes.
 #[derive(Default)]
@@ -65,6 +79,19 @@ impl RunCache {
     /// coverage session ends.
     pub fn coverage_data_file(&self, worker_id: usize) -> Utf8PathBuf {
         CacheFile::Coverage.path_in(&self.worker_dir(worker_id))
+    }
+
+    /// Path to the per-worker file describing the test currently executing.
+    pub fn current_test_file(&self, worker_id: usize) -> Utf8PathBuf {
+        CacheFile::CurrentTest.path_in(&self.worker_dir(worker_id))
+    }
+
+    /// Reads the snapshot of which test the worker is currently running.
+    /// Returns `None` if the worker is between tests or hasn't started yet.
+    pub fn read_current_test(&self, worker_id: usize) -> Option<CurrentTest> {
+        read_json::<CurrentTest>(&self.worker_dir(worker_id), CacheFile::CurrentTest)
+            .ok()
+            .flatten()
     }
 
     /// Returns paths to every per-worker coverage file that exists for this

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
-use karva_diagnostic::{FlakyTest, TestResultStats, TestRunResult};
+use karva_diagnostic::{FlakyTest, TestResultKind, TestResultStats, TestRunResult};
 use ruff_db::diagnostic::{DisplayDiagnosticConfig, DisplayDiagnostics, FileResolver};
 use serde::{Deserialize, Serialize};
 
@@ -32,6 +32,17 @@ pub struct AggregatedResults {
     pub failed_tests: Vec<String>,
     pub flaky_tests: Vec<FlakyTest>,
     pub durations: HashMap<String, Duration>,
+}
+
+impl AggregatedResults {
+    pub fn register_interrupted_test(&mut self, name: &str, duration: Duration) {
+        let function_name = name
+            .split_once('[')
+            .map_or_else(|| name.to_string(), |(base, _)| base.to_string());
+        self.stats.add(TestResultKind::Failed);
+        self.failed_tests.push(function_name.clone());
+        self.durations.insert(function_name, duration);
+    }
 }
 
 /// Reads and writes test results in the cache directory for a specific run.
@@ -88,10 +99,8 @@ impl RunCache {
 
     /// Reads the snapshot of which test the worker is currently running.
     /// Returns `None` if the worker is between tests or hasn't started yet.
-    pub fn read_current_test(&self, worker_id: usize) -> Option<CurrentTest> {
+    pub fn read_current_test(&self, worker_id: usize) -> Result<Option<CurrentTest>> {
         read_json::<CurrentTest>(&self.worker_dir(worker_id), CacheFile::CurrentTest)
-            .ok()
-            .flatten()
     }
 
     /// Returns paths to every per-worker coverage file that exists for this
@@ -609,6 +618,25 @@ mod tests {
                 20ms,
             ),
         ]
+        "#);
+    }
+
+    #[test]
+    fn interrupted_tests_count_as_failures() {
+        let mut results = AggregatedResults::default();
+
+        results.register_interrupted_test("mod::test_slow[param]", Duration::from_millis(42));
+
+        assert_eq!(results.stats.failed(), 1);
+        assert_debug_snapshot!(results.failed_tests, @r#"
+        [
+            "mod::test_slow",
+        ]
+        "#);
+        assert_debug_snapshot!(results.durations, @r#"
+        {
+            "mod::test_slow": 42ms,
+        }
         "#);
     }
 

--- a/crates/karva_cache/src/lib.rs
+++ b/crates/karva_cache/src/lib.rs
@@ -3,8 +3,8 @@ pub(crate) mod cache;
 pub(crate) mod hash;
 
 pub use cache::{
-    AggregatedResults, PruneResult, RunCache, clean_cache, prune_cache, read_last_failed,
-    read_recent_durations, write_last_failed,
+    AggregatedResults, CurrentTest, PruneResult, RunCache, clean_cache, prune_cache,
+    read_last_failed, read_recent_durations, write_last_failed,
 };
 pub use hash::RunHash;
 pub use karva_diagnostic::{DisplayFlakyTests, FlakyTest};

--- a/crates/karva_diagnostic/Cargo.toml
+++ b/crates/karva_diagnostic/Cargo.toml
@@ -23,10 +23,10 @@ ruff_db = { workspace = true }
 ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
-serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/karva_diagnostic/src/reporter.rs
+++ b/crates/karva_diagnostic/src/reporter.rs
@@ -1,6 +1,7 @@
 use std::fmt::Write;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use camino::Utf8PathBuf;
 use colored::Colorize;
 use karva_logging::time::format_duration_bracketed;
 use karva_logging::{Printer, StatusLevel};
@@ -41,6 +42,21 @@ pub trait Reporter: Send + Sync {
     fn report_test_slow(&self, test_name: &QualifiedTestName, duration: Duration) {
         let _ = (test_name, duration);
     }
+
+    /// Called immediately before a test starts executing.
+    ///
+    /// Used by reporters that track in-flight tests for cancellation
+    /// reporting; default is a no-op.
+    fn report_test_started(&self, test_name: &QualifiedTestName) {
+        let _ = test_name;
+    }
+
+    /// Called when a test finishes (passed, failed, or skipped) so the
+    /// reporter can clear any in-flight state recorded by
+    /// [`Self::report_test_started`]. Default no-op.
+    fn report_test_finished(&self, test_name: &QualifiedTestName) {
+        let _ = test_name;
+    }
 }
 
 fn show_for_status_level(level: StatusLevel, kind: &IndividualTestResultKind) -> bool {
@@ -77,11 +93,27 @@ impl Reporter for DummyReporter {
 /// A reporter that outputs test results to stdout as they complete.
 pub struct TestCaseReporter {
     printer: Printer,
+    /// Optional path to a JSON file describing the test currently
+    /// executing. The orchestrator reads this on Ctrl+C to render
+    /// per-test `SIGINT` lines.
+    progress_file: Option<Utf8PathBuf>,
 }
 
 impl TestCaseReporter {
     pub fn new(printer: Printer) -> Self {
-        Self { printer }
+        Self {
+            printer,
+            progress_file: None,
+        }
+    }
+
+    /// Direct the reporter to write the currently running test's name and
+    /// start time to `path` whenever a test begins, and remove the file
+    /// when it ends.
+    #[must_use]
+    pub fn with_progress_file(mut self, path: Utf8PathBuf) -> Self {
+        self.progress_file = Some(path);
+        self
     }
 }
 
@@ -163,6 +195,51 @@ impl Reporter for TestCaseReporter {
         )
         .ok();
     }
+
+    fn report_test_started(&self, test_name: &QualifiedTestName) {
+        let Some(path) = self.progress_file.as_ref() else {
+            return;
+        };
+        let start_unix_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+            .unwrap_or(0);
+        // Avoid pulling in `karva_cache::CurrentTest` here (would be a
+        // circular dep). The cache crate deserialises the same JSON shape.
+        let body = format!(
+            "{{\"name\":{},\"start_unix_ms\":{start_unix_ms}}}",
+            json_string(&test_name.to_string()),
+        );
+        let _ = std::fs::write(path, body);
+    }
+
+    fn report_test_finished(&self, _test_name: &QualifiedTestName) {
+        if let Some(path) = self.progress_file.as_ref() {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
+/// Quote a string for JSON. Stays in this crate so we don't take a hard
+/// dependency on `serde_json` just for one field.
+fn json_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                let _ = write!(out, "\\u{:04x}", c as u32);
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
 }
 
 /// The width that result labels (`PASS`, `FAIL`, `SKIP`, `SLOW`, `TRY N PASS`,

--- a/crates/karva_diagnostic/src/reporter.rs
+++ b/crates/karva_diagnostic/src/reporter.rs
@@ -204,13 +204,11 @@ impl Reporter for TestCaseReporter {
             .duration_since(UNIX_EPOCH)
             .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
             .unwrap_or(0);
-        // Avoid pulling in `karva_cache::CurrentTest` here (would be a
-        // circular dep). The cache crate deserialises the same JSON shape.
-        let body = format!(
-            "{{\"name\":{},\"start_unix_ms\":{start_unix_ms}}}",
-            json_string(&test_name.to_string()),
-        );
-        let _ = std::fs::write(path, body);
+        let body = serde_json::json!({
+            "name": test_name.to_string(),
+            "start_unix_ms": start_unix_ms,
+        });
+        let _ = std::fs::write(path, body.to_string());
     }
 
     fn report_test_finished(&self, _test_name: &QualifiedTestName) {
@@ -218,28 +216,6 @@ impl Reporter for TestCaseReporter {
             let _ = std::fs::remove_file(path);
         }
     }
-}
-
-/// Quote a string for JSON. Stays in this crate so we don't take a hard
-/// dependency on `serde_json` just for one field.
-fn json_string(s: &str) -> String {
-    let mut out = String::with_capacity(s.len() + 2);
-    out.push('"');
-    for ch in s.chars() {
-        match ch {
-            '"' => out.push_str("\\\""),
-            '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            c if (c as u32) < 0x20 => {
-                let _ = write!(out, "\\u{:04x}", c as u32);
-            }
-            c => out.push(c),
-        }
-    }
-    out.push('"');
-    out
 }
 
 /// The width that result labels (`PASS`, `FAIL`, `SKIP`, `SLOW`, `TRY N PASS`,

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -146,55 +146,67 @@ impl WorkerManager {
         }
     }
 
-    /// Print a nextest-style cancellation banner naming the number of tests
-    /// still running across all live workers.
-    fn report_cancellation(&self, printer: Printer) {
-        if self.workers.is_empty() {
-            return;
-        }
-        let total: usize = self.workers.iter().map(|w| w.test_count).sum();
-        let label = "Cancelling".red().bold();
-        let mut stdout = printer.stream_for_test_result().lock();
-        let _ = writeln!(
-            stdout,
-            "  {label} due to interrupt: {total} tests still running"
-        );
-    }
-
     /// Kill and wait on any remaining worker processes.
     ///
     /// Uses two separate loops: the first sends kill signals to all workers
     /// immediately, and the second reaps them. This ensures every worker
     /// receives the signal without waiting for earlier ones to exit first.
-    ///
-    /// When `print_sigint` is `true`, emit a `SIGINT [duration] worker N`
-    /// line per remaining worker before killing it, mirroring nextest's
-    /// per-test cancellation output (we don't track individual tests at the
-    /// orchestrator level, so the line is per-worker).
-    fn kill_remaining(&mut self, printer: Printer, print_sigint: bool) {
-        if print_sigint && !self.workers.is_empty() {
-            let mut stdout = printer.stream_for_test_result().lock();
-            for worker in &self.workers {
-                let label = "SIGINT".red().bold();
-                let padding = " ".repeat(LABEL_COLUMN_WIDTH.saturating_sub("SIGINT".len()));
-                let duration_str = format_duration_bracketed(worker.duration());
-                let test_label = if worker.test_count == 1 {
-                    "test"
-                } else {
-                    "tests"
-                };
-                let _ = writeln!(
-                    stdout,
-                    "{padding}{label} {duration_str} worker {} ({} {test_label})",
-                    worker.id, worker.test_count
-                );
-            }
-        }
+    fn kill_remaining(&mut self) {
         for worker in &mut self.workers {
             let _ = worker.child.kill();
         }
         for worker in &mut self.workers {
             let _ = worker.child.wait();
+        }
+    }
+
+    /// Stop remaining workers and emit nextest-style cancellation lines.
+    ///
+    /// Workers are killed first (and reaped) so any in-flight `PASS`/`FAIL`
+    /// lines they were writing to the inherited stdout land before our
+    /// banner — otherwise the cancellation block interleaves with worker
+    /// output. A short settle pause lets any kernel-buffered writes drain
+    /// for the same reason.
+    ///
+    /// We emit a `SIGINT [duration] worker N (M tests)` line per remaining
+    /// worker, mirroring nextest's per-test cancellation output. We don't
+    /// track individual tests at the orchestrator level, so the line is
+    /// per-worker.
+    fn cancel_and_kill(&mut self, printer: Printer) {
+        if self.workers.is_empty() {
+            return;
+        }
+
+        let total_tests: usize = self.workers.iter().map(|w| w.test_count).sum();
+
+        for worker in &mut self.workers {
+            let _ = worker.child.kill();
+        }
+        for worker in &mut self.workers {
+            let _ = worker.child.wait();
+        }
+        std::thread::sleep(STDOUT_SETTLE);
+
+        let mut stdout = printer.stream_for_test_result().lock();
+        let cancel_label = "Cancelling".red().bold();
+        let _ = writeln!(
+            stdout,
+            "  {cancel_label} due to interrupt: {total_tests} tests still running"
+        );
+        for worker in &self.workers {
+            let label = "SIGINT".red().bold();
+            let padding = " ".repeat(LABEL_COLUMN_WIDTH.saturating_sub("SIGINT".len()));
+            let duration_str = format_duration_bracketed(worker.duration());
+            let test_label = if worker.test_count == 1 {
+                "test"
+            } else {
+                "tests"
+            };
+            let _ = writeln!(
+                stdout,
+                "{padding}{label} {duration_str} worker {} ({} {test_label})",
+                worker.id, worker.test_count
+            );
         }
     }
 }
@@ -398,9 +410,10 @@ pub fn run_parallel_tests(
 
     let outcome = worker_manager.wait_for_completion(shutdown_rx, max_fail_cache);
     if outcome == WaitOutcome::Cancelled {
-        worker_manager.report_cancellation(printer);
+        worker_manager.cancel_and_kill(printer);
+    } else {
+        worker_manager.kill_remaining();
     }
-    worker_manager.kill_remaining(printer, outcome == WaitOutcome::Cancelled);
 
     let results = cache.aggregate_results()?;
 
@@ -422,3 +435,6 @@ pub fn run_parallel_tests(
 
 const MIN_TESTS_PER_WORKER: usize = 5;
 const WORKER_POLL_INTERVAL: Duration = Duration::from_millis(10);
+/// Pause after killing workers to let kernel-buffered output drain to
+/// stdout before we emit the cancellation banner.
+const STDOUT_SETTLE: Duration = Duration::from_millis(50);

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -188,13 +188,14 @@ impl WorkerManager {
         std::thread::sleep(STDOUT_SETTLE);
 
         let mut stdout = printer.stream_for_test_result().lock();
-        let cancel_label = "Cancelling".red().bold();
+        let cancel_label = "Cancelling".yellow().bold();
+        let interrupt_label = "interrupt".yellow().bold();
         let _ = writeln!(
             stdout,
-            "  {cancel_label} due to interrupt: {total_tests} tests still running"
+            "  {cancel_label} due to {interrupt_label}: {total_tests} tests still running"
         );
         for worker in &self.workers {
-            let label = "SIGINT".red().bold();
+            let label = "SIGINT".yellow().bold();
             let padding = " ".repeat(LABEL_COLUMN_WIDTH.saturating_sub("SIGINT".len()));
             let duration_str = format_duration_bracketed(worker.duration());
             let test_label = if worker.test_count == 1 {

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::fmt::Write;
 use std::process::{Child, Stdio};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use camino::Utf8PathBuf;
@@ -162,20 +162,40 @@ impl WorkerManager {
 
     /// Stop remaining workers and emit nextest-style cancellation lines.
     ///
-    /// Workers are killed first (and reaped) so any in-flight `PASS`/`FAIL`
-    /// lines they were writing to the inherited stdout land before our
-    /// banner — otherwise the cancellation block interleaves with worker
-    /// output. A short settle pause lets any kernel-buffered writes drain
-    /// for the same reason.
+    /// Each worker writes a `current_test.json` file at the start of every
+    /// test and removes it when the test finishes. We read those files
+    /// *before* killing — once we kill the worker, that file may be removed
+    /// by an in-flight finalizer or simply lost — and remember a
+    /// `(worker_id, test name, test start time)` snapshot for each.
     ///
-    /// We emit a `SIGINT [duration] worker N (M tests)` line per remaining
-    /// worker, mirroring nextest's per-test cancellation output. We don't
-    /// track individual tests at the orchestrator level, so the line is
-    /// per-worker.
-    fn cancel_and_kill(&mut self, printer: Printer) {
+    /// Workers are killed and reaped before we print so any in-flight
+    /// `PASS`/`FAIL` lines they were writing to the inherited stdout land
+    /// before our banner; otherwise the cancellation block interleaves
+    /// with worker output. A short settle pause lets any kernel-buffered
+    /// writes drain.
+    fn cancel_and_kill(&mut self, printer: Printer, cache: &RunCache) {
         if self.workers.is_empty() {
             return;
         }
+
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+            .unwrap_or(0);
+
+        let in_flight: Vec<_> = self
+            .workers
+            .iter()
+            .map(|worker| {
+                let current = cache.read_current_test(worker.id);
+                let elapsed = current.as_ref().and_then(|c| {
+                    now_ms
+                        .checked_sub(c.start_unix_ms)
+                        .map(Duration::from_millis)
+                });
+                (worker.id, current.map(|c| c.name), elapsed)
+            })
+            .collect();
 
         let total_tests: usize = self.workers.iter().map(|w| w.test_count).sum();
 
@@ -194,21 +214,37 @@ impl WorkerManager {
             stdout,
             "  {cancel_label} due to {interrupt_label}: {total_tests} tests still running"
         );
-        for worker in &self.workers {
-            let label = "SIGINT".yellow().bold();
-            let padding = " ".repeat(LABEL_COLUMN_WIDTH.saturating_sub("SIGINT".len()));
-            let duration_str = format_duration_bracketed(worker.duration());
-            let test_label = if worker.test_count == 1 {
-                "test"
-            } else {
-                "tests"
-            };
-            let _ = writeln!(
-                stdout,
-                "{padding}{label} {duration_str} worker {} ({} {test_label})",
-                worker.id, worker.test_count
-            );
+
+        let label = "SIGINT".yellow().bold();
+        let padding = " ".repeat(LABEL_COLUMN_WIDTH.saturating_sub("SIGINT".len()));
+        for (worker_id, test_name, elapsed) in in_flight {
+            let duration_str = format_duration_bracketed(elapsed.unwrap_or_default());
+            match test_name {
+                Some(name) => {
+                    let colored = format_in_flight_test(&name);
+                    let _ = writeln!(stdout, "{padding}{label} {duration_str} {colored}");
+                }
+                None => {
+                    let _ = writeln!(
+                        stdout,
+                        "{padding}{label} {duration_str} worker {worker_id} (between tests)"
+                    );
+                }
+            }
         }
+    }
+}
+
+/// Render a `module::function[params]` test name as it was serialised by
+/// the worker (`QualifiedTestName::Display`), colouring the module cyan
+/// and the function blue+bold to match the per-test result line format.
+fn format_in_flight_test(name: &str) -> String {
+    if let Some((module, rest)) = name.split_once("::") {
+        let module = module.cyan();
+        let rest = rest.blue().bold();
+        format!("{module}::{rest}")
+    } else {
+        name.blue().bold().to_string()
     }
 }
 
@@ -411,7 +447,7 @@ pub fn run_parallel_tests(
 
     let outcome = worker_manager.wait_for_completion(shutdown_rx, max_fail_cache);
     if outcome == WaitOutcome::Cancelled {
-        worker_manager.cancel_and_kill(printer);
+        worker_manager.cancel_and_kill(printer, &cache);
     } else {
         worker_manager.kill_remaining();
     }

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -16,7 +16,7 @@ use karva_cache::{
 use karva_cli::SubTestCommand;
 use karva_collector::{CollectedPackage, CollectionSettings};
 use karva_logging::Printer;
-use karva_logging::time::format_duration;
+use karva_logging::time::{format_duration, format_duration_bracketed};
 use karva_project::Project;
 
 use crate::binary::find_karva_worker_binary;
@@ -24,19 +24,40 @@ use crate::collection::ParallelCollector;
 use crate::partition::{Partition, partition_collected_tests};
 use crate::worker_args::{WorkerSpawn, worker_command};
 
+/// Width that result labels (`PASS`, `FAIL`, `SIGINT`) are right-padded to so
+/// columns align. Mirrors the constant in `karva_diagnostic::reporter`.
+const LABEL_COLUMN_WIDTH: usize = 12;
+
+/// How `wait_for_completion` exited.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WaitOutcome {
+    /// Every worker exited on its own.
+    AllCompleted,
+    /// Ctrl+C was received; remaining workers must be killed.
+    Cancelled,
+    /// A worker hit the fail-fast budget; remaining workers must be killed.
+    FailFast,
+}
+
 #[derive(Debug)]
 struct Worker {
     id: usize,
     child: Child,
     start_time: Instant,
+    /// Number of tests assigned to this worker. Used to give a useful count in
+    /// the cancellation summary; the orchestrator can't see worker progress
+    /// (workers only flush results to the cache on exit), so this is an upper
+    /// bound on the tests still running in the worker.
+    test_count: usize,
 }
 
 impl Worker {
-    fn new(id: usize, child: Child) -> Self {
+    fn new(id: usize, child: Child, test_count: usize) -> Self {
         Self {
             id,
             child,
             start_time: Instant::now(),
+            test_count,
         }
     }
 
@@ -51,8 +72,8 @@ struct WorkerManager {
 }
 
 impl WorkerManager {
-    fn spawn(&mut self, worker_id: usize, child: Child) {
-        self.workers.push(Worker::new(worker_id, child));
+    fn spawn(&mut self, worker_id: usize, child: Child, test_count: usize) {
+        self.workers.push(Worker::new(worker_id, child, test_count));
     }
 
     /// Wait for all workers to complete.
@@ -62,9 +83,9 @@ impl WorkerManager {
         &mut self,
         shutdown_rx: Option<&Receiver<()>>,
         cache: Option<&RunCache>,
-    ) {
+    ) -> WaitOutcome {
         if self.workers.is_empty() {
-            return;
+            return WaitOutcome::AllCompleted;
         }
 
         tracing::info!(
@@ -77,7 +98,7 @@ impl WorkerManager {
                 match rx.try_recv() {
                     Ok(()) | Err(TryRecvError::Disconnected) => {
                         tracing::info!("Shutdown requested — stopping remaining workers");
-                        break;
+                        return WaitOutcome::Cancelled;
                     }
                     Err(TryRecvError::Empty) => {}
                 }
@@ -87,7 +108,7 @@ impl WorkerManager {
                 && cache.has_fail_fast_signal()
             {
                 tracing::info!("Fail-fast signal received — stopping remaining workers");
-                break;
+                return WaitOutcome::FailFast;
             }
 
             self.workers
@@ -118,11 +139,26 @@ impl WorkerManager {
 
             if self.workers.is_empty() {
                 tracing::info!("All workers completed");
-                break;
+                return WaitOutcome::AllCompleted;
             }
 
             std::thread::sleep(WORKER_POLL_INTERVAL);
         }
+    }
+
+    /// Print a nextest-style cancellation banner naming the number of tests
+    /// still running across all live workers.
+    fn report_cancellation(&self, printer: Printer) {
+        if self.workers.is_empty() {
+            return;
+        }
+        let total: usize = self.workers.iter().map(|w| w.test_count).sum();
+        let label = "Cancelling".red().bold();
+        let mut stdout = printer.stream_for_test_result().lock();
+        let _ = writeln!(
+            stdout,
+            "  {label} due to interrupt: {total} tests still running"
+        );
     }
 
     /// Kill and wait on any remaining worker processes.
@@ -130,7 +166,30 @@ impl WorkerManager {
     /// Uses two separate loops: the first sends kill signals to all workers
     /// immediately, and the second reaps them. This ensures every worker
     /// receives the signal without waiting for earlier ones to exit first.
-    fn kill_remaining(&mut self) {
+    ///
+    /// When `print_sigint` is `true`, emit a `SIGINT [duration] worker N`
+    /// line per remaining worker before killing it, mirroring nextest's
+    /// per-test cancellation output (we don't track individual tests at the
+    /// orchestrator level, so the line is per-worker).
+    fn kill_remaining(&mut self, printer: Printer, print_sigint: bool) {
+        if print_sigint && !self.workers.is_empty() {
+            let mut stdout = printer.stream_for_test_result().lock();
+            for worker in &self.workers {
+                let label = "SIGINT".red().bold();
+                let padding = " ".repeat(LABEL_COLUMN_WIDTH.saturating_sub("SIGINT".len()));
+                let duration_str = format_duration_bracketed(worker.duration());
+                let test_label = if worker.test_count == 1 {
+                    "test"
+                } else {
+                    "tests"
+                };
+                let _ = writeln!(
+                    stdout,
+                    "{padding}{label} {duration_str} worker {} ({} {test_label})",
+                    worker.id, worker.test_count
+                );
+            }
+        }
         for worker in &mut self.workers {
             let _ = worker.child.kill();
         }
@@ -181,7 +240,7 @@ fn spawn_workers(spawn: &WorkerSpawn, partitions: &[Partition]) -> Result<Worker
             partition.tests().len()
         );
 
-        worker_manager.spawn(worker_id, child);
+        worker_manager.spawn(worker_id, child, partition.tests().len());
     }
 
     Ok(worker_manager)
@@ -238,6 +297,16 @@ pub fn run_parallel_tests(
     args: &SubTestCommand,
     printer: Printer,
 ) -> Result<RunOutput> {
+    // Install the Ctrl+C handler before any potentially long-running work
+    // (collection, partitioning, worker spawn). Otherwise an early SIGINT
+    // hits the default disposition and the run terminates silently with no
+    // cancellation banner.
+    let shutdown_rx = if config.create_ctrlc_handler {
+        Some(shutdown_receiver())
+    } else {
+        None
+    };
+
     let collected = collect_tests(project)?;
 
     let total_tests = collected.test_count();
@@ -325,16 +394,13 @@ pub fn run_parallel_tests(
     };
     let mut worker_manager = spawn_workers(&spawn, &partitions)?;
 
-    let shutdown_rx = if config.create_ctrlc_handler {
-        Some(shutdown_receiver())
-    } else {
-        None
-    };
-
     let max_fail_cache = project.settings().max_fail().has_limit().then_some(&cache);
 
-    worker_manager.wait_for_completion(shutdown_rx, max_fail_cache);
-    worker_manager.kill_remaining();
+    let outcome = worker_manager.wait_for_completion(shutdown_rx, max_fail_cache);
+    if outcome == WaitOutcome::Cancelled {
+        worker_manager.report_cancellation(printer);
+    }
+    worker_manager.kill_remaining(printer, outcome == WaitOutcome::Cancelled);
 
     let results = cache.aggregate_results()?;
 

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -146,55 +146,67 @@ impl WorkerManager {
         }
     }
 
-    /// Print a nextest-style cancellation banner naming the number of tests
-    /// still running across all live workers.
-    fn report_cancellation(&self, printer: Printer) {
-        if self.workers.is_empty() {
-            return;
-        }
-        let total: usize = self.workers.iter().map(|w| w.test_count).sum();
-        let label = "Cancelling".red().bold();
-        let mut stdout = printer.stream_for_test_result().lock();
-        let _ = writeln!(
-            stdout,
-            "  {label} due to interrupt: {total} tests still running"
-        );
-    }
-
     /// Kill and wait on any remaining worker processes.
     ///
     /// Uses two separate loops: the first sends kill signals to all workers
     /// immediately, and the second reaps them. This ensures every worker
     /// receives the signal without waiting for earlier ones to exit first.
-    ///
-    /// When `print_sigint` is `true`, emit a `SIGINT [duration] worker N`
-    /// line per remaining worker before killing it, mirroring nextest's
-    /// per-test cancellation output (we don't track individual tests at the
-    /// orchestrator level, so the line is per-worker).
-    fn kill_remaining(&mut self, printer: Printer, print_sigint: bool) {
-        if print_sigint && !self.workers.is_empty() {
-            let mut stdout = printer.stream_for_test_result().lock();
-            for worker in &self.workers {
-                let label = "SIGINT".red().bold();
-                let padding = " ".repeat(LABEL_COLUMN_WIDTH.saturating_sub("SIGINT".len()));
-                let duration_str = format_duration_bracketed(worker.duration());
-                let test_label = if worker.test_count == 1 {
-                    "test"
-                } else {
-                    "tests"
-                };
-                let _ = writeln!(
-                    stdout,
-                    "{padding}{label} {duration_str} worker {} ({} {test_label})",
-                    worker.id, worker.test_count
-                );
-            }
-        }
+    fn kill_remaining(&mut self) {
         for worker in &mut self.workers {
             let _ = worker.child.kill();
         }
         for worker in &mut self.workers {
             let _ = worker.child.wait();
+        }
+    }
+
+    /// Stop remaining workers and emit nextest-style cancellation lines.
+    ///
+    /// Workers are killed first (and reaped) so any in-flight `PASS`/`FAIL`
+    /// lines they were writing to the inherited stdout land before our
+    /// banner — otherwise the cancellation block interleaves with worker
+    /// output. A short settle pause lets any kernel-buffered writes drain
+    /// for the same reason.
+    ///
+    /// We emit a `SIGINT [duration] worker N (M tests)` line per remaining
+    /// worker, mirroring nextest's per-test cancellation output. We don't
+    /// track individual tests at the orchestrator level, so the line is
+    /// per-worker.
+    fn cancel_and_kill(&mut self, printer: Printer) {
+        if self.workers.is_empty() {
+            return;
+        }
+
+        let total_tests: usize = self.workers.iter().map(|w| w.test_count).sum();
+
+        for worker in &mut self.workers {
+            let _ = worker.child.kill();
+        }
+        for worker in &mut self.workers {
+            let _ = worker.child.wait();
+        }
+        std::thread::sleep(STDOUT_SETTLE);
+
+        let mut stdout = printer.stream_for_test_result().lock();
+        let cancel_label = "Cancelling".red().bold();
+        let _ = writeln!(
+            stdout,
+            "  {cancel_label} due to interrupt: {total_tests} tests still running"
+        );
+        for worker in &self.workers {
+            let label = "SIGINT".red().bold();
+            let padding = " ".repeat(LABEL_COLUMN_WIDTH.saturating_sub("SIGINT".len()));
+            let duration_str = format_duration_bracketed(worker.duration());
+            let test_label = if worker.test_count == 1 {
+                "test"
+            } else {
+                "tests"
+            };
+            let _ = writeln!(
+                stdout,
+                "{padding}{label} {duration_str} worker {} ({} {test_label})",
+                worker.id, worker.test_count
+            );
         }
     }
 }
@@ -400,9 +412,10 @@ pub fn run_parallel_tests(
 
     let outcome = worker_manager.wait_for_completion(shutdown_rx, max_fail_cache);
     if outcome == WaitOutcome::Cancelled {
-        worker_manager.report_cancellation(printer);
+        worker_manager.cancel_and_kill(printer);
+    } else {
+        worker_manager.kill_remaining();
     }
-    worker_manager.kill_remaining(printer, outcome == WaitOutcome::Cancelled);
 
     let results = cache.aggregate_results()?;
 
@@ -424,3 +437,6 @@ pub fn run_parallel_tests(
 
 const MIN_TESTS_PER_WORKER: usize = 5;
 const WORKER_POLL_INTERVAL: Duration = Duration::from_millis(10);
+/// Pause after killing workers to let kernel-buffered output drain to
+/// stdout before we emit the cancellation banner.
+const STDOUT_SETTLE: Duration = Duration::from_millis(50);

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -44,20 +44,14 @@ struct Worker {
     id: usize,
     child: Child,
     start_time: Instant,
-    /// Number of tests assigned to this worker. Used to give a useful count in
-    /// the cancellation summary; the orchestrator can't see worker progress
-    /// (workers only flush results to the cache on exit), so this is an upper
-    /// bound on the tests still running in the worker.
-    test_count: usize,
 }
 
 impl Worker {
-    fn new(id: usize, child: Child, test_count: usize) -> Self {
+    fn new(id: usize, child: Child) -> Self {
         Self {
             id,
             child,
             start_time: Instant::now(),
-            test_count,
         }
     }
 
@@ -71,9 +65,20 @@ struct WorkerManager {
     workers: Vec<Worker>,
 }
 
+struct InFlightTest {
+    worker_id: usize,
+    name: Option<String>,
+    elapsed: Duration,
+}
+
+struct InterruptedTest {
+    name: String,
+    duration: Duration,
+}
+
 impl WorkerManager {
-    fn spawn(&mut self, worker_id: usize, child: Child, test_count: usize) {
-        self.workers.push(Worker::new(worker_id, child, test_count));
+    fn spawn(&mut self, worker_id: usize, child: Child) {
+        self.workers.push(Worker::new(worker_id, child));
     }
 
     /// Wait for all workers to complete.
@@ -173,9 +178,9 @@ impl WorkerManager {
     /// before our banner; otherwise the cancellation block interleaves
     /// with worker output. A short settle pause lets any kernel-buffered
     /// writes drain.
-    fn cancel_and_kill(&mut self, printer: Printer, cache: &RunCache) {
+    fn cancel_and_kill(&mut self, printer: Printer, cache: &RunCache) -> Vec<InterruptedTest> {
         if self.workers.is_empty() {
-            return;
+            return Vec::new();
         }
 
         let now_ms = SystemTime::now()
@@ -187,17 +192,34 @@ impl WorkerManager {
             .workers
             .iter()
             .map(|worker| {
-                let current = cache.read_current_test(worker.id);
-                let elapsed = current.as_ref().and_then(|c| {
-                    now_ms
-                        .checked_sub(c.start_unix_ms)
-                        .map(Duration::from_millis)
-                });
-                (worker.id, current.map(|c| c.name), elapsed)
+                let current = match cache.read_current_test(worker.id) {
+                    Ok(current) => current,
+                    Err(err) => {
+                        tracing::warn!(
+                            worker_id = worker.id,
+                            "failed to read in-flight test state: {err}"
+                        );
+                        None
+                    }
+                };
+                let elapsed = current
+                    .as_ref()
+                    .and_then(|c| {
+                        now_ms
+                            .checked_sub(c.start_unix_ms)
+                            .map(Duration::from_millis)
+                    })
+                    .unwrap_or_default();
+                InFlightTest {
+                    worker_id: worker.id,
+                    name: current.map(|c| c.name),
+                    elapsed,
+                }
             })
             .collect();
 
-        let total_tests: usize = self.workers.iter().map(|w| w.test_count).sum();
+        let running_tests = in_flight.iter().filter(|test| test.name.is_some()).count();
+        let test_label = if running_tests == 1 { "test" } else { "tests" };
 
         for worker in &mut self.workers {
             let _ = worker.child.kill();
@@ -212,26 +234,37 @@ impl WorkerManager {
         let interrupt_label = "interrupt".yellow().bold();
         let _ = writeln!(
             stdout,
-            "  {cancel_label} due to {interrupt_label}: {total_tests} tests still running"
+            "  {cancel_label} due to {interrupt_label}: {running_tests} {test_label} still running"
         );
 
         let label = "SIGINT".yellow().bold();
         let padding = " ".repeat(LABEL_COLUMN_WIDTH.saturating_sub("SIGINT".len()));
-        for (worker_id, test_name, elapsed) in in_flight {
-            let duration_str = format_duration_bracketed(elapsed.unwrap_or_default());
-            match test_name {
+        for test in &in_flight {
+            let duration_str = format_duration_bracketed(test.elapsed);
+            match &test.name {
                 Some(name) => {
-                    let colored = format_in_flight_test(&name);
+                    let colored = format_in_flight_test(name);
                     let _ = writeln!(stdout, "{padding}{label} {duration_str} {colored}");
                 }
                 None => {
                     let _ = writeln!(
                         stdout,
-                        "{padding}{label} {duration_str} worker {worker_id} (between tests)"
+                        "{padding}{label} {duration_str} worker {} (between tests)",
+                        test.worker_id
                     );
                 }
             }
         }
+
+        in_flight
+            .into_iter()
+            .filter_map(|test| {
+                test.name.map(|name| InterruptedTest {
+                    name,
+                    duration: test.elapsed,
+                })
+            })
+            .collect()
     }
 }
 
@@ -291,7 +324,7 @@ fn spawn_workers(spawn: &WorkerSpawn, partitions: &[Partition]) -> Result<Worker
             partition.tests().len()
         );
 
-        worker_manager.spawn(worker_id, child, partition.tests().len());
+        worker_manager.spawn(worker_id, child);
     }
 
     Ok(worker_manager)
@@ -448,13 +481,17 @@ pub fn run_parallel_tests(
     let max_fail_cache = project.settings().max_fail().has_limit().then_some(&cache);
 
     let outcome = worker_manager.wait_for_completion(shutdown_rx, max_fail_cache);
-    if outcome == WaitOutcome::Cancelled {
-        worker_manager.cancel_and_kill(printer, &cache);
+    let interrupted_tests = if outcome == WaitOutcome::Cancelled {
+        worker_manager.cancel_and_kill(printer, &cache)
     } else {
         worker_manager.kill_remaining();
-    }
+        Vec::new()
+    };
 
-    let results = cache.aggregate_results()?;
+    let mut results = cache.aggregate_results()?;
+    for test in interrupted_tests {
+        results.register_interrupted_test(&test.name, test.duration);
+    }
 
     if !config.no_cache {
         let _ = write_last_failed(&cache_dir, &results.failed_tests);

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::fmt::Write;
 use std::process::{Child, Stdio};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use camino::Utf8PathBuf;
@@ -162,20 +162,40 @@ impl WorkerManager {
 
     /// Stop remaining workers and emit nextest-style cancellation lines.
     ///
-    /// Workers are killed first (and reaped) so any in-flight `PASS`/`FAIL`
-    /// lines they were writing to the inherited stdout land before our
-    /// banner — otherwise the cancellation block interleaves with worker
-    /// output. A short settle pause lets any kernel-buffered writes drain
-    /// for the same reason.
+    /// Each worker writes a `current_test.json` file at the start of every
+    /// test and removes it when the test finishes. We read those files
+    /// *before* killing — once we kill the worker, that file may be removed
+    /// by an in-flight finalizer or simply lost — and remember a
+    /// `(worker_id, test name, test start time)` snapshot for each.
     ///
-    /// We emit a `SIGINT [duration] worker N (M tests)` line per remaining
-    /// worker, mirroring nextest's per-test cancellation output. We don't
-    /// track individual tests at the orchestrator level, so the line is
-    /// per-worker.
-    fn cancel_and_kill(&mut self, printer: Printer) {
+    /// Workers are killed and reaped before we print so any in-flight
+    /// `PASS`/`FAIL` lines they were writing to the inherited stdout land
+    /// before our banner; otherwise the cancellation block interleaves
+    /// with worker output. A short settle pause lets any kernel-buffered
+    /// writes drain.
+    fn cancel_and_kill(&mut self, printer: Printer, cache: &RunCache) {
         if self.workers.is_empty() {
             return;
         }
+
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+            .unwrap_or(0);
+
+        let in_flight: Vec<_> = self
+            .workers
+            .iter()
+            .map(|worker| {
+                let current = cache.read_current_test(worker.id);
+                let elapsed = current.as_ref().and_then(|c| {
+                    now_ms
+                        .checked_sub(c.start_unix_ms)
+                        .map(Duration::from_millis)
+                });
+                (worker.id, current.map(|c| c.name), elapsed)
+            })
+            .collect();
 
         let total_tests: usize = self.workers.iter().map(|w| w.test_count).sum();
 
@@ -194,21 +214,37 @@ impl WorkerManager {
             stdout,
             "  {cancel_label} due to {interrupt_label}: {total_tests} tests still running"
         );
-        for worker in &self.workers {
-            let label = "SIGINT".yellow().bold();
-            let padding = " ".repeat(LABEL_COLUMN_WIDTH.saturating_sub("SIGINT".len()));
-            let duration_str = format_duration_bracketed(worker.duration());
-            let test_label = if worker.test_count == 1 {
-                "test"
-            } else {
-                "tests"
-            };
-            let _ = writeln!(
-                stdout,
-                "{padding}{label} {duration_str} worker {} ({} {test_label})",
-                worker.id, worker.test_count
-            );
+
+        let label = "SIGINT".yellow().bold();
+        let padding = " ".repeat(LABEL_COLUMN_WIDTH.saturating_sub("SIGINT".len()));
+        for (worker_id, test_name, elapsed) in in_flight {
+            let duration_str = format_duration_bracketed(elapsed.unwrap_or_default());
+            match test_name {
+                Some(name) => {
+                    let colored = format_in_flight_test(&name);
+                    let _ = writeln!(stdout, "{padding}{label} {duration_str} {colored}");
+                }
+                None => {
+                    let _ = writeln!(
+                        stdout,
+                        "{padding}{label} {duration_str} worker {worker_id} (between tests)"
+                    );
+                }
+            }
         }
+    }
+}
+
+/// Render a `module::function[params]` test name as it was serialised by
+/// the worker (`QualifiedTestName::Display`), colouring the module cyan
+/// and the function blue+bold to match the per-test result line format.
+fn format_in_flight_test(name: &str) -> String {
+    if let Some((module, rest)) = name.split_once("::") {
+        let module = module.cyan();
+        let rest = rest.blue().bold();
+        format!("{module}::{rest}")
+    } else {
+        name.blue().bold().to_string()
     }
 }
 
@@ -413,7 +449,7 @@ pub fn run_parallel_tests(
 
     let outcome = worker_manager.wait_for_completion(shutdown_rx, max_fail_cache);
     if outcome == WaitOutcome::Cancelled {
-        worker_manager.cancel_and_kill(printer);
+        worker_manager.cancel_and_kill(printer, &cache);
     } else {
         worker_manager.kill_remaining();
     }

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -16,7 +16,7 @@ use karva_cache::{
 use karva_cli::{PartitionSelection, SubTestCommand};
 use karva_collector::{CollectedPackage, CollectionSettings};
 use karva_logging::Printer;
-use karva_logging::time::format_duration;
+use karva_logging::time::{format_duration, format_duration_bracketed};
 use karva_project::Project;
 
 use crate::binary::find_karva_worker_binary;
@@ -24,19 +24,40 @@ use crate::collection::ParallelCollector;
 use crate::partition::{Partition, partition_collected_tests};
 use crate::worker_args::{WorkerSpawn, worker_command};
 
+/// Width that result labels (`PASS`, `FAIL`, `SIGINT`) are right-padded to so
+/// columns align. Mirrors the constant in `karva_diagnostic::reporter`.
+const LABEL_COLUMN_WIDTH: usize = 12;
+
+/// How `wait_for_completion` exited.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WaitOutcome {
+    /// Every worker exited on its own.
+    AllCompleted,
+    /// Ctrl+C was received; remaining workers must be killed.
+    Cancelled,
+    /// A worker hit the fail-fast budget; remaining workers must be killed.
+    FailFast,
+}
+
 #[derive(Debug)]
 struct Worker {
     id: usize,
     child: Child,
     start_time: Instant,
+    /// Number of tests assigned to this worker. Used to give a useful count in
+    /// the cancellation summary; the orchestrator can't see worker progress
+    /// (workers only flush results to the cache on exit), so this is an upper
+    /// bound on the tests still running in the worker.
+    test_count: usize,
 }
 
 impl Worker {
-    fn new(id: usize, child: Child) -> Self {
+    fn new(id: usize, child: Child, test_count: usize) -> Self {
         Self {
             id,
             child,
             start_time: Instant::now(),
+            test_count,
         }
     }
 
@@ -51,8 +72,8 @@ struct WorkerManager {
 }
 
 impl WorkerManager {
-    fn spawn(&mut self, worker_id: usize, child: Child) {
-        self.workers.push(Worker::new(worker_id, child));
+    fn spawn(&mut self, worker_id: usize, child: Child, test_count: usize) {
+        self.workers.push(Worker::new(worker_id, child, test_count));
     }
 
     /// Wait for all workers to complete.
@@ -62,9 +83,9 @@ impl WorkerManager {
         &mut self,
         shutdown_rx: Option<&Receiver<()>>,
         cache: Option<&RunCache>,
-    ) {
+    ) -> WaitOutcome {
         if self.workers.is_empty() {
-            return;
+            return WaitOutcome::AllCompleted;
         }
 
         tracing::info!(
@@ -77,7 +98,7 @@ impl WorkerManager {
                 match rx.try_recv() {
                     Ok(()) | Err(TryRecvError::Disconnected) => {
                         tracing::info!("Shutdown requested — stopping remaining workers");
-                        break;
+                        return WaitOutcome::Cancelled;
                     }
                     Err(TryRecvError::Empty) => {}
                 }
@@ -87,7 +108,7 @@ impl WorkerManager {
                 && cache.has_fail_fast_signal()
             {
                 tracing::info!("Fail-fast signal received — stopping remaining workers");
-                break;
+                return WaitOutcome::FailFast;
             }
 
             self.workers
@@ -118,11 +139,26 @@ impl WorkerManager {
 
             if self.workers.is_empty() {
                 tracing::info!("All workers completed");
-                break;
+                return WaitOutcome::AllCompleted;
             }
 
             std::thread::sleep(WORKER_POLL_INTERVAL);
         }
+    }
+
+    /// Print a nextest-style cancellation banner naming the number of tests
+    /// still running across all live workers.
+    fn report_cancellation(&self, printer: Printer) {
+        if self.workers.is_empty() {
+            return;
+        }
+        let total: usize = self.workers.iter().map(|w| w.test_count).sum();
+        let label = "Cancelling".red().bold();
+        let mut stdout = printer.stream_for_test_result().lock();
+        let _ = writeln!(
+            stdout,
+            "  {label} due to interrupt: {total} tests still running"
+        );
     }
 
     /// Kill and wait on any remaining worker processes.
@@ -130,7 +166,30 @@ impl WorkerManager {
     /// Uses two separate loops: the first sends kill signals to all workers
     /// immediately, and the second reaps them. This ensures every worker
     /// receives the signal without waiting for earlier ones to exit first.
-    fn kill_remaining(&mut self) {
+    ///
+    /// When `print_sigint` is `true`, emit a `SIGINT [duration] worker N`
+    /// line per remaining worker before killing it, mirroring nextest's
+    /// per-test cancellation output (we don't track individual tests at the
+    /// orchestrator level, so the line is per-worker).
+    fn kill_remaining(&mut self, printer: Printer, print_sigint: bool) {
+        if print_sigint && !self.workers.is_empty() {
+            let mut stdout = printer.stream_for_test_result().lock();
+            for worker in &self.workers {
+                let label = "SIGINT".red().bold();
+                let padding = " ".repeat(LABEL_COLUMN_WIDTH.saturating_sub("SIGINT".len()));
+                let duration_str = format_duration_bracketed(worker.duration());
+                let test_label = if worker.test_count == 1 {
+                    "test"
+                } else {
+                    "tests"
+                };
+                let _ = writeln!(
+                    stdout,
+                    "{padding}{label} {duration_str} worker {} ({} {test_label})",
+                    worker.id, worker.test_count
+                );
+            }
+        }
         for worker in &mut self.workers {
             let _ = worker.child.kill();
         }
@@ -183,7 +242,7 @@ fn spawn_workers(spawn: &WorkerSpawn, partitions: &[Partition]) -> Result<Worker
             partition.tests().len()
         );
 
-        worker_manager.spawn(worker_id, child);
+        worker_manager.spawn(worker_id, child, partition.tests().len());
     }
 
     Ok(worker_manager)
@@ -240,6 +299,16 @@ pub fn run_parallel_tests(
     args: &SubTestCommand,
     printer: Printer,
 ) -> Result<RunOutput> {
+    // Install the Ctrl+C handler before any potentially long-running work
+    // (collection, partitioning, worker spawn). Otherwise an early SIGINT
+    // hits the default disposition and the run terminates silently with no
+    // cancellation banner.
+    let shutdown_rx = if config.create_ctrlc_handler {
+        Some(shutdown_receiver())
+    } else {
+        None
+    };
+
     let collected = collect_tests(project)?;
 
     let total_tests = collected.test_count();
@@ -327,16 +396,13 @@ pub fn run_parallel_tests(
     };
     let mut worker_manager = spawn_workers(&spawn, &partitions)?;
 
-    let shutdown_rx = if config.create_ctrlc_handler {
-        Some(shutdown_receiver())
-    } else {
-        None
-    };
-
     let max_fail_cache = project.settings().max_fail().has_limit().then_some(&cache);
 
-    worker_manager.wait_for_completion(shutdown_rx, max_fail_cache);
-    worker_manager.kill_remaining();
+    let outcome = worker_manager.wait_for_completion(shutdown_rx, max_fail_cache);
+    if outcome == WaitOutcome::Cancelled {
+        worker_manager.report_cancellation(printer);
+    }
+    worker_manager.kill_remaining(printer, outcome == WaitOutcome::Cancelled);
 
     let results = cache.aggregate_results()?;
 

--- a/crates/karva_test_semantic/src/context.rs
+++ b/crates/karva_test_semantic/src/context.rs
@@ -72,6 +72,19 @@ impl<'a> Context<'a> {
         self.result.borrow().clone().into_sorted()
     }
 
+    /// Record the start of a test execution. Forwarded to the reporter
+    /// so cancellation logic can render per-test `SIGINT` lines naming
+    /// the in-flight test.
+    pub fn report_test_started(&self, test_case_name: &QualifiedTestName) {
+        self.reporter.report_test_started(test_case_name);
+    }
+
+    /// Pair to [`Self::report_test_started`]: clears the in-flight marker
+    /// once the test completes (passed, failed, or skipped).
+    pub fn report_test_finished(&self, test_case_name: &QualifiedTestName) {
+        self.reporter.report_test_finished(test_case_name);
+    }
+
     pub fn register_test_case_result(
         &self,
         test_case_name: &QualifiedTestName,

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -551,12 +551,14 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         };
 
         let configured_retries = self.context.settings().test().retry;
+        self.context.report_test_started(&qualified_test_name);
         let RetryOutcome {
             test_result,
             attempt,
             max_attempts,
             was_retried,
         } = self.run_with_retries(py, &qualified_test_name, configured_retries, run_test);
+        self.context.report_test_finished(&qualified_test_name);
 
         let report_ctx = VariantReportCtx {
             name: &name,

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -545,12 +545,14 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         };
 
         let configured_retries = self.context.settings().test().retry;
+        self.context.report_test_started(&qualified_test_name);
         let RetryOutcome {
             test_result,
             attempt,
             max_attempts,
             was_retried,
         } = self.run_with_retries(py, &qualified_test_name, configured_retries, run_test);
+        self.context.report_test_finished(&qualified_test_name);
 
         let report_ctx = VariantReportCtx {
             name: &name,

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -166,10 +166,16 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
 
     let cache = RunCache::new(&args.cache_dir, &run_hash);
 
+    let progress_file = cache.current_test_file(args.worker_id);
+    // Make sure the worker dir exists so the reporter can write the
+    // progress file before the worker has otherwise touched it.
+    if let Some(parent) = progress_file.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
     let reporter: Box<dyn Reporter> = if matches!(printer.status_level(), StatusLevel::None) {
         Box::new(DummyReporter)
     } else {
-        Box::new(TestCaseReporter::new(printer))
+        Box::new(TestCaseReporter::new(printer).with_progress_file(progress_file))
     };
 
     let result = karva_test_semantic::run_tests(

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -167,10 +167,16 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
 
     let cache = RunCache::new(&args.cache_dir, &run_hash);
 
+    let progress_file = cache.current_test_file(args.worker_id);
+    // Make sure the worker dir exists so the reporter can write the
+    // progress file before the worker has otherwise touched it.
+    if let Some(parent) = progress_file.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
     let reporter: Box<dyn Reporter> = if matches!(printer.status_level(), StatusLevel::None) {
         Box::new(DummyReporter)
     } else {
-        Box::new(TestCaseReporter::new(printer))
+        Box::new(TestCaseReporter::new(printer).with_progress_file(progress_file))
     };
 
     let result = karva_test_semantic::run_tests(


### PR DESCRIPTION
## Summary

Pressing Ctrl+C during a test run now reports cancellation in the same shape as nextest. The orchestrator installs the handler before collection and worker spawn, records each worker's current test, kills remaining workers without interleaving output, prints `Cancelling due to interrupt: N tests still running`, and emits one `SIGINT [duration] test` line for each in-flight test. Interrupted in-flight tests are counted as failures in the final summary instead of falling through to `no tests to run`.

Sample output:

```
    Starting 10 tests across 2 workers
  Cancelling due to interrupt: 2 tests still running
      SIGINT [   2.970s] test_mixed::test_slow_a
      SIGINT [   2.970s] test_mixed::test_slow_b
```

## Test Plan

Verified against local `cargo nextest` cancellation output, the cancellation integration test, the interrupted-test cache unit test, and `uvx prek run -a`.
