### PR TITLE
Fix show-config serialization for overrides

### DIFF
--- a/crates/karva/tests/it/show_config.rs
+++ b/crates/karva/tests/it/show_config.rs
@@ -169,6 +169,53 @@ fail-under = 90
 }
 
 #[test]
+fn show_config_emits_per_test_overrides() {
+    let context = TestContext::with_file(
+        "karva.toml",
+        r#"
+[[profile.default.overrides]]
+filter = "tag(network)"
+retries = 2
+timeout = 30
+slow-timeout = 1.5
+"#,
+    );
+
+    assert_cmd_snapshot!(context.show_config(), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [src]
+    respect-ignore-files = true
+    include = []
+
+    [terminal]
+    output-format = "full"
+    show-python-output = false
+    status-level = "pass"
+    final-status-level = "pass"
+
+    [test]
+    test-function-prefix = "test"
+    try-import-fixtures = false
+    retry = 0
+    no-tests = "auto"
+
+    [coverage]
+    sources = []
+    report = "term"
+
+    [[overrides]]
+    filter = "tag(network)"
+    retries = 2
+    timeout = 30.0
+    slow-timeout = 1.5
+
+    ----- stderr -----
+    "#);
+}
+
+#[test]
 fn show_config_unknown_profile_errors() {
     let context = TestContext::with_file(
         "karva.toml",

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -128,16 +128,21 @@ pub struct ProjectSettings {
     pub(crate) terminal: TerminalSettings,
     pub(crate) test: TestSettings,
     pub(crate) coverage: CoverageSettings,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub(crate) overrides: Vec<OverrideSettings>,
 }
 
 /// A compiled per-test override applied when its [filter](Self::filter)
 /// matches the running test.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct OverrideSettings {
     pub filter: ValidatedFilter,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub retries: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout: Option<TestTimeoutSecs>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub slow_timeout: Option<SlowTimeoutSecs>,
 }
 


### PR DESCRIPTION
## Summary

Fixes main CI by making resolved per-test override settings serializable for `karva show-config` and omitting empty override lists. Adds a regression test that confirms non-empty overrides are printed as `[[overrides]]`.

## Test Plan

`maturin build`; `cargo test -p karva --test it show_config`; `uvx prek run -a`