### PR TITLE
Fix pre-commit clippy failure

### DIFF
--- a/crates/karva_logging/src/time.rs
+++ b/crates/karva_logging/src/time.rs
@@ -39,7 +39,7 @@ mod tests {
     /// including the exact one-second boundary and values like 1999 ms.
     #[test]
     fn format_duration_sub_two_seconds_uses_milliseconds() {
-        assert_snapshot!(format_duration(Duration::from_millis(1000)), @"1000ms");
+        assert_snapshot!(format_duration(Duration::from_secs(1)), @"1000ms");
         assert_snapshot!(format_duration(Duration::from_millis(1999)), @"1999ms");
     }
 

--- a/crates/karva_macros/src/lib.rs
+++ b/crates/karva_macros/src/lib.rs
@@ -5,7 +5,7 @@ mod combine;
 mod combine_options;
 mod config;
 
-#[proc_macro_derive(OptionsMetadata, attributes(option, doc, option_group))]
+#[proc_macro_derive(OptionsMetadata, attributes(option, option_group))]
 pub fn derive_options_metadata(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 

--- a/crates/karva_snapshot/src/storage.rs
+++ b/crates/karva_snapshot/src/storage.rs
@@ -1,3 +1,4 @@
+use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::io;
 
@@ -194,7 +195,7 @@ fn process_inline_snapshots(
     inline_by_source: &mut HashMap<String, Vec<InlineInfo<'_>>>,
 ) -> io::Result<()> {
     for (source_file, group) in inline_by_source.iter_mut() {
-        group.sort_by(|a, b| b.line.cmp(&a.line));
+        group.sort_by_key(|info| Reverse(info.line));
         for item in group.iter() {
             let content = item.content.trim_end();
             crate::inline::rewrite_inline_snapshot(


### PR DESCRIPTION
## Summary

Fixes the pre-commit clippy failures caused by newer Rust 1.96 lints. The `OptionsMetadata` derive helper list no longer registers the built-in `doc` attribute, inline snapshot processing uses `sort_by_key` for descending line order, and the duration formatting test uses `from_secs(1)` for the one-second case.

## Test Plan

`cargo +1.96 clippy --all-targets --all-features -- -D warnings` and `uvx prek run -a` with local stable updated to Rust 1.96.