### PR TITLE
Add --show-progress and serialize worker output to fix interleaving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,6 +919,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
 name = "inotify"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,6 +1290,7 @@ dependencies = [
  "ctrlc",
  "fastrand",
  "ignore",
+ "indicatif",
  "karva_cache",
  "karva_cli",
  "karva_collector",
@@ -2748,6 +2762,12 @@ dependencies = [
  "phf_codegen",
  "rand 0.8.5",
 ]
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,6 +919,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
 name = "inotify"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,6 +1294,7 @@ dependencies = [
  "ctrlc",
  "fastrand",
  "ignore",
+ "indicatif",
  "karva_cache",
  "karva_cli",
  "karva_collector",
@@ -2755,6 +2769,12 @@ dependencies = [
  "phf_codegen",
  "rand 0.8.5",
 ]
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ dunce = { version = "1.0.5" }
 fastrand = { version = "2.4" }
 globset = { version = "0.4" }
 ignore = { version = "0.4.25" }
+indicatif = { version = "0.18" }
 insta = { version = "1.47.1" }
 insta-cmd = { version = "0.6.0" }
 itertools = { version = "0.14.0" }

--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -1798,6 +1798,81 @@ def test_3(): pass
     ");
 }
 
+/// `--show-progress=bar` is accepted and does not corrupt stdout. The bar
+/// itself is rendered on stderr and gated on stderr being a TTY, so in the
+/// test harness (where stderr is captured) it produces no visible output.
+#[test]
+fn test_show_progress_bar_does_not_alter_stdout() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+def test_1(): pass
+def test_2(): pass
+",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--show-progress=bar"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            PASS [TIME] test::test_1
+            PASS [TIME] test::test_2
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+/// `--show-progress=counter` is accepted; the counter is rendered on stderr
+/// and gated on TTY, so it produces no visible output in tests.
+#[test]
+fn test_show_progress_counter_does_not_alter_stdout() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+def test_1(): pass
+",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--show-progress=counter"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_1
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+/// `--show-progress=none` is the default and matches the run with the flag
+/// omitted.
+#[test]
+fn test_show_progress_none_matches_default() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+def test_1(): pass
+",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--show-progress=none"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_1
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
 /// `--no-progress` still emits diagnostics for failing tests.
 #[test]
 fn test_no_progress_with_failure_shows_diagnostics() {

--- a/crates/karva_cache/src/artifact.rs
+++ b/crates/karva_cache/src/artifact.rs
@@ -33,6 +33,12 @@ pub enum CacheFile {
     /// Used by [`crate::RunCache::progress_file`] so the orchestrator can
     /// poll completion counts mid-run without coordinating with workers.
     Progress,
+    /// Per-worker append-only file: newline-delimited preformatted result
+    /// lines (PASS/FAIL/SKIP/SLOW/TRY). The orchestrator drains these files
+    /// and prints whole lines to its stdout to prevent worker output from
+    /// interleaving — multiple processes locking their own stdouts does not
+    /// actually serialize writes. See [`crate::RunCache::output_file`].
+    Output,
     /// Per-run empty sentinel marking that fail-fast was triggered.
     FailFastSignal,
     /// Cache-root JSON: list of last-run failed test names.
@@ -50,6 +56,7 @@ impl CacheFile {
             Self::FlakyTests => "flaky_tests.json",
             Self::Coverage => "coverage.json",
             Self::Progress => "progress",
+            Self::Output => "output",
             Self::FailFastSignal => "fail-fast",
             Self::LastFailed => "last-failed.json",
         }

--- a/crates/karva_cache/src/artifact.rs
+++ b/crates/karva_cache/src/artifact.rs
@@ -28,6 +28,11 @@ pub enum CacheFile {
     FlakyTests,
     /// Per-worker JSON: line-coverage data for sources tracked during the run.
     Coverage,
+    /// Per-worker append-only file: one byte per completed test.
+    ///
+    /// Used by [`crate::RunCache::progress_file`] so the orchestrator can
+    /// poll completion counts mid-run without coordinating with workers.
+    Progress,
     /// Per-run empty sentinel marking that fail-fast was triggered.
     FailFastSignal,
     /// Cache-root JSON: list of last-run failed test names.
@@ -44,6 +49,7 @@ impl CacheFile {
             Self::FailedTests => "failed_tests.json",
             Self::FlakyTests => "flaky_tests.json",
             Self::Coverage => "coverage.json",
+            Self::Progress => "progress",
             Self::FailFastSignal => "fail-fast",
             Self::LastFailed => "last-failed.json",
         }

--- a/crates/karva_cache/src/artifact.rs
+++ b/crates/karva_cache/src/artifact.rs
@@ -33,6 +33,12 @@ pub enum CacheFile {
     /// Used by [`crate::RunCache::progress_file`] so the orchestrator can
     /// poll completion counts mid-run without coordinating with workers.
     Progress,
+    /// Per-worker append-only file: newline-delimited preformatted result
+    /// lines (PASS/FAIL/SKIP/SLOW/TRY). The orchestrator drains these files
+    /// and prints whole lines to its stdout to prevent worker output from
+    /// interleaving — multiple processes locking their own stdouts does not
+    /// actually serialize writes. See [`crate::RunCache::output_file`].
+    Output,
     /// Per-run empty sentinel marking that fail-fast was triggered.
     FailFastSignal,
     /// Cache-root JSON: list of last-run failed test names.
@@ -54,6 +60,7 @@ impl CacheFile {
             Self::FlakyTests => "flaky_tests.json",
             Self::Coverage => "coverage.json",
             Self::Progress => "progress",
+            Self::Output => "output",
             Self::FailFastSignal => "fail-fast",
             Self::LastFailed => "last-failed.json",
             Self::CurrentTest => "current_test.json",

--- a/crates/karva_cache/src/artifact.rs
+++ b/crates/karva_cache/src/artifact.rs
@@ -28,6 +28,11 @@ pub enum CacheFile {
     FlakyTests,
     /// Per-worker JSON: line-coverage data for sources tracked during the run.
     Coverage,
+    /// Per-worker append-only file: one byte per completed test.
+    ///
+    /// Used by [`crate::RunCache::progress_file`] so the orchestrator can
+    /// poll completion counts mid-run without coordinating with workers.
+    Progress,
     /// Per-run empty sentinel marking that fail-fast was triggered.
     FailFastSignal,
     /// Cache-root JSON: list of last-run failed test names.
@@ -48,6 +53,7 @@ impl CacheFile {
             Self::FailedTests => "failed_tests.json",
             Self::FlakyTests => "flaky_tests.json",
             Self::Coverage => "coverage.json",
+            Self::Progress => "progress",
             Self::FailFastSignal => "fail-fast",
             Self::LastFailed => "last-failed.json",
             Self::CurrentTest => "current_test.json",

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -78,6 +78,16 @@ impl RunCache {
         CacheFile::Progress.path_in(&self.worker_dir(worker_id))
     }
 
+    /// Path to the per-worker output file.
+    ///
+    /// Workers append newline-delimited result lines to this file via
+    /// `FileLineSink`. The orchestrator's drain reads new bytes since the
+    /// last poll, splits on `\n`, and prints whole lines to its own stdout —
+    /// keeping worker output from interleaving on a shared terminal.
+    pub fn output_file(&self, worker_id: usize) -> Utf8PathBuf {
+        CacheFile::Output.path_in(&self.worker_dir(worker_id))
+    }
+
     /// Sum of completed-test counts across every worker for this run.
     ///
     /// Each worker's progress file is one byte per completed test, so the

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -21,6 +21,7 @@ pub struct AggregatedResults {
 }
 
 /// Reads and writes test results in the cache directory for a specific run.
+#[derive(Clone)]
 pub struct RunCache {
     run_dir: Utf8PathBuf,
 }
@@ -65,6 +66,34 @@ impl RunCache {
     /// coverage session ends.
     pub fn coverage_data_file(&self, worker_id: usize) -> Utf8PathBuf {
         CacheFile::Coverage.path_in(&self.worker_dir(worker_id))
+    }
+
+    /// Path to the per-worker progress file.
+    ///
+    /// The worker appends one byte to this file each time a test completes;
+    /// the orchestrator polls the file lengths of every worker to drive a
+    /// progress display. The append is atomic on POSIX, so readers can use
+    /// the file length without locking.
+    pub fn progress_file(&self, worker_id: usize) -> Utf8PathBuf {
+        CacheFile::Progress.path_in(&self.worker_dir(worker_id))
+    }
+
+    /// Sum of completed-test counts across every worker for this run.
+    ///
+    /// Each worker's progress file is one byte per completed test, so the
+    /// per-worker count is exactly the file length. Missing files (worker
+    /// hasn't started yet, or no tests completed) contribute zero.
+    pub fn completed_count(&self) -> u64 {
+        let Ok(worker_dirs) = list_worker_dirs(&self.run_dir) else {
+            return 0;
+        };
+        worker_dirs
+            .iter()
+            .map(|dir| {
+                let path = CacheFile::Progress.path_in(dir);
+                fs::metadata(&path).map(|m| m.len()).unwrap_or(0)
+            })
+            .sum()
     }
 
     /// Returns paths to every per-worker coverage file that exists for this

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -46,6 +46,7 @@ impl AggregatedResults {
 }
 
 /// Reads and writes test results in the cache directory for a specific run.
+#[derive(Clone)]
 pub struct RunCache {
     run_dir: Utf8PathBuf,
 }
@@ -101,6 +102,34 @@ impl RunCache {
     /// Returns `None` if the worker is between tests or hasn't started yet.
     pub fn read_current_test(&self, worker_id: usize) -> Result<Option<CurrentTest>> {
         read_json::<CurrentTest>(&self.worker_dir(worker_id), CacheFile::CurrentTest)
+    }
+
+    /// Path to the per-worker progress file.
+    ///
+    /// The worker appends one byte to this file each time a test completes;
+    /// the orchestrator polls the file lengths of every worker to drive a
+    /// progress display. The append is atomic on POSIX, so readers can use
+    /// the file length without locking.
+    pub fn progress_file(&self, worker_id: usize) -> Utf8PathBuf {
+        CacheFile::Progress.path_in(&self.worker_dir(worker_id))
+    }
+
+    /// Sum of completed-test counts across every worker for this run.
+    ///
+    /// Each worker's progress file is one byte per completed test, so the
+    /// per-worker count is exactly the file length. Missing files (worker
+    /// hasn't started yet, or no tests completed) contribute zero.
+    pub fn completed_count(&self) -> u64 {
+        let Ok(worker_dirs) = list_worker_dirs(&self.run_dir) else {
+            return 0;
+        };
+        worker_dirs
+            .iter()
+            .map(|dir| {
+                let path = CacheFile::Progress.path_in(dir);
+                fs::metadata(&path).map(|m| m.len()).unwrap_or(0)
+            })
+            .sum()
     }
 
     /// Returns paths to every per-worker coverage file that exists for this

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -114,6 +114,16 @@ impl RunCache {
         CacheFile::Progress.path_in(&self.worker_dir(worker_id))
     }
 
+    /// Path to the per-worker output file.
+    ///
+    /// Workers append newline-delimited result lines to this file via
+    /// `FileLineSink`. The orchestrator's drain reads new bytes since the
+    /// last poll, splits on `\n`, and prints whole lines to its own stdout —
+    /// keeping worker output from interleaving on a shared terminal.
+    pub fn output_file(&self, worker_id: usize) -> Utf8PathBuf {
+        CacheFile::Output.path_in(&self.worker_dir(worker_id))
+    }
+
     /// Sum of completed-test counts across every worker for this run.
     ///
     /// Each worker's progress file is one byte per completed test, so the

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroU32;
 
 use camino::Utf8PathBuf;
 use clap::Parser;
-use karva_logging::{FinalStatusLevel, StatusLevel, TerminalColor};
+use karva_logging::{FinalStatusLevel, ProgressMode, StatusLevel, TerminalColor};
 use karva_metadata::{
     CovFailUnder, CoverageOptions, MaxFail, Options, SlowTimeoutSecs, SrcOptions, TerminalOptions,
     TestOptions, TestTimeoutSecs,
@@ -157,6 +157,20 @@ pub struct SubTestCommand {
         help_heading = "Reporter options"
     )]
     pub final_status_level: Option<FinalStatusLevel>,
+
+    /// Live progress display while tests run [default: none]
+    ///
+    /// `none` leaves output untouched. `counter` prints a refreshing
+    /// `N/M tests` line on stderr. `bar` renders a visual progress bar.
+    /// Stderr is used so the display does not interfere with per-test
+    /// result lines on stdout.
+    #[arg(
+        long,
+        value_name = "MODE",
+        env = "KARVA_SHOW_PROGRESS",
+        help_heading = "Reporter options"
+    )]
+    pub show_progress: Option<ProgressMode>,
 
     /// Measure code coverage for the given source path.
     ///
@@ -338,6 +352,7 @@ impl SubTestCommand {
                 show_python_output: self.show_output,
                 status_level: self.status_level,
                 final_status_level: self.final_status_level,
+                show_progress: self.show_progress,
             }),
             test: Some(TestOptions {
                 test_function_prefix: self.test_prefix,

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroU32;
 
 use camino::Utf8PathBuf;
 use clap::Parser;
-use karva_logging::{FinalStatusLevel, StatusLevel, TerminalColor};
+use karva_logging::{FinalStatusLevel, ProgressMode, StatusLevel, TerminalColor};
 use karva_metadata::{
     CovFailUnder, CoverageOptions, MaxFail, Options, SlowTimeoutSecs, SrcOptions, TerminalOptions,
     TestOptions, TestTimeoutSecs,
@@ -157,6 +157,20 @@ pub struct SubTestCommand {
         help_heading = "Reporter options"
     )]
     pub final_status_level: Option<FinalStatusLevel>,
+
+    /// Live progress display while tests run [default: none]
+    ///
+    /// `none` leaves output untouched. `counter` prints a refreshing
+    /// `N/M tests` line on stderr. `bar` renders a visual progress bar.
+    /// Stderr is used so the display does not interfere with per-test
+    /// result lines on stdout.
+    #[arg(
+        long,
+        value_name = "MODE",
+        env = "KARVA_SHOW_PROGRESS",
+        help_heading = "Reporter options"
+    )]
+    pub show_progress: Option<ProgressMode>,
 
     /// Measure code coverage for the given source path.
     ///
@@ -340,6 +354,7 @@ impl SubTestCommand {
                 show_python_output: self.show_output,
                 status_level: self.status_level,
                 final_status_level: self.final_status_level,
+                show_progress: self.show_progress,
             }),
             test: Some(TestOptions {
                 test_function_prefix: self.test_prefix,

--- a/crates/karva_diagnostic/src/lib.rs
+++ b/crates/karva_diagnostic/src/lib.rs
@@ -3,7 +3,10 @@ mod result;
 #[cfg(feature = "traceback")]
 mod traceback;
 
-pub use reporter::{DummyReporter, ProgressTrackingReporter, Reporter, TestCaseReporter};
+pub use reporter::{
+    DummyReporter, FileLineSink, LineSink, ProgressTrackingReporter, Reporter, StdoutLineSink,
+    TestCaseReporter,
+};
 pub use result::{
     DisplayFlakyTest, DisplayFlakyTests, FlakyTest, IndividualTestResultKind, TestResultKind,
     TestResultStats, TestRunResult,

--- a/crates/karva_diagnostic/src/lib.rs
+++ b/crates/karva_diagnostic/src/lib.rs
@@ -3,7 +3,7 @@ mod result;
 #[cfg(feature = "traceback")]
 mod traceback;
 
-pub use reporter::{DummyReporter, Reporter, TestCaseReporter};
+pub use reporter::{DummyReporter, ProgressTrackingReporter, Reporter, TestCaseReporter};
 pub use result::{
     DisplayFlakyTest, DisplayFlakyTests, FlakyTest, IndividualTestResultKind, TestResultKind,
     TestResultStats, TestRunResult,

--- a/crates/karva_diagnostic/src/reporter.rs
+++ b/crates/karva_diagnostic/src/reporter.rs
@@ -1,7 +1,7 @@
-use std::fmt::Write;
-use std::fs::OpenOptions;
-use std::io::Write as _;
-use std::path::PathBuf;
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 use std::time::Duration;
 
 use colored::Colorize;
@@ -87,14 +87,69 @@ impl Reporter for DummyReporter {
     }
 }
 
-/// A reporter that outputs test results to stdout as they complete.
+/// Sink for preformatted reporter result lines.
+///
+/// Each `write_line` call must emit exactly one line (a `\n` is appended by
+/// the implementation). Lines from one sink are serialized; the orchestrator
+/// merges across sinks. Used to keep worker output from interleaving on
+/// stdout — workers write to a [`FileLineSink`] backed by a per-worker file
+/// and the orchestrator drains those files line by line.
+pub trait LineSink: Send + Sync {
+    fn write_line(&self, line: &str);
+}
+
+/// Writes lines straight to the process stdout (locked per call).
+///
+/// Suitable when the reporter runs in the same process that owns stdout.
+/// Cross-process workers should use [`FileLineSink`] instead — multiple
+/// processes locking stdout independently does not actually serialize their
+/// writes.
+pub struct StdoutLineSink;
+
+impl LineSink for StdoutLineSink {
+    fn write_line(&self, line: &str) {
+        let mut out = std::io::stdout().lock();
+        let _ = writeln!(out, "{line}");
+    }
+}
+
+/// Appends lines to a file opened with `O_APPEND`.
+///
+/// A `Mutex` guards against intra-process races (the reporter is shared
+/// across worker threads). Each `write_line` issues a single `writeln!` so
+/// the orchestrator's drain — which reads from the file and splits on `\n` —
+/// either sees a complete line or buffers a trailing partial line for the
+/// next read.
+pub struct FileLineSink {
+    file: Mutex<File>,
+}
+
+impl FileLineSink {
+    pub fn open(path: &Path) -> std::io::Result<Self> {
+        let file = OpenOptions::new().create(true).append(true).open(path)?;
+        Ok(Self {
+            file: Mutex::new(file),
+        })
+    }
+}
+
+impl LineSink for FileLineSink {
+    fn write_line(&self, line: &str) {
+        if let Ok(mut file) = self.file.lock() {
+            let _ = writeln!(file, "{line}");
+        }
+    }
+}
+
+/// A reporter that emits one line per result to a [`LineSink`].
 pub struct TestCaseReporter {
     printer: Printer,
+    sink: Box<dyn LineSink>,
 }
 
 impl TestCaseReporter {
-    pub fn new(printer: Printer) -> Self {
-        Self { printer }
+    pub fn new(printer: Printer, sink: Box<dyn LineSink>) -> Self {
+        Self { printer, sink }
     }
 }
 
@@ -122,12 +177,9 @@ impl Reporter for TestCaseReporter {
             _ => String::new(),
         };
 
-        let mut stdout = self.printer.stream_for_test_result().lock();
-        writeln!(
-            stdout,
+        self.sink.write_line(&format!(
             "{padding}{colored_label} {duration_str} {test_path}{suffix}"
-        )
-        .ok();
+        ));
     }
 
     fn report_test_slow(&self, test_name: &QualifiedTestName, duration: Duration) {
@@ -141,12 +193,9 @@ impl Reporter for TestCaseReporter {
         let duration_str = format_duration_bracketed(duration);
         let test_path = format_test_path(test_name);
 
-        let mut stdout = self.printer.stream_for_test_result().lock();
-        writeln!(
-            stdout,
+        self.sink.write_line(&format!(
             "{padding}{colored_label} {duration_str} {test_path}"
-        )
-        .ok();
+        ));
     }
 
     fn report_test_attempt(
@@ -169,12 +218,9 @@ impl Reporter for TestCaseReporter {
         let duration_str = format_duration_bracketed(duration);
         let test_path = format_test_path(test_name);
 
-        let mut stdout = self.printer.stream_for_test_result().lock();
-        writeln!(
-            stdout,
+        self.sink.write_line(&format!(
             "{padding}TRY {attempt} {colored_status} {duration_str} {test_path}"
-        )
-        .ok();
+        ));
     }
 }
 

--- a/crates/karva_diagnostic/src/reporter.rs
+++ b/crates/karva_diagnostic/src/reporter.rs
@@ -1,4 +1,7 @@
 use std::fmt::Write;
+use std::fs::OpenOptions;
+use std::io::Write as _;
+use std::path::PathBuf;
 use std::time::Duration;
 
 use colored::Colorize;
@@ -40,6 +43,16 @@ pub trait Reporter: Send + Sync {
     /// no-op for reporters that don't surface slow-test detail.
     fn report_test_slow(&self, test_name: &QualifiedTestName, duration: Duration) {
         let _ = (test_name, duration);
+    }
+
+    /// Notify that a test has fully completed for accounting purposes.
+    ///
+    /// Called exactly once per test (after every attempt has run for retried
+    /// tests, after the single attempt for non-retried tests). Reporters
+    /// that drive a progress display use this hook so the count advances
+    /// once per test rather than once per attempt. Default no-op.
+    fn notify_test_completed(&self, test_name: &QualifiedTestName) {
+        let _ = test_name;
     }
 }
 
@@ -162,6 +175,69 @@ impl Reporter for TestCaseReporter {
             "{padding}TRY {attempt} {colored_status} {duration_str} {test_path}"
         )
         .ok();
+    }
+}
+
+/// Wraps another reporter and appends one byte to a file each time a test
+/// completes (counted once per test, regardless of retries).
+///
+/// The orchestrator polls the file's length to drive a live progress
+/// display without coordinating with workers via a richer protocol. The
+/// append uses `O_APPEND`, which is atomic on POSIX, so the orchestrator
+/// can read the length concurrently without locking.
+pub struct ProgressTrackingReporter<R: Reporter> {
+    inner: R,
+    progress_file: PathBuf,
+}
+
+impl<R: Reporter> ProgressTrackingReporter<R> {
+    pub fn new(inner: R, progress_file: PathBuf) -> Self {
+        Self {
+            inner,
+            progress_file,
+        }
+    }
+
+    fn append_tick(&self) {
+        if let Ok(mut file) = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.progress_file)
+        {
+            let _ = file.write_all(b"\x01");
+        }
+    }
+}
+
+impl<R: Reporter> Reporter for ProgressTrackingReporter<R> {
+    fn report_test_case_result(
+        &self,
+        test_name: &QualifiedTestName,
+        result_kind: IndividualTestResultKind,
+        duration: Duration,
+    ) {
+        self.inner
+            .report_test_case_result(test_name, result_kind, duration);
+    }
+
+    fn report_test_attempt(
+        &self,
+        test_name: &QualifiedTestName,
+        attempt: u32,
+        result_kind: IndividualTestResultKind,
+        duration: Duration,
+    ) {
+        self.inner
+            .report_test_attempt(test_name, attempt, result_kind, duration);
+    }
+
+    fn report_test_slow(&self, test_name: &QualifiedTestName, duration: Duration) {
+        self.inner.report_test_slow(test_name, duration);
+    }
+
+    fn notify_test_completed(&self, test_name: &QualifiedTestName) {
+        self.inner.notify_test_completed(test_name);
+        self.append_tick();
     }
 }
 

--- a/crates/karva_diagnostic/src/reporter.rs
+++ b/crates/karva_diagnostic/src/reporter.rs
@@ -1,4 +1,7 @@
 use std::fmt::Write;
+use std::fs::OpenOptions;
+use std::io::Write as _;
+use std::path::PathBuf;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use camino::Utf8PathBuf;
@@ -55,6 +58,16 @@ pub trait Reporter: Send + Sync {
     /// reporter can clear any in-flight state recorded by
     /// [`Self::report_test_started`]. Default no-op.
     fn report_test_finished(&self, test_name: &QualifiedTestName) {
+        let _ = test_name;
+    }
+
+    /// Notify that a test has fully completed for accounting purposes.
+    ///
+    /// Called exactly once per test (after every attempt has run for retried
+    /// tests, after the single attempt for non-retried tests). Reporters
+    /// that drive a progress display use this hook so the count advances
+    /// once per test rather than once per attempt. Default no-op.
+    fn notify_test_completed(&self, test_name: &QualifiedTestName) {
         let _ = test_name;
     }
 }
@@ -215,6 +228,77 @@ impl Reporter for TestCaseReporter {
         if let Some(path) = self.progress_file.as_ref() {
             let _ = std::fs::remove_file(path);
         }
+    }
+}
+
+/// Wraps another reporter and appends one byte to a file each time a test
+/// completes (counted once per test, regardless of retries).
+///
+/// The orchestrator polls the file's length to drive a live progress
+/// display without coordinating with workers via a richer protocol. The
+/// append uses `O_APPEND`, which is atomic on POSIX, so the orchestrator
+/// can read the length concurrently without locking.
+pub struct ProgressTrackingReporter<R: Reporter> {
+    inner: R,
+    progress_file: PathBuf,
+}
+
+impl<R: Reporter> ProgressTrackingReporter<R> {
+    pub fn new(inner: R, progress_file: PathBuf) -> Self {
+        Self {
+            inner,
+            progress_file,
+        }
+    }
+
+    fn append_tick(&self) {
+        if let Ok(mut file) = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.progress_file)
+        {
+            let _ = file.write_all(b"\x01");
+        }
+    }
+}
+
+impl<R: Reporter> Reporter for ProgressTrackingReporter<R> {
+    fn report_test_case_result(
+        &self,
+        test_name: &QualifiedTestName,
+        result_kind: IndividualTestResultKind,
+        duration: Duration,
+    ) {
+        self.inner
+            .report_test_case_result(test_name, result_kind, duration);
+    }
+
+    fn report_test_attempt(
+        &self,
+        test_name: &QualifiedTestName,
+        attempt: u32,
+        result_kind: IndividualTestResultKind,
+        duration: Duration,
+    ) {
+        self.inner
+            .report_test_attempt(test_name, attempt, result_kind, duration);
+    }
+
+    fn report_test_slow(&self, test_name: &QualifiedTestName, duration: Duration) {
+        self.inner.report_test_slow(test_name, duration);
+    }
+
+    fn report_test_started(&self, test_name: &QualifiedTestName) {
+        self.inner.report_test_started(test_name);
+    }
+
+    fn report_test_finished(&self, test_name: &QualifiedTestName) {
+        self.inner.report_test_finished(test_name);
+    }
+
+    fn notify_test_completed(&self, test_name: &QualifiedTestName) {
+        self.inner.notify_test_completed(test_name);
+        self.append_tick();
     }
 }
 

--- a/crates/karva_diagnostic/src/reporter.rs
+++ b/crates/karva_diagnostic/src/reporter.rs
@@ -1,7 +1,7 @@
-use std::fmt::Write;
-use std::fs::OpenOptions;
-use std::io::Write as _;
-use std::path::PathBuf;
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use camino::Utf8PathBuf;
@@ -103,20 +103,76 @@ impl Reporter for DummyReporter {
     }
 }
 
-/// A reporter that outputs test results to stdout as they complete.
+/// Sink for preformatted reporter result lines.
+///
+/// Each `write_line` call must emit exactly one line (a `\n` is appended by
+/// the implementation). Lines from one sink are serialized; the orchestrator
+/// merges across sinks. Used to keep worker output from interleaving on
+/// stdout — workers write to a [`FileLineSink`] backed by a per-worker file
+/// and the orchestrator drains those files line by line.
+pub trait LineSink: Send + Sync {
+    fn write_line(&self, line: &str);
+}
+
+/// Writes lines straight to the process stdout (locked per call).
+///
+/// Suitable when the reporter runs in the same process that owns stdout.
+/// Cross-process workers should use [`FileLineSink`] instead — multiple
+/// processes locking stdout independently does not actually serialize their
+/// writes.
+pub struct StdoutLineSink;
+
+impl LineSink for StdoutLineSink {
+    fn write_line(&self, line: &str) {
+        let mut out = std::io::stdout().lock();
+        let _ = writeln!(out, "{line}");
+    }
+}
+
+/// Appends lines to a file opened with `O_APPEND`.
+///
+/// A `Mutex` guards against intra-process races (the reporter is shared
+/// across worker threads). Each `write_line` issues a single `writeln!` so
+/// the orchestrator's drain — which reads from the file and splits on `\n` —
+/// either sees a complete line or buffers a trailing partial line for the
+/// next read.
+pub struct FileLineSink {
+    file: Mutex<File>,
+}
+
+impl FileLineSink {
+    pub fn open(path: &Path) -> std::io::Result<Self> {
+        let file = OpenOptions::new().create(true).append(true).open(path)?;
+        Ok(Self {
+            file: Mutex::new(file),
+        })
+    }
+}
+
+impl LineSink for FileLineSink {
+    fn write_line(&self, line: &str) {
+        if let Ok(mut file) = self.file.lock() {
+            let _ = writeln!(file, "{line}");
+        }
+    }
+}
+
+/// A reporter that emits one line per result to a [`LineSink`].
 pub struct TestCaseReporter {
     printer: Printer,
+    sink: Box<dyn LineSink>,
     /// Optional path to a JSON file describing the test currently
     /// executing. The orchestrator reads this on Ctrl+C to render
     /// per-test `SIGINT` lines.
-    progress_file: Option<Utf8PathBuf>,
+    current_test_file: Option<Utf8PathBuf>,
 }
 
 impl TestCaseReporter {
-    pub fn new(printer: Printer) -> Self {
+    pub fn new(printer: Printer, sink: Box<dyn LineSink>) -> Self {
         Self {
             printer,
-            progress_file: None,
+            sink,
+            current_test_file: None,
         }
     }
 
@@ -124,8 +180,8 @@ impl TestCaseReporter {
     /// start time to `path` whenever a test begins, and remove the file
     /// when it ends.
     #[must_use]
-    pub fn with_progress_file(mut self, path: Utf8PathBuf) -> Self {
-        self.progress_file = Some(path);
+    pub fn with_current_test_file(mut self, path: Utf8PathBuf) -> Self {
+        self.current_test_file = Some(path);
         self
     }
 }
@@ -154,12 +210,9 @@ impl Reporter for TestCaseReporter {
             _ => String::new(),
         };
 
-        let mut stdout = self.printer.stream_for_test_result().lock();
-        writeln!(
-            stdout,
+        self.sink.write_line(&format!(
             "{padding}{colored_label} {duration_str} {test_path}{suffix}"
-        )
-        .ok();
+        ));
     }
 
     fn report_test_slow(&self, test_name: &QualifiedTestName, duration: Duration) {
@@ -173,12 +226,9 @@ impl Reporter for TestCaseReporter {
         let duration_str = format_duration_bracketed(duration);
         let test_path = format_test_path(test_name);
 
-        let mut stdout = self.printer.stream_for_test_result().lock();
-        writeln!(
-            stdout,
+        self.sink.write_line(&format!(
             "{padding}{colored_label} {duration_str} {test_path}"
-        )
-        .ok();
+        ));
     }
 
     fn report_test_attempt(
@@ -201,16 +251,13 @@ impl Reporter for TestCaseReporter {
         let duration_str = format_duration_bracketed(duration);
         let test_path = format_test_path(test_name);
 
-        let mut stdout = self.printer.stream_for_test_result().lock();
-        writeln!(
-            stdout,
+        self.sink.write_line(&format!(
             "{padding}TRY {attempt} {colored_status} {duration_str} {test_path}"
-        )
-        .ok();
+        ));
     }
 
     fn report_test_started(&self, test_name: &QualifiedTestName) {
-        let Some(path) = self.progress_file.as_ref() else {
+        let Some(path) = self.current_test_file.as_ref() else {
             return;
         };
         let start_unix_ms = SystemTime::now()
@@ -225,7 +272,7 @@ impl Reporter for TestCaseReporter {
     }
 
     fn report_test_finished(&self, _test_name: &QualifiedTestName) {
-        if let Some(path) = self.progress_file.as_ref() {
+        if let Some(path) = self.current_test_file.as_ref() {
             let _ = std::fs::remove_file(path);
         }
     }

--- a/crates/karva_diagnostic/src/result/mod.rs
+++ b/crates/karva_diagnostic/src/result/mod.rs
@@ -65,6 +65,7 @@ impl TestRunResult {
 
         if let Some(reporter) = reporter {
             reporter.report_test_case_result(test_case_name, result, duration);
+            reporter.notify_test_completed(test_case_name);
         }
 
         self.durations
@@ -90,7 +91,7 @@ impl TestRunResult {
         duration: std::time::Duration,
         passed_on: u32,
         total_attempts: u32,
-        _reporter: Option<&dyn Reporter>,
+        reporter: Option<&dyn Reporter>,
     ) {
         self.stats.add(result.clone().into());
 
@@ -106,6 +107,10 @@ impl TestRunResult {
                 total_attempts,
                 duration,
             ));
+        }
+
+        if let Some(reporter) = reporter {
+            reporter.notify_test_completed(test_case_name);
         }
 
         self.durations

--- a/crates/karva_diagnostic/src/result/mod.rs
+++ b/crates/karva_diagnostic/src/result/mod.rs
@@ -65,7 +65,6 @@ impl TestRunResult {
 
         if let Some(reporter) = reporter {
             reporter.report_test_case_result(test_case_name, result, duration);
-            reporter.notify_test_completed(test_case_name);
         }
 
         self.durations
@@ -91,7 +90,6 @@ impl TestRunResult {
         duration: std::time::Duration,
         passed_on: u32,
         total_attempts: u32,
-        reporter: Option<&dyn Reporter>,
     ) {
         self.stats.add(result.clone().into());
 
@@ -107,10 +105,6 @@ impl TestRunResult {
                 total_attempts,
                 duration,
             ));
-        }
-
-        if let Some(reporter) = reporter {
-            reporter.notify_test_completed(test_case_name);
         }
 
         self.durations

--- a/crates/karva_logging/src/lib.rs
+++ b/crates/karva_logging/src/lib.rs
@@ -11,11 +11,13 @@ use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields};
 use tracing_subscriber::registry::LookupSpan;
 
 mod printer;
+mod progress;
 mod status_level;
 pub mod time;
 mod verbosity;
 
 pub use printer::{Printer, Stdout};
+pub use progress::ProgressMode;
 pub use status_level::{FinalStatusLevel, StatusLevel};
 pub use verbosity::VerbosityLevel;
 

--- a/crates/karva_logging/src/progress.rs
+++ b/crates/karva_logging/src/progress.rs
@@ -1,0 +1,51 @@
+use karva_combine::Combine;
+use serde::{Deserialize, Serialize};
+
+/// How to display run progress while tests are executing.
+///
+/// Modeled after `cargo-nextest`'s `--progress-bar` setting. The bar/counter
+/// are rendered by the orchestrator on stderr; per-test result lines (gated
+/// on [`crate::StatusLevel`]) continue to flow through stdout independently.
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    clap::ValueEnum,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProgressMode {
+    /// No live progress display (default).
+    #[default]
+    None,
+    /// Print a one-line `N/M tests` counter, refreshed periodically.
+    Counter,
+    /// Render a visual progress bar with completion stats.
+    Bar,
+}
+
+impl ProgressMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Counter => "counter",
+            Self::Bar => "bar",
+        }
+    }
+}
+
+impl Combine for ProgressMode {
+    #[inline(always)]
+    fn combine_with(&mut self, _other: Self) {}
+
+    #[inline]
+    fn combine(self, _other: Self) -> Self {
+        self
+    }
+}

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -2,7 +2,7 @@ mod config;
 mod overrides;
 
 use karva_combine::Combine;
-use karva_logging::{FinalStatusLevel, StatusLevel};
+use karva_logging::{FinalStatusLevel, ProgressMode, StatusLevel};
 use karva_macros::{Combine, OptionsMetadata};
 use ruff_db::diagnostic::DiagnosticFormat;
 use serde::{Deserialize, Serialize};
@@ -155,6 +155,25 @@ pub struct TerminalOptions {
         "#
     )]
     pub final_status_level: Option<FinalStatusLevel>,
+
+    /// Live progress display rendered while tests run.
+    ///
+    /// `none` (the default) leaves output untouched. `counter` prints a
+    /// `N/M tests` line on stderr that refreshes periodically. `bar` shows
+    /// a visual progress bar with completion stats. The display is rendered
+    /// on stderr so it does not interfere with per-test result lines on
+    /// stdout (gated by [`status_level`](#status-level)).
+    ///
+    /// Defaults to `none`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"none"#,
+        value_type = "none | counter | bar",
+        example = r#"
+            show-progress = "bar"
+        "#
+    )]
+    pub show_progress: Option<ProgressMode>,
 }
 
 impl TerminalOptions {
@@ -164,6 +183,7 @@ impl TerminalOptions {
             show_python_output: self.show_python_output.unwrap_or_default(),
             status_level: self.status_level.unwrap_or_default(),
             final_status_level: self.final_status_level.unwrap_or_default(),
+            show_progress: self.show_progress.unwrap_or_default(),
         }
     }
 }

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -2,7 +2,7 @@ mod config;
 mod overrides;
 
 use karva_combine::Combine;
-use karva_logging::{FinalStatusLevel, StatusLevel};
+use karva_logging::{FinalStatusLevel, ProgressMode, StatusLevel};
 use karva_macros::{Combine, OptionsMetadata};
 use ruff_db::diagnostic::DiagnosticFormat;
 use serde::{Deserialize, Serialize};
@@ -157,6 +157,25 @@ pub struct TerminalOptions {
         "#
     )]
     pub final_status_level: Option<FinalStatusLevel>,
+
+    /// Live progress display rendered while tests run.
+    ///
+    /// `none` (the default) leaves output untouched. `counter` prints a
+    /// `N/M tests` line on stderr that refreshes periodically. `bar` shows
+    /// a visual progress bar with completion stats. The display is rendered
+    /// on stderr so it does not interfere with per-test result lines on
+    /// stdout (gated by [`status_level`](#status-level)).
+    ///
+    /// Defaults to `none`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"none"#,
+        value_type = "none | counter | bar",
+        example = r#"
+            show-progress = "bar"
+        "#
+    )]
+    pub show_progress: Option<ProgressMode>,
 }
 
 impl TerminalOptions {
@@ -166,6 +185,7 @@ impl TerminalOptions {
             show_python_output: self.show_python_output.unwrap_or_default(),
             status_level: self.status_level.unwrap_or_default(),
             final_status_level: self.final_status_level.unwrap_or_default(),
+            show_progress: self.show_progress.unwrap_or_default(),
         }
     }
 }

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use karva_combine::Combine;
-use karva_logging::{FinalStatusLevel, StatusLevel};
+use karva_logging::{FinalStatusLevel, ProgressMode, StatusLevel};
 use serde::{Deserialize, Serialize};
 
 use crate::filter::FiltersetSet;
@@ -165,6 +165,7 @@ pub struct TerminalSettings {
     pub show_python_output: bool,
     pub status_level: StatusLevel,
     pub final_status_level: FinalStatusLevel,
+    pub show_progress: ProgressMode,
 }
 
 #[derive(Default, Debug, Clone)]

--- a/crates/karva_runner/Cargo.toml
+++ b/crates/karva_runner/Cargo.toml
@@ -28,6 +28,7 @@ crossbeam-channel = { workspace = true }
 ctrlc = { workspace = true }
 fastrand = { workspace = true }
 ignore = { workspace = true }
+indicatif = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 which = { workspace = true }

--- a/crates/karva_runner/Cargo.toml
+++ b/crates/karva_runner/Cargo.toml
@@ -28,6 +28,7 @@ crossbeam-channel = { workspace = true }
 ctrlc = { workspace = true }
 fastrand = { workspace = true }
 ignore = { workspace = true }
+indicatif = { workspace = true }
 tracing = { workspace = true }
 which = { workspace = true }
 

--- a/crates/karva_runner/src/lib.rs
+++ b/crates/karva_runner/src/lib.rs
@@ -2,6 +2,7 @@ mod binary;
 mod collection;
 mod orchestration;
 mod partition;
+mod progress;
 mod shutdown;
 mod worker_args;
 

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -22,6 +22,7 @@ use karva_project::Project;
 use crate::binary::find_karva_worker_binary;
 use crate::collection::ParallelCollector;
 use crate::partition::{Partition, partition_collected_tests};
+use crate::progress::ProgressDisplay;
 use crate::worker_args::{WorkerSpawn, worker_command};
 
 #[derive(Debug)]
@@ -336,8 +337,18 @@ pub fn run_parallel_tests(
 
     let max_fail_cache = project.settings().max_fail().has_limit().then_some(&cache);
 
+    let progress = ProgressDisplay::start(
+        project.settings().terminal().show_progress,
+        total_tests as u64,
+        cache.clone(),
+    );
+
     worker_manager.wait_for_completion(shutdown_rx, max_fail_cache);
     worker_manager.kill_remaining();
+
+    if let Some(progress) = progress {
+        progress.finish();
+    }
 
     let results = cache.aggregate_results()?;
 

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -22,7 +22,7 @@ use karva_project::Project;
 use crate::binary::find_karva_worker_binary;
 use crate::collection::ParallelCollector;
 use crate::partition::{Partition, partition_collected_tests};
-use crate::progress::ProgressDisplay;
+use crate::progress::OutputDrain;
 use crate::worker_args::{WorkerSpawn, worker_command};
 
 #[derive(Debug)]
@@ -337,18 +337,17 @@ pub fn run_parallel_tests(
 
     let max_fail_cache = project.settings().max_fail().has_limit().then_some(&cache);
 
-    let progress = ProgressDisplay::start(
+    let drain = OutputDrain::start(
         project.settings().terminal().show_progress,
         total_tests as u64,
+        num_workers,
         cache.clone(),
     );
 
     worker_manager.wait_for_completion(shutdown_rx, max_fail_cache);
     worker_manager.kill_remaining();
 
-    if let Some(progress) = progress {
-        progress.finish();
-    }
+    drain.finish();
 
     let results = cache.aggregate_results()?;
 

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::fmt::Write;
-use std::process::{Child, Stdio};
+use std::process::{Child, ChildStdout, Stdio};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
@@ -22,7 +22,7 @@ use karva_project::Project;
 use crate::binary::find_karva_worker_binary;
 use crate::collection::ParallelCollector;
 use crate::partition::{Partition, partition_collected_tests};
-use crate::progress::OutputDrain;
+use crate::progress::{OutputDrain, WorkerPipes};
 use crate::worker_args::{WorkerSpawn, worker_command};
 
 #[derive(Debug)]
@@ -163,8 +163,12 @@ pub struct ParallelTestConfig {
 ///
 /// Creates a worker process for each non-empty partition, passing the appropriate
 /// subset of tests and command-line arguments to each worker.
-fn spawn_workers(spawn: &WorkerSpawn, partitions: &[Partition]) -> Result<WorkerManager> {
+fn spawn_workers(
+    spawn: &WorkerSpawn,
+    partitions: &[Partition],
+) -> Result<(WorkerManager, Vec<WorkerPipes>)> {
     let mut worker_manager = WorkerManager::default();
+    let mut pipes: Vec<WorkerPipes> = Vec::new();
 
     for (worker_id, partition) in partitions.iter().enumerate() {
         if partition.tests().is_empty() {
@@ -172,11 +176,13 @@ fn spawn_workers(spawn: &WorkerSpawn, partitions: &[Partition]) -> Result<Worker
             continue;
         }
 
-        let child = worker_command(spawn, worker_id, partition)
-            .stdout(Stdio::inherit())
+        let mut child = worker_command(spawn, worker_id, partition)
+            .stdout(Stdio::piped())
             .stderr(Stdio::inherit())
             .spawn()
             .context("Failed to spawn karva-worker process")?;
+
+        let stdout: Option<ChildStdout> = child.stdout.take();
 
         tracing::info!(
             "Worker {} spawned with {} tests",
@@ -185,9 +191,10 @@ fn spawn_workers(spawn: &WorkerSpawn, partitions: &[Partition]) -> Result<Worker
         );
 
         worker_manager.spawn(worker_id, child);
+        pipes.push(WorkerPipes { stdout });
     }
 
-    Ok(worker_manager)
+    Ok((worker_manager, pipes))
 }
 
 /// Collect tests from the project without executing them.
@@ -327,7 +334,7 @@ pub fn run_parallel_tests(
         worker_binary: &worker_binary,
         coverage_enabled: !project.settings().coverage().sources.is_empty(),
     };
-    let mut worker_manager = spawn_workers(&spawn, &partitions)?;
+    let (mut worker_manager, pipes) = spawn_workers(&spawn, &partitions)?;
 
     let shutdown_rx = if config.create_ctrlc_handler {
         Some(shutdown_receiver())
@@ -342,6 +349,7 @@ pub fn run_parallel_tests(
         total_tests as u64,
         num_workers,
         cache.clone(),
+        pipes,
     );
 
     worker_manager.wait_for_completion(shutdown_rx, max_fail_cache);

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -22,7 +22,7 @@ use karva_project::Project;
 use crate::binary::find_karva_worker_binary;
 use crate::collection::ParallelCollector;
 use crate::partition::{Partition, partition_collected_tests};
-use crate::progress::ProgressDisplay;
+use crate::progress::OutputDrain;
 use crate::worker_args::{WorkerSpawn, worker_command};
 
 /// Width that result labels (`PASS`, `FAIL`, `SIGINT`) are right-padded to so
@@ -481,17 +481,16 @@ pub fn run_parallel_tests(
 
     let max_fail_cache = project.settings().max_fail().has_limit().then_some(&cache);
 
-    let progress = ProgressDisplay::start(
+    let drain = OutputDrain::start(
         project.settings().terminal().show_progress,
         total_tests as u64,
+        num_workers,
         cache.clone(),
     );
 
     let outcome = worker_manager.wait_for_completion(shutdown_rx, max_fail_cache);
 
-    if let Some(progress) = progress {
-        progress.finish();
-    }
+    drain.finish();
 
     let interrupted_tests = if outcome == WaitOutcome::Cancelled {
         worker_manager.cancel_and_kill(printer, &cache)

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -182,8 +182,7 @@ impl WorkerManager {
             .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
             .unwrap_or(0);
 
-        self
-            .workers
+        self.workers
             .iter()
             .map(|worker| {
                 let current = match cache.read_current_test(worker.id) {
@@ -242,7 +241,7 @@ fn print_cancellation(printer: Printer, in_flight: &[InFlightTest]) {
                     test.worker_id
                 );
             }
-        };
+        }
     }
 }
 

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::fmt::Write;
-use std::process::{Child, Stdio};
+use std::process::{Child, ChildStdout, Stdio};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
@@ -22,7 +22,7 @@ use karva_project::Project;
 use crate::binary::find_karva_worker_binary;
 use crate::collection::ParallelCollector;
 use crate::partition::{Partition, partition_collected_tests};
-use crate::progress::OutputDrain;
+use crate::progress::{OutputDrain, WorkerPipes};
 use crate::worker_args::{WorkerSpawn, worker_command};
 
 /// Width that result labels (`PASS`, `FAIL`, `SIGINT`) are right-padded to so
@@ -166,20 +166,13 @@ impl WorkerManager {
         }
     }
 
-    /// Stop remaining workers and emit nextest-style cancellation lines.
+    /// Snapshot which tests are currently in flight.
     ///
     /// Each worker writes a `current_test.json` file at the start of every
     /// test and removes it when the test finishes. We read those files
-    /// *before* killing — once we kill the worker, that file may be removed
-    /// by an in-flight finalizer or simply lost — and remember a
-    /// `(worker_id, test name, test start time)` snapshot for each.
-    ///
-    /// Workers are killed and reaped before we print so any in-flight
-    /// `PASS`/`FAIL` lines they were writing to the inherited stdout land
-    /// before our banner; otherwise the cancellation block interleaves
-    /// with worker output. A short settle pause lets any kernel-buffered
-    /// writes drain.
-    fn cancel_and_kill(&mut self, printer: Printer, cache: &RunCache) -> Vec<InterruptedTest> {
+    /// before killing workers so the cancellation block can report the
+    /// interrupted tests even if the files disappear during shutdown.
+    fn snapshot_in_flight(&self, cache: &RunCache) -> Vec<InFlightTest> {
         if self.workers.is_empty() {
             return Vec::new();
         }
@@ -189,7 +182,7 @@ impl WorkerManager {
             .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
             .unwrap_or(0);
 
-        let in_flight: Vec<_> = self
+        self
             .workers
             .iter()
             .map(|worker| {
@@ -217,56 +210,52 @@ impl WorkerManager {
                     elapsed,
                 }
             })
-            .collect();
-
-        let running_tests = in_flight.iter().filter(|test| test.name.is_some()).count();
-        let test_label = if running_tests == 1 { "test" } else { "tests" };
-
-        for worker in &mut self.workers {
-            let _ = worker.child.kill();
-        }
-        for worker in &mut self.workers {
-            let _ = worker.child.wait();
-        }
-        std::thread::sleep(STDOUT_SETTLE);
-
-        let mut stdout = printer.stream_for_test_result().lock();
-        let cancel_label = "Cancelling".yellow().bold();
-        let interrupt_label = "interrupt".yellow().bold();
-        let _ = writeln!(
-            stdout,
-            "  {cancel_label} due to {interrupt_label}: {running_tests} {test_label} still running"
-        );
-
-        let label = "SIGINT".yellow().bold();
-        let padding = " ".repeat(LABEL_COLUMN_WIDTH.saturating_sub("SIGINT".len()));
-        for test in &in_flight {
-            let duration_str = format_duration_bracketed(test.elapsed);
-            match &test.name {
-                Some(name) => {
-                    let colored = format_in_flight_test(name);
-                    let _ = writeln!(stdout, "{padding}{label} {duration_str} {colored}");
-                }
-                None => {
-                    let _ = writeln!(
-                        stdout,
-                        "{padding}{label} {duration_str} worker {} (between tests)",
-                        test.worker_id
-                    );
-                }
-            }
-        }
-
-        in_flight
-            .into_iter()
-            .filter_map(|test| {
-                test.name.map(|name| InterruptedTest {
-                    name,
-                    duration: test.elapsed,
-                })
-            })
             .collect()
     }
+}
+
+fn print_cancellation(printer: Printer, in_flight: &[InFlightTest]) {
+    let running_tests = in_flight.iter().filter(|test| test.name.is_some()).count();
+    let test_label = if running_tests == 1 { "test" } else { "tests" };
+
+    let mut stdout = printer.stream_for_test_result().lock();
+    let cancel_label = "Cancelling".yellow().bold();
+    let interrupt_label = "interrupt".yellow().bold();
+    let _ = writeln!(
+        stdout,
+        "  {cancel_label} due to {interrupt_label}: {running_tests} {test_label} still running"
+    );
+
+    let label = "SIGINT".yellow().bold();
+    let padding = " ".repeat(LABEL_COLUMN_WIDTH.saturating_sub("SIGINT".len()));
+    for test in in_flight {
+        let duration_str = format_duration_bracketed(test.elapsed);
+        match &test.name {
+            Some(name) => {
+                let colored = format_in_flight_test(name);
+                let _ = writeln!(stdout, "{padding}{label} {duration_str} {colored}");
+            }
+            None => {
+                let _ = writeln!(
+                    stdout,
+                    "{padding}{label} {duration_str} worker {} (between tests)",
+                    test.worker_id
+                );
+            }
+        };
+    }
+}
+
+fn interrupted_tests_from(in_flight: Vec<InFlightTest>) -> Vec<InterruptedTest> {
+    in_flight
+        .into_iter()
+        .filter_map(|test| {
+            test.name.map(|name| InterruptedTest {
+                name,
+                duration: test.elapsed,
+            })
+        })
+        .collect()
 }
 
 /// Render a `module::function[params]` test name as it was serialised by
@@ -304,8 +293,12 @@ pub struct ParallelTestConfig {
 ///
 /// Creates a worker process for each non-empty partition, passing the appropriate
 /// subset of tests and command-line arguments to each worker.
-fn spawn_workers(spawn: &WorkerSpawn, partitions: &[Partition]) -> Result<WorkerManager> {
+fn spawn_workers(
+    spawn: &WorkerSpawn,
+    partitions: &[Partition],
+) -> Result<(WorkerManager, Vec<WorkerPipes>)> {
     let mut worker_manager = WorkerManager::default();
+    let mut pipes: Vec<WorkerPipes> = Vec::new();
 
     for (worker_id, partition) in partitions.iter().enumerate() {
         if partition.tests().is_empty() {
@@ -313,11 +306,13 @@ fn spawn_workers(spawn: &WorkerSpawn, partitions: &[Partition]) -> Result<Worker
             continue;
         }
 
-        let child = worker_command(spawn, worker_id, partition)
-            .stdout(Stdio::inherit())
+        let mut child = worker_command(spawn, worker_id, partition)
+            .stdout(Stdio::piped())
             .stderr(Stdio::inherit())
             .spawn()
             .context("Failed to spawn karva-worker process")?;
+
+        let stdout: Option<ChildStdout> = child.stdout.take();
 
         tracing::info!(
             "Worker {} spawned with {} tests",
@@ -326,9 +321,10 @@ fn spawn_workers(spawn: &WorkerSpawn, partitions: &[Partition]) -> Result<Worker
         );
 
         worker_manager.spawn(worker_id, child);
+        pipes.push(WorkerPipes { stdout });
     }
 
-    Ok(worker_manager)
+    Ok((worker_manager, pipes))
 }
 
 /// Collect tests from the project without executing them.
@@ -477,7 +473,7 @@ pub fn run_parallel_tests(
         worker_binary: &worker_binary,
         coverage_enabled: !project.settings().coverage().sources.is_empty(),
     };
-    let mut worker_manager = spawn_workers(&spawn, &partitions)?;
+    let (mut worker_manager, pipes) = spawn_workers(&spawn, &partitions)?;
 
     let max_fail_cache = project.settings().max_fail().has_limit().then_some(&cache);
 
@@ -486,21 +482,25 @@ pub fn run_parallel_tests(
         total_tests as u64,
         num_workers,
         cache.clone(),
+        pipes,
     );
 
     let outcome = worker_manager.wait_for_completion(shutdown_rx, max_fail_cache);
 
-    drain.finish();
-
-    let interrupted_tests = if outcome == WaitOutcome::Cancelled {
-        worker_manager.cancel_and_kill(printer, &cache)
+    let in_flight = if outcome == WaitOutcome::Cancelled {
+        worker_manager.snapshot_in_flight(&cache)
     } else {
-        worker_manager.kill_remaining();
         Vec::new()
     };
+    worker_manager.kill_remaining();
+    drain.finish();
+
+    if outcome == WaitOutcome::Cancelled {
+        print_cancellation(printer, &in_flight);
+    }
 
     let mut results = cache.aggregate_results()?;
-    for test in interrupted_tests {
+    for test in interrupted_tests_from(in_flight) {
         results.register_interrupted_test(&test.name, test.duration);
     }
 
@@ -522,6 +522,3 @@ pub fn run_parallel_tests(
 
 const MIN_TESTS_PER_WORKER: usize = 5;
 const WORKER_POLL_INTERVAL: Duration = Duration::from_millis(10);
-/// Pause after killing workers to let kernel-buffered output drain to
-/// stdout before we emit the cancellation banner.
-const STDOUT_SETTLE: Duration = Duration::from_millis(50);

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -22,6 +22,7 @@ use karva_project::Project;
 use crate::binary::find_karva_worker_binary;
 use crate::collection::ParallelCollector;
 use crate::partition::{Partition, partition_collected_tests};
+use crate::progress::ProgressDisplay;
 use crate::worker_args::{WorkerSpawn, worker_command};
 
 /// Width that result labels (`PASS`, `FAIL`, `SIGINT`) are right-padded to so
@@ -480,7 +481,18 @@ pub fn run_parallel_tests(
 
     let max_fail_cache = project.settings().max_fail().has_limit().then_some(&cache);
 
+    let progress = ProgressDisplay::start(
+        project.settings().terminal().show_progress,
+        total_tests as u64,
+        cache.clone(),
+    );
+
     let outcome = worker_manager.wait_for_completion(shutdown_rx, max_fail_cache);
+
+    if let Some(progress) = progress {
+        progress.finish();
+    }
+
     let interrupted_tests = if outcome == WaitOutcome::Cancelled {
         worker_manager.cancel_and_kill(printer, &cache)
     } else {

--- a/crates/karva_runner/src/progress.rs
+++ b/crates/karva_runner/src/progress.rs
@@ -1,20 +1,32 @@
-//! Live progress display for parallel test runs.
+//! Live progress display + serialized worker output.
 //!
-//! Workers append one byte to a per-worker progress file each time a test
-//! completes (see `ProgressTrackingReporter`). A polling thread in the
-//! orchestrator reads the aggregate completion count and renders it on
-//! stderr — either as a one-line counter or an indicatif progress bar.
+//! Workers write per-test result lines to per-worker `output` files (via
+//! `FileLineSink`) and append a single byte to per-worker `progress` files
+//! when each test finishes (via `ProgressTrackingReporter`). The orchestrator
+//! drains those files from a single background thread:
+//!
+//! - reads new bytes from each worker's `output` file, splits on `\n`, and
+//!   prints whole lines to its own stdout — preventing worker output from
+//!   interleaving on a shared terminal (multiple processes locking their
+//!   own stdouts does not actually serialize writes; see issue #502)
+//! - reads the aggregate `progress` file length to drive the optional
+//!   `indicatif` progress bar on stderr
+//!
+//! The drain runs whenever workers exist; the bar is gated on `--show-progress`.
 
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom, Write as _};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
+use camino::Utf8PathBuf;
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use karva_cache::RunCache;
 use karva_logging::ProgressMode;
 
-const POLL_INTERVAL: Duration = Duration::from_millis(100);
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 /// Refresh frequency for the bar/counter.
 ///
@@ -22,46 +34,62 @@ const POLL_INTERVAL: Duration = Duration::from_millis(100);
 /// independently of how fast we observe count changes.
 const STEADY_TICK: Duration = Duration::from_millis(120);
 
-/// Owns the indicatif handle and the polling thread that drives it.
+/// Drains per-worker output files and optionally drives a progress bar.
 ///
-/// Drop or call [`Self::finish`] to stop the thread and clear the bar
-/// before printing the run summary.
-pub struct ProgressDisplay {
-    bar: ProgressBar,
+/// Drop or call [`Self::finish`] to stop the polling thread, do a final
+/// drain so no buffered output is lost, and clear the bar.
+pub struct OutputDrain {
+    bar: Option<ProgressBar>,
     stop: Arc<AtomicBool>,
     handle: Option<JoinHandle<()>>,
 }
 
-impl ProgressDisplay {
-    /// Start a progress display.
+impl OutputDrain {
+    /// Start the drain.
     ///
-    /// Returns `None` when `mode` is [`ProgressMode::None`] or when there
-    /// are no tests to run — neither case warrants a live display.
-    pub fn start(mode: ProgressMode, total_tests: u64, cache: RunCache) -> Option<Self> {
-        if total_tests == 0 || matches!(mode, ProgressMode::None) {
-            return None;
-        }
-
-        let bar = ProgressBar::with_draw_target(Some(total_tests), ProgressDrawTarget::stderr());
-        bar.set_style(style_for(mode));
-        bar.enable_steady_tick(STEADY_TICK);
+    /// `mode` selects the bar style; `total_tests` is the initial estimate
+    /// of test cases (parametrize-aware counts aren't known up front, so
+    /// the bar grows its length dynamically when ticks overrun the estimate).
+    /// `num_workers` is the number of worker output files to poll.
+    pub fn start(
+        mode: ProgressMode,
+        total_tests: u64,
+        num_workers: usize,
+        cache: RunCache,
+    ) -> Self {
+        let bar = if total_tests > 0 && !matches!(mode, ProgressMode::None) {
+            let b = ProgressBar::with_draw_target(Some(total_tests), ProgressDrawTarget::stderr());
+            b.set_style(style_for(mode));
+            if matches!(mode, ProgressMode::Bar) {
+                b.set_message("Testing");
+            }
+            b.enable_steady_tick(STEADY_TICK);
+            Some(b)
+        } else {
+            None
+        };
 
         let stop = Arc::new(AtomicBool::new(false));
+
+        let output_paths: Vec<Utf8PathBuf> =
+            (0..num_workers).map(|id| cache.output_file(id)).collect();
 
         let handle = {
             let bar = bar.clone();
             let stop = Arc::clone(&stop);
-            thread::spawn(move || poll_loop(&bar, &stop, &cache, total_tests))
+            thread::spawn(move || {
+                drain_loop(&output_paths, &cache, total_tests, bar.as_ref(), &stop);
+            })
         };
 
-        Some(Self {
+        Self {
             bar,
             stop,
             handle: Some(handle),
-        })
+        }
     }
 
-    /// Stop polling and clear the bar from the terminal.
+    /// Stop polling, drain any remaining whole lines, and clear the bar.
     pub fn finish(mut self) {
         self.shutdown();
     }
@@ -71,11 +99,13 @@ impl ProgressDisplay {
         if let Some(handle) = self.handle.take() {
             let _ = handle.join();
         }
-        self.bar.finish_and_clear();
+        if let Some(bar) = self.bar.take() {
+            bar.finish_and_clear();
+        }
     }
 }
 
-impl Drop for ProgressDisplay {
+impl Drop for OutputDrain {
     fn drop(&mut self) {
         if !self.stop.load(Ordering::SeqCst) {
             self.shutdown();
@@ -83,31 +113,169 @@ impl Drop for ProgressDisplay {
     }
 }
 
-fn poll_loop(bar: &ProgressBar, stop: &AtomicBool, cache: &RunCache, total: u64) {
-    loop {
-        let completed = cache.completed_count().min(total);
-        bar.set_position(completed);
+/// Per-worker drain state: open file handle (lazily) + a buffer for the
+/// trailing partial line that hasn't yet been newline-terminated.
+struct WorkerStream {
+    path: Utf8PathBuf,
+    file: Option<File>,
+    offset: u64,
+    partial: Vec<u8>,
+}
 
-        if stop.load(Ordering::SeqCst) || completed >= total {
+impl WorkerStream {
+    fn new(path: Utf8PathBuf) -> Self {
+        Self {
+            path,
+            file: None,
+            offset: 0,
+            partial: Vec::new(),
+        }
+    }
+
+    /// Read whatever has been appended since the last poll, push complete
+    /// lines into `out`, and retain any trailing partial line for next time.
+    /// Returns `true` when at least one byte was read.
+    fn poll(&mut self, out: &mut Vec<String>) -> bool {
+        if self.file.is_none() {
+            if !self.path.exists() {
+                return false;
+            }
+            match File::open(&self.path) {
+                Ok(f) => self.file = Some(f),
+                Err(_) => return false,
+            }
+        }
+
+        let Some(file) = self.file.as_mut() else {
+            return false;
+        };
+
+        if file.seek(SeekFrom::Start(self.offset)).is_err() {
+            return false;
+        }
+
+        let mut buf = Vec::new();
+        let Ok(n) = file.read_to_end(&mut buf) else {
+            return false;
+        };
+        if n == 0 {
+            return false;
+        }
+        self.offset += n as u64;
+
+        let mut start = 0usize;
+        for (i, byte) in buf.iter().enumerate() {
+            if *byte == b'\n' {
+                let line_bytes = if self.partial.is_empty() {
+                    &buf[start..i]
+                } else {
+                    self.partial.extend_from_slice(&buf[start..i]);
+                    self.partial.as_slice()
+                };
+                let line = String::from_utf8_lossy(line_bytes).into_owned();
+                out.push(line);
+                if !self.partial.is_empty() {
+                    self.partial.clear();
+                }
+                start = i + 1;
+            }
+        }
+        if start < buf.len() {
+            self.partial.extend_from_slice(&buf[start..]);
+        }
+
+        true
+    }
+}
+
+fn drain_loop(
+    output_paths: &[Utf8PathBuf],
+    cache: &RunCache,
+    initial_total: u64,
+    bar: Option<&ProgressBar>,
+    stop: &AtomicBool,
+) {
+    let mut streams: Vec<WorkerStream> = output_paths
+        .iter()
+        .cloned()
+        .map(WorkerStream::new)
+        .collect();
+    let mut current_total = initial_total;
+
+    loop {
+        let mut lines: Vec<String> = Vec::new();
+        let mut progressed = false;
+        for stream in &mut streams {
+            if stream.poll(&mut lines) {
+                progressed = true;
+            }
+        }
+        emit_lines(&lines, bar);
+
+        if let Some(bar) = bar {
+            let completed = cache.completed_count();
+            // `initial_total` counts test function definitions; workers tick
+            // once per parametrized case, so completion can overrun the
+            // estimate. Grow the bar's length to keep position <= len.
+            if completed > current_total {
+                current_total = completed;
+                bar.set_length(current_total);
+            }
+            bar.set_position(completed);
+        }
+
+        if stop.load(Ordering::SeqCst) {
+            // Final drain: pick up anything written between the last poll
+            // and the worker exiting.
+            let mut final_lines: Vec<String> = Vec::new();
+            for stream in &mut streams {
+                stream.poll(&mut final_lines);
+            }
+            emit_lines(&final_lines, bar);
+            if let Some(bar) = bar {
+                bar.set_position(cache.completed_count());
+            }
             break;
         }
 
-        thread::sleep(POLL_INTERVAL);
+        if !progressed {
+            thread::sleep(POLL_INTERVAL);
+        }
+    }
+}
+
+fn emit_lines(lines: &[String], bar: Option<&ProgressBar>) {
+    if lines.is_empty() {
+        return;
+    }
+    let write = || {
+        let mut out = std::io::stdout().lock();
+        for line in lines {
+            let _ = writeln!(out, "{line}");
+        }
+    };
+    // Reporter lines belong on stdout, but the bar redraws on stderr — without
+    // suspending the bar, its tick can clobber the cursor mid-write. `suspend`
+    // clears the bar from stderr, runs the closure, then re-renders.
+    if let Some(bar) = bar {
+        bar.suspend(write);
+    } else {
+        write();
     }
 }
 
 fn style_for(mode: ProgressMode) -> ProgressStyle {
     match mode {
-        ProgressMode::Bar => ProgressStyle::with_template(
-            "{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len} tests",
-        )
-        .expect("hardcoded template is valid")
-        .progress_chars("=> "),
+        ProgressMode::Bar => {
+            ProgressStyle::with_template("{msg:8.dim} {bar:60.green/dim} {pos}/{len} tests")
+                .expect("hardcoded template is valid")
+                .progress_chars("--")
+        }
         ProgressMode::Counter => {
             ProgressStyle::with_template("{pos}/{len} tests").expect("hardcoded template is valid")
         }
-        // unreachable: `start` returns None for `None`. Fall back to counter
-        // so we never panic if a future caller bypasses that gate.
+        // unreachable: `start` constructs no bar for `None`. Fall back to
+        // counter so we never panic if a future caller bypasses that gate.
         ProgressMode::None => {
             ProgressStyle::with_template("{pos}/{len} tests").expect("hardcoded template is valid")
         }

--- a/crates/karva_runner/src/progress.rs
+++ b/crates/karva_runner/src/progress.rs
@@ -47,10 +47,10 @@ pub struct OutputDrain {
 impl OutputDrain {
     /// Start the drain.
     ///
-    /// `mode` selects the bar style; `total_tests` is the initial estimate
-    /// of test cases (parametrize-aware counts aren't known up front, so
-    /// the bar grows its length dynamically when ticks overrun the estimate).
-    /// `num_workers` is the number of worker output files to poll.
+    /// `mode` selects the bar style; `total_tests` is the count of test
+    /// function definitions (matching the per-function tick semantics in
+    /// `notify_test_completed`). `num_workers` is the number of worker
+    /// output files to poll.
     pub fn start(
         mode: ProgressMode,
         total_tests: u64,
@@ -78,7 +78,7 @@ impl OutputDrain {
             let bar = bar.clone();
             let stop = Arc::clone(&stop);
             thread::spawn(move || {
-                drain_loop(&output_paths, &cache, total_tests, bar.as_ref(), &stop);
+                drain_loop(&output_paths, &cache, bar.as_ref(), &stop);
             })
         };
 
@@ -191,7 +191,6 @@ impl WorkerStream {
 fn drain_loop(
     output_paths: &[Utf8PathBuf],
     cache: &RunCache,
-    initial_total: u64,
     bar: Option<&ProgressBar>,
     stop: &AtomicBool,
 ) {
@@ -200,7 +199,6 @@ fn drain_loop(
         .cloned()
         .map(WorkerStream::new)
         .collect();
-    let mut current_total = initial_total;
 
     loop {
         let mut lines: Vec<String> = Vec::new();
@@ -213,15 +211,7 @@ fn drain_loop(
         emit_lines(&lines, bar);
 
         if let Some(bar) = bar {
-            let completed = cache.completed_count();
-            // `initial_total` counts test function definitions; workers tick
-            // once per parametrized case, so completion can overrun the
-            // estimate. Grow the bar's length to keep position <= len.
-            if completed > current_total {
-                current_total = completed;
-                bar.set_length(current_total);
-            }
-            bar.set_position(completed);
+            bar.set_position(cache.completed_count());
         }
 
         if stop.load(Ordering::SeqCst) {

--- a/crates/karva_runner/src/progress.rs
+++ b/crates/karva_runner/src/progress.rs
@@ -1,0 +1,115 @@
+//! Live progress display for parallel test runs.
+//!
+//! Workers append one byte to a per-worker progress file each time a test
+//! completes (see `ProgressTrackingReporter`). A polling thread in the
+//! orchestrator reads the aggregate completion count and renders it on
+//! stderr — either as a one-line counter or an indicatif progress bar.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
+use karva_cache::RunCache;
+use karva_logging::ProgressMode;
+
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Refresh frequency for the bar/counter.
+///
+/// Higher than [`POLL_INTERVAL`] so the display redraw rate is bounded
+/// independently of how fast we observe count changes.
+const STEADY_TICK: Duration = Duration::from_millis(120);
+
+/// Owns the indicatif handle and the polling thread that drives it.
+///
+/// Drop or call [`Self::finish`] to stop the thread and clear the bar
+/// before printing the run summary.
+pub struct ProgressDisplay {
+    bar: ProgressBar,
+    stop: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl ProgressDisplay {
+    /// Start a progress display.
+    ///
+    /// Returns `None` when `mode` is [`ProgressMode::None`] or when there
+    /// are no tests to run — neither case warrants a live display.
+    pub fn start(mode: ProgressMode, total_tests: u64, cache: RunCache) -> Option<Self> {
+        if total_tests == 0 || matches!(mode, ProgressMode::None) {
+            return None;
+        }
+
+        let bar = ProgressBar::with_draw_target(Some(total_tests), ProgressDrawTarget::stderr());
+        bar.set_style(style_for(mode));
+        bar.enable_steady_tick(STEADY_TICK);
+
+        let stop = Arc::new(AtomicBool::new(false));
+
+        let handle = {
+            let bar = bar.clone();
+            let stop = Arc::clone(&stop);
+            thread::spawn(move || poll_loop(&bar, &stop, &cache, total_tests))
+        };
+
+        Some(Self {
+            bar,
+            stop,
+            handle: Some(handle),
+        })
+    }
+
+    /// Stop polling and clear the bar from the terminal.
+    pub fn finish(mut self) {
+        self.shutdown();
+    }
+
+    fn shutdown(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+        self.bar.finish_and_clear();
+    }
+}
+
+impl Drop for ProgressDisplay {
+    fn drop(&mut self) {
+        if !self.stop.load(Ordering::SeqCst) {
+            self.shutdown();
+        }
+    }
+}
+
+fn poll_loop(bar: &ProgressBar, stop: &AtomicBool, cache: &RunCache, total: u64) {
+    loop {
+        let completed = cache.completed_count().min(total);
+        bar.set_position(completed);
+
+        if stop.load(Ordering::SeqCst) || completed >= total {
+            break;
+        }
+
+        thread::sleep(POLL_INTERVAL);
+    }
+}
+
+fn style_for(mode: ProgressMode) -> ProgressStyle {
+    match mode {
+        ProgressMode::Bar => ProgressStyle::with_template(
+            "{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len} tests",
+        )
+        .expect("hardcoded template is valid")
+        .progress_chars("=> "),
+        ProgressMode::Counter => {
+            ProgressStyle::with_template("{pos}/{len} tests").expect("hardcoded template is valid")
+        }
+        // unreachable: `start` returns None for `None`. Fall back to counter
+        // so we never panic if a future caller bypasses that gate.
+        ProgressMode::None => {
+            ProgressStyle::with_template("{pos}/{len} tests").expect("hardcoded template is valid")
+        }
+    }
+}

--- a/crates/karva_runner/src/progress.rs
+++ b/crates/karva_runner/src/progress.rs
@@ -12,12 +12,22 @@
 //! - reads the aggregate `progress` file length to drive the optional
 //!   `indicatif` progress bar on stderr
 //!
+//! Worker stdout pipes are also drained: each worker is spawned with
+//! `Stdio::piped()` for stdout so anything the worker writes outside the
+//! reporter (e.g. Python `print()` from user tests) flows through a dedicated
+//! reader thread into the orchestrator's stdout under the same
+//! `bar.suspend(...)` serialization. Stderr stays inherited so worker tracing
+//! lines retain their real-time ordering relative to the orchestrator's own
+//! tracing output.
+//!
 //! The drain runs whenever workers exist; the bar is gated on `--show-progress`.
 
 use std::fs::File;
-use std::io::{Read, Seek, SeekFrom, Write as _};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write as _};
+use std::process::ChildStdout;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
@@ -34,7 +44,16 @@ const POLL_INTERVAL: Duration = Duration::from_millis(50);
 /// independently of how fast we observe count changes.
 const STEADY_TICK: Duration = Duration::from_millis(120);
 
-/// Drains per-worker output files and optionally drives a progress bar.
+/// Captured stdout pipe for a single worker child process.
+///
+/// Held by the orchestrator until [`OutputDrain::start`] hands ownership to
+/// a per-pipe reader thread.
+pub struct WorkerPipes {
+    pub stdout: Option<ChildStdout>,
+}
+
+/// Drains per-worker output files and pipes, and optionally drives a
+/// progress bar.
 ///
 /// Drop or call [`Self::finish`] to stop the polling thread, do a final
 /// drain so no buffered output is lost, and clear the bar.
@@ -42,6 +61,7 @@ pub struct OutputDrain {
     bar: Option<ProgressBar>,
     stop: Arc<AtomicBool>,
     handle: Option<JoinHandle<()>>,
+    pipe_handles: Vec<JoinHandle<()>>,
 }
 
 impl OutputDrain {
@@ -50,12 +70,15 @@ impl OutputDrain {
     /// `mode` selects the bar style; `total_tests` is the count of test
     /// function definitions (matching the per-function tick semantics in
     /// `notify_test_completed`). `num_workers` is the number of worker
-    /// output files to poll.
+    /// output files to poll. `pipes` are the captured stdout/stderr pipes
+    /// for each worker — they MUST come from children spawned with
+    /// `Stdio::piped()` so the orchestrator owns their read ends.
     pub fn start(
         mode: ProgressMode,
         total_tests: u64,
         num_workers: usize,
         cache: RunCache,
+        pipes: Vec<WorkerPipes>,
     ) -> Self {
         let bar = if total_tests > 0 && !matches!(mode, ProgressMode::None) {
             let b = ProgressBar::with_draw_target(Some(total_tests), ProgressDrawTarget::stderr());
@@ -74,11 +97,24 @@ impl OutputDrain {
         let output_paths: Vec<Utf8PathBuf> =
             (0..num_workers).map(|id| cache.output_file(id)).collect();
 
+        let (stdout_tx, stdout_rx) = mpsc::channel::<String>();
+
+        let mut pipe_handles: Vec<JoinHandle<()>> = Vec::new();
+        for pipe in pipes {
+            if let Some(out) = pipe.stdout {
+                let tx = stdout_tx.clone();
+                pipe_handles.push(thread::spawn(move || forward_pipe(out, &tx)));
+            }
+        }
+        // Drop the original sender so the receiver disconnects once every
+        // pipe-reader thread has exited (each holds its own clone of `tx`).
+        drop(stdout_tx);
+
         let handle = {
             let bar = bar.clone();
             let stop = Arc::clone(&stop);
             thread::spawn(move || {
-                drain_loop(&output_paths, &cache, bar.as_ref(), &stop);
+                drain_loop(&output_paths, &cache, bar.as_ref(), &stop, &stdout_rx);
             })
         };
 
@@ -86,6 +122,7 @@ impl OutputDrain {
             bar,
             stop,
             handle: Some(handle),
+            pipe_handles,
         }
     }
 
@@ -95,6 +132,13 @@ impl OutputDrain {
     }
 
     fn shutdown(&mut self) {
+        // Pipe readers exit on EOF when their worker closes its end. Callers
+        // are expected to have already waited on / killed every worker before
+        // reaching shutdown, so joining the readers first guarantees the last
+        // pipe lines are queued before we tell the drain loop to stop.
+        for handle in self.pipe_handles.drain(..) {
+            let _ = handle.join();
+        }
         self.stop.store(true, Ordering::SeqCst);
         if let Some(handle) = self.handle.take() {
             let _ = handle.join();
@@ -109,6 +153,31 @@ impl Drop for OutputDrain {
     fn drop(&mut self) {
         if !self.stop.load(Ordering::SeqCst) {
             self.shutdown();
+        }
+    }
+}
+
+/// Read a worker pipe to EOF, forwarding each line into `tx`.
+///
+/// `read_until('\n')` + `from_utf8_lossy` keeps non-UTF-8 bytes from
+/// dropping the line entirely (matching the file path's behaviour).
+fn forward_pipe<R: Read + Send>(reader: R, tx: &mpsc::Sender<String>) {
+    let mut reader = BufReader::new(reader);
+    let mut buf: Vec<u8> = Vec::new();
+    loop {
+        buf.clear();
+        match reader.read_until(b'\n', &mut buf) {
+            Ok(0) => return,
+            Ok(_) => {
+                if buf.last() == Some(&b'\n') {
+                    buf.pop();
+                }
+                let line = String::from_utf8_lossy(&buf).into_owned();
+                if tx.send(line).is_err() {
+                    return;
+                }
+            }
+            Err(_) => return,
         }
     }
 }
@@ -193,6 +262,7 @@ fn drain_loop(
     cache: &RunCache,
     bar: Option<&ProgressBar>,
     stop: &AtomicBool,
+    stdout_rx: &mpsc::Receiver<String>,
 ) {
     let mut streams: Vec<WorkerStream> = output_paths
         .iter()
@@ -203,6 +273,14 @@ fn drain_loop(
     loop {
         let mut lines: Vec<String> = Vec::new();
         let mut progressed = false;
+        // Drain the pipe channel before polling result files: a `print()`
+        // inside a test runs *before* the test returns and the reporter
+        // writes its result line, so pipe lines should appear before the
+        // file lines from the same iteration.
+        while let Ok(line) = stdout_rx.try_recv() {
+            lines.push(line);
+            progressed = true;
+        }
         for stream in &mut streams {
             if stream.poll(&mut lines) {
                 progressed = true;
@@ -218,6 +296,9 @@ fn drain_loop(
             // Final drain: pick up anything written between the last poll
             // and the worker exiting.
             let mut final_lines: Vec<String> = Vec::new();
+            while let Ok(line) = stdout_rx.try_recv() {
+                final_lines.push(line);
+            }
             for stream in &mut streams {
                 stream.poll(&mut final_lines);
             }

--- a/crates/karva_runner/src/worker_args.rs
+++ b/crates/karva_runner/src/worker_args.rs
@@ -91,10 +91,22 @@ fn inner_cli_args(settings: &ProjectSettings, args: &SubTestCommand) -> Vec<Stri
     cli_args.push("--final-status-level".to_string());
     cli_args.push(settings.terminal().final_status_level.as_str().to_string());
 
-    if let Some(color) = args.color {
-        cli_args.push("--color".to_string());
-        cli_args.push(color.as_str().to_string());
-    }
+    // Worker stdout is a pipe to the orchestrator's drain, so the worker's
+    // own TTY-based auto-detection would always strip ANSI. Forward an
+    // explicit color choice that matches what the orchestrator decided for
+    // its own stdout — the drain copies the worker's bytes through verbatim,
+    // so the orchestrator-side TTY check is the one that actually matters.
+    cli_args.push("--color".to_string());
+    cli_args.push(match args.color {
+        Some(color) => color.as_str().to_string(),
+        None => {
+            if colored::control::SHOULD_COLORIZE.should_colorize() {
+                "always".to_string()
+            } else {
+                "never".to_string()
+            }
+        }
+    });
 
     if settings.test().try_import_fixtures {
         cli_args.push("--try-import-fixtures".to_string());

--- a/crates/karva_runner/src/worker_args.rs
+++ b/crates/karva_runner/src/worker_args.rs
@@ -90,10 +90,22 @@ fn inner_cli_args(settings: &ProjectSettings, args: &SubTestCommand) -> Vec<Stri
     cli_args.push("--final-status-level".to_string());
     cli_args.push(settings.terminal().final_status_level.as_str().to_string());
 
-    if let Some(color) = args.color {
-        cli_args.push("--color".to_string());
-        cli_args.push(color.as_str().to_string());
-    }
+    // Worker stdout is a pipe to the orchestrator's drain, so the worker's
+    // own TTY-based auto-detection would always strip ANSI. Forward an
+    // explicit color choice that matches what the orchestrator decided for
+    // its own stdout — the drain copies the worker's bytes through verbatim,
+    // so the orchestrator-side TTY check is the one that actually matters.
+    cli_args.push("--color".to_string());
+    cli_args.push(match args.color {
+        Some(color) => color.as_str().to_string(),
+        None => {
+            if colored::control::SHOULD_COLORIZE.should_colorize() {
+                "always".to_string()
+            } else {
+                "never".to_string()
+            }
+        }
+    });
 
     if settings.test().try_import_fixtures {
         cli_args.push("--try-import-fixtures".to_string());

--- a/crates/karva_test_semantic/src/context.rs
+++ b/crates/karva_test_semantic/src/context.rs
@@ -146,9 +146,16 @@ impl<'a> Context<'a> {
             duration,
             passed_on,
             total_attempts,
-            Some(self.reporter),
         );
         passed
+    }
+
+    /// Notify the reporter that a test function has fully completed —
+    /// fired once per function definition regardless of how many parametrize
+    /// variants it expanded into. Drives the orchestrator's progress bar
+    /// (which is sized by `test_count()` = function defs).
+    pub fn notify_test_function_completed(&self, function_name: &QualifiedTestName) {
+        self.reporter.notify_test_completed(function_name);
     }
 
     pub(crate) fn report_diagnostic<'ctx>(

--- a/crates/karva_test_semantic/src/context.rs
+++ b/crates/karva_test_semantic/src/context.rs
@@ -159,9 +159,16 @@ impl<'a> Context<'a> {
             duration,
             passed_on,
             total_attempts,
-            Some(self.reporter),
         );
         passed
+    }
+
+    /// Notify the reporter that a test function has fully completed —
+    /// fired once per function definition regardless of how many parametrize
+    /// variants it expanded into. Drives the orchestrator's progress bar
+    /// (which is sized by `test_count()` = function defs).
+    pub fn notify_test_function_completed(&self, function_name: &QualifiedTestName) {
+        self.reporter.notify_test_completed(function_name);
     }
 
     pub(crate) fn report_diagnostic<'ctx>(

--- a/crates/karva_test_semantic/src/py_attach.rs
+++ b/crates/karva_test_semantic/src/py_attach.rs
@@ -4,6 +4,8 @@
 //! and optional suppression of `sys.stdout` / `sys.stderr` to `/dev/null`
 //! for the duration of the callback.
 
+use std::ffi::CString;
+
 use pyo3::prelude::*;
 
 /// Initialize the Python interpreter (idempotent) and attach to it for the
@@ -27,6 +29,15 @@ where
 {
     attach(|py| {
         if show_output {
+            // The worker's stdout is a pipe to the orchestrator (see
+            // `karva_runner::progress::OutputDrain`). Python defaults to
+            // block-buffering when sys.stdout isn't a TTY, which delays
+            // every `print()` until the buffer fills or the interpreter
+            // shuts down — so the orchestrator only sees test output at
+            // worker exit, after the reporter has already emitted result
+            // lines. Forcing line-buffering here keeps prints flowing
+            // alongside reporter output in real time.
+            let _ = enable_line_buffering(py);
             return f(py);
         }
 
@@ -39,6 +50,24 @@ where
         let _ = flush_and_mute(py, &null_file);
         result
     })
+}
+
+/// Reconfigure `sys.stdout` and `sys.stderr` to line-buffer their writes.
+///
+/// Best-effort: silently no-ops if either stream isn't a `TextIOWrapper`
+/// (e.g. when something earlier in the run replaced them with a custom
+/// object that lacks `reconfigure`).
+fn enable_line_buffering(py: Python<'_>) -> PyResult<()> {
+    let code = CString::new(
+        "import sys\n\
+         for s in (sys.stdout, sys.stderr):\n\
+         \x20   try:\n\
+         \x20       s.reconfigure(line_buffering=True)\n\
+         \x20   except (AttributeError, ValueError):\n\
+         \x20       pass\n",
+    )
+    .expect("hardcoded code has no nul bytes");
+    py.run(code.as_c_str(), None, None)
 }
 
 fn open_devnull(py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -164,6 +164,15 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                 }
             }
 
+            // Tick once per test function (parametrize variants don't each
+            // tick — `total_tests` counts function defs, so per-variant ticks
+            // would overrun the bar).
+            self.context
+                .notify_test_function_completed(&QualifiedTestName::new(
+                    test_function.name.clone(),
+                    None,
+                ));
+
             if self.max_fail_reached() {
                 break;
             }

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -8,7 +8,9 @@ use clap::Parser;
 use colored::Colorize;
 use karva_cache::{RunCache, RunHash};
 use karva_cli::{SubTestCommand, Verbosity};
-use karva_diagnostic::{DummyReporter, ProgressTrackingReporter, Reporter, TestCaseReporter};
+use karva_diagnostic::{
+    DummyReporter, FileLineSink, LineSink, ProgressTrackingReporter, Reporter, TestCaseReporter,
+};
 use karva_logging::{Printer, StatusLevel, set_colored_override, setup_tracing};
 use karva_metadata::RunIgnoredMode;
 use karva_metadata::filter::FiltersetSet;
@@ -173,8 +175,13 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
     let reporter: Box<dyn Reporter> = if matches!(printer.status_level(), StatusLevel::None) {
         Box::new(ProgressTrackingReporter::new(DummyReporter, progress_file))
     } else {
+        let output_path = cache.output_file(args.worker_id);
+        let sink: Box<dyn LineSink> = Box::new(
+            FileLineSink::open(output_path.as_std_path())
+                .with_context(|| format!("Failed to open worker output file at {output_path}"))?,
+        );
         Box::new(ProgressTrackingReporter::new(
-            TestCaseReporter::new(printer),
+            TestCaseReporter::new(printer, sink),
             progress_file,
         ))
     };

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -8,7 +8,7 @@ use clap::Parser;
 use colored::Colorize;
 use karva_cache::{RunCache, RunHash};
 use karva_cli::{SubTestCommand, Verbosity};
-use karva_diagnostic::{DummyReporter, Reporter, TestCaseReporter};
+use karva_diagnostic::{DummyReporter, ProgressTrackingReporter, Reporter, TestCaseReporter};
 use karva_logging::{Printer, StatusLevel, set_colored_override, setup_tracing};
 use karva_metadata::RunIgnoredMode;
 use karva_metadata::filter::FiltersetSet;
@@ -166,10 +166,17 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
 
     let cache = RunCache::new(&args.cache_dir, &run_hash);
 
+    let worker_dir = cache.worker_dir(args.worker_id);
+    std::fs::create_dir_all(&worker_dir)
+        .with_context(|| format!("Failed to create worker dir at {worker_dir}"))?;
+    let progress_file = cache.progress_file(args.worker_id).into_std_path_buf();
     let reporter: Box<dyn Reporter> = if matches!(printer.status_level(), StatusLevel::None) {
-        Box::new(DummyReporter)
+        Box::new(ProgressTrackingReporter::new(DummyReporter, progress_file))
     } else {
-        Box::new(TestCaseReporter::new(printer))
+        Box::new(ProgressTrackingReporter::new(
+            TestCaseReporter::new(printer),
+            progress_file,
+        ))
     };
 
     let result = karva_test_semantic::run_tests(

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -8,7 +8,7 @@ use clap::Parser;
 use colored::Colorize;
 use karva_cache::{RunCache, RunHash};
 use karva_cli::{SubTestCommand, Verbosity};
-use karva_diagnostic::{DummyReporter, Reporter, TestCaseReporter};
+use karva_diagnostic::{DummyReporter, ProgressTrackingReporter, Reporter, TestCaseReporter};
 use karva_logging::{Printer, StatusLevel, set_colored_override, setup_tracing};
 use karva_metadata::RunIgnoredMode;
 use karva_metadata::filter::FiltersetSet;
@@ -167,16 +167,18 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
 
     let cache = RunCache::new(&args.cache_dir, &run_hash);
 
-    let progress_file = cache.current_test_file(args.worker_id);
-    // Make sure the worker dir exists so the reporter can write the
-    // progress file before the worker has otherwise touched it.
-    if let Some(parent) = progress_file.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
+    let worker_dir = cache.worker_dir(args.worker_id);
+    std::fs::create_dir_all(&worker_dir)
+        .with_context(|| format!("Failed to create worker dir at {worker_dir}"))?;
+    let current_test_file = cache.current_test_file(args.worker_id);
+    let progress_file = cache.progress_file(args.worker_id).into_std_path_buf();
     let reporter: Box<dyn Reporter> = if matches!(printer.status_level(), StatusLevel::None) {
-        Box::new(DummyReporter)
+        Box::new(ProgressTrackingReporter::new(DummyReporter, progress_file))
     } else {
-        Box::new(TestCaseReporter::new(printer).with_progress_file(progress_file))
+        Box::new(ProgressTrackingReporter::new(
+            TestCaseReporter::new(printer).with_progress_file(current_test_file),
+            progress_file,
+        ))
     };
 
     let result = karva_test_semantic::run_tests(

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -8,7 +8,9 @@ use clap::Parser;
 use colored::Colorize;
 use karva_cache::{RunCache, RunHash};
 use karva_cli::{SubTestCommand, Verbosity};
-use karva_diagnostic::{DummyReporter, ProgressTrackingReporter, Reporter, TestCaseReporter};
+use karva_diagnostic::{
+    DummyReporter, FileLineSink, LineSink, ProgressTrackingReporter, Reporter, TestCaseReporter,
+};
 use karva_logging::{Printer, StatusLevel, set_colored_override, setup_tracing};
 use karva_metadata::RunIgnoredMode;
 use karva_metadata::filter::FiltersetSet;
@@ -175,8 +177,13 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
     let reporter: Box<dyn Reporter> = if matches!(printer.status_level(), StatusLevel::None) {
         Box::new(ProgressTrackingReporter::new(DummyReporter, progress_file))
     } else {
+        let output_path = cache.output_file(args.worker_id);
+        let sink: Box<dyn LineSink> = Box::new(
+            FileLineSink::open(output_path.as_std_path())
+                .with_context(|| format!("Failed to open worker output file at {output_path}"))?,
+        );
         Box::new(ProgressTrackingReporter::new(
-            TestCaseReporter::new(printer).with_progress_file(current_test_file),
+            TestCaseReporter::new(printer, sink).with_current_test_file(current_test_file),
             progress_file,
         ))
     };

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -158,6 +158,31 @@ output-format = "concise"
 
 ---
 
+### `show-progress`
+
+Live progress display rendered while tests run.
+
+`none` (the default) leaves output untouched. `counter` prints a
+`N/M tests` line on stderr that refreshes periodically. `bar` shows
+a visual progress bar with completion stats. The display is rendered
+on stderr so it does not interfere with per-test result lines on
+stdout (gated by [`status_level`](#status-level)).
+
+Defaults to `none`.
+
+**Default value**: `none`
+
+**Type**: `none | counter | bar`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.karva.profile.default.terminal]
+show-progress = "bar"
+```
+
+---
+
 ### `show-python-output`
 
 Whether to show the python output.

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -207,6 +207,31 @@ output-format = "concise"
 
 ---
 
+### `show-progress`
+
+Live progress display rendered while tests run.
+
+`none` (the default) leaves output untouched. `counter` prints a
+`N/M tests` line on stderr that refreshes periodically. `bar` shows
+a visual progress bar with completion stats. The display is rendered
+on stderr so it does not interfere with per-test result lines on
+stdout (gated by [`status_level`](#status-level)).
+
+Defaults to `none`.
+
+**Default value**: `none`
+
+**Type**: `none | counter | bar`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.karva.profile.default.terminal]
+show-progress = "bar"
+```
+
+---
+
 ### `show-python-output`
 
 Whether to show the python output.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -114,7 +114,14 @@ karva test [OPTIONS] [PATH]...
 <li><code>only</code>:  Run only ignored tests</li>
 <li><code>all</code>:  Run both ignored and non-ignored tests</li>
 </ul></dd><dt id="karva-test--show-output"><a href="#karva-test--show-output"><code>--show-output</code></a>, <code>-s</code></dt><dd><p>Show Python stdout during test execution</p>
-</dd><dt id="karva-test--slow-timeout"><a href="#karva-test--slow-timeout"><code>--slow-timeout</code></a> <i>seconds</i></dt><dd><p>Threshold in seconds after which a test is flagged as slow.</p>
+</dd><dt id="karva-test--show-progress"><a href="#karva-test--show-progress"><code>--show-progress</code></a> <i>mode</i></dt><dd><p>Live progress display while tests run &#91;default: none&#93;</p>
+<p><code>none</code> leaves output untouched. <code>counter</code> prints a refreshing <code>N/M tests</code> line on stderr. <code>bar</code> renders a visual progress bar. Stderr is used so the display does not interfere with per-test result lines on stdout.</p>
+<p>May also be set with the <code>KARVA_SHOW_PROGRESS</code> environment variable.</p><p>Possible values:</p>
+<ul>
+<li><code>none</code>:  No live progress display (default)</li>
+<li><code>counter</code>:  Print a one-line <code>N/M tests</code> counter, refreshed periodically</li>
+<li><code>bar</code>:  Render a visual progress bar with completion stats</li>
+</ul></dd><dt id="karva-test--slow-timeout"><a href="#karva-test--slow-timeout"><code>--slow-timeout</code></a> <i>seconds</i></dt><dd><p>Threshold in seconds after which a test is flagged as slow.</p>
 <p>When a test takes longer than this duration, it is reported with a <code>SLOW</code> status line (gated on <code>--status-level=slow</code> or higher) and counted in the run summary. Pass a positive number such as <code>--slow-timeout=60</code> or <code>--slow-timeout=0.5</code>.</p>
 </dd><dt id="karva-test--snapshot-update"><a href="#karva-test--snapshot-update"><code>--snapshot-update</code></a></dt><dd><p>Update snapshots directly instead of creating pending <code>.snap.new</code> files.</p>
 <p>When set, <code>karva.assert_snapshot()</code> will write directly to <code>.snap</code> files, accepting any changes automatically.</p>

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -110,7 +110,14 @@ karva test [OPTIONS] [PATH]...
 <li><code>only</code>:  Run only ignored tests</li>
 <li><code>all</code>:  Run both ignored and non-ignored tests</li>
 </ul></dd><dt id="karva-test--show-output"><a href="#karva-test--show-output"><code>--show-output</code></a>, <code>-s</code></dt><dd><p>Show Python stdout during test execution</p>
-</dd><dt id="karva-test--slow-timeout"><a href="#karva-test--slow-timeout"><code>--slow-timeout</code></a> <i>seconds</i></dt><dd><p>Threshold in seconds after which a test is flagged as slow.</p>
+</dd><dt id="karva-test--show-progress"><a href="#karva-test--show-progress"><code>--show-progress</code></a> <i>mode</i></dt><dd><p>Live progress display while tests run &#91;default: none&#93;</p>
+<p><code>none</code> leaves output untouched. <code>counter</code> prints a refreshing <code>N/M tests</code> line on stderr. <code>bar</code> renders a visual progress bar. Stderr is used so the display does not interfere with per-test result lines on stdout.</p>
+<p>May also be set with the <code>KARVA_SHOW_PROGRESS</code> environment variable.</p><p>Possible values:</p>
+<ul>
+<li><code>none</code>:  No live progress display (default)</li>
+<li><code>counter</code>:  Print a one-line <code>N/M tests</code> counter, refreshed periodically</li>
+<li><code>bar</code>:  Render a visual progress bar with completion stats</li>
+</ul></dd><dt id="karva-test--slow-timeout"><a href="#karva-test--slow-timeout"><code>--slow-timeout</code></a> <i>seconds</i></dt><dd><p>Threshold in seconds after which a test is flagged as slow.</p>
 <p>When a test takes longer than this duration, it is reported with a <code>SLOW</code> status line (gated on <code>--status-level=slow</code> or higher) and counted in the run summary. Pass a positive number such as <code>--slow-timeout=60</code> or <code>--slow-timeout=0.5</code>.</p>
 </dd><dt id="karva-test--snapshot-update"><a href="#karva-test--snapshot-update"><code>--snapshot-update</code></a></dt><dd><p>Update snapshots directly instead of creating pending <code>.snap.new</code> files.</p>
 <p>When set, <code>karva.assert_snapshot()</code> will write directly to <code>.snap</code> files, accepting any changes automatically.</p>


### PR DESCRIPTION
## Summary

Adds a live progress display while tests run, configurable via `--show-progress` (`none` | `counter` | `bar`) or `[terminal] show-progress` in `karva.toml`. The display is rendered on stderr by `indicatif` so it does not interfere with per-test result lines on stdout.

```
karva test --show-progress=bar
karva test --show-progress=counter
```

Closes #570.

In the course of wiring this up, the per-test result lines themselves had a longstanding bug: in parallel runs, multiple worker processes lock their own stdouts independently, which does not actually serialize their writes. Lines from different workers could splice mid-line, producing output like `... oktest tests.test_currency...`. Closes #502.

This PR fixes the interleave at the source. Workers no longer write reporter lines directly to the inherited stdout — instead, each worker writes newline-delimited preformatted lines to a per-worker `output` file in its cache directory (via a new `FileLineSink`), and the orchestrator runs a background thread that drains those files, splits on `\n`, and prints whole lines to its own stdout. Single-writer per file plus newline-bounded reads means partial-line splices are impossible.

The same drain thread also drives the optional progress bar from the existing per-worker `progress` files. The bar is sized by `test_count()` (function definitions) and ticked once per test function — variants from `@parametrize` no longer each tick, so the bar reaches 100% exactly when the run finishes regardless of how many cases each function expanded into.

The bar style now matches ty's: `{msg:8.dim} {bar:60.green/dim} {pos}/{len} tests`, `progress_chars("--")`. Output writes use `bar.suspend(|| writeln!(stdout, …))` so the bar's stderr redraws don't clash with stdout writes.

## Test Plan

ci