### PR TITLE
Reduce runner collection allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,6 +1303,7 @@ dependencies = [
  "karva_project",
  "karva_static",
  "karva_version",
+ "ruff_python_ast",
  "serde_json",
  "tempfile",
  "tracing",

--- a/crates/karva_collector/src/lib.rs
+++ b/crates/karva_collector/src/lib.rs
@@ -30,6 +30,8 @@ pub struct CollectionSettings<'a> {
     pub respect_ignore_files: bool,
     /// Whether to collect fixture function definitions in addition to test functions.
     pub collect_fixtures: bool,
+    /// Whether collected modules need to retain their full source text.
+    pub retain_source_text: bool,
 }
 
 /// Collects test functions and fixtures from a Python file.
@@ -63,7 +65,12 @@ pub fn collect_file(
         return Ok(None);
     };
 
-    let mut collected_module = CollectedModule::new(module_path, module_type, source_text);
+    let module_source_text = if settings.retain_source_text {
+        source_text
+    } else {
+        String::new()
+    };
+    let mut collected_module = CollectedModule::new(module_path, module_type, module_source_text);
 
     for stmt in parsed.into_syntax().body {
         if let Stmt::FunctionDef(function_def) = stmt {
@@ -110,6 +117,7 @@ mod tests {
             test_function_prefix: "test_",
             respect_ignore_files: true,
             collect_fixtures: false,
+            retain_source_text: true,
         }
     }
 
@@ -126,5 +134,25 @@ mod tests {
             error,
             CollectionError::ReadSource { path: error_path, .. } if error_path == path
         ));
+    }
+
+    #[test]
+    fn collect_file_can_drop_source_text() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let cwd = Utf8Path::from_path(temp_dir.path()).expect("temp dir should be UTF-8");
+        let path = cwd.join("test_sample.py");
+        std::fs::write(&path, "def test_sample():\n    assert True\n").expect("write test file");
+
+        let settings = CollectionSettings {
+            retain_source_text: false,
+            ..settings()
+        };
+
+        let module = collect_file(&path, cwd, &settings, &[])
+            .expect("collection should succeed")
+            .expect("module should be collected");
+
+        assert!(module.source_text.is_empty());
+        assert_eq!(module.test_function_defs.len(), 1);
     }
 }

--- a/crates/karva_collector/src/lib.rs
+++ b/crates/karva_collector/src/lib.rs
@@ -1,5 +1,5 @@
 use camino::{Utf8Path, Utf8PathBuf};
-use ruff_python_ast::{PythonVersion, Stmt};
+use ruff_python_ast::{PythonVersion, Stmt, StmtFunctionDef};
 use ruff_python_parser::{Mode, ParseOptions, parse_unchecked};
 use thiserror::Error;
 
@@ -84,7 +84,8 @@ pub fn collect_file(
                 function_names,
                 settings.test_function_prefix,
             ) {
-                collected_module.add_test_function_def(function_def);
+                collected_module
+                    .add_test_function_def(collected_test_function_def(function_def, settings));
             }
         }
     }
@@ -103,6 +104,21 @@ fn is_test_function_to_collect(name: &str, explicit_names: &[String], prefix: &s
     } else {
         explicit_names.iter().any(|n| n == name)
     }
+}
+
+fn collected_test_function_def(
+    mut function_def: StmtFunctionDef,
+    settings: &CollectionSettings,
+) -> StmtFunctionDef {
+    if !settings.retain_source_text && !settings.collect_fixtures {
+        function_def.decorator_list.clear();
+        function_def.type_params = None;
+        function_def.parameters = Box::default();
+        function_def.returns = None;
+        function_def.body.clear();
+    }
+
+    function_def
 }
 
 #[cfg(test)]
@@ -141,7 +157,11 @@ mod tests {
         let temp_dir = tempfile::tempdir().expect("create temp dir");
         let cwd = Utf8Path::from_path(temp_dir.path()).expect("temp dir should be UTF-8");
         let path = cwd.join("test_sample.py");
-        std::fs::write(&path, "def test_sample():\n    assert True\n").expect("write test file");
+        std::fs::write(
+            &path,
+            "def test_sample(value: int = 1) -> int:\n    x = value + 1\n    return x\n",
+        )
+        .expect("write test file");
 
         let settings = CollectionSettings {
             retain_source_text: false,
@@ -154,5 +174,10 @@ mod tests {
 
         assert!(module.source_text.is_empty());
         assert_eq!(module.test_function_defs.len(), 1);
+
+        let function_def = &module.test_function_defs[0];
+        assert!(function_def.body.is_empty());
+        assert_eq!(function_def.parameters.len(), 0);
+        assert!(function_def.returns.is_none());
     }
 }

--- a/crates/karva_runner/Cargo.toml
+++ b/crates/karva_runner/Cargo.toml
@@ -33,6 +33,7 @@ tracing = { workspace = true }
 which = { workspace = true }
 
 [dev-dependencies]
+ruff_python_ast = { workspace = true }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/karva_runner/src/collection.rs
+++ b/crates/karva_runner/src/collection.rs
@@ -1,6 +1,5 @@
 use karva_collector::{
-    CollectedModule, CollectedPackage, CollectionError, CollectionSettings, ModuleType,
-    collect_file,
+    CollectedModule, CollectedPackage, CollectionError, CollectionSettings, collect_file,
 };
 
 use std::thread;
@@ -45,14 +44,7 @@ impl<'a> ParallelCollector<'a> {
             for message in rx {
                 match message {
                     CollectionMessage::Module(collected_module) => {
-                        match collected_module.module_type() {
-                            ModuleType::Test => {
-                                package.add_module(collected_module);
-                            }
-                            ModuleType::Configuration => {
-                                package.add_configuration_module(collected_module);
-                            }
-                        }
+                        package.add_module(collected_module);
                     }
                     CollectionMessage::Error(error) => {
                         if first_error.is_none() {
@@ -86,6 +78,10 @@ impl<'a> ParallelCollector<'a> {
                 let Ok(file_path) = Utf8PathBuf::from_path_buf(entry.path().to_path_buf()) else {
                     return WalkState::Continue;
                 };
+
+                if is_configuration_module_path(&file_path) {
+                    return WalkState::Continue;
+                }
 
                 match collect_file(&file_path, self.cwd, &self.settings, &[]) {
                     Ok(Some(module)) => {
@@ -182,4 +178,49 @@ fn python_file_types() -> Result<Types> {
     types
         .build()
         .context("failed to build Python file type matcher")
+}
+
+fn is_configuration_module_path(path: &Utf8Path) -> bool {
+    path.file_name()
+        .is_some_and(|file_name| file_name == "conftest.py")
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_python_ast::PythonVersion;
+
+    use super::*;
+
+    fn settings() -> CollectionSettings<'static> {
+        CollectionSettings {
+            python_version: PythonVersion::PY312,
+            test_function_prefix: "test_",
+            respect_ignore_files: true,
+            collect_fixtures: false,
+            retain_source_text: false,
+        }
+    }
+
+    #[test]
+    fn directory_collection_skips_configuration_modules() -> Result<()> {
+        let temp_dir = tempfile::tempdir().context("create temp dir")?;
+        let cwd = Utf8Path::from_path(temp_dir.path())
+            .context("temp dir should be UTF-8")?
+            .to_path_buf();
+        std::fs::write(cwd.join("conftest.py"), "def helper():\n    return 1\n")
+            .context("write conftest")?;
+        std::fs::write(
+            cwd.join("test_sample.py"),
+            "def test_sample():\n    assert True\n",
+        )
+        .context("write test module")?;
+
+        let collector = ParallelCollector::new(&cwd, settings());
+        let package = collector.collect_directory(&cwd)?;
+
+        assert!(package.configuration_module.is_none());
+        assert_eq!(package.test_count(), 1);
+
+        Ok(())
+    }
 }

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -406,6 +406,7 @@ pub fn collect_tests(project: &Project) -> Result<CollectedPackage> {
         test_function_prefix: &project.settings().test().test_function_prefix,
         respect_ignore_files: project.settings().src().respect_ignore_files,
         collect_fixtures: false,
+        retain_source_text: false,
     };
 
     let collector = ParallelCollector::new(project.cwd(), collection_settings);

--- a/crates/karva_runner/src/partition.rs
+++ b/crates/karva_runner/src/partition.rs
@@ -144,7 +144,11 @@ pub fn partition_collected_tests(
         });
     }
 
-    order_tests_for_partitioning(&mut test_infos, test_ordering);
+    order_tests_for_partitioning(&mut test_infos, test_ordering, num_workers);
+
+    if num_workers == 1 {
+        return vec![single_partition(test_infos)];
+    }
 
     // Step 1: Group tests by module and calculate module weights
     let mut module_groups: Vec<Vec<TestInfo>> = (0..module_index).map(|_| Vec::new()).collect();
@@ -230,6 +234,15 @@ fn compare_test_weights(a: &TestInfo, b: &TestInfo) -> std::cmp::Ordering {
     }
 }
 
+fn single_partition(test_infos: Vec<TestInfo>) -> Partition {
+    let mut partition = Partition::new();
+    for test_info in test_infos {
+        let weight = test_weight(test_info.duration);
+        partition.add_test(test_info, weight);
+    }
+    partition
+}
+
 /// Shuffles only the tests that have no historical duration data.
 ///
 /// This ensures tests without timing info are randomly distributed across partitions
@@ -251,9 +264,17 @@ fn shuffle_tests_without_durations(test_infos: &mut [TestInfo]) {
     }
 }
 
-fn order_tests_for_partitioning(test_infos: &mut [TestInfo], ordering: TestOrdering) {
+fn order_tests_for_partitioning(
+    test_infos: &mut [TestInfo],
+    ordering: TestOrdering,
+    num_workers: usize,
+) {
     match ordering {
-        TestOrdering::ShuffleUnknownDurations => shuffle_tests_without_durations(test_infos),
+        TestOrdering::ShuffleUnknownDurations => {
+            if num_workers > 1 {
+                shuffle_tests_without_durations(test_infos);
+            }
+        }
         TestOrdering::Stable => {
             test_infos.sort_by(|a, b| a.qualified_name.cmp(&b.qualified_name));
         }
@@ -315,7 +336,7 @@ mod tests {
             test_info("test_module::test_b"),
         ];
 
-        order_tests_for_partitioning(&mut tests, TestOrdering::Stable);
+        order_tests_for_partitioning(&mut tests, TestOrdering::Stable, 1);
 
         let ordered_names: Vec<_> = tests
             .iter()
@@ -327,6 +348,30 @@ mod tests {
                 "test_module::test_a",
                 "test_module::test_b",
                 "test_module::test_c"
+            ]
+        );
+    }
+
+    #[test]
+    fn one_worker_shuffle_ordering_preserves_input_order() {
+        let mut tests = vec![
+            test_info("test_module::test_c"),
+            test_info("test_module::test_a"),
+            test_info("test_module::test_b"),
+        ];
+
+        order_tests_for_partitioning(&mut tests, TestOrdering::ShuffleUnknownDurations, 1);
+
+        let ordered_names: Vec<_> = tests
+            .iter()
+            .map(|test| test.qualified_name.as_str())
+            .collect();
+        assert_eq!(
+            ordered_names,
+            [
+                "test_module::test_c",
+                "test_module::test_a",
+                "test_module::test_b"
             ]
         );
     }

--- a/crates/karva_runner/src/partition.rs
+++ b/crates/karva_runner/src/partition.rs
@@ -15,7 +15,7 @@ pub enum TestOrdering {
 /// Test metadata used for partitioning decisions
 #[derive(Debug, Clone)]
 struct TestInfo {
-    module_name: String,
+    module_index: usize,
     /// The qualified name of the test (e.g., `test_a::test_1`), used for last-failed filtering.
     qualified_name: String,
     path: String,
@@ -118,8 +118,14 @@ pub fn partition_collected_tests(
     partition_selection: Option<PartitionSelection>,
     test_ordering: TestOrdering,
 ) -> Vec<Partition> {
-    let mut test_infos = Vec::new();
-    collect_test_paths_recursive(package, &mut test_infos, previous_durations);
+    let mut test_infos = Vec::with_capacity(package.test_count());
+    let mut module_index = 0;
+    collect_test_paths_recursive(
+        package,
+        &mut test_infos,
+        previous_durations,
+        &mut module_index,
+    );
 
     if !last_failed.is_empty() {
         test_infos.retain(|info| last_failed.contains(&info.qualified_name));
@@ -141,23 +147,19 @@ pub fn partition_collected_tests(
     order_tests_for_partitioning(&mut test_infos, test_ordering);
 
     // Step 1: Group tests by module and calculate module weights
-    let mut module_groups: HashMap<String, Vec<TestInfo>> = HashMap::new();
-    let mut module_weights: HashMap<String, u128> = HashMap::new();
+    let mut module_groups: Vec<Vec<TestInfo>> = (0..module_index).map(|_| Vec::new()).collect();
+    let mut module_weights = vec![0; module_index];
 
     for test_info in test_infos {
         let weight = test_weight(test_info.duration);
+        let module_index = test_info.module_index;
 
-        *module_weights
-            .entry(test_info.module_name.clone())
-            .or_default() += weight;
-        module_groups
-            .entry(test_info.module_name.clone())
-            .or_default()
-            .push(test_info);
+        module_weights[module_index] += weight;
+        module_groups[module_index].push(test_info);
     }
 
     // Step 2: Calculate threshold for splitting decision
-    let total_weight: u128 = module_weights.values().sum();
+    let total_weight: u128 = module_weights.iter().sum();
     let target_partition_weight = total_weight / num_workers.max(1) as u128;
     let split_threshold = target_partition_weight / 2;
 
@@ -165,8 +167,12 @@ pub fn partition_collected_tests(
     let mut small_modules = Vec::new();
     let mut large_modules = Vec::new();
 
-    for (module_name, tests) in module_groups {
-        let weight = module_weights[&module_name];
+    for (module_index, tests) in module_groups.into_iter().enumerate() {
+        if tests.is_empty() {
+            continue;
+        }
+
+        let weight = module_weights[module_index];
         let module_group = ModuleGroup::new(tests, weight);
 
         if module_group.weight() < split_threshold {
@@ -259,14 +265,18 @@ fn collect_test_paths_recursive(
     package: &karva_collector::CollectedPackage,
     test_infos: &mut Vec<TestInfo>,
     previous_durations: &HashMap<String, Duration>,
+    next_module_index: &mut usize,
 ) {
     for module in package.modules.values() {
+        let module_index = *next_module_index;
+        *next_module_index += 1;
+
         for test_fn_def in &module.test_function_defs {
             let qualified_name = format!("{}::{}", module.path.module_name(), test_fn_def.name);
             let duration = previous_durations.get(&qualified_name).copied();
 
             test_infos.push(TestInfo {
-                module_name: module.path.module_name().to_string(),
+                module_index,
                 qualified_name,
                 path: format!("{}::{}", module.path.path(), test_fn_def.name),
                 duration,
@@ -275,7 +285,12 @@ fn collect_test_paths_recursive(
     }
 
     for subpackage in package.packages.values() {
-        collect_test_paths_recursive(subpackage, test_infos, previous_durations);
+        collect_test_paths_recursive(
+            subpackage,
+            test_infos,
+            previous_durations,
+            next_module_index,
+        );
     }
 }
 
@@ -285,7 +300,7 @@ mod tests {
 
     fn test_info(qualified_name: &str) -> TestInfo {
         TestInfo {
-            module_name: "test_module".to_string(),
+            module_index: 0,
             qualified_name: qualified_name.to_string(),
             path: qualified_name.to_string(),
             duration: None,

--- a/crates/karva_test_semantic/src/context.rs
+++ b/crates/karva_test_semantic/src/context.rs
@@ -61,6 +61,7 @@ impl<'a> Context<'a> {
             test_function_prefix: &self.settings.test().test_function_prefix,
             respect_ignore_files: self.settings.src().respect_ignore_files,
             collect_fixtures: true,
+            retain_source_text: true,
         }
     }
 


### PR DESCRIPTION
## Summary

Reduces allocation work in runner-side collection and partitioning. The main process now drops retained Python source text after parsing, skips conftest.py during directory collection because configuration modules are only needed by worker discovery, preallocates test info, and groups partition inputs by numeric module ids instead of cloning module names into hash maps.

Local exact pyparsing benchmark runs were suggestive but noisy: baseline was 2.351s, 2.213s, and 2.231s; the first post-change set was 2.186s, 2.137s, and 2.118s. A later local run moved back to 2.29s, so local wall-time is not stable enough to prove small changes.

CI benchmark shards pass consistently, but CodSpeed wall-time analysis is flaky on hosted runners. It warns about an unknown walltime environment and different runtime environments, and repeated runs changed which benchmarks were labeled regressions versus improvements.

## Test Plan

Ran targeted collector, runner, and test-semantic library tests; rebuilt the wheel; ran exact pyparsing, h11, and markupsafe benchmarks locally; ran uvx prek run -a; watched CI benchmark shards pass.