### PR TITLE
Add PR benchmark comparison workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ permissions: {}
 
 env:
   PYTHON_VERSION: "3.14"
-  BENCHMARK_PYTHON_VERSION: "3.13"
   NEXTEST_PROFILE: ci
 
 jobs:
@@ -243,85 +242,3 @@ jobs:
 
       - name: Build docs
         run: uv run --isolated --only-group docs zensical build
-
-  benchmarks-walltime:
-    name: "walltime benchmarks (${{ matrix.project }})"
-
-    runs-on: ubuntu-latest
-
-    needs: determine_changes
-    if: ${{ (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - project: karva-benchmark-1
-            benchmark: karva_benchmark_walltime::karva_benchmark_1
-          - project: packaging
-            benchmark: karva_benchmark_walltime::packaging
-          - project: parse
-            benchmark: karva_benchmark_walltime::parse
-          - project: h11
-            benchmark: karva_benchmark_walltime::h11
-          - project: markupsafe
-            benchmark: karva_benchmark_walltime::markupsafe
-          - project: sniffio
-            benchmark: karva_benchmark_walltime::sniffio
-          - project: itsdangerous
-            benchmark: karva_benchmark_walltime::itsdangerous
-          - project: pyparsing
-            benchmark: karva_benchmark_walltime::pyparsing
-          - project: blinker
-            benchmark: karva_benchmark_walltime::blinker
-          - project: jinja
-            benchmark: karva_benchmark_walltime::jinja
-          - project: installer
-            benchmark: karva_benchmark_walltime::installer
-          - project: tomlkit
-            benchmark: karva_benchmark_walltime::tomlkit
-          - project: outcome
-            benchmark: karva_benchmark_walltime::outcome
-
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-        with:
-          persist-credentials: false
-
-      - name: "Install Rust toolchain"
-        run: rustup update && rustup show
-
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
-
-      - name: "Install cargo codspeed"
-        uses: taiki-e/install-action@a416ddeedbd372e614cc1386e8b642692f66865e # v2.57.1
-        with:
-          tool: cargo-codspeed
-
-      - name: Setup Python
-        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
-        id: setup-python
-        with:
-          python-version: ${{ env.BENCHMARK_PYTHON_VERSION }}
-
-      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
-        with:
-          python-version: ${{ env.BENCHMARK_PYTHON_VERSION }}
-
-      - name: Build wheels
-        run: |
-          uv run --no-project --with maturin maturin build
-
-      - name: Build benchmarks
-        env:
-          PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
-        run: cargo codspeed build -m walltime
-
-      - name: Run benchmarks
-        continue-on-error: true
-        uses: CodSpeedHQ/action@972e3437949c89e1357ebd1a2dbc852fcbc57245 # v4.5.1
-        env:
-          PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
-        with:
-          run: cargo codspeed run --bench karva_benchmark_walltime -- --exact ${{ matrix.benchmark }}
-          mode: walltime

--- a/.github/workflows/pr-benchmarks.yml
+++ b/.github/workflows/pr-benchmarks.yml
@@ -1,0 +1,293 @@
+name: PR Benchmarks
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/pr-benchmarks.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/**"
+      - "pyproject.toml"
+      - "python/**"
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-benchmarks-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  BENCHMARK_ITERATIONS: "3"
+  BENCHMARK_PYTHON_VERSION: "3.13"
+
+jobs:
+  benchmark-projects:
+    name: "benchmark projects"
+
+    runs-on: ubuntu-latest
+
+    outputs:
+      matrix: ${{ steps.projects.outputs.matrix }}
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: "Install Rust toolchain"
+        run: rustup show
+
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+
+      - name: Setup Python
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
+        id: setup-python
+        with:
+          python-version: ${{ env.BENCHMARK_PYTHON_VERSION }}
+
+      - name: Generate project matrix
+        id: projects
+        env:
+          PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
+        run: |
+          matrix=$(cargo run -p karva_benchmark --bin karva-benchmark -- list-projects)
+          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
+
+  build-wheels:
+    name: "build benchmark wheels"
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    outputs:
+      base_short: ${{ steps.wheels.outputs.base_short }}
+      head_short: ${{ steps.wheels.outputs.head_short }}
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: "Install Rust toolchain"
+        run: rustup show
+
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+
+      - name: Setup Python
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
+        id: setup-python
+        with:
+          python-version: ${{ env.BENCHMARK_PYTHON_VERSION }}
+
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        with:
+          python-version: ${{ env.BENCHMARK_PYTHON_VERSION }}
+
+      - name: Build comparison wheels
+        id: wheels
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
+        run: |
+          set -euo pipefail
+
+          git remote add base "https://github.com/${GITHUB_REPOSITORY}.git" 2>/dev/null || \
+            git remote set-url base "https://github.com/${GITHUB_REPOSITORY}.git"
+          git fetch --no-tags --depth=1 base "${BASE_SHA}"
+
+          base_worktree="${RUNNER_TEMP}/karva-base"
+          base_wheel_dir="${RUNNER_TEMP}/karva-wheels/base"
+          head_wheel_dir="${RUNNER_TEMP}/karva-wheels/head"
+          artifact_dir="${RUNNER_TEMP}/benchmark-wheels"
+
+          git worktree add --detach "${base_worktree}" "${BASE_SHA}"
+          (
+            cd "${base_worktree}"
+            uv run --no-project --with maturin maturin build --out "${base_wheel_dir}"
+          )
+          uv run --no-project --with maturin maturin build --out "${head_wheel_dir}"
+
+          base_wheel=$(find "${base_wheel_dir}" -maxdepth 1 -name "karva-*.whl" -print -quit)
+          head_wheel=$(find "${head_wheel_dir}" -maxdepth 1 -name "karva-*.whl" -print -quit)
+
+          if [[ -z "${base_wheel}" || -z "${head_wheel}" ]]; then
+            echo "Failed to find both benchmark wheels" >&2
+            exit 1
+          fi
+
+          mkdir -p "${artifact_dir}/base" "${artifact_dir}/head"
+          cp "${base_wheel}" "${artifact_dir}/base/"
+          cp "${head_wheel}" "${artifact_dir}/head/"
+
+          {
+            echo "base_short=${BASE_SHA::7}"
+            echo "head_short=${HEAD_SHA::7}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Upload benchmark wheels
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: benchmark-wheels
+          path: ${{ runner.temp }}/benchmark-wheels
+
+  compare-benchmarks:
+    name: "compare benchmarks (${{ matrix.project }})"
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    needs:
+      - benchmark-projects
+      - build-wheels
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.benchmark-projects.outputs.matrix) }}
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: "Install Rust toolchain"
+        run: rustup show
+
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+
+      - name: Setup Python
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
+        id: setup-python
+        with:
+          python-version: ${{ env.BENCHMARK_PYTHON_VERSION }}
+
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        with:
+          python-version: ${{ env.BENCHMARK_PYTHON_VERSION }}
+
+      - name: Build benchmark runner
+        env:
+          PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
+        run: cargo build -p karva_benchmark --bin karva-benchmark --release
+
+      - name: Download benchmark wheels
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: benchmark-wheels
+          path: ${{ runner.temp }}/benchmark-wheels
+
+      - name: Compare benchmarks
+        env:
+          BASE_LABEL: main (${{ needs.build-wheels.outputs.base_short }})
+          HEAD_LABEL: PR (${{ needs.build-wheels.outputs.head_short }})
+          PROJECT: ${{ matrix.project }}
+        run: |
+          set -euo pipefail
+
+          base_wheel=$(find "${RUNNER_TEMP}/benchmark-wheels/base" -maxdepth 1 -name "karva-*.whl" -print -quit)
+          head_wheel=$(find "${RUNNER_TEMP}/benchmark-wheels/head" -maxdepth 1 -name "karva-*.whl" -print -quit)
+          report_dir="${RUNNER_TEMP}/benchmark-reports"
+          mkdir -p "${report_dir}"
+
+          target/release/karva-benchmark compare \
+            --baseline-label "${BASE_LABEL}" \
+            --baseline-wheel "${base_wheel}" \
+            --candidate-label "${HEAD_LABEL}" \
+            --candidate-wheel "${head_wheel}" \
+            --iterations "${BENCHMARK_ITERATIONS}" \
+            --project "${PROJECT}" \
+            --output-json "${report_dir}/${PROJECT}.json" \
+            --output-markdown "${report_dir}/${PROJECT}.md"
+
+      - name: Upload benchmark report
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: benchmark-report-${{ matrix.project }}
+          path: ${{ runner.temp }}/benchmark-reports/${{ matrix.project }}.json
+
+  comment:
+    name: "comment benchmark report"
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+
+    needs:
+      - benchmark-projects
+      - build-wheels
+      - compare-benchmarks
+
+    if: ${{ needs.compare-benchmarks.result == 'success' }}
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: "Install Rust toolchain"
+        run: rustup show
+
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+
+      - name: Setup Python
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
+        id: setup-python
+        with:
+          python-version: ${{ env.BENCHMARK_PYTHON_VERSION }}
+
+      - name: Download benchmark reports
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: benchmark-report-*
+          merge-multiple: true
+          path: ${{ runner.temp }}/benchmark-reports
+
+      - name: Merge benchmark reports
+        env:
+          PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
+        run: |
+          cargo run -p karva_benchmark --bin karva-benchmark -- merge-reports \
+            --input-dir "${RUNNER_TEMP}/benchmark-reports" \
+            --output-markdown "${RUNNER_TEMP}/benchmark-report.md"
+
+      - name: Comment benchmark report
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          marker="<!-- karva-benchmark-comparison -->"
+          report_path="${RUNNER_TEMP}/benchmark-report.md"
+          payload_path="${RUNNER_TEMP}/benchmark-comment.json"
+
+          comment_id=$(
+            gh api --paginate "/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"${marker}\"))) | .id" \
+              | tail -n 1
+          )
+
+          jq -n --rawfile body "${report_path}" '{body: $body}' > "${payload_path}"
+
+          if [[ -n "${comment_id}" ]]; then
+            gh api --method PATCH "/repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" \
+              --input "${payload_path}"
+          else
+            gh api --method POST "/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              --input "${payload_path}"
+          fi

--- a/.github/workflows/pr-benchmarks.yml
+++ b/.github/workflows/pr-benchmarks.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  BENCHMARK_ITERATIONS: "3"
+  BENCHMARK_ITERATIONS: "9"
   BENCHMARK_PYTHON_VERSION: "3.13"
 
 jobs:

--- a/.github/workflows/pr-benchmarks.yml
+++ b/.github/workflows/pr-benchmarks.yml
@@ -19,7 +19,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  BENCHMARK_ITERATIONS: "9"
   BENCHMARK_PYTHON_VERSION: "3.13"
 
 jobs:
@@ -189,6 +188,7 @@ jobs:
         env:
           BASE_LABEL: main (${{ needs.build-wheels.outputs.base_short }})
           HEAD_LABEL: PR (${{ needs.build-wheels.outputs.head_short }})
+          ITERATIONS: ${{ matrix.iterations }}
           PROJECT: ${{ matrix.project }}
         run: |
           set -euo pipefail
@@ -203,7 +203,7 @@ jobs:
             --baseline-wheel "${base_wheel}" \
             --candidate-label "${HEAD_LABEL}" \
             --candidate-wheel "${head_wheel}" \
-            --iterations "${BENCHMARK_ITERATIONS}" \
+            --iterations "${ITERATIONS}" \
             --project "${PROJECT}" \
             --output-json "${report_dir}/${PROJECT}.json" \
             --output-markdown "${report_dir}/${PROJECT}.md"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,10 +113,12 @@ just test
 ### Benchmarks
 
 Karva has a pinned wall-time benchmark suite for CI. It includes the synthetic
-`karva-benchmark-1` project plus selected open-source projects that Karva can
-run cleanly today. CI shards the suite by benchmark project so independent
-projects can run in parallel, and each shard runs one exact Divan benchmark
-through CodSpeed.
+`karva-benchmark-1` project plus selected open-source projects that the
+installed Karva CLI can run cleanly today. Pull requests build both the base
+commit and the PR commit as wheels, then run each CLI-compatible open-source
+benchmark project as a separate matrix job. Each matrix job compares base and PR
+wheels on the same GitHub Actions runner, and the benchmark workflow posts one
+sticky PR comment with the merged median CLI wall-time results.
 
 ### Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,8 +117,9 @@ Karva has a pinned wall-time benchmark suite for CI. It includes the synthetic
 installed Karva CLI can run cleanly today. Pull requests build both the base
 commit and the PR commit as wheels, then run each CLI-compatible open-source
 benchmark project as a separate matrix job. Each matrix job compares base and PR
-wheels on the same GitHub Actions runner, and the benchmark workflow posts one
-sticky PR comment with the merged median CLI wall-time results.
+wheels on the same GitHub Actions runner using a project-specific iteration
+count, and the benchmark workflow posts one sticky PR comment with the merged
+median CLI wall-time results.
 
 ### Documentation
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1081,6 +1081,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "camino",
+ "clap",
  "codspeed-divan-compat",
  "karva_cache",
  "karva_cli",

--- a/crates/karva_benchmark/Cargo.toml
+++ b/crates/karva_benchmark/Cargo.toml
@@ -11,9 +11,14 @@ documentation = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
 
+[[bin]]
+name = "karva-benchmark"
+path = "src/bin/karva_benchmark.rs"
+
 [dependencies]
 anyhow = { workspace = true }
 camino = { workspace = true }
+clap = { workspace = true }
 divan = { workspace = true }
 karva_cache = { workspace = true }
 karva_cli = { workspace = true }

--- a/crates/karva_benchmark/src/bin/karva_benchmark.rs
+++ b/crates/karva_benchmark/src/bin/karva_benchmark.rs
@@ -101,6 +101,13 @@ struct Measurement {
     median_secs: f64,
 }
 
+#[derive(Debug, Default)]
+struct ReportSummary {
+    faster: usize,
+    slower: usize,
+    unchanged: usize,
+}
+
 struct Subject<'a> {
     label: &'a str,
     wheel: &'a Utf8Path,
@@ -406,14 +413,34 @@ fn create_parent_dir(path: &Utf8Path) -> Result<()> {
 fn markdown_report(report: &ComparisonReport) -> std::result::Result<String, std::fmt::Error> {
     use std::fmt::Write as _;
 
+    let summary = ReportSummary::new(&report.projects);
     let mut body = String::from("<!-- karva-benchmark-comparison -->\n");
-    body.push_str("### Karva benchmark comparison\n\n");
+    writeln!(body, "### {}", verdict(&summary))?;
+    writeln!(body)?;
     writeln!(
         body,
-        "Baseline: `{}`. Candidate: `{}`. Each row is a median CLI wall-time measurement on one runner, alternating install order. Runs are configured per project. Lower is better. Karva runs with one worker and no cache. Only projects with at least {:.1}% median change are shown.",
-        report.baseline_label, report.candidate_label, MATERIAL_CHANGE_PERCENT
+        "Baseline: `{}`. Candidate: `{}`. Each benchmark compares median CLI wall time on one GitHub Actions runner, alternating install order. Runs are configured per project. Lower is better.",
+        report.baseline_label, report.candidate_label
     )?;
     writeln!(body)?;
+    write_summary_line(&mut body, ":zap:", summary.faster, "improved benchmark")?;
+    write_summary_line(&mut body, ":x:", summary.slower, "regressed benchmark")?;
+    write_summary_line(
+        &mut body,
+        ":white_check_mark:",
+        summary.unchanged,
+        "unchanged benchmark",
+    )?;
+    writeln!(body)?;
+
+    if summary.slower > 0 {
+        writeln!(body, "> [!WARNING]")?;
+        writeln!(
+            body,
+            "> Benchmark regressions were detected. Review the wall-time changes before merging."
+        )?;
+        writeln!(body)?;
+    }
 
     let visible_projects = report
         .projects
@@ -429,23 +456,62 @@ fn markdown_report(report: &ComparisonReport) -> std::result::Result<String, std
         return Ok(body);
     }
 
-    body.push_str("| Project | Runs | Baseline | Candidate | Change | Result |\n");
-    body.push_str("| --- | ---: | ---: | ---: | ---: | --- |\n");
+    body.push_str("#### Performance Changes\n\n");
+    body.push_str("|  | Mode | Benchmark | Base | Head | Change | Runs |\n");
+    body.push_str("| --- | --- | --- | ---: | ---: | ---: | ---: |\n");
 
     for project in visible_projects {
         writeln!(
             body,
-            "| {} | {} | {} | {} | {} | {} |",
+            "| {} | WallTime | `{}` | {} | {} | {} | {} |",
+            trend_marker(project.percent_change),
             project.name,
-            project.iterations,
             format_seconds(project.baseline.median_secs),
             format_seconds(project.candidate.median_secs),
             format_percent(project.percent_change),
-            trend(project.percent_change),
+            project.iterations,
         )?;
     }
 
     Ok(body)
+}
+
+impl ReportSummary {
+    fn new(projects: &[ProjectComparison]) -> Self {
+        let mut summary = Self::default();
+
+        for project in projects {
+            match trend(project.percent_change) {
+                "faster" => summary.faster += 1,
+                "slower" => summary.slower += 1,
+                _ => summary.unchanged += 1,
+            }
+        }
+
+        summary
+    }
+}
+
+fn verdict(summary: &ReportSummary) -> &'static str {
+    if summary.slower > 0 {
+        "Merging this PR may alter performance"
+    } else if summary.faster > 0 {
+        "Merging this PR improves performance"
+    } else {
+        "Merging this PR will not alter performance"
+    }
+}
+
+fn write_summary_line(
+    body: &mut String,
+    marker: &str,
+    count: usize,
+    singular_label: &str,
+) -> std::result::Result<(), std::fmt::Error> {
+    use std::fmt::Write as _;
+
+    let suffix = if count == 1 { "" } else { "s" };
+    writeln!(body, "{marker} **{count}** {singular_label}{suffix}")
 }
 
 fn matrix_iterations(project_name: &str) -> usize {
@@ -468,6 +534,14 @@ fn trend(percent_change: f64) -> &'static str {
 
 fn is_material_change(percent_change: f64) -> bool {
     percent_change.abs() >= MATERIAL_CHANGE_PERCENT
+}
+
+fn trend_marker(percent_change: f64) -> &'static str {
+    match trend(percent_change) {
+        "faster" => ":zap:",
+        "slower" => ":x:",
+        _ => ":white_check_mark:",
+    }
 }
 
 fn median(values: &[f64]) -> f64 {
@@ -549,8 +623,19 @@ mod tests {
         let markdown = markdown_report(&report).expect("report should render");
 
         assert!(!markdown.contains("flat-project"));
-        assert!(markdown.contains("| faster-project | 21 | 1.000 s | 990.0 ms | -1.0% | faster |"));
-        assert!(markdown.contains("| slower-project | 15 | 1.000 s | 1.012 s | +1.2% | slower |"));
+        assert!(markdown.contains(":zap: **1** improved benchmark"));
+        assert!(markdown.contains(":x: **1** regressed benchmark"));
+        assert!(markdown.contains(":white_check_mark: **1** unchanged benchmark"));
+        assert!(markdown.contains("> [!WARNING]"));
+        assert!(
+            markdown.contains(
+                "| :zap: | WallTime | `faster-project` | 1.000 s | 990.0 ms | -1.0% | 21 |"
+            )
+        );
+        assert!(
+            markdown
+                .contains("| :x: | WallTime | `slower-project` | 1.000 s | 1.012 s | +1.2% | 15 |")
+        );
     }
 
     #[test]
@@ -560,7 +645,9 @@ mod tests {
         let markdown = markdown_report(&report).expect("report should render");
 
         assert!(markdown.contains("No project changed by at least 1.0%."));
-        assert!(!markdown.contains("| Project | Runs | Baseline | Candidate | Change | Result |"));
+        assert!(markdown.contains("Merging this PR will not alter performance"));
+        assert!(!markdown.contains("|  | Mode | Benchmark | Base | Head | Change | Runs |"));
+        assert!(!markdown.contains("> [!WARNING]"));
         assert!(!markdown.contains("flat-project"));
     }
 

--- a/crates/karva_benchmark/src/bin/karva_benchmark.rs
+++ b/crates/karva_benchmark/src/bin/karva_benchmark.rs
@@ -12,6 +12,9 @@ use karva_benchmark::{BENCHMARK_PROJECTS, BenchmarkProject, CLI_BENCHMARK_PROJEC
 use serde::{Deserialize, Serialize};
 
 const MATERIAL_CHANGE_PERCENT: f64 = 1.0;
+const FAST_PROJECT_ITERATIONS: usize = 21;
+const MEDIUM_PROJECT_ITERATIONS: usize = 15;
+const SLOW_PROJECT_ITERATIONS: usize = 9;
 
 #[derive(Debug, Parser)]
 #[command(about = "Run Karva benchmark comparisons")]
@@ -71,6 +74,7 @@ struct Matrix {
 #[derive(Debug, Serialize)]
 struct MatrixProject {
     project: &'static str,
+    iterations: usize,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -79,13 +83,13 @@ struct ComparisonReport {
     baseline_wheel: Utf8PathBuf,
     candidate_label: String,
     candidate_wheel: Utf8PathBuf,
-    iterations: usize,
     projects: Vec<ProjectComparison>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 struct ProjectComparison {
     name: String,
+    iterations: usize,
     baseline: Measurement,
     candidate: Measurement,
     percent_change: f64,
@@ -119,6 +123,7 @@ fn list_projects() -> Result<()> {
             .iter()
             .map(|project| MatrixProject {
                 project: project.name,
+                iterations: matrix_iterations(project.name),
             })
             .collect(),
     };
@@ -173,6 +178,7 @@ fn compare(args: CompareArgs) -> Result<()> {
 
         comparisons.push(ProjectComparison {
             name: config.name.to_string(),
+            iterations: args.iterations,
             baseline,
             candidate,
             percent_change,
@@ -184,7 +190,6 @@ fn compare(args: CompareArgs) -> Result<()> {
         baseline_wheel,
         candidate_label: args.candidate_label,
         candidate_wheel,
-        iterations: args.iterations,
         projects: comparisons,
     };
 
@@ -227,11 +232,6 @@ fn merge_report_files(input_dir: &Utf8Path) -> Result<ComparisonReport> {
             report.candidate_label == merged.candidate_label,
             "Benchmark reports use different candidate labels"
         );
-        anyhow::ensure!(
-            report.iterations == merged.iterations,
-            "Benchmark reports use different iteration counts"
-        );
-
         for project in report.projects {
             anyhow::ensure!(
                 seen.insert(project.name.clone()),
@@ -406,21 +406,12 @@ fn create_parent_dir(path: &Utf8Path) -> Result<()> {
 fn markdown_report(report: &ComparisonReport) -> std::result::Result<String, std::fmt::Error> {
     use std::fmt::Write as _;
 
-    let run_word = if report.iterations == 1 {
-        "run"
-    } else {
-        "runs"
-    };
     let mut body = String::from("<!-- karva-benchmark-comparison -->\n");
     body.push_str("### Karva benchmark comparison\n\n");
     writeln!(
         body,
-        "Baseline: `{}`. Candidate: `{}`. Each row is the median of {} CLI {} on one runner, alternating install order. Lower is better. Karva runs with one worker and no cache. Only projects with at least {:.1}% median change are shown.",
-        report.baseline_label,
-        report.candidate_label,
-        report.iterations,
-        run_word,
-        MATERIAL_CHANGE_PERCENT
+        "Baseline: `{}`. Candidate: `{}`. Each row is a median CLI wall-time measurement on one runner, alternating install order. Runs are configured per project. Lower is better. Karva runs with one worker and no cache. Only projects with at least {:.1}% median change are shown.",
+        report.baseline_label, report.candidate_label, MATERIAL_CHANGE_PERCENT
     )?;
     writeln!(body)?;
 
@@ -438,14 +429,15 @@ fn markdown_report(report: &ComparisonReport) -> std::result::Result<String, std
         return Ok(body);
     }
 
-    body.push_str("| Project | Baseline | Candidate | Change | Result |\n");
-    body.push_str("| --- | ---: | ---: | ---: | --- |\n");
+    body.push_str("| Project | Runs | Baseline | Candidate | Change | Result |\n");
+    body.push_str("| --- | ---: | ---: | ---: | ---: | --- |\n");
 
     for project in visible_projects {
         writeln!(
             body,
-            "| {} | {} | {} | {} | {} |",
+            "| {} | {} | {} | {} | {} | {} |",
             project.name,
+            project.iterations,
             format_seconds(project.baseline.median_secs),
             format_seconds(project.candidate.median_secs),
             format_percent(project.percent_change),
@@ -454,6 +446,14 @@ fn markdown_report(report: &ComparisonReport) -> std::result::Result<String, std
     }
 
     Ok(body)
+}
+
+fn matrix_iterations(project_name: &str) -> usize {
+    match project_name {
+        "packaging" | "pyparsing" => SLOW_PROJECT_ITERATIONS,
+        "tomlkit" => MEDIUM_PROJECT_ITERATIONS,
+        _ => FAST_PROJECT_ITERATIONS,
+    }
 }
 
 fn trend(percent_change: f64) -> &'static str {
@@ -533,31 +533,34 @@ fn utf8_path(path: PathBuf) -> Result<Utf8PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::{ComparisonReport, Measurement, ProjectComparison, markdown_report, trend};
+    use super::{
+        ComparisonReport, FAST_PROJECT_ITERATIONS, MEDIUM_PROJECT_ITERATIONS, Measurement,
+        ProjectComparison, SLOW_PROJECT_ITERATIONS, markdown_report, matrix_iterations, trend,
+    };
 
     #[test]
     fn markdown_report_omits_projects_under_material_change_threshold() {
         let report = report_with_projects(vec![
-            project("flat-project", 1.0, 1.004),
-            project("faster-project", 1.0, 0.99),
-            project("slower-project", 1.0, 1.012),
+            project("flat-project", 21, 1.0, 1.004),
+            project("faster-project", 21, 1.0, 0.99),
+            project("slower-project", 15, 1.0, 1.012),
         ]);
 
         let markdown = markdown_report(&report).expect("report should render");
 
         assert!(!markdown.contains("flat-project"));
-        assert!(markdown.contains("| faster-project | 1.000 s | 990.0 ms | -1.0% | faster |"));
-        assert!(markdown.contains("| slower-project | 1.000 s | 1.012 s | +1.2% | slower |"));
+        assert!(markdown.contains("| faster-project | 21 | 1.000 s | 990.0 ms | -1.0% | faster |"));
+        assert!(markdown.contains("| slower-project | 15 | 1.000 s | 1.012 s | +1.2% | slower |"));
     }
 
     #[test]
     fn markdown_report_says_when_all_projects_are_under_material_change_threshold() {
-        let report = report_with_projects(vec![project("flat-project", 1.0, 1.004)]);
+        let report = report_with_projects(vec![project("flat-project", 21, 1.0, 1.004)]);
 
         let markdown = markdown_report(&report).expect("report should render");
 
         assert!(markdown.contains("No project changed by at least 1.0%."));
-        assert!(!markdown.contains("| Project | Baseline | Candidate | Change | Result |"));
+        assert!(!markdown.contains("| Project | Runs | Baseline | Candidate | Change | Result |"));
         assert!(!markdown.contains("flat-project"));
     }
 
@@ -569,20 +572,29 @@ mod tests {
         assert_eq!(trend(-0.9), "flat");
     }
 
+    #[test]
+    fn matrix_iterations_are_higher_for_fast_projects() {
+        assert_eq!(matrix_iterations("sniffio"), FAST_PROJECT_ITERATIONS);
+        assert_eq!(matrix_iterations("h11"), FAST_PROJECT_ITERATIONS);
+        assert_eq!(matrix_iterations("tomlkit"), MEDIUM_PROJECT_ITERATIONS);
+        assert_eq!(matrix_iterations("packaging"), SLOW_PROJECT_ITERATIONS);
+        assert_eq!(matrix_iterations("pyparsing"), SLOW_PROJECT_ITERATIONS);
+    }
+
     fn report_with_projects(projects: Vec<ProjectComparison>) -> ComparisonReport {
         ComparisonReport {
             baseline_label: "main".to_string(),
             baseline_wheel: "baseline.whl".into(),
             candidate_label: "PR".to_string(),
             candidate_wheel: "candidate.whl".into(),
-            iterations: 3,
             projects,
         }
     }
 
-    fn project(name: &str, baseline: f64, candidate: f64) -> ProjectComparison {
+    fn project(name: &str, iterations: usize, baseline: f64, candidate: f64) -> ProjectComparison {
         ProjectComparison {
             name: name.to_string(),
+            iterations,
             baseline: measurement(baseline),
             candidate: measurement(candidate),
             percent_change: super::percent_change(baseline, candidate),

--- a/crates/karva_benchmark/src/bin/karva_benchmark.rs
+++ b/crates/karva_benchmark/src/bin/karva_benchmark.rs
@@ -11,6 +11,8 @@ use clap::Parser;
 use karva_benchmark::{BENCHMARK_PROJECTS, BenchmarkProject, CLI_BENCHMARK_PROJECTS, WORKER_COUNT};
 use serde::{Deserialize, Serialize};
 
+const MATERIAL_CHANGE_PERCENT: f64 = 1.0;
+
 #[derive(Debug, Parser)]
 #[command(about = "Run Karva benchmark comparisons")]
 struct Cli {
@@ -413,14 +415,33 @@ fn markdown_report(report: &ComparisonReport) -> std::result::Result<String, std
     body.push_str("### Karva benchmark comparison\n\n");
     writeln!(
         body,
-        "Baseline: `{}`. Candidate: `{}`. Each row is the median of {} CLI {} on one runner, alternating install order. Lower is better. Karva runs with one worker and no cache.",
-        report.baseline_label, report.candidate_label, report.iterations, run_word
+        "Baseline: `{}`. Candidate: `{}`. Each row is the median of {} CLI {} on one runner, alternating install order. Lower is better. Karva runs with one worker and no cache. Only projects with at least {:.1}% median change are shown.",
+        report.baseline_label,
+        report.candidate_label,
+        report.iterations,
+        run_word,
+        MATERIAL_CHANGE_PERCENT
     )?;
     writeln!(body)?;
+
+    let visible_projects = report
+        .projects
+        .iter()
+        .filter(|project| is_material_change(project.percent_change))
+        .collect::<Vec<_>>();
+
+    if visible_projects.is_empty() {
+        writeln!(
+            body,
+            "No project changed by at least {MATERIAL_CHANGE_PERCENT:.1}%."
+        )?;
+        return Ok(body);
+    }
+
     body.push_str("| Project | Baseline | Candidate | Change | Result |\n");
     body.push_str("| --- | ---: | ---: | ---: | --- |\n");
 
-    for project in &report.projects {
+    for project in visible_projects {
         writeln!(
             body,
             "| {} | {} | {} | {} | {} |",
@@ -436,13 +457,17 @@ fn markdown_report(report: &ComparisonReport) -> std::result::Result<String, std
 }
 
 fn trend(percent_change: f64) -> &'static str {
-    if percent_change <= -1.0 {
+    if percent_change <= -MATERIAL_CHANGE_PERCENT {
         "faster"
-    } else if percent_change >= 1.0 {
+    } else if percent_change >= MATERIAL_CHANGE_PERCENT {
         "slower"
     } else {
         "flat"
     }
+}
+
+fn is_material_change(percent_change: f64) -> bool {
+    percent_change.abs() >= MATERIAL_CHANGE_PERCENT
 }
 
 fn median(values: &[f64]) -> f64 {
@@ -504,4 +529,70 @@ fn path_with_venv_first(bin_dir: &Utf8Path) -> Result<std::ffi::OsString> {
 fn utf8_path(path: PathBuf) -> Result<Utf8PathBuf> {
     Utf8PathBuf::from_path_buf(path)
         .map_err(|path| anyhow::anyhow!("Path is not valid UTF-8: {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ComparisonReport, Measurement, ProjectComparison, markdown_report, trend};
+
+    #[test]
+    fn markdown_report_omits_projects_under_material_change_threshold() {
+        let report = report_with_projects(vec![
+            project("flat-project", 1.0, 1.004),
+            project("faster-project", 1.0, 0.99),
+            project("slower-project", 1.0, 1.012),
+        ]);
+
+        let markdown = markdown_report(&report).expect("report should render");
+
+        assert!(!markdown.contains("flat-project"));
+        assert!(markdown.contains("| faster-project | 1.000 s | 990.0 ms | -1.0% | faster |"));
+        assert!(markdown.contains("| slower-project | 1.000 s | 1.012 s | +1.2% | slower |"));
+    }
+
+    #[test]
+    fn markdown_report_says_when_all_projects_are_under_material_change_threshold() {
+        let report = report_with_projects(vec![project("flat-project", 1.0, 1.004)]);
+
+        let markdown = markdown_report(&report).expect("report should render");
+
+        assert!(markdown.contains("No project changed by at least 1.0%."));
+        assert!(!markdown.contains("| Project | Baseline | Candidate | Change | Result |"));
+        assert!(!markdown.contains("flat-project"));
+    }
+
+    #[test]
+    fn trend_uses_material_change_threshold() {
+        assert_eq!(trend(-1.0), "faster");
+        assert_eq!(trend(1.0), "slower");
+        assert_eq!(trend(0.9), "flat");
+        assert_eq!(trend(-0.9), "flat");
+    }
+
+    fn report_with_projects(projects: Vec<ProjectComparison>) -> ComparisonReport {
+        ComparisonReport {
+            baseline_label: "main".to_string(),
+            baseline_wheel: "baseline.whl".into(),
+            candidate_label: "PR".to_string(),
+            candidate_wheel: "candidate.whl".into(),
+            iterations: 3,
+            projects,
+        }
+    }
+
+    fn project(name: &str, baseline: f64, candidate: f64) -> ProjectComparison {
+        ProjectComparison {
+            name: name.to_string(),
+            baseline: measurement(baseline),
+            candidate: measurement(candidate),
+            percent_change: super::percent_change(baseline, candidate),
+        }
+    }
+
+    fn measurement(median_secs: f64) -> Measurement {
+        Measurement {
+            durations_secs: vec![median_secs],
+            median_secs,
+        }
+    }
 }

--- a/crates/karva_benchmark/src/bin/karva_benchmark.rs
+++ b/crates/karva_benchmark/src/bin/karva_benchmark.rs
@@ -1,0 +1,507 @@
+use std::fs::File;
+use std::io::Write as _;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, Instant};
+use std::{collections::HashSet, io};
+
+use anyhow::{Context as _, Result};
+use camino::{Utf8Path, Utf8PathBuf};
+use clap::Parser;
+use karva_benchmark::{BENCHMARK_PROJECTS, BenchmarkProject, CLI_BENCHMARK_PROJECTS, WORKER_COUNT};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Parser)]
+#[command(about = "Run Karva benchmark comparisons")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Debug, clap::Subcommand)]
+enum Commands {
+    Compare(CompareArgs),
+    ListProjects,
+    MergeReports(MergeReportsArgs),
+}
+
+#[derive(Debug, Parser)]
+struct CompareArgs {
+    #[arg(long)]
+    baseline_label: String,
+
+    #[arg(long, value_name = "PATH")]
+    baseline_wheel: PathBuf,
+
+    #[arg(long)]
+    candidate_label: String,
+
+    #[arg(long, value_name = "PATH")]
+    candidate_wheel: PathBuf,
+
+    #[arg(long, default_value_t = 3)]
+    iterations: usize,
+
+    #[arg(long = "project", value_name = "NAME")]
+    projects: Vec<String>,
+
+    #[arg(long, value_name = "PATH")]
+    output_json: PathBuf,
+
+    #[arg(long, value_name = "PATH")]
+    output_markdown: PathBuf,
+}
+
+#[derive(Debug, Parser)]
+struct MergeReportsArgs {
+    #[arg(long, value_name = "PATH")]
+    input_dir: PathBuf,
+
+    #[arg(long, value_name = "PATH")]
+    output_markdown: PathBuf,
+}
+
+#[derive(Debug, Serialize)]
+struct Matrix {
+    include: Vec<MatrixProject>,
+}
+
+#[derive(Debug, Serialize)]
+struct MatrixProject {
+    project: &'static str,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ComparisonReport {
+    baseline_label: String,
+    baseline_wheel: Utf8PathBuf,
+    candidate_label: String,
+    candidate_wheel: Utf8PathBuf,
+    iterations: usize,
+    projects: Vec<ProjectComparison>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ProjectComparison {
+    name: String,
+    baseline: Measurement,
+    candidate: Measurement,
+    percent_change: f64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Measurement {
+    durations_secs: Vec<f64>,
+    median_secs: f64,
+}
+
+struct Subject<'a> {
+    label: &'a str,
+    wheel: &'a Utf8Path,
+    durations: &'a mut Vec<f64>,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Compare(args) => compare(args),
+        Commands::ListProjects => list_projects(),
+        Commands::MergeReports(args) => merge_reports(args),
+    }
+}
+
+fn list_projects() -> Result<()> {
+    let matrix = Matrix {
+        include: CLI_BENCHMARK_PROJECTS
+            .iter()
+            .map(|project| MatrixProject {
+                project: project.name,
+            })
+            .collect(),
+    };
+
+    serde_json::to_writer(io::stdout(), &matrix).context("Failed to write benchmark matrix")?;
+    println!();
+
+    Ok(())
+}
+
+fn compare(args: CompareArgs) -> Result<()> {
+    anyhow::ensure!(args.iterations > 0, "iterations must be greater than zero");
+
+    let baseline_wheel = utf8_path(args.baseline_wheel)?;
+    let candidate_wheel = utf8_path(args.candidate_wheel)?;
+    let output_json = utf8_path(args.output_json)?;
+    let output_markdown = utf8_path(args.output_markdown)?;
+    let projects = selected_projects(&args.projects)?;
+    let mut comparisons = Vec::with_capacity(projects.len());
+
+    for config in projects {
+        eprintln!("Preparing benchmark project `{}`", config.name);
+        let project = karva_benchmark::prepare_benchmark_project_environment(config)
+            .with_context(|| format!("Failed to prepare benchmark project `{}`", config.name))?;
+        let mut baseline_durations = Vec::with_capacity(args.iterations);
+        let mut candidate_durations = Vec::with_capacity(args.iterations);
+
+        for iteration in 0..args.iterations {
+            let mut baseline = Subject {
+                label: &args.baseline_label,
+                wheel: &baseline_wheel,
+                durations: &mut baseline_durations,
+            };
+            let mut candidate = Subject {
+                label: &args.candidate_label,
+                wheel: &candidate_wheel,
+                durations: &mut candidate_durations,
+            };
+
+            if iteration % 2 == 0 {
+                run_subject(config, project.cwd(), &mut baseline)?;
+                run_subject(config, project.cwd(), &mut candidate)?;
+            } else {
+                run_subject(config, project.cwd(), &mut candidate)?;
+                run_subject(config, project.cwd(), &mut baseline)?;
+            }
+        }
+
+        let baseline = Measurement::new(baseline_durations);
+        let candidate = Measurement::new(candidate_durations);
+        let percent_change = percent_change(baseline.median_secs, candidate.median_secs);
+
+        comparisons.push(ProjectComparison {
+            name: config.name.to_string(),
+            baseline,
+            candidate,
+            percent_change,
+        });
+    }
+
+    let report = ComparisonReport {
+        baseline_label: args.baseline_label,
+        baseline_wheel,
+        candidate_label: args.candidate_label,
+        candidate_wheel,
+        iterations: args.iterations,
+        projects: comparisons,
+    };
+
+    write_json(&output_json, &report)?;
+    write_markdown(&output_markdown, &report)?;
+
+    Ok(())
+}
+
+fn merge_reports(args: MergeReportsArgs) -> Result<()> {
+    let input_dir = utf8_path(args.input_dir)?;
+    let output_markdown = utf8_path(args.output_markdown)?;
+    let report = merge_report_files(&input_dir)?;
+
+    write_markdown(&output_markdown, &report)
+}
+
+fn merge_report_files(input_dir: &Utf8Path) -> Result<ComparisonReport> {
+    let mut reports = read_report_files(input_dir)?;
+    let first = reports
+        .pop()
+        .ok_or_else(|| anyhow::anyhow!("No benchmark reports found in `{input_dir}`"))?;
+    let mut merged = first;
+    let mut seen = HashSet::new();
+
+    for project in &merged.projects {
+        anyhow::ensure!(
+            seen.insert(project.name.clone()),
+            "Duplicate benchmark report for `{}`",
+            project.name
+        );
+    }
+
+    for report in reports {
+        anyhow::ensure!(
+            report.baseline_label == merged.baseline_label,
+            "Benchmark reports use different baseline labels"
+        );
+        anyhow::ensure!(
+            report.candidate_label == merged.candidate_label,
+            "Benchmark reports use different candidate labels"
+        );
+        anyhow::ensure!(
+            report.iterations == merged.iterations,
+            "Benchmark reports use different iteration counts"
+        );
+
+        for project in report.projects {
+            anyhow::ensure!(
+                seen.insert(project.name.clone()),
+                "Duplicate benchmark report for `{}`",
+                project.name
+            );
+            merged.projects.push(project);
+        }
+    }
+
+    merged.projects.sort_by_key(|project| {
+        BENCHMARK_PROJECTS
+            .iter()
+            .position(|config| config.name == project.name)
+            .unwrap_or(BENCHMARK_PROJECTS.len())
+    });
+
+    Ok(merged)
+}
+
+fn read_report_files(input_dir: &Utf8Path) -> Result<Vec<ComparisonReport>> {
+    let mut reports = Vec::new();
+    for entry in std::fs::read_dir(input_dir)
+        .with_context(|| format!("Failed to read benchmark report directory `{input_dir}`"))?
+    {
+        let entry =
+            entry.with_context(|| format!("Failed to read entry in directory `{input_dir}`"))?;
+        let path = Utf8PathBuf::from_path_buf(entry.path()).map_err(|path| {
+            anyhow::anyhow!(
+                "Benchmark report path is not valid UTF-8: {}",
+                path.display()
+            )
+        })?;
+        if path
+            .extension()
+            .is_none_or(|extension| !extension.eq_ignore_ascii_case("json"))
+        {
+            continue;
+        }
+
+        let file = File::open(&path)
+            .with_context(|| format!("Failed to open benchmark report `{path}`"))?;
+        let report = serde_json::from_reader(file)
+            .with_context(|| format!("Failed to parse benchmark report `{path}`"))?;
+        reports.push(report);
+    }
+
+    Ok(reports)
+}
+
+impl Measurement {
+    fn new(durations_secs: Vec<f64>) -> Self {
+        Self {
+            median_secs: median(&durations_secs),
+            durations_secs,
+        }
+    }
+}
+
+fn selected_projects(names: &[String]) -> Result<Vec<&'static BenchmarkProject>> {
+    if names.is_empty() {
+        return Ok(BENCHMARK_PROJECTS.iter().collect());
+    }
+
+    let mut projects = Vec::with_capacity(names.len());
+    for name in names {
+        let Some(project) = karva_benchmark::find_benchmark_project(name) else {
+            let available = BENCHMARK_PROJECTS
+                .iter()
+                .map(|project| project.name)
+                .collect::<Vec<_>>()
+                .join(", ");
+            anyhow::bail!("Unknown benchmark project `{name}`. Available projects: {available}");
+        };
+        projects.push(project);
+    }
+
+    Ok(projects)
+}
+
+fn run_subject(
+    config: &BenchmarkProject,
+    project_root: &Utf8Path,
+    subject: &mut Subject<'_>,
+) -> Result<()> {
+    karva_benchmark::install_benchmark_tools(config, project_root, subject.wheel)
+        .with_context(|| format!("Failed to install `{}` benchmark wheel", subject.label))?;
+    karva_benchmark::clean_project_cache(project_root)
+        .with_context(|| format!("Failed to clean benchmark cache for `{}`", config.name))?;
+
+    let duration = run_project_cli(config, project_root)
+        .with_context(|| format!("Failed to run `{}` with `{}`", config.name, subject.label))?;
+    subject.durations.push(duration.as_secs_f64());
+
+    eprintln!(
+        "{} / {}: {}",
+        config.name,
+        subject.label,
+        format_seconds(duration.as_secs_f64())
+    );
+
+    Ok(())
+}
+
+fn run_project_cli(config: &BenchmarkProject, project_root: &Utf8Path) -> Result<Duration> {
+    let bin_dir = venv_bin_dir(project_root);
+    let binary = bin_dir.join(executable_name("karva"));
+    let path = path_with_venv_first(&bin_dir)?;
+    let worker_count = WORKER_COUNT.to_string();
+
+    let mut command = Command::new(&binary);
+    command.current_dir(project_root).env("PATH", path).args([
+        "test",
+        "--num-workers",
+        &worker_count,
+        "--no-cache",
+        "--no-ignore",
+        "--output-format",
+        "concise",
+        "--status-level",
+        "none",
+        "--final-status-level",
+        "none",
+    ]);
+
+    if config.try_import_fixtures {
+        command.arg("--try-import-fixtures");
+    }
+    command.args(config.paths);
+
+    let start = Instant::now();
+    let output = command
+        .output()
+        .with_context(|| format!("Failed to execute `{binary}`"))?;
+    let elapsed = start.elapsed();
+
+    anyhow::ensure!(
+        output.status.success(),
+        "Karva exited with status {} for `{}`\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        config.name,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    Ok(elapsed)
+}
+
+fn write_json(path: &Utf8Path, report: &ComparisonReport) -> Result<()> {
+    create_parent_dir(path)?;
+    let mut file = File::create(path).with_context(|| format!("Failed to create `{path}`"))?;
+    serde_json::to_writer_pretty(&mut file, report)
+        .with_context(|| format!("Failed to write `{path}`"))?;
+    writeln!(file).with_context(|| format!("Failed to finish writing `{path}`"))?;
+    Ok(())
+}
+
+fn write_markdown(path: &Utf8Path, report: &ComparisonReport) -> Result<()> {
+    create_parent_dir(path)?;
+    let body = markdown_report(report).context("Failed to render markdown benchmark report")?;
+    std::fs::write(path, body).with_context(|| format!("Failed to write `{path}`"))
+}
+
+fn create_parent_dir(path: &Utf8Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create parent directory `{parent}`"))?;
+    }
+    Ok(())
+}
+
+fn markdown_report(report: &ComparisonReport) -> std::result::Result<String, std::fmt::Error> {
+    use std::fmt::Write as _;
+
+    let run_word = if report.iterations == 1 {
+        "run"
+    } else {
+        "runs"
+    };
+    let mut body = String::from("<!-- karva-benchmark-comparison -->\n");
+    body.push_str("### Karva benchmark comparison\n\n");
+    writeln!(
+        body,
+        "Baseline: `{}`. Candidate: `{}`. Each row is the median of {} CLI {} on one runner, alternating install order. Lower is better. Karva runs with one worker and no cache.",
+        report.baseline_label, report.candidate_label, report.iterations, run_word
+    )?;
+    writeln!(body)?;
+    body.push_str("| Project | Baseline | Candidate | Change | Result |\n");
+    body.push_str("| --- | ---: | ---: | ---: | --- |\n");
+
+    for project in &report.projects {
+        writeln!(
+            body,
+            "| {} | {} | {} | {} | {} |",
+            project.name,
+            format_seconds(project.baseline.median_secs),
+            format_seconds(project.candidate.median_secs),
+            format_percent(project.percent_change),
+            trend(project.percent_change),
+        )?;
+    }
+
+    Ok(body)
+}
+
+fn trend(percent_change: f64) -> &'static str {
+    if percent_change <= -1.0 {
+        "faster"
+    } else if percent_change >= 1.0 {
+        "slower"
+    } else {
+        "flat"
+    }
+}
+
+fn median(values: &[f64]) -> f64 {
+    let mut sorted = values.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    let midpoint = sorted.len() / 2;
+
+    if sorted.len().is_multiple_of(2) {
+        f64::midpoint(sorted[midpoint - 1], sorted[midpoint])
+    } else {
+        sorted[midpoint]
+    }
+}
+
+fn percent_change(baseline: f64, candidate: f64) -> f64 {
+    ((candidate - baseline) / baseline) * 100.0
+}
+
+fn format_seconds(seconds: f64) -> String {
+    if seconds < 1.0 {
+        format!("{:.1} ms", seconds * 1000.0)
+    } else {
+        format!("{seconds:.3} s")
+    }
+}
+
+fn format_percent(percent: f64) -> String {
+    if percent.is_sign_positive() {
+        format!("+{percent:.1}%")
+    } else {
+        format!("{percent:.1}%")
+    }
+}
+
+fn venv_bin_dir(project_root: &Utf8Path) -> Utf8PathBuf {
+    if cfg!(target_os = "windows") {
+        project_root.join(".venv").join("Scripts")
+    } else {
+        project_root.join(".venv").join("bin")
+    }
+}
+
+fn executable_name(name: &str) -> String {
+    if cfg!(target_os = "windows") {
+        format!("{name}.exe")
+    } else {
+        name.to_string()
+    }
+}
+
+fn path_with_venv_first(bin_dir: &Utf8Path) -> Result<std::ffi::OsString> {
+    let mut paths = vec![PathBuf::from(bin_dir.as_str())];
+    if let Some(existing_path) = std::env::var_os("PATH") {
+        paths.extend(std::env::split_paths(&existing_path));
+    }
+    std::env::join_paths(paths).context("Failed to construct PATH for benchmark command")
+}
+
+fn utf8_path(path: PathBuf) -> Result<Utf8PathBuf> {
+    Utf8PathBuf::from_path_buf(path)
+        .map_err(|path| anyhow::anyhow!("Path is not valid UTF-8: {}", path.display()))
+}

--- a/crates/karva_benchmark/src/lib.rs
+++ b/crates/karva_benchmark/src/lib.rs
@@ -190,7 +190,16 @@ pub const TOMLKIT_PROJECT: BenchmarkProject = BenchmarkProject {
     name: "tomlkit",
     repository: "https://github.com/python-poetry/tomlkit",
     commit: "ae1b6790d99b21bc0a339a5825e7d5e40e7e6f6a",
-    paths: &["tests"],
+    paths: &[
+        "tests/test_toml_file.py",
+        "tests/test_parser.py",
+        "tests/test_write.py",
+        "tests/test_items.py",
+        "tests/test_build.py",
+        "tests/test_api.py",
+        "tests/test_toml_document.py",
+        "tests/test_utils.py",
+    ],
     python_version: PythonVersion::PY313,
     dependency_setup: DependencySetup::DateCappedUvSync {
         exclude_newer: "2026-01-01",
@@ -228,7 +237,38 @@ pub const BENCHMARK_PROJECTS: &[BenchmarkProject] = &[
     OUTCOME_PROJECT,
 ];
 
+pub const CLI_BENCHMARK_PROJECTS: &[BenchmarkProject] = &[
+    PACKAGING_PROJECT,
+    PARSE_PROJECT,
+    H11_PROJECT,
+    SNIFFIO_PROJECT,
+    ITSDANGEROUS_PROJECT,
+    PYPARSING_PROJECT,
+    BLINKER_PROJECT,
+    JINJA_PROJECT,
+    INSTALLER_PROJECT,
+    TOMLKIT_PROJECT,
+    OUTCOME_PROJECT,
+];
+
 pub fn prepare_benchmark_project(config: &BenchmarkProject) -> Result<Project> {
+    let karva_wheel = karva_project::find_karva_wheel()
+        .context("Karva wheel must be built before benchmarking")?;
+    prepare_benchmark_project_with_wheel(config, &karva_wheel)
+}
+
+pub fn prepare_benchmark_project_with_wheel(
+    config: &BenchmarkProject,
+    karva_wheel: &Utf8Path,
+) -> Result<Project> {
+    let project = prepare_benchmark_project_environment(config)?;
+    install_benchmark_tools(config, project.cwd(), karva_wheel)?;
+    clean_project_cache(project.cwd()).context("Failed to clean benchmark cache")?;
+
+    Ok(project)
+}
+
+pub fn prepare_benchmark_project_environment(config: &BenchmarkProject) -> Result<Project> {
     let project_root = ensure_checkout(config).context("Failed to checkout benchmark project")?;
     install_dependencies(config, &project_root)
         .context("Failed to install benchmark dependencies")?;
@@ -444,17 +484,26 @@ fn install_dependencies(config: &BenchmarkProject, project_root: &Utf8PathBuf) -
         }
     }
 
-    install_benchmark_tools(config, project_root)
+    Ok(())
 }
 
-fn install_benchmark_tools(config: &BenchmarkProject, project_root: &Utf8PathBuf) -> Result<()> {
+pub fn install_benchmark_tools(
+    config: &BenchmarkProject,
+    project_root: &Utf8Path,
+    karva_wheel: &Utf8Path,
+) -> Result<()> {
     let venv_path = project_root.join(".venv");
-    let karva_wheel = karva_project::find_karva_wheel()
-        .context("Karva wheel must be built before benchmarking")?;
 
     let mut command = Command::new("uv");
     command
-        .args(["pip", "install", "--python", venv_path.as_str()])
+        .args([
+            "pip",
+            "install",
+            "--python",
+            venv_path.as_str(),
+            "--reinstall-package",
+            "karva",
+        ])
         .arg(karva_wheel);
 
     if let DependencySetup::DateCappedUvSync { exclude_newer, .. } = config.dependency_setup {


### PR DESCRIPTION
## Summary

This replaces the CodSpeed walltime CI job with a repo-owned PR benchmark workflow. The workflow builds wheels for the PR base and head commits, runs the pinned benchmark projects sequentially on one runner through the installed CLI, alternates wheel install order, and updates one sticky PR comment with median timings.

## Test Plan

Ran `uvx prek run -a`, targeted benchmark crate checks, and a one-project same-wheel smoke comparison for `karva-benchmark-1`.