### PR TITLE
Improve nextest CI output

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,16 @@
 [profile.ci]
 retries = 2
 fail-fast = false
+
+# Print failing test output immediately and again at the end for easier CI
+# scrollback.
+failure-output = "immediate-final"
+
+# Keep routine passing test output quiet, but include slow tests in the final
+# summary.
+status-level = "skip"
+final-status-level = "slow"
+
+# Mark tests that take longer than 1s as slow, and terminate tests that exceed
+# 60s as a stop-gap against deadlocks.
+slow-timeout = { period = "1s", terminate-after = 60 }


### PR DESCRIPTION
## Summary

Updates the CI nextest profile so failing test output is printed immediately and repeated at the end, while routine passing output stays quiet. The profile now also reports slow tests in the final summary and terminates tests that exceed the configured timeout.

## Test Plan

`cargo nextest run --profile ci -p karva_static`; `uvx prek run -a`.