### PR TITLE
Add global run timeout (`--run-timeout`)

### DIFF
--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -95,9 +95,16 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
     let karva_runner::RunOutput {
         results: result,
         coverage_files,
+        timed_out,
     } = karva_runner::run_parallel_tests(&project, &config, &sub_command, printer)?;
 
     print_test_output(printer, start_time, &result, durations)?;
+
+    if timed_out {
+        let mut stdout = printer.stream_for_message().lock();
+        writeln!(stdout, "\nerror: run timed out before all tests completed")?;
+        return Ok(ExitStatus::Failure);
+    }
 
     let coverage_total = if coverage_files.is_empty() {
         None

--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -101,8 +101,7 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
     print_test_output(printer, start_time, &result, durations)?;
 
     if timed_out {
-        let mut stdout = printer.stream_for_message().lock();
-        writeln!(stdout, "\nerror: run timed out before all tests completed")?;
+        print_run_timed_out(printer)?;
         return Ok(ExitStatus::Failure);
     }
 
@@ -208,6 +207,14 @@ fn coverage_report_path(
 
 fn no_tests_collected(result: &AggregatedResults) -> bool {
     result.stats.total() == 0 && result.diagnostics.is_empty()
+}
+
+/// Print the message shown when a run is stopped by `--run-timeout`.
+///
+/// Shared by the one-shot and watch-mode paths.
+pub(super) fn print_run_timed_out(printer: Printer) -> std::io::Result<()> {
+    let mut stdout = printer.stream_for_message().lock();
+    writeln!(stdout, "\nerror: run timed out before all tests completed")
 }
 
 /// Print test output: diagnostics, durations, and result summary.

--- a/crates/karva/src/commands/test/watch.rs
+++ b/crates/karva/src/commands/test/watch.rs
@@ -28,6 +28,11 @@ fn run_and_print(
             if let Err(err) = print_test_output(printer, start_time, &output.results, durations) {
                 tracing::error!("Failed to print test output: {err}");
             }
+            if output.timed_out
+                && let Err(err) = super::print_run_timed_out(printer)
+            {
+                tracing::error!("Failed to print run timeout message: {err}");
+            }
         }
         Err(err) => {
             let mut stderr = std::io::stderr().lock();

--- a/crates/karva/tests/it/main.rs
+++ b/crates/karva/tests/it/main.rs
@@ -13,6 +13,7 @@ mod filterset;
 mod last_failed;
 mod partition;
 mod run_ignored;
+mod run_timeout;
 mod show_config;
 mod version;
 mod watch;

--- a/crates/karva/tests/it/run_timeout.rs
+++ b/crates/karva/tests/it/run_timeout.rs
@@ -1,0 +1,93 @@
+use insta_cmd::assert_cmd_snapshot;
+
+use crate::common::TestContext;
+
+/// A run that exceeds `--run-timeout` is stopped and reported as a failure.
+///
+/// The test sleeps far longer than the one-second limit, so the timeout fires
+/// deterministically before it can finish.
+#[test]
+fn test_run_timeout_stops_long_run() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import time
+
+def test_slow():
+    time.sleep(30)
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command().arg("--run-timeout").arg("1"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+    ────────────
+         Summary [TIME] 0 tests run: 0 passed, 0 skipped
+
+    error: run timed out before all tests completed
+
+    ----- stderr -----
+    ");
+}
+
+/// `run-timeout` is also honored when set in configuration.
+#[test]
+fn test_run_timeout_from_config() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r"
+[profile.default.test]
+run-timeout = 1.0
+",
+        ),
+        (
+            "test.py",
+            r"
+import time
+
+def test_slow():
+    time.sleep(30)
+        ",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+    ────────────
+         Summary [TIME] 0 tests run: 0 passed, 0 skipped
+
+    error: run timed out before all tests completed
+
+    ----- stderr -----
+    ");
+}
+
+/// A run that finishes within `--run-timeout` is unaffected.
+#[test]
+fn test_run_timeout_allows_fast_run() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+def test_fast():
+    assert True
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command().arg("--run-timeout").arg("600"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_fast
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -4,8 +4,8 @@ use camino::Utf8PathBuf;
 use clap::Parser;
 use karva_logging::{FinalStatusLevel, StatusLevel, TerminalColor};
 use karva_metadata::{
-    CovFailUnder, CoverageOptions, MaxFail, Options, OverrideOptions, SlowTimeoutSecs, SrcOptions,
-    TerminalOptions, TestOptions, TestTimeoutSecs,
+    CovFailUnder, CoverageOptions, MaxFail, Options, OverrideOptions, RunTimeoutSecs,
+    SlowTimeoutSecs, SrcOptions, TerminalOptions, TestOptions, TestTimeoutSecs,
 };
 
 use crate::enums::{CovReport, NoTests, OutputFormat, RunIgnored};
@@ -265,6 +265,14 @@ pub struct TestCommand {
     #[clap(short = 'n', long, help_heading = "Runner options")]
     pub num_workers: Option<usize>,
 
+    /// Wall-clock limit for the whole run, in seconds.
+    ///
+    /// When the run takes longer than this duration, karva stops the
+    /// remaining workers and exits with a failure status. Accepts fractional
+    /// seconds such as `--run-timeout=1800` or `--run-timeout=0.5`.
+    #[clap(long, value_name = "SECONDS", help_heading = "Runner options")]
+    pub run_timeout: Option<f64>,
+
     /// Disable parallel execution (equivalent to `--num-workers 1`)
     #[clap(long, default_missing_value = "true", num_args=0..1, help_heading = "Runner options")]
     pub no_parallel: Option<bool>,
@@ -365,6 +373,7 @@ impl SubTestCommand {
                 no_tests: self.no_tests.map(Into::into),
                 slow_timeout: self.slow_timeout.map(SlowTimeoutSecs),
                 timeout: self.timeout.map(TestTimeoutSecs),
+                run_timeout: None,
             }),
             coverage: Some(CoverageOptions {
                 sources: (!self.cov.is_empty()).then(|| self.cov.clone()),
@@ -385,11 +394,16 @@ impl SubTestCommand {
 
 impl TestCommand {
     pub fn into_options(self) -> Options {
+        let run_timeout = self.run_timeout;
         let mut sub_command = self.sub_command;
         if self.no_capture {
             sub_command.show_output = Some(true);
         }
-        sub_command.into_options()
+        let mut options = sub_command.into_options();
+        if let Some(test) = options.test.as_mut() {
+            test.run_timeout = run_timeout.map(RunTimeoutSecs);
+        }
+        options
     }
 }
 

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -373,6 +373,10 @@ impl SubTestCommand {
                 no_tests: self.no_tests.map(Into::into),
                 slow_timeout: self.slow_timeout.map(SlowTimeoutSecs),
                 timeout: self.timeout.map(TestTimeoutSecs),
+                // `run-timeout` is a main-process-only option and is never
+                // forwarded to workers, so it lives on `TestCommand` rather
+                // than this worker-shared struct. `TestCommand::into_options`
+                // sets the real value.
                 run_timeout: None,
             }),
             coverage: Some(CoverageOptions {

--- a/crates/karva_metadata/src/lib.rs
+++ b/crates/karva_metadata/src/lib.rs
@@ -18,7 +18,7 @@ pub use options::{
 pub use pyproject::{PyProject, PyProjectError};
 pub use settings::{
     CovFailUnder, CoverageSettings, NoTestsMode, OverrideSettings, ProjectSettings, RunIgnoredMode,
-    SlowTimeoutSecs, TestTimeoutSecs,
+    RunTimeoutSecs, SlowTimeoutSecs, TestTimeoutSecs,
 };
 
 use crate::options::KarvaTomlError;

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -16,7 +16,7 @@ use crate::filter::{FiltersetSet, ValidatedFilter};
 use crate::max_fail::MaxFail;
 use crate::settings::{
     CovFailUnder, CoverageSettings, NoTestsMode, OverrideSettings, ProjectSettings, RunIgnoredMode,
-    SlowTimeoutSecs, SrcSettings, TerminalSettings, TestSettings, TestTimeoutSecs,
+    RunTimeoutSecs, SlowTimeoutSecs, SrcSettings, TerminalSettings, TestSettings, TestTimeoutSecs,
 };
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, OptionsMetadata)]
@@ -367,6 +367,24 @@ pub struct TestOptions {
         "#
     )]
     pub timeout: Option<TestTimeoutSecs>,
+
+    /// Wall-clock limit (in seconds) for the entire run.
+    ///
+    /// When the run takes longer than this duration, karva stops the
+    /// remaining workers and exits with a failure status. This is a safety
+    /// net for CI to bound runaway suites; it does not affect individual
+    /// test results that already completed.
+    ///
+    /// Defaults to unset, which lets the run take as long as it needs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"null"#,
+        value_type = "float (seconds)",
+        example = r#"
+            run-timeout = 1800.0
+        "#
+    )]
+    pub run_timeout: Option<RunTimeoutSecs>,
 }
 
 impl TestOptions {
@@ -389,6 +407,7 @@ impl TestOptions {
             no_tests: self.no_tests.unwrap_or_default(),
             slow_timeout: self.slow_timeout.and_then(SlowTimeoutSecs::as_duration),
             timeout: self.timeout.and_then(TestTimeoutSecs::as_duration),
+            run_timeout: self.run_timeout.and_then(RunTimeoutSecs::as_duration),
         }
     }
 }
@@ -656,7 +675,7 @@ nonsense = 42
           |
         4 | nonsense = 42
           | ^^^^^^^^
-        unknown field `nonsense`, expected one of `test-function-prefix`, `fail-fast`, `max-fail`, `try-import-fixtures`, `retry`, `no-tests`, `slow-timeout`, `timeout`
+        unknown field `nonsense`, expected one of `test-function-prefix`, `fail-fast`, `max-fail`, `try-import-fixtures`, `retry`, `no-tests`, `slow-timeout`, `timeout`, `run-timeout`
         "
         );
     }
@@ -756,6 +775,7 @@ max-fail = 0
             no_tests: None,
             slow_timeout: None,
             timeout: None,
+            run_timeout: None,
         }
         "#);
     }
@@ -785,6 +805,7 @@ max-fail = 0
             no_tests: None,
             slow_timeout: None,
             timeout: None,
+            run_timeout: None,
         }
         "#);
     }
@@ -847,6 +868,7 @@ retry = 2
                 no_tests: None,
                 slow_timeout: None,
                 timeout: None,
+                run_timeout: None,
             },
         )
         "#);
@@ -903,6 +925,7 @@ retry = 5
                 no_tests: None,
                 slow_timeout: None,
                 timeout: None,
+                run_timeout: None,
             },
         )
         "#);

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -99,6 +99,33 @@ impl Combine for TestTimeoutSecs {
     }
 }
 
+/// A global run timeout expressed in seconds.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RunTimeoutSecs(pub f64);
+
+impl Eq for RunTimeoutSecs {}
+
+impl RunTimeoutSecs {
+    pub fn as_duration(self) -> Option<Duration> {
+        if self.0.is_finite() && self.0 > 0.0 {
+            Some(Duration::from_secs_f64(self.0))
+        } else {
+            None
+        }
+    }
+}
+
+impl Combine for RunTimeoutSecs {
+    #[inline(always)]
+    fn combine_with(&mut self, _other: Self) {}
+
+    #[inline]
+    fn combine(self, _other: Self) -> Self {
+        self
+    }
+}
+
 /// A coverage threshold expressed as a percentage (`0..=100`).
 ///
 /// Wraps `f64` for the same reason as [`SlowTimeoutSecs`]: keeps the
@@ -309,4 +336,8 @@ pub struct TestSettings {
         serialize_with = "serialize_duration_secs"
     )]
     pub timeout: Option<Duration>,
+    /// Wall-clock limit for the entire run. When the run exceeds this
+    /// duration, the remaining workers are stopped and the run fails.
+    /// `None` disables the limit.
+    pub run_timeout: Option<Duration>,
 }

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -87,13 +87,18 @@ impl WorkerManager {
     ///
     /// Returns early if a message is received on `shutdown_rx`, if the cache
     /// contains a fail-fast signal indicating a worker encountered a test
-    /// failure, or if `run_timeout` elapses. The timeout is measured from the
-    /// start of this call (test execution); collection happens beforehand.
+    /// failure, or if `deadline` passes. Finished workers are reaped at the
+    /// top of each iteration before any of those conditions are checked, so a
+    /// run that completes just as the deadline passes (or a signal arrives) is
+    /// reported as `AllCompleted` rather than `TimedOut`/`Cancelled`.
+    ///
+    /// `deadline` is the absolute instant at which the whole run times out; it
+    /// is computed before collection so the limit covers the entire run.
     fn wait_for_completion(
         &mut self,
         shutdown_rx: Option<&Receiver<()>>,
         cache: Option<&RunCache>,
-        run_timeout: Option<Duration>,
+        deadline: Option<Instant>,
     ) -> WaitOutcome {
         if self.workers.is_empty() {
             return WaitOutcome::AllCompleted;
@@ -104,33 +109,7 @@ impl WorkerManager {
             self.workers.len()
         );
 
-        let start = Instant::now();
-
         loop {
-            if let Some(rx) = shutdown_rx {
-                match rx.try_recv() {
-                    Ok(()) | Err(TryRecvError::Disconnected) => {
-                        tracing::info!("Shutdown requested — stopping remaining workers");
-                        return WaitOutcome::Cancelled;
-                    }
-                    Err(TryRecvError::Empty) => {}
-                }
-            }
-
-            if let Some(cache) = cache
-                && cache.has_fail_fast_signal()
-            {
-                tracing::info!("Fail-fast signal received — stopping remaining workers");
-                return WaitOutcome::FailFast;
-            }
-
-            if let Some(timeout) = run_timeout
-                && start.elapsed() >= timeout
-            {
-                tracing::info!("Run timeout exceeded — stopping remaining workers");
-                return WaitOutcome::TimedOut;
-            }
-
             self.workers
                 .retain_mut(|worker| match worker.child.try_wait() {
                     Ok(Some(status)) => {
@@ -160,6 +139,30 @@ impl WorkerManager {
             if self.workers.is_empty() {
                 tracing::info!("All workers completed");
                 return WaitOutcome::AllCompleted;
+            }
+
+            if let Some(rx) = shutdown_rx {
+                match rx.try_recv() {
+                    Ok(()) | Err(TryRecvError::Disconnected) => {
+                        tracing::info!("Shutdown requested — stopping remaining workers");
+                        return WaitOutcome::Cancelled;
+                    }
+                    Err(TryRecvError::Empty) => {}
+                }
+            }
+
+            if let Some(cache) = cache
+                && cache.has_fail_fast_signal()
+            {
+                tracing::info!("Fail-fast signal received — stopping remaining workers");
+                return WaitOutcome::FailFast;
+            }
+
+            if let Some(deadline) = deadline
+                && Instant::now() >= deadline
+            {
+                tracing::info!("Run timeout exceeded — stopping remaining workers");
+                return WaitOutcome::TimedOut;
             }
 
             std::thread::sleep(WORKER_POLL_INTERVAL);
@@ -448,6 +451,14 @@ pub fn run_parallel_tests(
         None
     };
 
+    // Anchor the run-timeout deadline before collection so the limit covers
+    // the whole run, not just test execution.
+    let run_deadline = project
+        .settings()
+        .test()
+        .run_timeout
+        .map(|timeout| Instant::now() + timeout);
+
     let collected = collect_tests(project)?;
 
     let total_tests = collected.test_count();
@@ -527,11 +538,7 @@ pub fn run_parallel_tests(
 
     let max_fail_cache = project.settings().max_fail().has_limit().then_some(&cache);
 
-    let outcome = worker_manager.wait_for_completion(
-        shutdown_rx,
-        max_fail_cache,
-        project.settings().test().run_timeout,
-    );
+    let outcome = worker_manager.wait_for_completion(shutdown_rx, max_fail_cache, run_deadline);
     let interrupted_tests = if outcome == WaitOutcome::Cancelled {
         worker_manager.cancel_and_kill(printer, &cache)
     } else {

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -37,6 +37,8 @@ enum WaitOutcome {
     Cancelled,
     /// A worker hit the fail-fast budget; remaining workers must be killed.
     FailFast,
+    /// The run timeout elapsed before the workers finished.
+    TimedOut,
 }
 
 #[derive(Debug)]
@@ -82,12 +84,16 @@ impl WorkerManager {
     }
 
     /// Wait for all workers to complete.
-    /// Returns early if a message is received on `shutdown_rx` or if the cache
-    /// contains a fail-fast signal indicating a worker encountered a test failure.
+    ///
+    /// Returns early if a message is received on `shutdown_rx`, if the cache
+    /// contains a fail-fast signal indicating a worker encountered a test
+    /// failure, or if `run_timeout` elapses. The timeout is measured from the
+    /// start of this call (test execution); collection happens beforehand.
     fn wait_for_completion(
         &mut self,
         shutdown_rx: Option<&Receiver<()>>,
         cache: Option<&RunCache>,
+        run_timeout: Option<Duration>,
     ) -> WaitOutcome {
         if self.workers.is_empty() {
             return WaitOutcome::AllCompleted;
@@ -97,6 +103,8 @@ impl WorkerManager {
             "Waiting for {} workers to complete (Ctrl+C to cancel)",
             self.workers.len()
         );
+
+        let start = Instant::now();
 
         loop {
             if let Some(rx) = shutdown_rx {
@@ -114,6 +122,13 @@ impl WorkerManager {
             {
                 tracing::info!("Fail-fast signal received — stopping remaining workers");
                 return WaitOutcome::FailFast;
+            }
+
+            if let Some(timeout) = run_timeout
+                && start.elapsed() >= timeout
+            {
+                tracing::info!("Run timeout exceeded — stopping remaining workers");
+                return WaitOutcome::TimedOut;
             }
 
             self.workers
@@ -413,6 +428,8 @@ pub struct RunOutput {
     /// [`karva_coverage::combine_and_report`] to render the coverage table at
     /// the right point in its output sequence (after the test summary).
     pub coverage_files: Vec<Utf8PathBuf>,
+    /// Whether the run was stopped because the configured run timeout elapsed.
+    pub timed_out: bool,
 }
 
 pub fn run_parallel_tests(
@@ -510,13 +527,19 @@ pub fn run_parallel_tests(
 
     let max_fail_cache = project.settings().max_fail().has_limit().then_some(&cache);
 
-    let outcome = worker_manager.wait_for_completion(shutdown_rx, max_fail_cache);
+    let outcome = worker_manager.wait_for_completion(
+        shutdown_rx,
+        max_fail_cache,
+        project.settings().test().run_timeout,
+    );
     let interrupted_tests = if outcome == WaitOutcome::Cancelled {
         worker_manager.cancel_and_kill(printer, &cache)
     } else {
         worker_manager.kill_remaining();
         Vec::new()
     };
+
+    let timed_out = outcome == WaitOutcome::TimedOut;
 
     let mut results = cache.aggregate_results()?;
     for test in interrupted_tests {
@@ -536,6 +559,7 @@ pub fn run_parallel_tests(
     Ok(RunOutput {
         results,
         coverage_files,
+        timed_out,
     })
 }
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -337,6 +337,30 @@ retry = 3
 
 ---
 
+### `run-timeout`
+
+Wall-clock limit (in seconds) for the entire run.
+
+When the run takes longer than this duration, karva stops the
+remaining workers and exits with a failure status. This is a safety
+net for CI to bound runaway suites; it does not affect individual
+test results that already completed.
+
+Defaults to unset, which lets the run take as long as it needs.
+
+**Default value**: `null`
+
+**Type**: `float (seconds)`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.karva.profile.default.test]
+run-timeout = 1800.0
+```
+
+---
+
 ### `slow-timeout`
 
 Threshold (in seconds) after which a test is flagged as slow.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -110,7 +110,9 @@ karva test [OPTIONS] [PATH]...
 <ul>
 <li><code>only</code>:  Run only ignored tests</li>
 <li><code>all</code>:  Run both ignored and non-ignored tests</li>
-</ul></dd><dt id="karva-test--show-output"><a href="#karva-test--show-output"><code>--show-output</code></a>, <code>-s</code></dt><dd><p>Show Python stdout during test execution</p>
+</ul></dd><dt id="karva-test--run-timeout"><a href="#karva-test--run-timeout"><code>--run-timeout</code></a> <i>seconds</i></dt><dd><p>Wall-clock limit for the whole run, in seconds.</p>
+<p>When the run takes longer than this duration, karva stops the remaining workers and exits with a failure status. Accepts fractional seconds such as <code>--run-timeout=1800</code> or <code>--run-timeout=0.5</code>.</p>
+</dd><dt id="karva-test--show-output"><a href="#karva-test--show-output"><code>--show-output</code></a>, <code>-s</code></dt><dd><p>Show Python stdout during test execution</p>
 </dd><dt id="karva-test--slow-timeout"><a href="#karva-test--slow-timeout"><code>--slow-timeout</code></a> <i>seconds</i></dt><dd><p>Threshold in seconds after which a test is flagged as slow.</p>
 <p>When a test takes longer than this duration, it is reported with a <code>SLOW</code> status line (gated on <code>--status-level=slow</code> or higher) and counted in the run summary. Pass a positive number such as <code>--slow-timeout=60</code> or <code>--slow-timeout=0.5</code>.</p>
 </dd><dt id="karva-test--snapshot-update"><a href="#karva-test--snapshot-update"><code>--snapshot-update</code></a></dt><dd><p>Update snapshots directly instead of creating pending <code>.snap.new</code> files.</p>


### PR DESCRIPTION
## Summary

This adds a wall-clock limit for the entire test run, which closes #560. It gives CI a safety net against runaway suites: if the whole run takes longer than the configured limit, karva stops the remaining workers and exits with a failure status instead of letting the job hang until the CI provider's own timeout kills it.

It can be set on the command line or in configuration:

```bash
karva test --run-timeout 1800
```

```toml
[profile.default.test]
run-timeout = 1800.0
```

I went with plain seconds (an `f64`) rather than the `"30m"` duration string sketched in the issue, to stay consistent with the existing `--timeout` and `--slow-timeout` flags and to avoid pulling in a duration-parsing dependency. Happy to switch to a humantime-style string if you'd prefer the issue's original shape.

The important design point is that this is **not** the same machinery as the per-test `timeout`. A per-test timeout is enforced inside the worker (in Python), so it gets forwarded to every worker process. The run timeout is a property of the run as a whole, so it lives entirely in the main process. The flag is therefore on `TestCommand` rather than `SubTestCommand`, and it is never forwarded to workers. Enforcement is a third early-exit condition in the existing `wait_for_completion` poll loop, sitting right next to the Ctrl+C shutdown and fail-fast checks that were already there. When the deadline passes, the loop returns a small `RunCompletion::TimedOut` outcome, the existing `kill_remaining` logic reaps the surviving workers, and the result is surfaced up as `RunOutput.timed_out`.

One edge case worth calling out: when a run is killed with nothing completed, the aggregated results are empty, which would otherwise look identical to "no tests were found". To avoid that confusion, the timeout is reported before the no-tests check, so the user sees `error: run timed out before all tests completed` and a non-zero exit rather than a misleading "no tests to run".

The configuration and CLI reference docs were regenerated with `cargo run -p karva_dev generate-all`.

## Test Plan

Added integration tests in `crates/karva/tests/it/run_timeout.rs` covering a run that exceeds the limit on the command line, the same via `karva.toml`, and a fast run that finishes comfortably under a generous limit (to confirm the flag doesn't disturb normal runs). The metadata unit-test snapshots were updated for the new option, and the existing `deny_unknown_fields` coverage now exercises the `run-timeout` key.

`just test` passes (728 integration tests, plus the workspace unit tests), and `uvx prek run -a` is clean aside from a pre-existing `ambiguous_derive_helpers` clippy warning in `karva_macros` that is unrelated to this change.

---

*I used an AI assistant to help with this contribution.*