### PR TITLE
Serialize worker output

### DIFF
--- a/crates/karva_cache/src/artifact.rs
+++ b/crates/karva_cache/src/artifact.rs
@@ -28,6 +28,10 @@ pub enum CacheFile {
     FlakyTests,
     /// Per-worker JSON: line-coverage data for sources tracked during the run.
     Coverage,
+    /// Per-worker append-only file: newline-delimited preformatted result
+    /// lines. The orchestrator drains these files and prints whole lines to
+    /// its stdout to prevent worker output from interleaving.
+    Output,
     /// Per-run empty sentinel marking that fail-fast was triggered.
     FailFastSignal,
     /// Cache-root JSON: list of last-run failed test names.
@@ -48,6 +52,7 @@ impl CacheFile {
             Self::FailedTests => "failed_tests.json",
             Self::FlakyTests => "flaky_tests.json",
             Self::Coverage => "coverage.json",
+            Self::Output => "output",
             Self::FailFastSignal => "fail-fast",
             Self::LastFailed => "last-failed.json",
             Self::CurrentTest => "current_test.json",

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -98,6 +98,11 @@ impl RunCache {
         CacheFile::CurrentTest.path_in(&self.worker_dir(worker_id))
     }
 
+    /// Path to the per-worker output file.
+    pub fn output_file(&self, worker_id: usize) -> Utf8PathBuf {
+        CacheFile::Output.path_in(&self.worker_dir(worker_id))
+    }
+
     /// Reads the snapshot of which test the worker is currently running.
     /// Returns `None` if the worker is between tests or hasn't started yet.
     pub fn read_current_test(&self, worker_id: usize) -> Result<Option<CurrentTest>> {

--- a/crates/karva_diagnostic/src/lib.rs
+++ b/crates/karva_diagnostic/src/lib.rs
@@ -3,7 +3,9 @@ mod result;
 #[cfg(feature = "traceback")]
 mod traceback;
 
-pub use reporter::{DummyReporter, Reporter, TestCaseReporter};
+pub use reporter::{
+    DummyReporter, FileLineSink, LineSink, Reporter, StdoutLineSink, TestCaseReporter,
+};
 pub use result::{
     DisplayFlakyTest, DisplayFlakyTests, FlakyTest, IndividualTestResultKind, TestResultKind,
     TestResultStats, TestRunResult,

--- a/crates/karva_diagnostic/src/reporter.rs
+++ b/crates/karva_diagnostic/src/reporter.rs
@@ -1,5 +1,8 @@
+use std::fs::{File, OpenOptions};
 use std::io::ErrorKind;
 use std::io::Write;
+use std::path::Path;
+use std::sync::Mutex;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use camino::Utf8PathBuf;
@@ -91,20 +94,67 @@ impl Reporter for DummyReporter {
     }
 }
 
-/// A reporter that outputs test results to stdout as they complete.
+/// Sink for preformatted reporter result lines.
+pub trait LineSink: Send + Sync {
+    /// Write exactly one logical output line.
+    fn write_line(&self, line: &str);
+}
+
+/// Writes lines straight to process stdout.
+pub struct StdoutLineSink;
+
+impl LineSink for StdoutLineSink {
+    fn write_line(&self, line: &str) {
+        let mut stdout = std::io::stdout().lock();
+        if let Err(err) = writeln!(stdout, "{line}") {
+            tracing::warn!("failed to write test result line: {err}");
+        }
+    }
+}
+
+/// Appends reporter lines to a file.
+pub struct FileLineSink {
+    file: Mutex<File>,
+}
+
+impl FileLineSink {
+    /// Open `path` for append, creating it if needed.
+    pub fn open(path: &Path) -> std::io::Result<Self> {
+        let file = OpenOptions::new().create(true).append(true).open(path)?;
+        Ok(Self {
+            file: Mutex::new(file),
+        })
+    }
+}
+
+impl LineSink for FileLineSink {
+    fn write_line(&self, line: &str) {
+        let Ok(mut file) = self.file.lock() else {
+            tracing::warn!("failed to lock worker output file");
+            return;
+        };
+        if let Err(err) = writeln!(file, "{line}") {
+            tracing::warn!("failed to write worker output line: {err}");
+        }
+    }
+}
+
+/// A reporter that outputs test results as they complete.
 pub struct TestCaseReporter {
     printer: Printer,
+    sink: Box<dyn LineSink>,
     /// Optional path to a JSON file describing the test currently
     /// executing. The orchestrator reads this on Ctrl+C to render
     /// per-test `SIGINT` lines.
-    progress_file: Option<Utf8PathBuf>,
+    current_test_file: Option<Utf8PathBuf>,
 }
 
 impl TestCaseReporter {
-    pub fn new(printer: Printer) -> Self {
+    pub fn new(printer: Printer, sink: Box<dyn LineSink>) -> Self {
         Self {
             printer,
-            progress_file: None,
+            sink,
+            current_test_file: None,
         }
     }
 
@@ -112,8 +162,8 @@ impl TestCaseReporter {
     /// start time to `path` whenever a test begins, and remove the file
     /// when it ends.
     #[must_use]
-    pub fn with_progress_file(mut self, path: Utf8PathBuf) -> Self {
-        self.progress_file = Some(path);
+    pub fn with_current_test_file(mut self, path: Utf8PathBuf) -> Self {
+        self.current_test_file = Some(path);
         self
     }
 }
@@ -142,13 +192,9 @@ impl Reporter for TestCaseReporter {
             _ => String::new(),
         };
 
-        let mut stdout = self.printer.stream_for_test_result().lock();
-        if let Err(err) = writeln!(
-            stdout,
+        self.sink.write_line(&format!(
             "{padding}{colored_label} {duration_str} {test_path}{suffix}"
-        ) {
-            tracing::warn!("failed to write test result line: {err}");
-        }
+        ));
     }
 
     fn report_test_slow(&self, test_name: &QualifiedTestName, duration: Duration) {
@@ -162,13 +208,9 @@ impl Reporter for TestCaseReporter {
         let duration_str = format_duration_bracketed(duration);
         let test_path = format_test_path(test_name);
 
-        let mut stdout = self.printer.stream_for_test_result().lock();
-        if let Err(err) = writeln!(
-            stdout,
+        self.sink.write_line(&format!(
             "{padding}{colored_label} {duration_str} {test_path}"
-        ) {
-            tracing::warn!("failed to write slow test line: {err}");
-        }
+        ));
     }
 
     fn report_test_attempt(
@@ -191,17 +233,13 @@ impl Reporter for TestCaseReporter {
         let duration_str = format_duration_bracketed(duration);
         let test_path = format_test_path(test_name);
 
-        let mut stdout = self.printer.stream_for_test_result().lock();
-        if let Err(err) = writeln!(
-            stdout,
+        self.sink.write_line(&format!(
             "{padding}TRY {attempt} {colored_status} {duration_str} {test_path}"
-        ) {
-            tracing::warn!("failed to write test attempt line: {err}");
-        }
+        ));
     }
 
     fn report_test_started(&self, test_name: &QualifiedTestName) {
-        let Some(path) = self.progress_file.as_ref() else {
+        let Some(path) = self.current_test_file.as_ref() else {
             return;
         };
         let start_unix_ms = SystemTime::now()
@@ -218,7 +256,7 @@ impl Reporter for TestCaseReporter {
     }
 
     fn report_test_finished(&self, _test_name: &QualifiedTestName) {
-        let Some(path) = self.progress_file.as_ref() else {
+        let Some(path) = self.current_test_file.as_ref() else {
             return;
         };
         match std::fs::remove_file(path) {
@@ -309,20 +347,21 @@ mod tests {
     }
 
     #[test]
-    fn progress_file_is_written_and_removed() {
+    fn current_test_file_is_written_and_removed() {
         let temp_dir = tempfile::tempdir().expect("create temp dir");
         let path = Utf8PathBuf::try_from(temp_dir.path().join("current-test.json"))
             .expect("temp path should be UTF-8");
-        let reporter = TestCaseReporter::new(Printer::default()).with_progress_file(path.clone());
+        let reporter = TestCaseReporter::new(Printer::default(), Box::new(StdoutLineSink))
+            .with_current_test_file(path.clone());
         let test_name = qualified_test_name();
 
         reporter.report_test_started(&test_name);
 
-        let body = std::fs::read_to_string(&path).expect("progress file should exist");
-        let progress: serde_json::Value =
-            serde_json::from_str(&body).expect("progress file should be valid JSON");
-        assert_eq!(progress["name"], "test_module::test_example");
-        assert!(progress["start_unix_ms"].as_u64().is_some());
+        let body = std::fs::read_to_string(&path).expect("current test file should exist");
+        let current_test: serde_json::Value =
+            serde_json::from_str(&body).expect("current test file should be valid JSON");
+        assert_eq!(current_test["name"], "test_module::test_example");
+        assert!(current_test["start_unix_ms"].as_u64().is_some());
 
         reporter.report_test_finished(&test_name);
 
@@ -330,11 +369,12 @@ mod tests {
     }
 
     #[test]
-    fn progress_file_cleanup_allows_missing_marker() {
+    fn current_test_file_cleanup_allows_missing_marker() {
         let temp_dir = tempfile::tempdir().expect("create temp dir");
         let path = Utf8PathBuf::try_from(temp_dir.path().join("current-test.json"))
             .expect("temp path should be UTF-8");
-        let reporter = TestCaseReporter::new(Printer::default()).with_progress_file(path);
+        let reporter = TestCaseReporter::new(Printer::default(), Box::new(StdoutLineSink))
+            .with_current_test_file(path);
 
         reporter.report_test_finished(&qualified_test_name());
     }

--- a/crates/karva_runner/src/lib.rs
+++ b/crates/karva_runner/src/lib.rs
@@ -1,6 +1,7 @@
 mod binary;
 mod collection;
 mod orchestration;
+mod output;
 mod partition;
 mod shutdown;
 mod worker_args;

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
-use std::process::{Child, Stdio};
+use std::process::{Child, ChildStdout, Stdio};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
@@ -21,6 +21,7 @@ use karva_project::Project;
 
 use crate::binary::find_karva_worker_binary;
 use crate::collection::ParallelCollector;
+use crate::output::{OutputDrain, WorkerPipes};
 use crate::partition::{Partition, TestOrdering, partition_collected_tests};
 use crate::worker_args::{WorkerSpawn, worker_command};
 
@@ -193,20 +194,13 @@ impl WorkerManager {
         }
     }
 
-    /// Stop remaining workers and emit nextest-style cancellation lines.
+    /// Snapshot which tests are currently in flight.
     ///
     /// Each worker writes a `current_test.json` file at the start of every
-    /// test and removes it when the test finishes. We read those files
-    /// *before* killing — once we kill the worker, that file may be removed
-    /// by an in-flight finalizer or simply lost — and remember a
-    /// `(worker_id, test name, test start time)` snapshot for each.
-    ///
-    /// Workers are killed and reaped before we print so any in-flight
-    /// `PASS`/`FAIL` lines they were writing to the inherited stdout land
-    /// before our banner; otherwise the cancellation block interleaves
-    /// with worker output. A short settle pause lets any kernel-buffered
-    /// writes drain.
-    fn cancel_and_kill(&mut self, printer: Printer, cache: &RunCache) -> Vec<InterruptedTest> {
+    /// test and removes it when the test finishes. We read those files before
+    /// killing workers so the cancellation block can report interrupted tests
+    /// even if the files disappear during shutdown.
+    fn snapshot_in_flight(&self, cache: &RunCache) -> Vec<InFlightTest> {
         if self.workers.is_empty() {
             return Vec::new();
         }
@@ -216,8 +210,7 @@ impl WorkerManager {
             .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
             .unwrap_or(0);
 
-        let in_flight: Vec<_> = self
-            .workers
+        self.workers
             .iter()
             .map(|worker| {
                 let current = match cache.read_current_test(worker.id) {
@@ -240,73 +233,58 @@ impl WorkerManager {
                     elapsed,
                 }
             })
-            .collect();
-
-        let running_tests = in_flight.iter().filter(|test| test.name.is_some()).count();
-        let test_label = if running_tests == 1 { "test" } else { "tests" };
-
-        for worker in &mut self.workers {
-            if let Err(err) = worker.child.kill() {
-                tracing::warn!(
-                    worker_id = worker.id,
-                    "failed to kill worker process: {err}"
-                );
-            }
-        }
-        for worker in &mut self.workers {
-            if let Err(err) = worker.child.wait() {
-                tracing::warn!(
-                    worker_id = worker.id,
-                    "failed to wait for worker process: {err}"
-                );
-            }
-        }
-        std::thread::sleep(STDOUT_SETTLE);
-
-        let mut stdout = printer.stream_for_test_result().lock();
-        let cancel_label = "Cancelling".yellow().bold();
-        let interrupt_label = "interrupt".yellow().bold();
-        if let Err(err) = writeln!(
-            stdout,
-            "  {cancel_label} due to {interrupt_label}: {running_tests} {test_label} still running"
-        ) {
-            tracing::warn!("failed to write cancellation banner: {err}");
-        }
-
-        let label = "SIGINT".yellow().bold();
-        let padding = " ".repeat(LABEL_COLUMN_WIDTH.saturating_sub("SIGINT".len()));
-        for test in &in_flight {
-            let duration_str = format_duration_bracketed(test.elapsed);
-            match &test.name {
-                Some(name) => {
-                    let colored = format_in_flight_test(name);
-                    if let Err(err) = writeln!(stdout, "{padding}{label} {duration_str} {colored}")
-                    {
-                        tracing::warn!("failed to write interrupted test line: {err}");
-                    }
-                }
-                None => {
-                    if let Err(err) = writeln!(
-                        stdout,
-                        "{padding}{label} {duration_str} worker {} (between tests)",
-                        test.worker_id
-                    ) {
-                        tracing::warn!("failed to write interrupted worker line: {err}");
-                    }
-                }
-            }
-        }
-
-        in_flight
-            .into_iter()
-            .filter_map(|test| {
-                test.name.map(|name| InterruptedTest {
-                    name,
-                    duration: test.elapsed,
-                })
-            })
             .collect()
     }
+}
+
+fn print_cancellation(printer: Printer, in_flight: &[InFlightTest]) {
+    let running_tests = in_flight.iter().filter(|test| test.name.is_some()).count();
+    let test_label = if running_tests == 1 { "test" } else { "tests" };
+
+    let mut stdout = printer.stream_for_test_result().lock();
+    let cancel_label = "Cancelling".yellow().bold();
+    let interrupt_label = "interrupt".yellow().bold();
+    if let Err(err) = writeln!(
+        stdout,
+        "  {cancel_label} due to {interrupt_label}: {running_tests} {test_label} still running"
+    ) {
+        tracing::warn!("failed to write cancellation banner: {err}");
+    }
+
+    let label = "SIGINT".yellow().bold();
+    let padding = " ".repeat(LABEL_COLUMN_WIDTH.saturating_sub("SIGINT".len()));
+    for test in in_flight {
+        let duration_str = format_duration_bracketed(test.elapsed);
+        match &test.name {
+            Some(name) => {
+                let colored = format_in_flight_test(name);
+                if let Err(err) = writeln!(stdout, "{padding}{label} {duration_str} {colored}") {
+                    tracing::warn!("failed to write interrupted test line: {err}");
+                }
+            }
+            None => {
+                if let Err(err) = writeln!(
+                    stdout,
+                    "{padding}{label} {duration_str} worker {} (between tests)",
+                    test.worker_id
+                ) {
+                    tracing::warn!("failed to write interrupted worker line: {err}");
+                }
+            }
+        }
+    }
+}
+
+fn interrupted_tests_from(in_flight: Vec<InFlightTest>) -> Vec<InterruptedTest> {
+    in_flight
+        .into_iter()
+        .filter_map(|test| {
+            test.name.map(|name| InterruptedTest {
+                name,
+                duration: test.elapsed,
+            })
+        })
+        .collect()
 }
 
 fn elapsed_since_start(now_ms: u64, start_ms: u64, worker_id: usize) -> Duration {
@@ -361,8 +339,12 @@ pub struct ParallelTestConfig {
 ///
 /// Creates a worker process for each non-empty partition, passing the appropriate
 /// subset of tests and command-line arguments to each worker.
-fn spawn_workers(spawn: &WorkerSpawn, partitions: &[Partition]) -> Result<WorkerManager> {
+fn spawn_workers(
+    spawn: &WorkerSpawn,
+    partitions: &[Partition],
+) -> Result<(WorkerManager, Vec<WorkerPipes>)> {
     let mut worker_manager = WorkerManager::default();
+    let mut pipes: Vec<WorkerPipes> = Vec::new();
 
     for (worker_id, partition) in partitions.iter().enumerate() {
         if partition.tests().is_empty() {
@@ -370,11 +352,12 @@ fn spawn_workers(spawn: &WorkerSpawn, partitions: &[Partition]) -> Result<Worker
             continue;
         }
 
-        let child = worker_command(spawn, worker_id, partition)
-            .stdout(Stdio::inherit())
+        let mut child = worker_command(spawn, worker_id, partition)
+            .stdout(Stdio::piped())
             .stderr(Stdio::inherit())
             .spawn()
             .context("Failed to spawn karva-worker process")?;
+        let stdout: Option<ChildStdout> = child.stdout.take();
 
         tracing::info!(
             "Worker {} spawned with {} tests",
@@ -383,9 +366,10 @@ fn spawn_workers(spawn: &WorkerSpawn, partitions: &[Partition]) -> Result<Worker
         );
 
         worker_manager.spawn(worker_id, child);
+        pipes.push(WorkerPipes { stdout });
     }
 
-    Ok(worker_manager)
+    Ok((worker_manager, pipes))
 }
 
 /// Collect tests from the project without executing them.
@@ -534,15 +518,21 @@ pub fn run_parallel_tests(
         worker_binary: &worker_binary,
         coverage_enabled: !project.settings().coverage().sources.is_empty(),
     };
-    let mut worker_manager = spawn_workers(&spawn, &partitions)?;
+    let (mut worker_manager, pipes) = spawn_workers(&spawn, &partitions)?;
+    let drain = OutputDrain::start(num_workers, &cache, pipes);
 
     let max_fail_cache = project.settings().max_fail().has_limit().then_some(&cache);
 
     let outcome = worker_manager.wait_for_completion(shutdown_rx, max_fail_cache, run_deadline);
     let interrupted_tests = if outcome == WaitOutcome::Cancelled {
-        worker_manager.cancel_and_kill(printer, &cache)
+        let in_flight = worker_manager.snapshot_in_flight(&cache);
+        worker_manager.kill_remaining();
+        drain.finish();
+        print_cancellation(printer, &in_flight);
+        interrupted_tests_from(in_flight)
     } else {
         worker_manager.kill_remaining();
+        drain.finish();
         Vec::new()
     };
 
@@ -572,9 +562,6 @@ pub fn run_parallel_tests(
 
 const MIN_TESTS_PER_WORKER: usize = 5;
 const WORKER_POLL_INTERVAL: Duration = Duration::from_millis(10);
-/// Pause after killing workers to let kernel-buffered output drain to
-/// stdout before we emit the cancellation banner.
-const STDOUT_SETTLE: Duration = Duration::from_millis(50);
 
 fn previous_durations(cache_dir: &Utf8Path, no_cache: bool) -> HashMap<String, Duration> {
     if no_cache {

--- a/crates/karva_runner/src/output.rs
+++ b/crates/karva_runner/src/output.rs
@@ -1,0 +1,249 @@
+//! Serialized worker output drain.
+//!
+//! Workers write preformatted reporter lines to per-worker output files while
+//! their stdout is piped to the orchestrator. The drain below is the single
+//! owner that prints those lines to stdout, which prevents parallel workers
+//! from interleaving bytes on the shared terminal.
+
+use std::fs::File;
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write as _};
+use std::process::ChildStdout;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use camino::Utf8PathBuf;
+use karva_cache::RunCache;
+
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Captured stdout pipe for a single worker child process.
+pub struct WorkerPipes {
+    pub stdout: Option<ChildStdout>,
+}
+
+/// Drains per-worker output files and stdout pipes.
+pub struct OutputDrain {
+    stop: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+    pipe_handles: Vec<JoinHandle<()>>,
+}
+
+impl OutputDrain {
+    /// Start the output drain.
+    pub fn start(num_workers: usize, cache: &RunCache, pipes: Vec<WorkerPipes>) -> Self {
+        let output_paths: Vec<Utf8PathBuf> =
+            (0..num_workers).map(|id| cache.output_file(id)).collect();
+
+        let (stdout_tx, stdout_rx) = mpsc::channel::<String>();
+
+        let mut pipe_handles: Vec<JoinHandle<()>> = Vec::new();
+        for pipe in pipes {
+            if let Some(out) = pipe.stdout {
+                let tx = stdout_tx.clone();
+                pipe_handles.push(thread::spawn(move || forward_pipe(out, &tx)));
+            }
+        }
+        drop(stdout_tx);
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let handle = {
+            let stop = Arc::clone(&stop);
+            thread::spawn(move || drain_loop(&output_paths, &stop, &stdout_rx))
+        };
+
+        Self {
+            stop,
+            handle: Some(handle),
+            pipe_handles,
+        }
+    }
+
+    /// Stop polling and drain remaining whole lines.
+    pub fn finish(mut self) {
+        self.shutdown();
+    }
+
+    fn shutdown(&mut self) {
+        for handle in self.pipe_handles.drain(..) {
+            if handle.join().is_err() {
+                tracing::warn!("worker stdout drain thread panicked");
+            }
+        }
+        self.stop.store(true, Ordering::SeqCst);
+        if let Some(handle) = self.handle.take()
+            && handle.join().is_err()
+        {
+            tracing::warn!("worker output drain thread panicked");
+        }
+    }
+}
+
+impl Drop for OutputDrain {
+    fn drop(&mut self) {
+        if !self.stop.load(Ordering::SeqCst) {
+            self.shutdown();
+        }
+    }
+}
+
+fn forward_pipe<R: Read>(reader: R, tx: &mpsc::Sender<String>) {
+    let mut reader = BufReader::new(reader);
+    let mut buf: Vec<u8> = Vec::new();
+    loop {
+        buf.clear();
+        match reader.read_until(b'\n', &mut buf) {
+            Ok(0) => return,
+            Ok(_) => {
+                if buf.last() == Some(&b'\n') {
+                    buf.pop();
+                }
+                let line = String::from_utf8_lossy(&buf).into_owned();
+                if tx.send(line).is_err() {
+                    return;
+                }
+            }
+            Err(err) => {
+                tracing::warn!("failed to read worker stdout pipe: {err}");
+                return;
+            }
+        }
+    }
+}
+
+struct WorkerStream {
+    path: Utf8PathBuf,
+    file: Option<File>,
+    offset: u64,
+    partial: Vec<u8>,
+}
+
+impl WorkerStream {
+    fn new(path: Utf8PathBuf) -> Self {
+        Self {
+            path,
+            file: None,
+            offset: 0,
+            partial: Vec::new(),
+        }
+    }
+
+    fn poll(&mut self, out: &mut Vec<String>) -> bool {
+        if self.file.is_none() {
+            if !self.path.exists() {
+                return false;
+            }
+            match File::open(&self.path) {
+                Ok(file) => self.file = Some(file),
+                Err(err) => {
+                    tracing::warn!(path = %self.path, "failed to open worker output file: {err}");
+                    return false;
+                }
+            }
+        }
+
+        let Some(file) = self.file.as_mut() else {
+            return false;
+        };
+
+        if let Err(err) = file.seek(SeekFrom::Start(self.offset)) {
+            tracing::warn!(path = %self.path, "failed to seek worker output file: {err}");
+            return false;
+        }
+
+        let mut buf = Vec::new();
+        let n = match file.read_to_end(&mut buf) {
+            Ok(n) => n,
+            Err(err) => {
+                tracing::warn!(path = %self.path, "failed to read worker output file: {err}");
+                return false;
+            }
+        };
+        if n == 0 {
+            return false;
+        }
+        let Ok(read_len) = u64::try_from(n) else {
+            tracing::warn!(path = %self.path, "worker output file read length does not fit u64");
+            return false;
+        };
+        self.offset = self.offset.saturating_add(read_len);
+
+        let mut start = 0usize;
+        for (index, byte) in buf.iter().enumerate() {
+            if *byte == b'\n' {
+                let line_bytes = if self.partial.is_empty() {
+                    &buf[start..index]
+                } else {
+                    self.partial.extend_from_slice(&buf[start..index]);
+                    self.partial.as_slice()
+                };
+                out.push(String::from_utf8_lossy(line_bytes).into_owned());
+                if !self.partial.is_empty() {
+                    self.partial.clear();
+                }
+                start = index + 1;
+            }
+        }
+        if start < buf.len() {
+            self.partial.extend_from_slice(&buf[start..]);
+        }
+
+        true
+    }
+}
+
+fn drain_loop(output_paths: &[Utf8PathBuf], stop: &AtomicBool, stdout_rx: &mpsc::Receiver<String>) {
+    let mut streams: Vec<WorkerStream> = output_paths
+        .iter()
+        .cloned()
+        .map(WorkerStream::new)
+        .collect();
+
+    loop {
+        let mut lines: Vec<String> = Vec::new();
+        let mut progressed = false;
+
+        while let Ok(line) = stdout_rx.try_recv() {
+            lines.push(line);
+            progressed = true;
+        }
+        for stream in &mut streams {
+            if stream.poll(&mut lines) {
+                progressed = true;
+            }
+        }
+        emit_lines(&lines);
+
+        if stop.load(Ordering::SeqCst) {
+            let mut final_lines: Vec<String> = Vec::new();
+            while let Ok(line) = stdout_rx.try_recv() {
+                final_lines.push(line);
+            }
+            for stream in &mut streams {
+                stream.poll(&mut final_lines);
+            }
+            emit_lines(&final_lines);
+            break;
+        }
+
+        if !progressed {
+            thread::sleep(POLL_INTERVAL);
+        }
+    }
+}
+
+fn emit_lines(lines: &[String]) {
+    if lines.is_empty() {
+        return;
+    }
+
+    let mut stdout = std::io::stdout().lock();
+    for line in lines {
+        if let Err(err) = writeln!(stdout, "{line}") {
+            tracing::warn!("failed to write worker output line: {err}");
+            return;
+        }
+    }
+}

--- a/crates/karva_runner/src/worker_args.rs
+++ b/crates/karva_runner/src/worker_args.rs
@@ -90,10 +90,17 @@ fn inner_cli_args(settings: &ProjectSettings, args: &SubTestCommand) -> Vec<Stri
     cli_args.push("--final-status-level".to_string());
     cli_args.push(settings.terminal().final_status_level.as_str().to_string());
 
-    if let Some(color) = args.color {
-        cli_args.push("--color".to_string());
-        cli_args.push(color.as_str().to_string());
-    }
+    cli_args.push("--color".to_string());
+    cli_args.push(match args.color {
+        Some(color) => color.as_str().to_string(),
+        None => {
+            if colored::control::SHOULD_COLORIZE.should_colorize() {
+                "always".to_string()
+            } else {
+                "never".to_string()
+            }
+        }
+    });
 
     if settings.test().try_import_fixtures {
         cli_args.push("--try-import-fixtures".to_string());

--- a/crates/karva_test_semantic/src/py_attach.rs
+++ b/crates/karva_test_semantic/src/py_attach.rs
@@ -27,6 +27,9 @@ where
 {
     attach(|py| {
         if show_output {
+            if let Err(err) = enable_line_buffering(py) {
+                tracing::warn!("failed to line-buffer Python stdout and stderr: {err}");
+            }
             return f(py);
         }
 
@@ -51,6 +54,20 @@ where
         }
         result
     })
+}
+
+fn enable_line_buffering(py: Python<'_>) -> PyResult<()> {
+    py.run(
+        c"import sys
+for stream in (sys.stdout, sys.stderr):
+    try:
+        stream.reconfigure(line_buffering=True)
+    except (AttributeError, ValueError):
+        pass
+",
+        None,
+        None,
+    )
 }
 
 fn open_devnull(py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -6,7 +6,7 @@ use camino::Utf8PathBuf;
 use clap::Parser;
 use karva_cache::{RunCache, RunHash};
 use karva_cli::{SubTestCommand, Verbosity};
-use karva_diagnostic::{DummyReporter, Reporter, TestCaseReporter};
+use karva_diagnostic::{DummyReporter, FileLineSink, LineSink, Reporter, TestCaseReporter};
 use karva_logging::{Printer, StatusLevel, set_colored_override, setup_tracing};
 use karva_metadata::RunIgnoredMode;
 use karva_metadata::filter::FiltersetSet;
@@ -149,17 +149,20 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
 
     let cache = RunCache::new(&args.cache_dir, &run_hash);
 
-    let progress_file = cache.current_test_file(args.worker_id);
-    // Make sure the worker dir exists so the reporter can write the
-    // progress file before the worker has otherwise touched it.
-    if let Some(parent) = progress_file.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("Failed to create worker progress directory `{parent}`"))?;
-    }
+    let worker_dir = cache.worker_dir(args.worker_id);
+    std::fs::create_dir_all(&worker_dir)
+        .with_context(|| format!("Failed to create worker directory `{worker_dir}`"))?;
+
+    let current_test_file = cache.current_test_file(args.worker_id);
     let reporter: Box<dyn Reporter> = if matches!(printer.status_level(), StatusLevel::None) {
         Box::new(DummyReporter)
     } else {
-        Box::new(TestCaseReporter::new(printer).with_progress_file(progress_file))
+        let output_path = cache.output_file(args.worker_id);
+        let sink: Box<dyn LineSink> = Box::new(
+            FileLineSink::open(output_path.as_std_path())
+                .with_context(|| format!("Failed to open worker output file `{output_path}`"))?,
+        );
+        Box::new(TestCaseReporter::new(printer, sink).with_current_test_file(current_test_file))
     };
 
     let result = karva_test_semantic::run_tests(


### PR DESCRIPTION
## Summary

This fixes parallel worker output interleaving by writing worker reporter lines to per-worker output files and draining them from the orchestrator. Worker stdout is piped through the same orchestrator-owned drain so Python prints and reporter lines are emitted by one process.

Closes #502.

## Test Plan

cargo test -p karva_diagnostic --lib; cargo check -p karva_runner -p karva_worker -p karva_test_semantic; cargo clippy -p karva_runner -p karva_worker -p karva_test_semantic -p karva_diagnostic --all-targets --all-features -- -D warnings