### PR TITLE
Add issue template routing

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://matthewmckee4.github.io/karva/
+    about: Please consult the documentation before creating an issue.


### PR DESCRIPTION
## Summary

Adds an issue-template config file so the GitHub issue chooser can point users to the documentation before they open an issue. Blank issues remain enabled.

## Test Plan

`uvx prek run -a`.