### PR TITLE
Validate workflow schemas in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,12 @@ repos:
       - id: zizmor
         priority: 0
 
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.37.2
+    hooks:
+      - id: check-github-workflows
+        priority: 0
+
   - repo: https://github.com/executablebooks/mdformat
     rev: 1.0.0
     hooks:


### PR DESCRIPTION
## Summary

Adds the `check-github-workflows` pre-commit hook so workflow files are validated against the GitHub Actions schema in addition to actionlint and zizmor. This catches malformed workflow structure before CI.

## Test Plan

`uvx prek run -a`.