### PR TITLE
Add show progress display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -73,7 +73,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -387,7 +387,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -584,7 +584,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -641,7 +641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -916,6 +916,19 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
 ]
 
 [[package]]
@@ -1294,6 +1307,7 @@ dependencies = [
  "ctrlc",
  "fastrand",
  "ignore",
+ "indicatif",
  "karva_cache",
  "karva_cli",
  "karva_collector",
@@ -1590,7 +1604,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2234,7 +2248,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2502,7 +2516,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2512,7 +2526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2771,6 +2785,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2941,7 +2961,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ dunce = { version = "1.0.5" }
 fastrand = { version = "2.4" }
 globset = { version = "0.4" }
 ignore = { version = "0.4.25" }
+indicatif = { version = "0.18" }
 insta = { version = "1.47.1" }
 insta-cmd = { version = "0.6.0" }
 itertools = { version = "0.14.0" }

--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -1586,6 +1586,52 @@ def test_with_print():
 }
 
 #[test]
+fn test_show_progress_bar_does_not_alter_stdout() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+def test_1(): pass
+def test_2(): pass
+",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--show-progress=bar"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            PASS [TIME] test::test_1
+            PASS [TIME] test::test_2
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_show_progress_counter_does_not_alter_stdout() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+def test_1(): pass
+",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--show-progress=counter"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_1
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_retry_flag() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva/tests/it/show_config.rs
+++ b/crates/karva/tests/it/show_config.rs
@@ -19,6 +19,7 @@ fn show_config_default_profile() {
     show-python-output = false
     status-level = "pass"
     final-status-level = "pass"
+    show-progress = "none"
 
     [test]
     test-function-prefix = "test"
@@ -61,6 +62,7 @@ output-format = "concise"
     show-python-output = false
     status-level = "pass"
     final-status-level = "pass"
+    show-progress = "none"
 
     [test]
     test-function-prefix = "check"
@@ -106,6 +108,7 @@ output-format = "concise"
     show-python-output = false
     status-level = "pass"
     final-status-level = "pass"
+    show-progress = "none"
 
     [test]
     test-function-prefix = "check"
@@ -150,6 +153,7 @@ fail-under = 90
     show-python-output = false
     status-level = "pass"
     final-status-level = "pass"
+    show-progress = "none"
 
     [test]
     test-function-prefix = "test"
@@ -197,6 +201,7 @@ slow-timeout = 0.5
     show-python-output = false
     status-level = "pass"
     final-status-level = "pass"
+    show-progress = "none"
 
     [test]
     test-function-prefix = "test"

--- a/crates/karva_cache/src/artifact.rs
+++ b/crates/karva_cache/src/artifact.rs
@@ -28,6 +28,8 @@ pub enum CacheFile {
     FlakyTests,
     /// Per-worker JSON: line-coverage data for sources tracked during the run.
     Coverage,
+    /// Per-worker append-only file: one byte per completed test.
+    Progress,
     /// Per-worker append-only file: newline-delimited preformatted result
     /// lines. The orchestrator drains these files and prints whole lines to
     /// its stdout to prevent worker output from interleaving.
@@ -52,6 +54,7 @@ impl CacheFile {
             Self::FailedTests => "failed_tests.json",
             Self::FlakyTests => "flaky_tests.json",
             Self::Coverage => "coverage.json",
+            Self::Progress => "progress",
             Self::Output => "output",
             Self::FailFastSignal => "fail-fast",
             Self::LastFailed => "last-failed.json",

--- a/crates/karva_cache/src/artifact.rs
+++ b/crates/karva_cache/src/artifact.rs
@@ -28,6 +28,10 @@ pub enum CacheFile {
     FlakyTests,
     /// Per-worker JSON: line-coverage data for sources tracked during the run.
     Coverage,
+    /// Per-worker append-only file: newline-delimited preformatted result
+    /// lines. The orchestrator drains these files and prints whole lines to
+    /// its stdout to prevent worker output from interleaving.
+    Output,
     /// Per-run empty sentinel marking that fail-fast was triggered.
     FailFastSignal,
     /// Cache-root JSON: list of last-run failed test names.
@@ -48,6 +52,7 @@ impl CacheFile {
             Self::FailedTests => "failed_tests.json",
             Self::FlakyTests => "flaky_tests.json",
             Self::Coverage => "coverage.json",
+            Self::Output => "output",
             Self::FailFastSignal => "fail-fast",
             Self::LastFailed => "last-failed.json",
             Self::CurrentTest => "current_test.json",

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -98,6 +98,11 @@ impl RunCache {
         CacheFile::CurrentTest.path_in(&self.worker_dir(worker_id))
     }
 
+    /// Path to the per-worker output file.
+    pub fn output_file(&self, worker_id: usize) -> Utf8PathBuf {
+        CacheFile::Output.path_in(&self.worker_dir(worker_id))
+    }
+
     /// Reads the snapshot of which test the worker is currently running.
     /// Returns `None` if the worker is between tests or hasn't started yet.
     pub fn read_current_test(&self, worker_id: usize) -> Result<Option<CurrentTest>> {

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -47,6 +47,7 @@ impl AggregatedResults {
 }
 
 /// Reads and writes test results in the cache directory for a specific run.
+#[derive(Clone)]
 pub struct RunCache {
     run_dir: Utf8PathBuf,
 }
@@ -101,6 +102,25 @@ impl RunCache {
     /// Path to the per-worker output file.
     pub fn output_file(&self, worker_id: usize) -> Utf8PathBuf {
         CacheFile::Output.path_in(&self.worker_dir(worker_id))
+    }
+
+    /// Path to the per-worker progress file.
+    pub fn progress_file(&self, worker_id: usize) -> Utf8PathBuf {
+        CacheFile::Progress.path_in(&self.worker_dir(worker_id))
+    }
+
+    /// Sum of completed-test counts across every worker for this run.
+    pub fn completed_count(&self) -> u64 {
+        let Ok(worker_dirs) = list_worker_dirs(&self.run_dir) else {
+            return 0;
+        };
+        worker_dirs
+            .iter()
+            .map(|dir| {
+                let path = CacheFile::Progress.path_in(dir);
+                path.metadata().map_or(0, |meta| meta.len())
+            })
+            .sum()
     }
 
     /// Reads the snapshot of which test the worker is currently running.

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroU32;
 
 use camino::Utf8PathBuf;
 use clap::Parser;
-use karva_logging::{FinalStatusLevel, StatusLevel, TerminalColor};
+use karva_logging::{FinalStatusLevel, ProgressMode, StatusLevel, TerminalColor};
 use karva_metadata::{
     CovFailUnder, CoverageOptions, MaxFail, Options, OverrideOptions, RunTimeoutSecs,
     SlowTimeoutSecs, SrcOptions, TerminalOptions, TestOptions, TestTimeoutSecs,
@@ -157,6 +157,15 @@ pub struct SubTestCommand {
         help_heading = "Reporter options"
     )]
     pub final_status_level: Option<FinalStatusLevel>,
+
+    /// Live progress display while tests run [default: none]
+    #[arg(
+        long,
+        value_name = "MODE",
+        env = "KARVA_SHOW_PROGRESS",
+        help_heading = "Reporter options"
+    )]
+    pub show_progress: Option<ProgressMode>,
 
     /// Measure code coverage for the given source path.
     ///
@@ -363,6 +372,7 @@ impl SubTestCommand {
                 show_python_output: self.show_output,
                 status_level: self.status_level,
                 final_status_level: self.final_status_level,
+                show_progress: self.show_progress,
             }),
             test: Some(TestOptions {
                 test_function_prefix: self.test_prefix,

--- a/crates/karva_diagnostic/src/lib.rs
+++ b/crates/karva_diagnostic/src/lib.rs
@@ -3,7 +3,9 @@ mod result;
 #[cfg(feature = "traceback")]
 mod traceback;
 
-pub use reporter::{DummyReporter, Reporter, TestCaseReporter};
+pub use reporter::{
+    DummyReporter, FileLineSink, LineSink, Reporter, StdoutLineSink, TestCaseReporter,
+};
 pub use result::{
     DisplayFlakyTest, DisplayFlakyTests, FlakyTest, IndividualTestResultKind, TestResultKind,
     TestResultStats, TestRunResult,

--- a/crates/karva_diagnostic/src/lib.rs
+++ b/crates/karva_diagnostic/src/lib.rs
@@ -4,7 +4,8 @@ mod result;
 mod traceback;
 
 pub use reporter::{
-    DummyReporter, FileLineSink, LineSink, Reporter, StdoutLineSink, TestCaseReporter,
+    DummyReporter, FileLineSink, LineSink, ProgressTrackingReporter, Reporter, StdoutLineSink,
+    TestCaseReporter,
 };
 pub use result::{
     DisplayFlakyTest, DisplayFlakyTests, FlakyTest, IndividualTestResultKind, TestResultKind,

--- a/crates/karva_diagnostic/src/reporter.rs
+++ b/crates/karva_diagnostic/src/reporter.rs
@@ -1,5 +1,8 @@
+use std::fs::{File, OpenOptions};
 use std::io::ErrorKind;
 use std::io::Write;
+use std::path::Path;
+use std::sync::Mutex;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use camino::Utf8PathBuf;
@@ -91,20 +94,67 @@ impl Reporter for DummyReporter {
     }
 }
 
-/// A reporter that outputs test results to stdout as they complete.
+/// Sink for preformatted reporter result lines.
+pub trait LineSink: Send + Sync {
+    /// Write exactly one logical output line.
+    fn write_line(&self, line: &str);
+}
+
+/// Writes lines straight to process stdout.
+pub struct StdoutLineSink;
+
+impl LineSink for StdoutLineSink {
+    fn write_line(&self, line: &str) {
+        let mut stdout = std::io::stdout().lock();
+        if let Err(err) = writeln!(stdout, "{line}") {
+            tracing::warn!("failed to write test result line: {err}");
+        }
+    }
+}
+
+/// Appends reporter lines to a file.
+pub struct FileLineSink {
+    file: Mutex<File>,
+}
+
+impl FileLineSink {
+    /// Open `path` for append, creating it if needed.
+    pub fn open(path: &Path) -> std::io::Result<Self> {
+        let file = OpenOptions::new().create(true).append(true).open(path)?;
+        Ok(Self {
+            file: Mutex::new(file),
+        })
+    }
+}
+
+impl LineSink for FileLineSink {
+    fn write_line(&self, line: &str) {
+        let Ok(mut file) = self.file.lock() else {
+            tracing::warn!("failed to lock worker output file");
+            return;
+        };
+        if let Err(err) = writeln!(file, "{line}") {
+            tracing::warn!("failed to write worker output line: {err}");
+        }
+    }
+}
+
+/// A reporter that outputs test results as they complete.
 pub struct TestCaseReporter {
     printer: Printer,
+    sink: Box<dyn LineSink>,
     /// Optional path to a JSON file describing the test currently
     /// executing. The orchestrator reads this on Ctrl+C to render
     /// per-test `SIGINT` lines.
-    progress_file: Option<Utf8PathBuf>,
+    current_test_file: Option<Utf8PathBuf>,
 }
 
 impl TestCaseReporter {
-    pub fn new(printer: Printer) -> Self {
+    pub fn new(printer: Printer, sink: Box<dyn LineSink>) -> Self {
         Self {
             printer,
-            progress_file: None,
+            sink,
+            current_test_file: None,
         }
     }
 
@@ -112,8 +162,8 @@ impl TestCaseReporter {
     /// start time to `path` whenever a test begins, and remove the file
     /// when it ends.
     #[must_use]
-    pub fn with_progress_file(mut self, path: Utf8PathBuf) -> Self {
-        self.progress_file = Some(path);
+    pub fn with_current_test_file(mut self, path: Utf8PathBuf) -> Self {
+        self.current_test_file = Some(path);
         self
     }
 }
@@ -142,13 +192,9 @@ impl Reporter for TestCaseReporter {
             _ => String::new(),
         };
 
-        let mut stdout = self.printer.stream_for_test_result().lock();
-        if let Err(err) = writeln!(
-            stdout,
+        self.sink.write_line(&format!(
             "{padding}{colored_label} {duration_str} {test_path}{suffix}"
-        ) {
-            tracing::warn!("failed to write test result line: {err}");
-        }
+        ));
     }
 
     fn report_test_slow(&self, test_name: &QualifiedTestName, duration: Duration) {
@@ -162,13 +208,9 @@ impl Reporter for TestCaseReporter {
         let duration_str = format_duration_bracketed(duration);
         let test_path = format_test_path(test_name);
 
-        let mut stdout = self.printer.stream_for_test_result().lock();
-        if let Err(err) = writeln!(
-            stdout,
+        self.sink.write_line(&format!(
             "{padding}{colored_label} {duration_str} {test_path}"
-        ) {
-            tracing::warn!("failed to write slow test line: {err}");
-        }
+        ));
     }
 
     fn report_test_attempt(
@@ -191,17 +233,13 @@ impl Reporter for TestCaseReporter {
         let duration_str = format_duration_bracketed(duration);
         let test_path = format_test_path(test_name);
 
-        let mut stdout = self.printer.stream_for_test_result().lock();
-        if let Err(err) = writeln!(
-            stdout,
+        self.sink.write_line(&format!(
             "{padding}TRY {attempt} {colored_status} {duration_str} {test_path}"
-        ) {
-            tracing::warn!("failed to write test attempt line: {err}");
-        }
+        ));
     }
 
     fn report_test_started(&self, test_name: &QualifiedTestName) {
-        let Some(path) = self.progress_file.as_ref() else {
+        let Some(path) = self.current_test_file.as_ref() else {
             return;
         };
         let start_unix_ms = SystemTime::now()
@@ -218,7 +256,7 @@ impl Reporter for TestCaseReporter {
     }
 
     fn report_test_finished(&self, _test_name: &QualifiedTestName) {
-        let Some(path) = self.progress_file.as_ref() else {
+        let Some(path) = self.current_test_file.as_ref() else {
             return;
         };
         match std::fs::remove_file(path) {
@@ -309,20 +347,21 @@ mod tests {
     }
 
     #[test]
-    fn progress_file_is_written_and_removed() {
+    fn current_test_file_is_written_and_removed() {
         let temp_dir = tempfile::tempdir().expect("create temp dir");
         let path = Utf8PathBuf::try_from(temp_dir.path().join("current-test.json"))
             .expect("temp path should be UTF-8");
-        let reporter = TestCaseReporter::new(Printer::default()).with_progress_file(path.clone());
+        let reporter = TestCaseReporter::new(Printer::default(), Box::new(StdoutLineSink))
+            .with_current_test_file(path.clone());
         let test_name = qualified_test_name();
 
         reporter.report_test_started(&test_name);
 
-        let body = std::fs::read_to_string(&path).expect("progress file should exist");
-        let progress: serde_json::Value =
-            serde_json::from_str(&body).expect("progress file should be valid JSON");
-        assert_eq!(progress["name"], "test_module::test_example");
-        assert!(progress["start_unix_ms"].as_u64().is_some());
+        let body = std::fs::read_to_string(&path).expect("current test file should exist");
+        let current_test: serde_json::Value =
+            serde_json::from_str(&body).expect("current test file should be valid JSON");
+        assert_eq!(current_test["name"], "test_module::test_example");
+        assert!(current_test["start_unix_ms"].as_u64().is_some());
 
         reporter.report_test_finished(&test_name);
 
@@ -330,11 +369,12 @@ mod tests {
     }
 
     #[test]
-    fn progress_file_cleanup_allows_missing_marker() {
+    fn current_test_file_cleanup_allows_missing_marker() {
         let temp_dir = tempfile::tempdir().expect("create temp dir");
         let path = Utf8PathBuf::try_from(temp_dir.path().join("current-test.json"))
             .expect("temp path should be UTF-8");
-        let reporter = TestCaseReporter::new(Printer::default()).with_progress_file(path);
+        let reporter = TestCaseReporter::new(Printer::default(), Box::new(StdoutLineSink))
+            .with_current_test_file(path);
 
         reporter.report_test_finished(&qualified_test_name());
     }

--- a/crates/karva_diagnostic/src/reporter.rs
+++ b/crates/karva_diagnostic/src/reporter.rs
@@ -1,7 +1,7 @@
 use std::fs::{File, OpenOptions};
 use std::io::ErrorKind;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -59,6 +59,11 @@ pub trait Reporter: Send + Sync {
     /// reporter can clear any in-flight state recorded by
     /// [`Self::report_test_started`]. Default no-op.
     fn report_test_finished(&self, test_name: &QualifiedTestName) {
+        let _ = test_name;
+    }
+
+    /// Notify that a test has fully completed for accounting purposes.
+    fn notify_test_completed(&self, test_name: &QualifiedTestName) {
         let _ = test_name;
     }
 }
@@ -267,6 +272,84 @@ impl Reporter for TestCaseReporter {
     }
 }
 
+/// Wraps another reporter and appends one byte to a file when a test completes.
+pub struct ProgressTrackingReporter<R: Reporter> {
+    inner: R,
+    progress_file: PathBuf,
+}
+
+impl<R: Reporter> ProgressTrackingReporter<R> {
+    pub fn new(inner: R, progress_file: PathBuf) -> Self {
+        Self {
+            inner,
+            progress_file,
+        }
+    }
+
+    fn append_tick(&self) {
+        match OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.progress_file)
+        {
+            Ok(mut file) => {
+                if let Err(err) = file.write_all(b"\x01") {
+                    tracing::warn!(
+                        path = %self.progress_file.display(),
+                        "failed to write progress tick: {err}"
+                    );
+                }
+            }
+            Err(err) => {
+                tracing::warn!(
+                    path = %self.progress_file.display(),
+                    "failed to open progress file: {err}"
+                );
+            }
+        }
+    }
+}
+
+impl<R: Reporter> Reporter for ProgressTrackingReporter<R> {
+    fn report_test_case_result(
+        &self,
+        test_name: &QualifiedTestName,
+        result_kind: IndividualTestResultKind,
+        duration: Duration,
+    ) {
+        self.inner
+            .report_test_case_result(test_name, result_kind, duration);
+    }
+
+    fn report_test_attempt(
+        &self,
+        test_name: &QualifiedTestName,
+        attempt: u32,
+        result_kind: IndividualTestResultKind,
+        duration: Duration,
+    ) {
+        self.inner
+            .report_test_attempt(test_name, attempt, result_kind, duration);
+    }
+
+    fn report_test_slow(&self, test_name: &QualifiedTestName, duration: Duration) {
+        self.inner.report_test_slow(test_name, duration);
+    }
+
+    fn report_test_started(&self, test_name: &QualifiedTestName) {
+        self.inner.report_test_started(test_name);
+    }
+
+    fn report_test_finished(&self, test_name: &QualifiedTestName) {
+        self.inner.report_test_finished(test_name);
+    }
+
+    fn notify_test_completed(&self, test_name: &QualifiedTestName) {
+        self.inner.notify_test_completed(test_name);
+        self.append_tick();
+    }
+}
+
 /// The width that result labels (`PASS`, `FAIL`, `SKIP`, `SLOW`, `TRY N PASS`,
 /// etc.) are right-padded to so columns align.
 const LABEL_COLUMN_WIDTH: usize = 12;
@@ -377,5 +460,18 @@ mod tests {
             .with_current_test_file(path);
 
         reporter.report_test_finished(&qualified_test_name());
+    }
+
+    #[test]
+    fn progress_tracking_reporter_appends_one_byte_per_completion() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let path = temp_dir.path().join("progress");
+        let reporter = ProgressTrackingReporter::new(DummyReporter, path.clone());
+        let test_name = qualified_test_name();
+
+        reporter.notify_test_completed(&test_name);
+        reporter.notify_test_completed(&test_name);
+
+        assert_eq!(std::fs::metadata(path).expect("progress file").len(), 2);
     }
 }

--- a/crates/karva_logging/src/lib.rs
+++ b/crates/karva_logging/src/lib.rs
@@ -12,11 +12,13 @@ use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields};
 use tracing_subscriber::registry::LookupSpan;
 
 mod printer;
+mod progress;
 mod status_level;
 pub mod time;
 mod verbosity;
 
 pub use printer::{Printer, Stdout};
+pub use progress::ProgressMode;
 pub use status_level::{FinalStatusLevel, StatusLevel};
 pub use verbosity::VerbosityLevel;
 

--- a/crates/karva_logging/src/progress.rs
+++ b/crates/karva_logging/src/progress.rs
@@ -1,0 +1,47 @@
+use karva_combine::Combine;
+use serde::{Deserialize, Serialize};
+
+/// How to display run progress while tests are executing.
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    clap::ValueEnum,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProgressMode {
+    /// No live progress display.
+    #[default]
+    None,
+    /// Print a refreshing `N/M tests` counter on stderr.
+    Counter,
+    /// Render a visual progress bar on stderr.
+    Bar,
+}
+
+impl ProgressMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Counter => "counter",
+            Self::Bar => "bar",
+        }
+    }
+}
+
+impl Combine for ProgressMode {
+    #[inline(always)]
+    fn combine_with(&mut self, _other: Self) {}
+
+    #[inline]
+    fn combine(self, _other: Self) -> Self {
+        self
+    }
+}

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -2,7 +2,7 @@ mod config;
 mod overrides;
 
 use karva_combine::Combine;
-use karva_logging::{FinalStatusLevel, StatusLevel};
+use karva_logging::{FinalStatusLevel, ProgressMode, StatusLevel};
 use karva_macros::{Combine, OptionsMetadata};
 use ruff_db::diagnostic::DiagnosticFormat;
 use serde::{Deserialize, Serialize};
@@ -226,6 +226,19 @@ pub struct TerminalOptions {
         "#
     )]
     pub final_status_level: Option<FinalStatusLevel>,
+
+    /// Live progress display rendered while tests run.
+    ///
+    /// Defaults to `none`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"none"#,
+        value_type = "none | counter | bar",
+        example = r#"
+            show-progress = "bar"
+        "#
+    )]
+    pub show_progress: Option<ProgressMode>,
 }
 
 impl TerminalOptions {
@@ -235,6 +248,7 @@ impl TerminalOptions {
             show_python_output: self.show_python_output.unwrap_or_default(),
             status_level: self.status_level.unwrap_or_default(),
             final_status_level: self.final_status_level.unwrap_or_default(),
+            show_progress: self.show_progress.unwrap_or_default(),
         }
     }
 }

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use karva_combine::Combine;
-use karva_logging::{FinalStatusLevel, StatusLevel};
+use karva_logging::{FinalStatusLevel, ProgressMode, StatusLevel};
 use serde::{Deserialize, Serialize, Serializer};
 
 use crate::filter::{EvalContext, FiltersetSet, ValidatedFilter};
@@ -281,6 +281,7 @@ pub struct TerminalSettings {
     pub show_python_output: bool,
     pub status_level: StatusLevel,
     pub final_status_level: FinalStatusLevel,
+    pub show_progress: ProgressMode,
 }
 
 #[derive(Default, Debug, Clone, Serialize)]

--- a/crates/karva_runner/Cargo.toml
+++ b/crates/karva_runner/Cargo.toml
@@ -28,6 +28,7 @@ crossbeam-channel = { workspace = true }
 ctrlc = { workspace = true }
 fastrand = { workspace = true }
 ignore = { workspace = true }
+indicatif = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 which = { workspace = true }

--- a/crates/karva_runner/src/lib.rs
+++ b/crates/karva_runner/src/lib.rs
@@ -1,6 +1,7 @@
 mod binary;
 mod collection;
 mod orchestration;
+mod output;
 mod partition;
 mod shutdown;
 mod worker_args;

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
-use std::process::{Child, Stdio};
+use std::process::{Child, ChildStdout, Stdio};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
@@ -21,6 +21,7 @@ use karva_project::Project;
 
 use crate::binary::find_karva_worker_binary;
 use crate::collection::ParallelCollector;
+use crate::output::{OutputDrain, WorkerPipes};
 use crate::partition::{Partition, TestOrdering, partition_collected_tests};
 use crate::worker_args::{WorkerSpawn, worker_command};
 
@@ -193,20 +194,13 @@ impl WorkerManager {
         }
     }
 
-    /// Stop remaining workers and emit nextest-style cancellation lines.
+    /// Snapshot which tests are currently in flight.
     ///
     /// Each worker writes a `current_test.json` file at the start of every
-    /// test and removes it when the test finishes. We read those files
-    /// *before* killing — once we kill the worker, that file may be removed
-    /// by an in-flight finalizer or simply lost — and remember a
-    /// `(worker_id, test name, test start time)` snapshot for each.
-    ///
-    /// Workers are killed and reaped before we print so any in-flight
-    /// `PASS`/`FAIL` lines they were writing to the inherited stdout land
-    /// before our banner; otherwise the cancellation block interleaves
-    /// with worker output. A short settle pause lets any kernel-buffered
-    /// writes drain.
-    fn cancel_and_kill(&mut self, printer: Printer, cache: &RunCache) -> Vec<InterruptedTest> {
+    /// test and removes it when the test finishes. We read those files before
+    /// killing workers so the cancellation block can report interrupted tests
+    /// even if the files disappear during shutdown.
+    fn snapshot_in_flight(&self, cache: &RunCache) -> Vec<InFlightTest> {
         if self.workers.is_empty() {
             return Vec::new();
         }
@@ -216,8 +210,7 @@ impl WorkerManager {
             .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
             .unwrap_or(0);
 
-        let in_flight: Vec<_> = self
-            .workers
+        self.workers
             .iter()
             .map(|worker| {
                 let current = match cache.read_current_test(worker.id) {
@@ -240,73 +233,58 @@ impl WorkerManager {
                     elapsed,
                 }
             })
-            .collect();
-
-        let running_tests = in_flight.iter().filter(|test| test.name.is_some()).count();
-        let test_label = if running_tests == 1 { "test" } else { "tests" };
-
-        for worker in &mut self.workers {
-            if let Err(err) = worker.child.kill() {
-                tracing::warn!(
-                    worker_id = worker.id,
-                    "failed to kill worker process: {err}"
-                );
-            }
-        }
-        for worker in &mut self.workers {
-            if let Err(err) = worker.child.wait() {
-                tracing::warn!(
-                    worker_id = worker.id,
-                    "failed to wait for worker process: {err}"
-                );
-            }
-        }
-        std::thread::sleep(STDOUT_SETTLE);
-
-        let mut stdout = printer.stream_for_test_result().lock();
-        let cancel_label = "Cancelling".yellow().bold();
-        let interrupt_label = "interrupt".yellow().bold();
-        if let Err(err) = writeln!(
-            stdout,
-            "  {cancel_label} due to {interrupt_label}: {running_tests} {test_label} still running"
-        ) {
-            tracing::warn!("failed to write cancellation banner: {err}");
-        }
-
-        let label = "SIGINT".yellow().bold();
-        let padding = " ".repeat(LABEL_COLUMN_WIDTH.saturating_sub("SIGINT".len()));
-        for test in &in_flight {
-            let duration_str = format_duration_bracketed(test.elapsed);
-            match &test.name {
-                Some(name) => {
-                    let colored = format_in_flight_test(name);
-                    if let Err(err) = writeln!(stdout, "{padding}{label} {duration_str} {colored}")
-                    {
-                        tracing::warn!("failed to write interrupted test line: {err}");
-                    }
-                }
-                None => {
-                    if let Err(err) = writeln!(
-                        stdout,
-                        "{padding}{label} {duration_str} worker {} (between tests)",
-                        test.worker_id
-                    ) {
-                        tracing::warn!("failed to write interrupted worker line: {err}");
-                    }
-                }
-            }
-        }
-
-        in_flight
-            .into_iter()
-            .filter_map(|test| {
-                test.name.map(|name| InterruptedTest {
-                    name,
-                    duration: test.elapsed,
-                })
-            })
             .collect()
     }
+}
+
+fn print_cancellation(printer: Printer, in_flight: &[InFlightTest]) {
+    let running_tests = in_flight.iter().filter(|test| test.name.is_some()).count();
+    let test_label = if running_tests == 1 { "test" } else { "tests" };
+
+    let mut stdout = printer.stream_for_test_result().lock();
+    let cancel_label = "Cancelling".yellow().bold();
+    let interrupt_label = "interrupt".yellow().bold();
+    if let Err(err) = writeln!(
+        stdout,
+        "  {cancel_label} due to {interrupt_label}: {running_tests} {test_label} still running"
+    ) {
+        tracing::warn!("failed to write cancellation banner: {err}");
+    }
+
+    let label = "SIGINT".yellow().bold();
+    let padding = " ".repeat(LABEL_COLUMN_WIDTH.saturating_sub("SIGINT".len()));
+    for test in in_flight {
+        let duration_str = format_duration_bracketed(test.elapsed);
+        match &test.name {
+            Some(name) => {
+                let colored = format_in_flight_test(name);
+                if let Err(err) = writeln!(stdout, "{padding}{label} {duration_str} {colored}") {
+                    tracing::warn!("failed to write interrupted test line: {err}");
+                }
+            }
+            None => {
+                if let Err(err) = writeln!(
+                    stdout,
+                    "{padding}{label} {duration_str} worker {} (between tests)",
+                    test.worker_id
+                ) {
+                    tracing::warn!("failed to write interrupted worker line: {err}");
+                }
+            }
+        }
+    }
+}
+
+fn interrupted_tests_from(in_flight: Vec<InFlightTest>) -> Vec<InterruptedTest> {
+    in_flight
+        .into_iter()
+        .filter_map(|test| {
+            test.name.map(|name| InterruptedTest {
+                name,
+                duration: test.elapsed,
+            })
+        })
+        .collect()
 }
 
 fn elapsed_since_start(now_ms: u64, start_ms: u64, worker_id: usize) -> Duration {
@@ -361,8 +339,12 @@ pub struct ParallelTestConfig {
 ///
 /// Creates a worker process for each non-empty partition, passing the appropriate
 /// subset of tests and command-line arguments to each worker.
-fn spawn_workers(spawn: &WorkerSpawn, partitions: &[Partition]) -> Result<WorkerManager> {
+fn spawn_workers(
+    spawn: &WorkerSpawn,
+    partitions: &[Partition],
+) -> Result<(WorkerManager, Vec<WorkerPipes>)> {
     let mut worker_manager = WorkerManager::default();
+    let mut pipes: Vec<WorkerPipes> = Vec::new();
 
     for (worker_id, partition) in partitions.iter().enumerate() {
         if partition.tests().is_empty() {
@@ -370,11 +352,12 @@ fn spawn_workers(spawn: &WorkerSpawn, partitions: &[Partition]) -> Result<Worker
             continue;
         }
 
-        let child = worker_command(spawn, worker_id, partition)
-            .stdout(Stdio::inherit())
+        let mut child = worker_command(spawn, worker_id, partition)
+            .stdout(Stdio::piped())
             .stderr(Stdio::inherit())
             .spawn()
             .context("Failed to spawn karva-worker process")?;
+        let stdout: Option<ChildStdout> = child.stdout.take();
 
         tracing::info!(
             "Worker {} spawned with {} tests",
@@ -383,9 +366,10 @@ fn spawn_workers(spawn: &WorkerSpawn, partitions: &[Partition]) -> Result<Worker
         );
 
         worker_manager.spawn(worker_id, child);
+        pipes.push(WorkerPipes { stdout });
     }
 
-    Ok(worker_manager)
+    Ok((worker_manager, pipes))
 }
 
 /// Collect tests from the project without executing them.
@@ -534,15 +518,21 @@ pub fn run_parallel_tests(
         worker_binary: &worker_binary,
         coverage_enabled: !project.settings().coverage().sources.is_empty(),
     };
-    let mut worker_manager = spawn_workers(&spawn, &partitions)?;
+    let (mut worker_manager, pipes) = spawn_workers(&spawn, &partitions)?;
+    let drain = OutputDrain::start(num_workers, &cache, pipes);
 
     let max_fail_cache = project.settings().max_fail().has_limit().then_some(&cache);
 
     let outcome = worker_manager.wait_for_completion(shutdown_rx, max_fail_cache, run_deadline);
     let interrupted_tests = if outcome == WaitOutcome::Cancelled {
-        worker_manager.cancel_and_kill(printer, &cache)
+        let in_flight = worker_manager.snapshot_in_flight(&cache);
+        worker_manager.kill_remaining();
+        drain.finish();
+        print_cancellation(printer, &in_flight);
+        interrupted_tests_from(in_flight)
     } else {
         worker_manager.kill_remaining();
+        drain.finish();
         Vec::new()
     };
 
@@ -572,9 +562,6 @@ pub fn run_parallel_tests(
 
 const MIN_TESTS_PER_WORKER: usize = 5;
 const WORKER_POLL_INTERVAL: Duration = Duration::from_millis(10);
-/// Pause after killing workers to let kernel-buffered output drain to
-/// stdout before we emit the cancellation banner.
-const STDOUT_SETTLE: Duration = Duration::from_millis(50);
 
 fn previous_durations(cache_dir: &Utf8Path, no_cache: bool) -> HashMap<String, Duration> {
     if no_cache {

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -519,7 +519,14 @@ pub fn run_parallel_tests(
         coverage_enabled: !project.settings().coverage().sources.is_empty(),
     };
     let (mut worker_manager, pipes) = spawn_workers(&spawn, &partitions)?;
-    let drain = OutputDrain::start(num_workers, &cache, pipes);
+    let total_tests_for_progress = u64::try_from(total_tests).unwrap_or(u64::MAX);
+    let drain = OutputDrain::start(
+        project.settings().terminal().show_progress,
+        total_tests_for_progress,
+        num_workers,
+        cache.clone(),
+        pipes,
+    );
 
     let max_fail_cache = project.settings().max_fail().has_limit().then_some(&cache);
 

--- a/crates/karva_runner/src/output.rs
+++ b/crates/karva_runner/src/output.rs
@@ -15,9 +15,12 @@ use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 use camino::Utf8PathBuf;
+use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use karva_cache::RunCache;
+use karva_logging::ProgressMode;
 
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
+const STEADY_TICK: Duration = Duration::from_millis(120);
 
 /// Captured stdout pipe for a single worker child process.
 pub struct WorkerPipes {
@@ -26,6 +29,7 @@ pub struct WorkerPipes {
 
 /// Drains per-worker output files and stdout pipes.
 pub struct OutputDrain {
+    bar: Option<ProgressBar>,
     stop: Arc<AtomicBool>,
     handle: Option<JoinHandle<()>>,
     pipe_handles: Vec<JoinHandle<()>>,
@@ -33,7 +37,26 @@ pub struct OutputDrain {
 
 impl OutputDrain {
     /// Start the output drain.
-    pub fn start(num_workers: usize, cache: &RunCache, pipes: Vec<WorkerPipes>) -> Self {
+    pub fn start(
+        mode: ProgressMode,
+        total_tests: u64,
+        num_workers: usize,
+        cache: RunCache,
+        pipes: Vec<WorkerPipes>,
+    ) -> Self {
+        let bar = if total_tests > 0 && !matches!(mode, ProgressMode::None) {
+            let bar =
+                ProgressBar::with_draw_target(Some(total_tests), ProgressDrawTarget::stderr());
+            bar.set_style(style_for(mode));
+            if matches!(mode, ProgressMode::Bar) {
+                bar.set_message("Testing");
+            }
+            bar.enable_steady_tick(STEADY_TICK);
+            Some(bar)
+        } else {
+            None
+        };
+
         let output_paths: Vec<Utf8PathBuf> =
             (0..num_workers).map(|id| cache.output_file(id)).collect();
 
@@ -50,11 +73,15 @@ impl OutputDrain {
 
         let stop = Arc::new(AtomicBool::new(false));
         let handle = {
+            let bar = bar.clone();
             let stop = Arc::clone(&stop);
-            thread::spawn(move || drain_loop(&output_paths, &stop, &stdout_rx))
+            thread::spawn(move || {
+                drain_loop(&output_paths, &cache, bar.as_ref(), &stop, &stdout_rx);
+            })
         };
 
         Self {
+            bar,
             stop,
             handle: Some(handle),
             pipe_handles,
@@ -77,6 +104,9 @@ impl OutputDrain {
             && handle.join().is_err()
         {
             tracing::warn!("worker output drain thread panicked");
+        }
+        if let Some(bar) = self.bar.take() {
+            bar.finish_and_clear();
         }
     }
 }
@@ -194,7 +224,13 @@ impl WorkerStream {
     }
 }
 
-fn drain_loop(output_paths: &[Utf8PathBuf], stop: &AtomicBool, stdout_rx: &mpsc::Receiver<String>) {
+fn drain_loop(
+    output_paths: &[Utf8PathBuf],
+    cache: &RunCache,
+    bar: Option<&ProgressBar>,
+    stop: &AtomicBool,
+    stdout_rx: &mpsc::Receiver<String>,
+) {
     let mut streams: Vec<WorkerStream> = output_paths
         .iter()
         .cloned()
@@ -214,7 +250,11 @@ fn drain_loop(output_paths: &[Utf8PathBuf], stop: &AtomicBool, stdout_rx: &mpsc:
                 progressed = true;
             }
         }
-        emit_lines(&lines);
+        emit_lines(&lines, bar);
+
+        if let Some(bar) = bar {
+            bar.set_position(cache.completed_count());
+        }
 
         if stop.load(Ordering::SeqCst) {
             let mut final_lines: Vec<String> = Vec::new();
@@ -224,7 +264,10 @@ fn drain_loop(output_paths: &[Utf8PathBuf], stop: &AtomicBool, stdout_rx: &mpsc:
             for stream in &mut streams {
                 stream.poll(&mut final_lines);
             }
-            emit_lines(&final_lines);
+            emit_lines(&final_lines, bar);
+            if let Some(bar) = bar {
+                bar.set_position(cache.completed_count());
+            }
             break;
         }
 
@@ -234,16 +277,47 @@ fn drain_loop(output_paths: &[Utf8PathBuf], stop: &AtomicBool, stdout_rx: &mpsc:
     }
 }
 
-fn emit_lines(lines: &[String]) {
+fn emit_lines(lines: &[String], bar: Option<&ProgressBar>) {
     if lines.is_empty() {
         return;
     }
 
-    let mut stdout = std::io::stdout().lock();
-    for line in lines {
-        if let Err(err) = writeln!(stdout, "{line}") {
-            tracing::warn!("failed to write worker output line: {err}");
-            return;
+    let write = || {
+        let mut stdout = std::io::stdout().lock();
+        for line in lines {
+            if let Err(err) = writeln!(stdout, "{line}") {
+                tracing::warn!("failed to write worker output line: {err}");
+                return;
+            }
+        }
+    };
+
+    if let Some(bar) = bar {
+        bar.suspend(write);
+    } else {
+        write();
+    }
+}
+
+fn style_for(mode: ProgressMode) -> ProgressStyle {
+    match mode {
+        ProgressMode::Bar => {
+            match ProgressStyle::with_template("{msg:8.dim} {bar:60.green/dim} {pos}/{len} tests") {
+                Ok(style) => style.progress_chars("--"),
+                Err(err) => {
+                    tracing::warn!("failed to create progress bar style: {err}");
+                    ProgressStyle::default_bar()
+                }
+            }
+        }
+        ProgressMode::Counter | ProgressMode::None => {
+            match ProgressStyle::with_template("{pos}/{len} tests") {
+                Ok(style) => style,
+                Err(err) => {
+                    tracing::warn!("failed to create progress counter style: {err}");
+                    ProgressStyle::default_bar()
+                }
+            }
         }
     }
 }

--- a/crates/karva_runner/src/output.rs
+++ b/crates/karva_runner/src/output.rs
@@ -1,0 +1,249 @@
+//! Serialized worker output drain.
+//!
+//! Workers write preformatted reporter lines to per-worker output files while
+//! their stdout is piped to the orchestrator. The drain below is the single
+//! owner that prints those lines to stdout, which prevents parallel workers
+//! from interleaving bytes on the shared terminal.
+
+use std::fs::File;
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write as _};
+use std::process::ChildStdout;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use camino::Utf8PathBuf;
+use karva_cache::RunCache;
+
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Captured stdout pipe for a single worker child process.
+pub struct WorkerPipes {
+    pub stdout: Option<ChildStdout>,
+}
+
+/// Drains per-worker output files and stdout pipes.
+pub struct OutputDrain {
+    stop: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+    pipe_handles: Vec<JoinHandle<()>>,
+}
+
+impl OutputDrain {
+    /// Start the output drain.
+    pub fn start(num_workers: usize, cache: &RunCache, pipes: Vec<WorkerPipes>) -> Self {
+        let output_paths: Vec<Utf8PathBuf> =
+            (0..num_workers).map(|id| cache.output_file(id)).collect();
+
+        let (stdout_tx, stdout_rx) = mpsc::channel::<String>();
+
+        let mut pipe_handles: Vec<JoinHandle<()>> = Vec::new();
+        for pipe in pipes {
+            if let Some(out) = pipe.stdout {
+                let tx = stdout_tx.clone();
+                pipe_handles.push(thread::spawn(move || forward_pipe(out, &tx)));
+            }
+        }
+        drop(stdout_tx);
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let handle = {
+            let stop = Arc::clone(&stop);
+            thread::spawn(move || drain_loop(&output_paths, &stop, &stdout_rx))
+        };
+
+        Self {
+            stop,
+            handle: Some(handle),
+            pipe_handles,
+        }
+    }
+
+    /// Stop polling and drain remaining whole lines.
+    pub fn finish(mut self) {
+        self.shutdown();
+    }
+
+    fn shutdown(&mut self) {
+        for handle in self.pipe_handles.drain(..) {
+            if handle.join().is_err() {
+                tracing::warn!("worker stdout drain thread panicked");
+            }
+        }
+        self.stop.store(true, Ordering::SeqCst);
+        if let Some(handle) = self.handle.take()
+            && handle.join().is_err()
+        {
+            tracing::warn!("worker output drain thread panicked");
+        }
+    }
+}
+
+impl Drop for OutputDrain {
+    fn drop(&mut self) {
+        if !self.stop.load(Ordering::SeqCst) {
+            self.shutdown();
+        }
+    }
+}
+
+fn forward_pipe<R: Read>(reader: R, tx: &mpsc::Sender<String>) {
+    let mut reader = BufReader::new(reader);
+    let mut buf: Vec<u8> = Vec::new();
+    loop {
+        buf.clear();
+        match reader.read_until(b'\n', &mut buf) {
+            Ok(0) => return,
+            Ok(_) => {
+                if buf.last() == Some(&b'\n') {
+                    buf.pop();
+                }
+                let line = String::from_utf8_lossy(&buf).into_owned();
+                if tx.send(line).is_err() {
+                    return;
+                }
+            }
+            Err(err) => {
+                tracing::warn!("failed to read worker stdout pipe: {err}");
+                return;
+            }
+        }
+    }
+}
+
+struct WorkerStream {
+    path: Utf8PathBuf,
+    file: Option<File>,
+    offset: u64,
+    partial: Vec<u8>,
+}
+
+impl WorkerStream {
+    fn new(path: Utf8PathBuf) -> Self {
+        Self {
+            path,
+            file: None,
+            offset: 0,
+            partial: Vec::new(),
+        }
+    }
+
+    fn poll(&mut self, out: &mut Vec<String>) -> bool {
+        if self.file.is_none() {
+            if !self.path.exists() {
+                return false;
+            }
+            match File::open(&self.path) {
+                Ok(file) => self.file = Some(file),
+                Err(err) => {
+                    tracing::warn!(path = %self.path, "failed to open worker output file: {err}");
+                    return false;
+                }
+            }
+        }
+
+        let Some(file) = self.file.as_mut() else {
+            return false;
+        };
+
+        if let Err(err) = file.seek(SeekFrom::Start(self.offset)) {
+            tracing::warn!(path = %self.path, "failed to seek worker output file: {err}");
+            return false;
+        }
+
+        let mut buf = Vec::new();
+        let n = match file.read_to_end(&mut buf) {
+            Ok(n) => n,
+            Err(err) => {
+                tracing::warn!(path = %self.path, "failed to read worker output file: {err}");
+                return false;
+            }
+        };
+        if n == 0 {
+            return false;
+        }
+        let Ok(read_len) = u64::try_from(n) else {
+            tracing::warn!(path = %self.path, "worker output file read length does not fit u64");
+            return false;
+        };
+        self.offset = self.offset.saturating_add(read_len);
+
+        let mut start = 0usize;
+        for (index, byte) in buf.iter().enumerate() {
+            if *byte == b'\n' {
+                let line_bytes = if self.partial.is_empty() {
+                    &buf[start..index]
+                } else {
+                    self.partial.extend_from_slice(&buf[start..index]);
+                    self.partial.as_slice()
+                };
+                out.push(String::from_utf8_lossy(line_bytes).into_owned());
+                if !self.partial.is_empty() {
+                    self.partial.clear();
+                }
+                start = index + 1;
+            }
+        }
+        if start < buf.len() {
+            self.partial.extend_from_slice(&buf[start..]);
+        }
+
+        true
+    }
+}
+
+fn drain_loop(output_paths: &[Utf8PathBuf], stop: &AtomicBool, stdout_rx: &mpsc::Receiver<String>) {
+    let mut streams: Vec<WorkerStream> = output_paths
+        .iter()
+        .cloned()
+        .map(WorkerStream::new)
+        .collect();
+
+    loop {
+        let mut lines: Vec<String> = Vec::new();
+        let mut progressed = false;
+
+        while let Ok(line) = stdout_rx.try_recv() {
+            lines.push(line);
+            progressed = true;
+        }
+        for stream in &mut streams {
+            if stream.poll(&mut lines) {
+                progressed = true;
+            }
+        }
+        emit_lines(&lines);
+
+        if stop.load(Ordering::SeqCst) {
+            let mut final_lines: Vec<String> = Vec::new();
+            while let Ok(line) = stdout_rx.try_recv() {
+                final_lines.push(line);
+            }
+            for stream in &mut streams {
+                stream.poll(&mut final_lines);
+            }
+            emit_lines(&final_lines);
+            break;
+        }
+
+        if !progressed {
+            thread::sleep(POLL_INTERVAL);
+        }
+    }
+}
+
+fn emit_lines(lines: &[String]) {
+    if lines.is_empty() {
+        return;
+    }
+
+    let mut stdout = std::io::stdout().lock();
+    for line in lines {
+        if let Err(err) = writeln!(stdout, "{line}") {
+            tracing::warn!("failed to write worker output line: {err}");
+            return;
+        }
+    }
+}

--- a/crates/karva_runner/src/worker_args.rs
+++ b/crates/karva_runner/src/worker_args.rs
@@ -90,10 +90,17 @@ fn inner_cli_args(settings: &ProjectSettings, args: &SubTestCommand) -> Vec<Stri
     cli_args.push("--final-status-level".to_string());
     cli_args.push(settings.terminal().final_status_level.as_str().to_string());
 
-    if let Some(color) = args.color {
-        cli_args.push("--color".to_string());
-        cli_args.push(color.as_str().to_string());
-    }
+    cli_args.push("--color".to_string());
+    cli_args.push(match args.color {
+        Some(color) => color.as_str().to_string(),
+        None => {
+            if colored::control::SHOULD_COLORIZE.should_colorize() {
+                "always".to_string()
+            } else {
+                "never".to_string()
+            }
+        }
+    });
 
     if settings.test().try_import_fixtures {
         cli_args.push("--try-import-fixtures".to_string());

--- a/crates/karva_test_semantic/src/context.rs
+++ b/crates/karva_test_semantic/src/context.rs
@@ -85,6 +85,10 @@ impl<'a> Context<'a> {
         self.reporter.report_test_finished(test_case_name);
     }
 
+    pub fn notify_test_function_completed(&self, function_name: &QualifiedTestName) {
+        self.reporter.notify_test_completed(function_name);
+    }
+
     pub fn register_test_case_result(
         &self,
         test_case_name: &QualifiedTestName,

--- a/crates/karva_test_semantic/src/py_attach.rs
+++ b/crates/karva_test_semantic/src/py_attach.rs
@@ -27,6 +27,9 @@ where
 {
     attach(|py| {
         if show_output {
+            if let Err(err) = enable_line_buffering(py) {
+                tracing::warn!("failed to line-buffer Python stdout and stderr: {err}");
+            }
             return f(py);
         }
 
@@ -51,6 +54,20 @@ where
         }
         result
     })
+}
+
+fn enable_line_buffering(py: Python<'_>) -> PyResult<()> {
+    py.run(
+        c"import sys
+for stream in (sys.stdout, sys.stderr):
+    try:
+        stream.reconfigure(line_buffering=True)
+    except (AttributeError, ValueError):
+        pass
+",
+        None,
+        None,
+    )
 }
 
 fn open_devnull(py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -164,6 +164,12 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                 }
             }
 
+            self.context
+                .notify_test_function_completed(&QualifiedTestName::new(
+                    test_function.name.clone(),
+                    None,
+                ));
+
             if self.max_fail_reached() {
                 break;
             }

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -6,7 +6,7 @@ use camino::Utf8PathBuf;
 use clap::Parser;
 use karva_cache::{RunCache, RunHash};
 use karva_cli::{SubTestCommand, Verbosity};
-use karva_diagnostic::{DummyReporter, Reporter, TestCaseReporter};
+use karva_diagnostic::{DummyReporter, FileLineSink, LineSink, Reporter, TestCaseReporter};
 use karva_logging::{Printer, StatusLevel, set_colored_override, setup_tracing};
 use karva_metadata::RunIgnoredMode;
 use karva_metadata::filter::FiltersetSet;
@@ -149,17 +149,20 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
 
     let cache = RunCache::new(&args.cache_dir, &run_hash);
 
-    let progress_file = cache.current_test_file(args.worker_id);
-    // Make sure the worker dir exists so the reporter can write the
-    // progress file before the worker has otherwise touched it.
-    if let Some(parent) = progress_file.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("Failed to create worker progress directory `{parent}`"))?;
-    }
+    let worker_dir = cache.worker_dir(args.worker_id);
+    std::fs::create_dir_all(&worker_dir)
+        .with_context(|| format!("Failed to create worker directory `{worker_dir}`"))?;
+
+    let current_test_file = cache.current_test_file(args.worker_id);
     let reporter: Box<dyn Reporter> = if matches!(printer.status_level(), StatusLevel::None) {
         Box::new(DummyReporter)
     } else {
-        Box::new(TestCaseReporter::new(printer).with_progress_file(progress_file))
+        let output_path = cache.output_file(args.worker_id);
+        let sink: Box<dyn LineSink> = Box::new(
+            FileLineSink::open(output_path.as_std_path())
+                .with_context(|| format!("Failed to open worker output file `{output_path}`"))?,
+        );
+        Box::new(TestCaseReporter::new(printer, sink).with_current_test_file(current_test_file))
     };
 
     let result = karva_test_semantic::run_tests(

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -6,7 +6,9 @@ use camino::Utf8PathBuf;
 use clap::Parser;
 use karva_cache::{RunCache, RunHash};
 use karva_cli::{SubTestCommand, Verbosity};
-use karva_diagnostic::{DummyReporter, FileLineSink, LineSink, Reporter, TestCaseReporter};
+use karva_diagnostic::{
+    DummyReporter, FileLineSink, LineSink, ProgressTrackingReporter, Reporter, TestCaseReporter,
+};
 use karva_logging::{Printer, StatusLevel, set_colored_override, setup_tracing};
 use karva_metadata::RunIgnoredMode;
 use karva_metadata::filter::FiltersetSet;
@@ -154,15 +156,19 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
         .with_context(|| format!("Failed to create worker directory `{worker_dir}`"))?;
 
     let current_test_file = cache.current_test_file(args.worker_id);
+    let progress_file = cache.progress_file(args.worker_id).into_std_path_buf();
     let reporter: Box<dyn Reporter> = if matches!(printer.status_level(), StatusLevel::None) {
-        Box::new(DummyReporter)
+        Box::new(ProgressTrackingReporter::new(DummyReporter, progress_file))
     } else {
         let output_path = cache.output_file(args.worker_id);
         let sink: Box<dyn LineSink> = Box::new(
             FileLineSink::open(output_path.as_std_path())
                 .with_context(|| format!("Failed to open worker output file `{output_path}`"))?,
         );
-        Box::new(TestCaseReporter::new(printer, sink).with_current_test_file(current_test_file))
+        Box::new(ProgressTrackingReporter::new(
+            TestCaseReporter::new(printer, sink).with_current_test_file(current_test_file),
+            progress_file,
+        ))
     };
 
     let result = karva_test_semantic::run_tests(

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -207,6 +207,25 @@ output-format = "concise"
 
 ---
 
+### `show-progress`
+
+Live progress display rendered while tests run.
+
+Defaults to `none`.
+
+**Default value**: `none`
+
+**Type**: `none | counter | bar`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.karva.profile.default.terminal]
+show-progress = "bar"
+```
+
+---
+
 ### `show-python-output`
 
 Whether to show the python output.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -113,7 +113,13 @@ karva test [OPTIONS] [PATH]...
 </ul></dd><dt id="karva-test--run-timeout"><a href="#karva-test--run-timeout"><code>--run-timeout</code></a> <i>seconds</i></dt><dd><p>Wall-clock limit for the whole run, in seconds.</p>
 <p>When the run takes longer than this duration, karva stops the remaining workers and exits with a failure status. Accepts fractional seconds such as <code>--run-timeout=1800</code> or <code>--run-timeout=0.5</code>.</p>
 </dd><dt id="karva-test--show-output"><a href="#karva-test--show-output"><code>--show-output</code></a>, <code>-s</code></dt><dd><p>Show Python stdout during test execution</p>
-</dd><dt id="karva-test--slow-timeout"><a href="#karva-test--slow-timeout"><code>--slow-timeout</code></a> <i>seconds</i></dt><dd><p>Threshold in seconds after which a test is flagged as slow.</p>
+</dd><dt id="karva-test--show-progress"><a href="#karva-test--show-progress"><code>--show-progress</code></a> <i>mode</i></dt><dd><p>Live progress display while tests run &#91;default: none&#93;</p>
+<p>May also be set with the <code>KARVA_SHOW_PROGRESS</code> environment variable.</p><p>Possible values:</p>
+<ul>
+<li><code>none</code>:  No live progress display</li>
+<li><code>counter</code>:  Print a refreshing <code>N/M tests</code> counter on stderr</li>
+<li><code>bar</code>:  Render a visual progress bar on stderr</li>
+</ul></dd><dt id="karva-test--slow-timeout"><a href="#karva-test--slow-timeout"><code>--slow-timeout</code></a> <i>seconds</i></dt><dd><p>Threshold in seconds after which a test is flagged as slow.</p>
 <p>When a test takes longer than this duration, it is reported with a <code>SLOW</code> status line (gated on <code>--status-level=slow</code> or higher) and counted in the run summary. Pass a positive number such as <code>--slow-timeout=60</code> or <code>--slow-timeout=0.5</code>.</p>
 </dd><dt id="karva-test--snapshot-update"><a href="#karva-test--snapshot-update"><code>--snapshot-update</code></a></dt><dd><p>Update snapshots directly instead of creating pending <code>.snap.new</code> files.</p>
 <p>When set, <code>karva.assert_snapshot()</code> will write directly to <code>.snap</code> files, accepting any changes automatically.</p>


### PR DESCRIPTION
## Summary

This adds the `--show-progress` and `terminal.show-progress` option on top of the serialized worker output drain. The progress display renders a counter or bar on stderr and uses per-worker progress files so the orchestrator can update progress without interleaving stdout.

Closes #570.

## Test Plan

cargo test -p karva_diagnostic --lib; uvx maturin build; cargo test -p karva --test it test_show_progress -- --nocapture; uvx prek run -a