### PR TITLE
Split benchmark metric jobs

### DIFF
--- a/.github/workflows/pr-benchmarks.yml
+++ b/.github/workflows/pr-benchmarks.yml
@@ -196,8 +196,7 @@ jobs:
           base_wheel=$(find "${RUNNER_TEMP}/benchmark-wheels/base" -maxdepth 1 -name "karva-*.whl" -print -quit)
           head_wheel=$(find "${RUNNER_TEMP}/benchmark-wheels/head" -maxdepth 1 -name "karva-*.whl" -print -quit)
           report_dir="${RUNNER_TEMP}/benchmark-reports"
-          memory_report_dir="${RUNNER_TEMP}/benchmark-memory-reports"
-          mkdir -p "${report_dir}" "${memory_report_dir}"
+          mkdir -p "${report_dir}"
 
           target/release/karva-benchmark compare \
             --metric wall-time \
@@ -210,6 +209,73 @@ jobs:
             --output-json "${report_dir}/${PROJECT}.json" \
             --output-markdown "${report_dir}/${PROJECT}.md"
 
+      - name: Upload benchmark report
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: benchmark-report-${{ matrix.project }}
+          path: ${{ runner.temp }}/benchmark-reports/${{ matrix.project }}.json
+
+  compare-memory-benchmarks:
+    name: "compare memory benchmarks (${{ matrix.project }})"
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    needs:
+      - benchmark-projects
+      - build-wheels
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.benchmark-projects.outputs.matrix) }}
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: "Install Rust toolchain"
+        run: rustup show
+
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+
+      - name: Setup Python
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
+        id: setup-python
+        with:
+          python-version: ${{ env.BENCHMARK_PYTHON_VERSION }}
+
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        with:
+          python-version: ${{ env.BENCHMARK_PYTHON_VERSION }}
+
+      - name: Build benchmark runner
+        env:
+          PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
+        run: cargo build -p karva_benchmark --bin karva-benchmark --release
+
+      - name: Download benchmark wheels
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: benchmark-wheels
+          path: ${{ runner.temp }}/benchmark-wheels
+
+      - name: Compare memory benchmarks
+        env:
+          BASE_LABEL: main (${{ needs.build-wheels.outputs.base_short }})
+          HEAD_LABEL: PR (${{ needs.build-wheels.outputs.head_short }})
+          ITERATIONS: ${{ matrix.iterations }}
+          PROJECT: ${{ matrix.project }}
+        run: |
+          set -euo pipefail
+
+          base_wheel=$(find "${RUNNER_TEMP}/benchmark-wheels/base" -maxdepth 1 -name "karva-*.whl" -print -quit)
+          head_wheel=$(find "${RUNNER_TEMP}/benchmark-wheels/head" -maxdepth 1 -name "karva-*.whl" -print -quit)
+          report_dir="${RUNNER_TEMP}/benchmark-memory-reports"
+          mkdir -p "${report_dir}"
+
           target/release/karva-benchmark compare \
             --metric memory \
             --baseline-label "${BASE_LABEL}" \
@@ -218,14 +284,8 @@ jobs:
             --candidate-wheel "${head_wheel}" \
             --iterations "${ITERATIONS}" \
             --project "${PROJECT}" \
-            --output-json "${memory_report_dir}/${PROJECT}.json" \
-            --output-markdown "${memory_report_dir}/${PROJECT}.md"
-
-      - name: Upload benchmark report
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: benchmark-report-${{ matrix.project }}
-          path: ${{ runner.temp }}/benchmark-reports/${{ matrix.project }}.json
+            --output-json "${report_dir}/${PROJECT}.json" \
+            --output-markdown "${report_dir}/${PROJECT}.md"
 
       - name: Upload memory benchmark report
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
@@ -244,8 +304,6 @@ jobs:
       pull-requests: write
 
     needs:
-      - benchmark-projects
-      - build-wheels
       - compare-benchmarks
 
     if: ${{ needs.compare-benchmarks.result == 'success' }}
@@ -275,13 +333,6 @@ jobs:
           merge-multiple: true
           path: ${{ runner.temp }}/benchmark-reports
 
-      - name: Download memory benchmark reports
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          pattern: benchmark-memory-report-*
-          merge-multiple: true
-          path: ${{ runner.temp }}/benchmark-memory-reports
-
       - name: Merge benchmark reports
         env:
           PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
@@ -289,14 +340,6 @@ jobs:
           cargo run -p karva_benchmark --bin karva-benchmark -- merge-reports \
             --input-dir "${RUNNER_TEMP}/benchmark-reports" \
             --output-markdown "${RUNNER_TEMP}/benchmark-report.md"
-
-      - name: Merge memory benchmark reports
-        env:
-          PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
-        run: |
-          cargo run -p karva_benchmark --bin karva-benchmark -- merge-reports \
-            --input-dir "${RUNNER_TEMP}/benchmark-memory-reports" \
-            --output-markdown "${RUNNER_TEMP}/benchmark-memory-report.md"
 
       - name: Comment benchmark report
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
@@ -325,6 +368,54 @@ jobs:
             gh api --method POST "/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
               --input "${payload_path}"
           fi
+
+  comment-memory:
+    name: "comment memory benchmark report"
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+
+    needs:
+      - compare-memory-benchmarks
+
+    if: ${{ needs.compare-memory-benchmarks.result == 'success' }}
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: "Install Rust toolchain"
+        run: rustup show
+
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+
+      - name: Setup Python
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
+        id: setup-python
+        with:
+          python-version: ${{ env.BENCHMARK_PYTHON_VERSION }}
+
+      - name: Download memory benchmark reports
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: benchmark-memory-report-*
+          merge-multiple: true
+          path: ${{ runner.temp }}/benchmark-memory-reports
+
+      - name: Merge memory benchmark reports
+        env:
+          PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
+        run: |
+          cargo run -p karva_benchmark --bin karva-benchmark -- merge-reports \
+            --input-dir "${RUNNER_TEMP}/benchmark-memory-reports" \
+            --output-markdown "${RUNNER_TEMP}/benchmark-memory-report.md"
 
       - name: Comment memory benchmark report
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}


### PR DESCRIPTION
## Summary

This separates the PR benchmark workflow into independent wall-time and memory benchmark matrix jobs. Each metric now has its own compare and comment job so memory failures do not block wall-time reporting, and wall-time failures do not block memory reporting.

## Test Plan

uvx prek run -a