### PR TITLE
Add `show-config` command to print resolved configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,6 +1070,7 @@ dependencies = [
  "rstest",
  "ruff_python_trivia",
  "tempfile",
+ "toml",
  "tracing",
  "wild",
 ]

--- a/crates/karva/Cargo.toml
+++ b/crates/karva/Cargo.toml
@@ -36,6 +36,7 @@ clap = { workspace = true, features = ["wrap_help", "string", "env"] }
 colored = { workspace = true }
 crossbeam-channel = { workspace = true }
 notify-debouncer-mini = { workspace = true }
+toml = { workspace = true }
 tracing = { workspace = true, features = ["release_max_level_debug"] }
 wild = { workspace = true }
 

--- a/crates/karva/src/commands/mod.rs
+++ b/crates/karva/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod cache;
+pub mod show_config;
 pub mod snapshot;
 pub mod test;
 pub mod version;

--- a/crates/karva/src/commands/show_config.rs
+++ b/crates/karva/src/commands/show_config.rs
@@ -1,0 +1,46 @@
+use std::fmt::Write;
+
+use anyhow::{Context as _, Result};
+use karva_cli::ShowConfigCommand;
+use karva_logging::Printer;
+use karva_metadata::{Options, ProjectMetadata, ProjectOptionsOverrides};
+use karva_project::Project;
+use karva_project::path::absolute;
+use karva_python_semantic::current_python_version;
+
+use crate::ExitStatus;
+use crate::utils::cwd;
+
+pub fn show_config(args: ShowConfigCommand) -> Result<ExitStatus> {
+    let cwd = cwd().map_err(|_| {
+        anyhow::anyhow!(
+            "The current working directory contains non-Unicode characters. karva only supports Unicode paths."
+        )
+    })?;
+
+    let python_version = current_python_version();
+
+    let config_file = args.config_file.as_ref().map(|path| absolute(path, &cwd));
+
+    let mut project_metadata = if let Some(config_file) = &config_file {
+        ProjectMetadata::from_config_file(config_file.clone(), &cwd, python_version)?
+    } else {
+        ProjectMetadata::discover(&cwd, python_version)?
+    };
+
+    let overrides =
+        ProjectOptionsOverrides::new(config_file, Options::default()).with_profile(args.profile);
+    project_metadata
+        .apply_overrides(&overrides)
+        .map_err(|err| anyhow::anyhow!("{err}"))?;
+
+    let project = Project::from_metadata(project_metadata);
+    let resolved = project.settings().to_options();
+
+    let serialized = toml::to_string(&resolved).context("failed to serialize configuration")?;
+
+    let mut stdout = Printer::default().stream_for_message().lock();
+    write!(stdout, "{serialized}")?;
+
+    Ok(ExitStatus::Success)
+}

--- a/crates/karva/src/commands/show_config.rs
+++ b/crates/karva/src/commands/show_config.rs
@@ -35,9 +35,9 @@ pub fn show_config(args: ShowConfigCommand) -> Result<ExitStatus> {
         .map_err(|err| anyhow::anyhow!("{err}"))?;
 
     let project = Project::from_metadata(project_metadata);
-    let resolved = project.settings().to_options();
 
-    let serialized = toml::to_string(&resolved).context("failed to serialize configuration")?;
+    let serialized =
+        toml::to_string(project.settings()).context("failed to serialize configuration")?;
 
     let mut stdout = Printer::default().stream_for_message().lock();
     write!(stdout, "{serialized}")?;

--- a/crates/karva/src/commands/show_config.rs
+++ b/crates/karva/src/commands/show_config.rs
@@ -23,7 +23,7 @@ pub fn show_config(args: ShowConfigCommand) -> Result<ExitStatus> {
     let config_file = args.config_file.as_ref().map(|path| absolute(path, &cwd));
 
     let mut project_metadata = if let Some(config_file) = &config_file {
-        ProjectMetadata::from_config_file(config_file.clone(), &cwd, python_version)?
+        ProjectMetadata::from_config_file(config_file, &cwd, python_version)?
     } else {
         ProjectMetadata::discover(&cwd, python_version)?
     };
@@ -35,9 +35,9 @@ pub fn show_config(args: ShowConfigCommand) -> Result<ExitStatus> {
         .map_err(|err| anyhow::anyhow!("{err}"))?;
 
     let project = Project::from_metadata(project_metadata);
-    let resolved = project.settings().to_options();
 
-    let serialized = toml::to_string(&resolved).context("failed to serialize configuration")?;
+    let serialized =
+        toml::to_string(project.settings()).context("failed to serialize configuration")?;
 
     let mut stdout = Printer::default().stream_for_message().lock();
     write!(stdout, "{serialized}")?;

--- a/crates/karva/src/lib.rs
+++ b/crates/karva/src/lib.rs
@@ -45,6 +45,9 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
         Command::Test(test_args) => commands::test::test(*test_args),
         Command::Snapshot(snapshot_args) => commands::snapshot::snapshot(snapshot_args),
         Command::Cache(cache_args) => commands::cache::cache(&cache_args),
+        Command::ShowConfig(show_config_args) => {
+            commands::show_config::show_config(show_config_args)
+        }
         Command::Version => commands::version::version().map(|()| ExitStatus::Success),
     }
 }

--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -2653,11 +2653,12 @@ fn test_no_subcommand_prints_help() {
     Usage: karva <COMMAND>
 
     Commands:
-      test      Run tests
-      snapshot  Manage snapshots created by `karva.assert_snapshot()`
-      cache     Manage the karva cache
-      version   Display Karva's version
-      help      Print this message or the help of the given subcommand(s)
+      test         Run tests
+      snapshot     Manage snapshots created by `karva.assert_snapshot()`
+      cache        Manage the karva cache
+      show-config  Print the resolved configuration karva would run with
+      version      Display Karva's version
+      help         Print this message or the help of the given subcommand(s)
 
     Options:
       -h, --help     Print help

--- a/crates/karva/tests/it/common/mod.rs
+++ b/crates/karva/tests/it/common/mod.rs
@@ -190,6 +190,12 @@ impl TestContext {
         command.arg("version").current_dir(self.root());
         command
     }
+
+    pub fn show_config(&self) -> Command {
+        let mut command = self.karva_command();
+        command.arg("show-config").current_dir(self.root());
+        command
+    }
 }
 
 impl Default for TestContext {

--- a/crates/karva/tests/it/common/mod.rs
+++ b/crates/karva/tests/it/common/mod.rs
@@ -187,6 +187,12 @@ impl TestContext {
         command.arg("version").current_dir(self.root());
         command
     }
+
+    pub fn show_config(&self) -> Command {
+        let mut command = self.karva_command();
+        command.arg("show-config").current_dir(self.root());
+        command
+    }
 }
 
 impl Default for TestContext {

--- a/crates/karva/tests/it/main.rs
+++ b/crates/karva/tests/it/main.rs
@@ -12,5 +12,6 @@ mod filterset;
 mod last_failed;
 mod partition;
 mod run_ignored;
+mod show_config;
 mod version;
 mod watch;

--- a/crates/karva/tests/it/main.rs
+++ b/crates/karva/tests/it/main.rs
@@ -13,5 +13,6 @@ mod filterset;
 mod last_failed;
 mod partition;
 mod run_ignored;
+mod show_config;
 mod version;
 mod watch;

--- a/crates/karva/tests/it/show_config.rs
+++ b/crates/karva/tests/it/show_config.rs
@@ -1,0 +1,190 @@
+use insta_cmd::assert_cmd_snapshot;
+
+use crate::common::TestContext;
+
+#[test]
+fn show_config_default_profile() {
+    let context = TestContext::default();
+
+    assert_cmd_snapshot!(context.show_config(), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [src]
+    respect-ignore-files = true
+    include = []
+
+    [terminal]
+    output-format = "full"
+    show-python-output = false
+    status-level = "pass"
+    final-status-level = "pass"
+
+    [test]
+    test-function-prefix = "test"
+    try-import-fixtures = false
+    retry = 0
+    no-tests = "auto"
+
+    [coverage]
+    sources = []
+    report = "term"
+
+    ----- stderr -----
+    "#);
+}
+
+#[test]
+fn show_config_resolves_pyproject_options() {
+    let context = TestContext::with_file(
+        "pyproject.toml",
+        r#"
+[tool.karva.profile.default.test]
+test-function-prefix = "check"
+fail-fast = true
+
+[tool.karva.profile.default.terminal]
+output-format = "concise"
+"#,
+    );
+
+    assert_cmd_snapshot!(context.show_config(), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [src]
+    respect-ignore-files = true
+    include = []
+
+    [terminal]
+    output-format = "concise"
+    show-python-output = false
+    status-level = "pass"
+    final-status-level = "pass"
+
+    [test]
+    test-function-prefix = "check"
+    max-fail = 1
+    try-import-fixtures = false
+    retry = 0
+    no-tests = "auto"
+
+    [coverage]
+    sources = []
+    report = "term"
+
+    ----- stderr -----
+    "#);
+}
+
+#[test]
+fn show_config_named_profile_layers_over_default() {
+    let context = TestContext::with_file(
+        "karva.toml",
+        r#"
+[profile.default.test]
+test-function-prefix = "check"
+
+[profile.ci.test]
+retry = 3
+
+[profile.ci.terminal]
+output-format = "concise"
+"#,
+    );
+
+    assert_cmd_snapshot!(context.show_config().args(["--profile", "ci"]), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [src]
+    respect-ignore-files = true
+    include = []
+
+    [terminal]
+    output-format = "concise"
+    show-python-output = false
+    status-level = "pass"
+    final-status-level = "pass"
+
+    [test]
+    test-function-prefix = "check"
+    try-import-fixtures = false
+    retry = 3
+    no-tests = "auto"
+
+    [coverage]
+    sources = []
+    report = "term"
+
+    ----- stderr -----
+    "#);
+}
+
+#[test]
+fn show_config_emits_set_timeouts_and_coverage() {
+    let context = TestContext::with_file(
+        "karva.toml",
+        r#"
+[profile.default.test]
+slow-timeout = 0.5
+timeout = 120
+
+[profile.default.coverage]
+sources = ["src"]
+report = "term-missing"
+fail-under = 90
+"#,
+    );
+
+    assert_cmd_snapshot!(context.show_config(), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [src]
+    respect-ignore-files = true
+    include = []
+
+    [terminal]
+    output-format = "full"
+    show-python-output = false
+    status-level = "pass"
+    final-status-level = "pass"
+
+    [test]
+    test-function-prefix = "test"
+    try-import-fixtures = false
+    retry = 0
+    no-tests = "auto"
+    slow-timeout = 0.5
+    timeout = 120.0
+
+    [coverage]
+    sources = ["src"]
+    report = "term-missing"
+    fail-under = 90.0
+
+    ----- stderr -----
+    "#);
+}
+
+#[test]
+fn show_config_unknown_profile_errors() {
+    let context = TestContext::with_file(
+        "karva.toml",
+        r"
+[profile.ci.test]
+retry = 3
+",
+    );
+
+    assert_cmd_snapshot!(context.show_config().args(["--profile", "bogus"]), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Karva failed
+      Cause: profile `bogus` is not defined in configuration (available: ci, default)
+    ");
+}

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -5,6 +5,7 @@ use clap::builder::styling::{AnsiColor, Effects};
 mod cache;
 mod enums;
 mod partition;
+mod show_config;
 mod snapshot;
 mod test;
 mod verbosity;
@@ -12,6 +13,7 @@ mod verbosity;
 pub use cache::{CacheAction, CacheCommand};
 pub use enums::{CovReport, NoTests, OutputFormat, RunIgnored};
 pub use partition::PartitionSelection;
+pub use show_config::ShowConfigCommand;
 pub use snapshot::{
     SnapshotAction, SnapshotCommand, SnapshotDeleteArgs, SnapshotFilterArgs, SnapshotPruneArgs,
 };
@@ -43,6 +45,9 @@ pub enum Command {
 
     /// Manage the karva cache.
     Cache(CacheCommand),
+
+    /// Print the resolved configuration karva would run with.
+    ShowConfig(ShowConfigCommand),
 
     /// Display Karva's version
     Version,

--- a/crates/karva_cli/src/show_config.rs
+++ b/crates/karva_cli/src/show_config.rs
@@ -1,0 +1,31 @@
+use camino::Utf8PathBuf;
+use clap::Parser;
+
+/// Print the resolved configuration karva would run with.
+///
+/// Resolves the same settings the test runner builds — defaults layered with
+/// `karva.toml` / `pyproject.toml` and any selected profile — and prints them
+/// as TOML.
+#[derive(Debug, Parser)]
+pub struct ShowConfigCommand {
+    /// The path to a `karva.toml` file to use for configuration.
+    #[arg(
+        long,
+        env = "KARVA_CONFIG_FILE",
+        value_name = "PATH",
+        help_heading = "Config options"
+    )]
+    pub config_file: Option<Utf8PathBuf>,
+
+    /// Configuration profile to resolve.
+    ///
+    /// Defaults to `default`.
+    #[arg(
+        short = 'P',
+        long,
+        env = "KARVA_PROFILE",
+        value_name = "NAME",
+        help_heading = "Config options"
+    )]
+    pub profile: Option<String>,
+}

--- a/crates/karva_metadata/src/max_fail.rs
+++ b/crates/karva_metadata/src/max_fail.rs
@@ -48,6 +48,15 @@ impl MaxFail {
         self.0.is_some()
     }
 
+    /// Returns `true` when no failure limit is configured.
+    ///
+    /// `MaxFail::unlimited()` wraps `None`, which serializers like TOML
+    /// cannot represent — this is exposed primarily so `serde`'s
+    /// `skip_serializing_if` can omit the field.
+    pub fn is_unlimited(&self) -> bool {
+        self.0.is_none()
+    }
+
     /// Returns `true` when the configuration would stop after a single failure.
     ///
     /// This is how the legacy `--fail-fast` boolean is surfaced internally.

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -6,7 +6,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::filter::FiltersetSet;
 use crate::max_fail::MaxFail;
-use crate::options::{CovReport, OutputFormat};
+use crate::options::{
+    CovReport, CoverageOptions, Options, OutputFormat, SrcOptions, TerminalOptions, TestOptions,
+};
 
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RunIgnoredMode {
@@ -156,6 +158,50 @@ impl ProjectSettings {
 
     pub fn set_run_ignored(&mut self, mode: RunIgnoredMode) {
         self.test.run_ignored = mode;
+    }
+
+    /// Round-trip the resolved settings back to a fully-populated [`Options`].
+    ///
+    /// Every field is `Some(...)` so a serialized form reflects the values
+    /// karva is actually running with, including defaults. Runtime-only
+    /// fields (`filter`, `run_ignored`, coverage `disabled`) are excluded:
+    /// they do not come from configuration files. `fail_fast` is also
+    /// omitted since `max_fail` is the canonical form.
+    pub fn to_options(&self) -> Options {
+        Options {
+            src: Some(SrcOptions {
+                respect_ignore_files: Some(self.src.respect_ignore_files),
+                include: Some(self.src.include_paths.clone()),
+            }),
+            terminal: Some(TerminalOptions {
+                output_format: Some(self.terminal.output_format),
+                show_python_output: Some(self.terminal.show_python_output),
+                status_level: Some(self.terminal.status_level),
+                final_status_level: Some(self.terminal.final_status_level),
+            }),
+            test: Some(TestOptions {
+                test_function_prefix: Some(self.test.test_function_prefix.clone()),
+                fail_fast: None,
+                // `MaxFail::unlimited()` wraps `None`, which TOML cannot
+                // represent. Omit the field in that case so the TOML matches
+                // "no limit set".
+                max_fail: self.test.max_fail.has_limit().then_some(self.test.max_fail),
+                try_import_fixtures: Some(self.test.try_import_fixtures),
+                retry: Some(self.test.retry),
+                no_tests: Some(self.test.no_tests),
+                slow_timeout: self
+                    .test
+                    .slow_timeout
+                    .map(|d| SlowTimeoutSecs(d.as_secs_f64())),
+                timeout: self.test.timeout.map(|d| TestTimeoutSecs(d.as_secs_f64())),
+            }),
+            coverage: Some(CoverageOptions {
+                sources: Some(self.coverage.sources.clone()),
+                report: Some(self.coverage.report),
+                fail_under: self.coverage.fail_under.map(CovFailUnder),
+                disabled: None,
+            }),
+        }
     }
 }
 

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -2,13 +2,11 @@ use std::time::Duration;
 
 use karva_combine::Combine;
 use karva_logging::{FinalStatusLevel, StatusLevel};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 
 use crate::filter::FiltersetSet;
 use crate::max_fail::MaxFail;
-use crate::options::{
-    CovReport, CoverageOptions, Options, OutputFormat, SrcOptions, TerminalOptions, TestOptions,
-};
+use crate::options::{CovReport, OutputFormat};
 
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RunIgnoredMode {
@@ -123,10 +121,11 @@ impl Combine for CovFailUnder {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct ProjectSettings {
-    pub(crate) terminal: TerminalSettings,
     pub(crate) src: SrcSettings,
+    pub(crate) terminal: TerminalSettings,
     pub(crate) test: TestSettings,
     pub(crate) coverage: CoverageSettings,
 }
@@ -159,53 +158,26 @@ impl ProjectSettings {
     pub fn set_run_ignored(&mut self, mode: RunIgnoredMode) {
         self.test.run_ignored = mode;
     }
+}
 
-    /// Round-trip the resolved settings back to a fully-populated [`Options`].
-    ///
-    /// Every field is `Some(...)` so a serialized form reflects the values
-    /// karva is actually running with, including defaults. Runtime-only
-    /// fields (`filter`, `run_ignored`, coverage `disabled`) are excluded:
-    /// they do not come from configuration files. `fail_fast` is also
-    /// omitted since `max_fail` is the canonical form.
-    pub fn to_options(&self) -> Options {
-        Options {
-            src: Some(SrcOptions {
-                respect_ignore_files: Some(self.src.respect_ignore_files),
-                include: Some(self.src.include_paths.clone()),
-            }),
-            terminal: Some(TerminalOptions {
-                output_format: Some(self.terminal.output_format),
-                show_python_output: Some(self.terminal.show_python_output),
-                status_level: Some(self.terminal.status_level),
-                final_status_level: Some(self.terminal.final_status_level),
-            }),
-            test: Some(TestOptions {
-                test_function_prefix: Some(self.test.test_function_prefix.clone()),
-                fail_fast: None,
-                // `MaxFail::unlimited()` wraps `None`, which TOML cannot
-                // represent. Omit the field in that case so the TOML matches
-                // "no limit set".
-                max_fail: self.test.max_fail.has_limit().then_some(self.test.max_fail),
-                try_import_fixtures: Some(self.test.try_import_fixtures),
-                retry: Some(self.test.retry),
-                no_tests: Some(self.test.no_tests),
-                slow_timeout: self
-                    .test
-                    .slow_timeout
-                    .map(|d| SlowTimeoutSecs(d.as_secs_f64())),
-                timeout: self.test.timeout.map(|d| TestTimeoutSecs(d.as_secs_f64())),
-            }),
-            coverage: Some(CoverageOptions {
-                sources: Some(self.coverage.sources.clone()),
-                report: Some(self.coverage.report),
-                fail_under: self.coverage.fail_under.map(CovFailUnder),
-                disabled: None,
-            }),
-        }
+/// Serialize a `Duration` field as fractional seconds. Unset fields are
+/// guarded by `skip_serializing_if = "Option::is_none"`; the `None` arm is
+/// preserved so the function is sound when called directly.
+///
+/// The `&Option<T>` signature is dictated by serde's `serialize_with`.
+#[expect(clippy::ref_option)]
+fn serialize_duration_secs<S: Serializer>(
+    value: &Option<Duration>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    match value {
+        Some(d) => serializer.serialize_f64(d.as_secs_f64()),
+        None => serializer.serialize_none(),
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct TerminalSettings {
     pub output_format: OutputFormat,
     pub show_python_output: bool,
@@ -213,36 +185,56 @@ pub struct TerminalSettings {
     pub final_status_level: FinalStatusLevel,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct SrcSettings {
     pub respect_ignore_files: bool,
+    #[serde(rename = "include")]
     pub include_paths: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct CoverageSettings {
     pub sources: Vec<String>,
     pub report: CovReport,
     /// Minimum total coverage percentage (`0..=100`). When set and the
     /// reported `TOTAL` coverage is below this value, the test command
     /// exits with a non-zero status even if every test passed.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fail_under: Option<f64>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct TestSettings {
     pub test_function_prefix: String,
+    /// `MaxFail::unlimited()` wraps `None`, which TOML cannot represent —
+    /// omit the field when no limit is configured.
+    #[serde(skip_serializing_if = "MaxFail::is_unlimited")]
     pub max_fail: MaxFail,
     pub try_import_fixtures: bool,
     pub retry: u32,
+    /// Runtime-only: filters are sourced from CLI flags, never config files.
+    #[serde(skip)]
     pub filter: FiltersetSet,
+    /// Runtime-only: run-ignored mode is sourced from CLI flags.
+    #[serde(skip)]
     pub run_ignored: RunIgnoredMode,
     pub no_tests: NoTestsMode,
     /// Threshold after which a test is flagged as slow. `None` disables
     /// slow-test detection entirely.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_duration_secs"
+    )]
     pub slow_timeout: Option<Duration>,
     /// Hard per-test timeout. Tests that run longer than this duration are
     /// killed and reported as failures. `None` disables the hard timeout
     /// (tests may still set their own limit via `@karva.tags.timeout`).
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_duration_secs"
+    )]
     pub timeout: Option<Duration>,
 }

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -2,13 +2,11 @@ use std::time::Duration;
 
 use karva_combine::Combine;
 use karva_logging::{FinalStatusLevel, StatusLevel};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 
 use crate::filter::FiltersetSet;
 use crate::max_fail::MaxFail;
-use crate::options::{
-    CovReport, CoverageOptions, Options, OutputFormat, SrcOptions, TerminalOptions, TestOptions,
-};
+use crate::options::{CovReport, OutputFormat};
 
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RunIgnoredMode {
@@ -123,10 +121,11 @@ impl Combine for CovFailUnder {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct ProjectSettings {
-    pub(crate) terminal: TerminalSettings,
     pub(crate) src: SrcSettings,
+    pub(crate) terminal: TerminalSettings,
     pub(crate) test: TestSettings,
     pub(crate) coverage: CoverageSettings,
 }
@@ -159,53 +158,26 @@ impl ProjectSettings {
     pub fn set_run_ignored(&mut self, mode: RunIgnoredMode) {
         self.test.run_ignored = mode;
     }
+}
 
-    /// Round-trip the resolved settings back to a fully-populated [`Options`].
-    ///
-    /// Every field is `Some(...)` so a serialized form reflects the values
-    /// karva is actually running with, including defaults. Runtime-only
-    /// fields (`filter`, `run_ignored`, coverage `disabled`) are excluded:
-    /// they do not come from configuration files. `fail_fast` is also
-    /// omitted since `max_fail` is the canonical form.
-    pub fn to_options(&self) -> Options {
-        Options {
-            src: Some(SrcOptions {
-                respect_ignore_files: Some(self.src.respect_ignore_files),
-                include: Some(self.src.include_paths.clone()),
-            }),
-            terminal: Some(TerminalOptions {
-                output_format: Some(self.terminal.output_format),
-                show_python_output: Some(self.terminal.show_python_output),
-                status_level: Some(self.terminal.status_level),
-                final_status_level: Some(self.terminal.final_status_level),
-            }),
-            test: Some(TestOptions {
-                test_function_prefix: Some(self.test.test_function_prefix.clone()),
-                fail_fast: None,
-                // `MaxFail::unlimited()` wraps `None`, which TOML cannot
-                // represent. Omit the field in that case so the TOML matches
-                // "no limit set".
-                max_fail: self.test.max_fail.has_limit().then_some(self.test.max_fail),
-                try_import_fixtures: Some(self.test.try_import_fixtures),
-                retry: Some(self.test.retry),
-                no_tests: Some(self.test.no_tests),
-                slow_timeout: self
-                    .test
-                    .slow_timeout
-                    .map(|d| SlowTimeoutSecs(d.as_secs_f64())),
-                timeout: self.test.timeout.map(|d| TestTimeoutSecs(d.as_secs_f64())),
-            }),
-            coverage: Some(CoverageOptions {
-                sources: Some(self.coverage.sources.clone()),
-                report: Some(self.coverage.report),
-                fail_under: self.coverage.fail_under.map(CovFailUnder),
-                disabled: None,
-            }),
-        }
+/// Serialize a `Duration` field as fractional seconds. Unset fields are
+/// guarded by `skip_serializing_if = "Option::is_none"`; the `None` arm is
+/// preserved so the function is sound when called directly.
+///
+/// The `&Option<T>` signature is dictated by serde's `serialize_with`.
+#[expect(clippy::ref_option)]
+fn serialize_duration_secs<S: Serializer>(
+    value: &Option<Duration>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    match value {
+        Some(d) => serializer.serialize_f64(d.as_secs_f64()),
+        None => serializer.serialize_none(),
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct TerminalSettings {
     pub output_format: OutputFormat,
     pub show_python_output: bool,
@@ -213,13 +185,16 @@ pub struct TerminalSettings {
     pub final_status_level: FinalStatusLevel,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct SrcSettings {
     pub respect_ignore_files: bool,
+    #[serde(rename = "include")]
     pub include_paths: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct CoverageSettings {
     pub sources: Vec<String>,
     pub report: CovReport,
@@ -227,23 +202,40 @@ pub struct CoverageSettings {
     /// Minimum total coverage percentage (`0..=100`). When set and the
     /// reported `TOTAL` coverage is below this value, the test command
     /// exits with a non-zero status even if every test passed.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fail_under: Option<f64>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct TestSettings {
     pub test_function_prefix: String,
+    /// `MaxFail::unlimited()` wraps `None`, which TOML cannot represent —
+    /// omit the field when no limit is configured.
+    #[serde(skip_serializing_if = "MaxFail::is_unlimited")]
     pub max_fail: MaxFail,
     pub try_import_fixtures: bool,
     pub retry: u32,
+    /// Runtime-only: filters are sourced from CLI flags, never config files.
+    #[serde(skip)]
     pub filter: FiltersetSet,
+    /// Runtime-only: run-ignored mode is sourced from CLI flags.
+    #[serde(skip)]
     pub run_ignored: RunIgnoredMode,
     pub no_tests: NoTestsMode,
     /// Threshold after which a test is flagged as slow. `None` disables
     /// slow-test detection entirely.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_duration_secs"
+    )]
     pub slow_timeout: Option<Duration>,
     /// Hard per-test timeout. Tests that run longer than this duration are
     /// killed and reported as failures. `None` disables the hard timeout
     /// (tests may still set their own limit via `@karva.tags.timeout`).
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_duration_secs"
+    )]
     pub timeout: Option<Duration>,
 }

--- a/docs/configuration/profiles.md
+++ b/docs/configuration/profiles.md
@@ -73,6 +73,18 @@ highest to lowest priority. The first source that defines the field wins.
 Selecting a profile that is not defined in the configuration produces an
 error that lists the profiles that are available.
 
+## Inspecting the resolved configuration
+
+Use `karva show-config` to print the configuration Karva would actually run
+with for a given profile, formatted as TOML. This is helpful when debugging
+precedence between built-in defaults, `[profile.default]`, the selected
+profile, and any CLI overrides.
+
+```bash
+karva show-config              # default profile
+karva show-config --profile ci
+```
+
 ## See also
 
 - [Configuration](configuration.md) — reference for every supported field.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -17,6 +17,7 @@ karva <COMMAND>
 <dl class="cli-reference"><dt><a href="#karva-test"><code>karva test</code></a></dt><dd><p>Run tests</p></dd>
 <dt><a href="#karva-snapshot"><code>karva snapshot</code></a></dt><dd><p>Manage snapshots created by <code>karva.assert_snapshot()</code></p></dd>
 <dt><a href="#karva-cache"><code>karva cache</code></a></dt><dd><p>Manage the karva cache</p></dd>
+<dt><a href="#karva-show-config"><code>karva show-config</code></a></dt><dd><p>Print the resolved configuration karva would run with</p></dd>
 <dt><a href="#karva-version"><code>karva version</code></a></dt><dd><p>Display Karva's version</p></dd>
 <dt><a href="#karva-help"><code>karva help</code></a></dt><dd><p>Print this message or the help of the given subcommand(s)</p></dd>
 </dl>
@@ -347,6 +348,24 @@ Print this message or the help of the given subcommand(s)
 ```
 karva cache help [COMMAND]
 ```
+
+## karva show-config
+
+Print the resolved configuration karva would run with
+
+<h3 class="cli-reference">Usage</h3>
+
+```
+karva show-config [OPTIONS]
+```
+
+<h3 class="cli-reference">Options</h3>
+
+<dl class="cli-reference"><dt id="karva-show-config--config-file"><a href="#karva-show-config--config-file"><code>--config-file</code></a> <i>path</i></dt><dd><p>The path to a <code>karva.toml</code> file to use for configuration</p>
+<p>May also be set with the <code>KARVA_CONFIG_FILE</code> environment variable.</p></dd><dt id="karva-show-config--help"><a href="#karva-show-config--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Print help (see a summary with '-h')</p>
+</dd><dt id="karva-show-config--profile"><a href="#karva-show-config--profile"><code>--profile</code></a>, <code>-P</code> <i>name</i></dt><dd><p>Configuration profile to resolve.</p>
+<p>Defaults to <code>default</code>.</p>
+<p>May also be set with the <code>KARVA_PROFILE</code> environment variable.</p></dd></dl>
 
 ## karva version
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -17,6 +17,7 @@ karva <COMMAND>
 <dl class="cli-reference"><dt><a href="#karva-test"><code>karva test</code></a></dt><dd><p>Run tests</p></dd>
 <dt><a href="#karva-snapshot"><code>karva snapshot</code></a></dt><dd><p>Manage snapshots created by <code>karva.assert_snapshot()</code></p></dd>
 <dt><a href="#karva-cache"><code>karva cache</code></a></dt><dd><p>Manage the karva cache</p></dd>
+<dt><a href="#karva-show-config"><code>karva show-config</code></a></dt><dd><p>Print the resolved configuration karva would run with</p></dd>
 <dt><a href="#karva-version"><code>karva version</code></a></dt><dd><p>Display Karva's version</p></dd>
 <dt><a href="#karva-help"><code>karva help</code></a></dt><dd><p>Print this message or the help of the given subcommand(s)</p></dd>
 </dl>
@@ -343,6 +344,24 @@ Print this message or the help of the given subcommand(s)
 ```
 karva cache help [COMMAND]
 ```
+
+## karva show-config
+
+Print the resolved configuration karva would run with
+
+<h3 class="cli-reference">Usage</h3>
+
+```
+karva show-config [OPTIONS]
+```
+
+<h3 class="cli-reference">Options</h3>
+
+<dl class="cli-reference"><dt id="karva-show-config--config-file"><a href="#karva-show-config--config-file"><code>--config-file</code></a> <i>path</i></dt><dd><p>The path to a <code>karva.toml</code> file to use for configuration</p>
+<p>May also be set with the <code>KARVA_CONFIG_FILE</code> environment variable.</p></dd><dt id="karva-show-config--help"><a href="#karva-show-config--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Print help (see a summary with '-h')</p>
+</dd><dt id="karva-show-config--profile"><a href="#karva-show-config--profile"><code>--profile</code></a>, <code>-P</code> <i>name</i></dt><dd><p>Configuration profile to resolve.</p>
+<p>Defaults to <code>default</code>.</p>
+<p>May also be set with the <code>KARVA_PROFILE</code> environment variable.</p></dd></dl>
 
 ## karva version
 


### PR DESCRIPTION
## Summary

Closes #763. Adds a `karva show-config` subcommand that resolves the same `Settings` the test runner builds — defaults layered with `karva.toml`/`pyproject.toml` and the selected profile — and prints them as TOML. This gives users a way to ask "what config is karva actually running with?" when debugging precedence between built-in defaults, `[profile.default]`, a named profile, and CLI overrides.

The command takes the same `--config-file` and `--profile`/`-P` flags as `karva test`, so the resolution path matches what the runner would use. Output is a flat TOML body of the merged option groups (`src`, `terminal`, `test`, `coverage`) with every field populated to make defaults explicit.

```bash
karva show-config              # default profile
karva show-config --profile ci
```

The round-trip from resolved `ProjectSettings` back to `Options` lives on `ProjectSettings::to_options()` so there is a single source of truth (defaults still flow through `to_settings`). Runtime-only fields (`filter`, `run_ignored`, coverage `disabled`) are excluded since they don't come from configuration files, and `fail_fast` is omitted because `max_fail` is the canonical form. A future `--source` flag, as mentioned in the issue, would build on the same plumbing to annotate each value with its origin.

## Test Plan

ci