### PR TITLE
Improve CI workflow defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,16 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
   PYTHON_VERSION: "3.14"
+  RUSTUP_MAX_RETRIES: 10
   NEXTEST_PROFILE: ci
 
 jobs:


### PR DESCRIPTION
## Summary

Adds workflow-level concurrency so superseded CI runs are cancelled, and sets Cargo/Rustup defaults for non-incremental CI builds, retrying network operations, and colored Cargo output.

## Test Plan

`pinact run`; `uvx prek run -a`.