### PR TITLE
Reduce status output progress tracking overhead

### DIFF
--- a/crates/karva_benchmark/src/bin/karva_benchmark.rs
+++ b/crates/karva_benchmark/src/bin/karva_benchmark.rs
@@ -351,6 +351,8 @@ fn run_subject(
         .with_context(|| format!("Failed to install `{}` benchmark wheel", subject.label))?;
     karva_benchmark::clean_project_cache(project_root)
         .with_context(|| format!("Failed to clean benchmark cache for `{}`", config.name))?;
+    warm_project_cache(config, project_root)
+        .with_context(|| format!("Failed to warm benchmark cache for `{}`", config.name))?;
 
     let value = run_project_cli(metric, config, project_root)
         .with_context(|| format!("Failed to run `{}` with `{}`", config.name, subject.label))?;
@@ -378,16 +380,17 @@ fn run_project_cli(
     }
 }
 
+fn warm_project_cache(config: &BenchmarkProject, project_root: &Utf8Path) -> Result<()> {
+    let invocation = karva_invocation(config, project_root)?;
+    let output = run_invocation(&invocation, project_root)?;
+    ensure_karva_success(&output, config)
+}
+
 fn run_project_wall_time(config: &BenchmarkProject, project_root: &Utf8Path) -> Result<f64> {
     let invocation = karva_invocation(config, project_root)?;
 
     let start = Instant::now();
-    let output = invocation.command(project_root).output().with_context(|| {
-        format!(
-            "Failed to execute `{}`",
-            invocation.binary.as_std_path().display()
-        )
-    })?;
+    let output = run_invocation(&invocation, project_root)?;
     let elapsed = start.elapsed();
 
     ensure_karva_success(&output, config)?;
@@ -428,6 +431,15 @@ fn run_project_peak_rss_kib(config: &BenchmarkProject, project_root: &Utf8Path) 
     }
 }
 
+fn run_invocation(invocation: &KarvaInvocation, project_root: &Utf8Path) -> Result<Output> {
+    invocation.command(project_root).output().with_context(|| {
+        format!(
+            "Failed to execute `{}`",
+            invocation.binary.as_std_path().display()
+        )
+    })
+}
+
 fn karva_invocation(config: &BenchmarkProject, project_root: &Utf8Path) -> Result<KarvaInvocation> {
     let bin_dir = venv_bin_dir(project_root);
     let binary = bin_dir.join(executable_name("karva"));
@@ -438,14 +450,9 @@ fn karva_invocation(config: &BenchmarkProject, project_root: &Utf8Path) -> Resul
         "test".to_string(),
         "--num-workers".to_string(),
         worker_count,
-        "--no-cache".to_string(),
         "--no-ignore".to_string(),
         "--output-format".to_string(),
         "concise".to_string(),
-        "--status-level".to_string(),
-        "none".to_string(),
-        "--final-status-level".to_string(),
-        "none".to_string(),
     ];
 
     if config.try_import_fixtures {
@@ -684,10 +691,10 @@ impl BenchmarkMetric {
     fn report_context(self) -> &'static str {
         match self {
             Self::WallTime => {
-                "Each benchmark compares median CLI wall time on one GitHub Actions runner, alternating install order. Runs are configured per project. Lower is better."
+                "Each benchmark compares median CLI wall time on one GitHub Actions runner, alternating install order. Runs warm the duration cache before measuring and include default per-test status output. Lower is better."
             }
             Self::Memory => {
-                "Each benchmark compares median peak RSS for the installed Karva CLI on one GitHub Actions runner, alternating install order. Runs are configured per project. Lower is better."
+                "Each benchmark compares median peak RSS for the installed Karva CLI on one GitHub Actions runner, alternating install order. Runs warm the duration cache before measuring and are configured per project. Lower is better."
             }
         }
     }
@@ -792,9 +799,11 @@ fn utf8_path(path: PathBuf) -> Result<Utf8PathBuf> {
 
 #[cfg(test)]
 mod tests {
+    use camino::Utf8Path;
+
     use super::{
         BenchmarkMetric, ComparisonReport, FAST_PROJECT_ITERATIONS, MEDIUM_PROJECT_ITERATIONS,
-        Measurement, ProjectComparison, SLOW_PROJECT_ITERATIONS, markdown_report,
+        Measurement, ProjectComparison, SLOW_PROJECT_ITERATIONS, karva_invocation, markdown_report,
         matrix_iterations, trend,
     };
 
@@ -871,6 +880,23 @@ mod tests {
         assert_eq!(matrix_iterations("tomlkit"), MEDIUM_PROJECT_ITERATIONS);
         assert_eq!(matrix_iterations("packaging"), SLOW_PROJECT_ITERATIONS);
         assert_eq!(matrix_iterations("pyparsing"), SLOW_PROJECT_ITERATIONS);
+    }
+
+    #[test]
+    fn cli_benchmark_invocation_uses_normal_cached_status_output() {
+        let invocation = karva_invocation(
+            &karva_benchmark::SYNTHETIC_PROJECT,
+            Utf8Path::new("/tmp/project"),
+        )
+        .expect("invocation should build");
+
+        assert!(
+            !invocation
+                .args
+                .iter()
+                .any(|arg| arg == "--status-level" || arg == "--final-status-level")
+        );
+        assert!(!invocation.args.iter().any(|arg| arg == "--no-cache"));
     }
 
     fn report_with_projects(projects: Vec<ProjectComparison>) -> ComparisonReport {

--- a/crates/karva_cache/src/artifact.rs
+++ b/crates/karva_cache/src/artifact.rs
@@ -33,8 +33,8 @@ pub enum CacheFile {
     /// Cache-root JSON: list of last-run failed test names.
     LastFailed,
     /// Per-worker JSON: name + start time of the test currently executing,
-    /// or absent when the worker is between tests. Used by the orchestrator
-    /// to render per-test `SIGINT` lines on Ctrl+C.
+    /// or empty/absent when the worker is between tests. Used by the
+    /// orchestrator to render per-test `SIGINT` lines on Ctrl+C.
     CurrentTest,
 }
 

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::fs;
+use std::io::ErrorKind;
 use std::time::Duration;
 
 use anyhow::Result;
@@ -14,7 +15,7 @@ use crate::{RUN_PREFIX, RunHash, WORKER_PREFIX, worker_folder};
 
 /// Snapshot of the test a worker is currently executing.
 ///
-/// Workers update this file at the start of each test and remove it on
+/// Workers update this file at the start of each test and clear it on
 /// completion; the orchestrator reads it on Ctrl+C to render per-test
 /// `SIGINT` lines.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -99,9 +100,21 @@ impl RunCache {
     }
 
     /// Reads the snapshot of which test the worker is currently running.
-    /// Returns `None` if the worker is between tests or hasn't started yet.
+    /// Returns `None` if the worker is between tests, hasn't started yet, or
+    /// has cleared its progress file after finishing a test.
     pub fn read_current_test(&self, worker_id: usize) -> Result<Option<CurrentTest>> {
-        read_json::<CurrentTest>(&self.worker_dir(worker_id), CacheFile::CurrentTest)
+        let path = self.current_test_file(worker_id);
+        let content = match fs::read_to_string(path) {
+            Ok(content) => content,
+            Err(err) if err.kind() == ErrorKind::NotFound => return Ok(None),
+            Err(err) => return Err(err.into()),
+        };
+
+        if content.trim().is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(serde_json::from_str(&content)?))
     }
 
     /// Returns paths to every per-worker coverage file that exists for this
@@ -617,6 +630,19 @@ mod tests {
             "mod::test_slow": 42ms,
         }
         "#);
+    }
+
+    #[test]
+    fn read_current_test_treats_empty_progress_file_as_between_tests() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let run_hash = RunHash::from_existing("run-750");
+        let cache = RunCache::new(&cache_dir, &run_hash);
+        let progress_file = cache.current_test_file(0);
+        fs::create_dir_all(progress_file.parent().expect("progress file parent")).unwrap();
+        fs::write(progress_file, "").unwrap();
+
+        assert!(cache.read_current_test(0).unwrap().is_none());
     }
 
     #[test]

--- a/crates/karva_diagnostic/src/reporter.rs
+++ b/crates/karva_diagnostic/src/reporter.rs
@@ -1,12 +1,16 @@
-use std::io::ErrorKind;
-use std::io::Write;
+use std::fs::{File, OpenOptions};
+use std::io::{Seek, SeekFrom, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use camino::Utf8PathBuf;
+use camino::Utf8Path;
 use colored::Colorize;
 use karva_logging::time::format_duration_bracketed;
 use karva_logging::{Printer, StatusLevel};
 use karva_python_semantic::QualifiedTestName;
+use serde::Serialize;
 
 use crate::result::IndividualTestResultKind;
 
@@ -97,7 +101,7 @@ pub struct TestCaseReporter {
     /// Optional path to a JSON file describing the test currently
     /// executing. The orchestrator reads this on Ctrl+C to render
     /// per-test `SIGINT` lines.
-    progress_file: Option<Utf8PathBuf>,
+    progress_file: Option<Mutex<ProgressFile>>,
 }
 
 impl TestCaseReporter {
@@ -108,14 +112,131 @@ impl TestCaseReporter {
         }
     }
 
-    /// Direct the reporter to write the currently running test's name and
-    /// start time to `path` whenever a test begins, and remove the file
-    /// when it ends.
-    #[must_use]
-    pub fn with_progress_file(mut self, path: Utf8PathBuf) -> Self {
-        self.progress_file = Some(path);
-        self
+    /// Direct the reporter to publish the currently running test's name and
+    /// start time to `path` while it is in flight.
+    pub fn with_progress_file(mut self, path: &Utf8Path) -> std::io::Result<Self> {
+        self.progress_file = Some(Mutex::new(ProgressFile::spawn(path)?));
+        Ok(self)
     }
+}
+
+struct ProgressFile {
+    state: Arc<Mutex<Option<ProgressSnapshot>>>,
+    stop: Arc<AtomicBool>,
+    flusher: Option<JoinHandle<()>>,
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize)]
+struct ProgressSnapshot {
+    name: String,
+    start_unix_ms: u64,
+}
+
+impl ProgressFile {
+    fn spawn(path: &Utf8Path) -> std::io::Result<Self> {
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(path)?;
+        let state = Arc::new(Mutex::new(None));
+        let stop = Arc::new(AtomicBool::new(false));
+        let flusher_state = Arc::clone(&state);
+        let flusher_stop = Arc::clone(&stop);
+        let flusher = thread::spawn(move || {
+            flush_progress_file(file, &flusher_state, &flusher_stop);
+        });
+
+        Ok(Self {
+            state,
+            stop,
+            flusher: Some(flusher),
+        })
+    }
+
+    fn set_current_test(&self, snapshot: ProgressSnapshot) -> std::io::Result<()> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| std::io::Error::other("test progress state lock poisoned"))?;
+        *state = Some(snapshot);
+        Ok(())
+    }
+
+    fn clear(&self) -> std::io::Result<()> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| std::io::Error::other("test progress state lock poisoned"))?;
+        *state = None;
+        Ok(())
+    }
+}
+
+impl Drop for ProgressFile {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Release);
+        if let Some(flusher) = self.flusher.take()
+            && let Err(err) = flusher.join()
+        {
+            tracing::warn!(?err, "test progress flusher thread panicked");
+        }
+    }
+}
+
+const PROGRESS_FLUSH_INTERVAL: Duration = Duration::from_millis(25);
+
+fn flush_progress_file(mut file: File, state: &Mutex<Option<ProgressSnapshot>>, stop: &AtomicBool) {
+    let mut written = None;
+    while !stop.load(Ordering::Acquire) {
+        flush_progress_snapshot(&mut file, state, &mut written);
+        thread::sleep(PROGRESS_FLUSH_INTERVAL);
+    }
+    flush_progress_snapshot(&mut file, state, &mut written);
+    if let Err(err) = clear_progress_file(&mut file) {
+        tracing::warn!("failed to clear test progress file: {err}");
+    }
+}
+
+fn flush_progress_snapshot(
+    file: &mut File,
+    state: &Mutex<Option<ProgressSnapshot>>,
+    written: &mut Option<ProgressSnapshot>,
+) {
+    let snapshot = if let Ok(state) = state.lock() {
+        state.clone()
+    } else {
+        tracing::warn!("failed to lock test progress state");
+        return;
+    };
+
+    if snapshot == *written {
+        return;
+    }
+
+    let result = match snapshot.as_ref() {
+        Some(snapshot) => write_progress_file(file, snapshot),
+        None => clear_progress_file(file),
+    };
+    if let Err(err) = result {
+        tracing::warn!("failed to flush test progress file: {err}");
+        return;
+    }
+
+    *written = snapshot;
+}
+
+fn write_progress_file(file: &mut File, snapshot: &ProgressSnapshot) -> std::io::Result<()> {
+    file.set_len(0)?;
+    file.seek(SeekFrom::Start(0))?;
+    serde_json::to_writer(file, snapshot)?;
+    Ok(())
+}
+
+fn clear_progress_file(file: &mut File) -> std::io::Result<()> {
+    file.set_len(0)?;
+    file.seek(SeekFrom::Start(0))?;
+    Ok(())
 }
 
 impl Reporter for TestCaseReporter {
@@ -142,10 +263,9 @@ impl Reporter for TestCaseReporter {
             _ => String::new(),
         };
 
-        let mut stdout = self.printer.stream_for_test_result().lock();
-        if let Err(err) = writeln!(
-            stdout,
-            "{padding}{colored_label} {duration_str} {test_path}{suffix}"
+        if let Err(err) = write_test_result_line(
+            self.printer,
+            format!("{padding}{colored_label} {duration_str} {test_path}{suffix}"),
         ) {
             tracing::warn!("failed to write test result line: {err}");
         }
@@ -162,10 +282,9 @@ impl Reporter for TestCaseReporter {
         let duration_str = format_duration_bracketed(duration);
         let test_path = format_test_path(test_name);
 
-        let mut stdout = self.printer.stream_for_test_result().lock();
-        if let Err(err) = writeln!(
-            stdout,
-            "{padding}{colored_label} {duration_str} {test_path}"
+        if let Err(err) = write_test_result_line(
+            self.printer,
+            format!("{padding}{colored_label} {duration_str} {test_path}"),
         ) {
             tracing::warn!("failed to write slow test line: {err}");
         }
@@ -191,40 +310,45 @@ impl Reporter for TestCaseReporter {
         let duration_str = format_duration_bracketed(duration);
         let test_path = format_test_path(test_name);
 
-        let mut stdout = self.printer.stream_for_test_result().lock();
-        if let Err(err) = writeln!(
-            stdout,
-            "{padding}TRY {attempt} {colored_status} {duration_str} {test_path}"
+        if let Err(err) = write_test_result_line(
+            self.printer,
+            format!("{padding}TRY {attempt} {colored_status} {duration_str} {test_path}"),
         ) {
             tracing::warn!("failed to write test attempt line: {err}");
         }
     }
 
     fn report_test_started(&self, test_name: &QualifiedTestName) {
-        let Some(path) = self.progress_file.as_ref() else {
+        let Some(progress_file) = self.progress_file.as_ref() else {
             return;
         };
         let start_unix_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
             .unwrap_or(0);
-        let body = serde_json::json!({
-            "name": test_name.to_string(),
-            "start_unix_ms": start_unix_ms,
-        });
-        if let Err(err) = std::fs::write(path, body.to_string()) {
-            tracing::warn!(path = %path, "failed to write test progress file: {err}");
+        let snapshot = ProgressSnapshot {
+            name: test_name.to_string(),
+            start_unix_ms,
+        };
+        let Ok(progress_file) = progress_file.lock() else {
+            tracing::warn!("failed to lock test progress file");
+            return;
+        };
+        if let Err(err) = progress_file.set_current_test(snapshot) {
+            tracing::warn!("failed to update test progress state: {err}");
         }
     }
 
     fn report_test_finished(&self, _test_name: &QualifiedTestName) {
-        let Some(path) = self.progress_file.as_ref() else {
+        let Some(progress_file) = self.progress_file.as_ref() else {
             return;
         };
-        match std::fs::remove_file(path) {
-            Ok(()) => {}
-            Err(err) if err.kind() == ErrorKind::NotFound => {}
-            Err(err) => tracing::warn!(path = %path, "failed to remove test progress file: {err}"),
+        let Ok(progress_file) = progress_file.lock() else {
+            tracing::warn!("failed to lock test progress file");
+            return;
+        };
+        if let Err(err) = progress_file.clear() {
+            tracing::warn!("failed to clear test progress state: {err}");
         }
     }
 }
@@ -235,6 +359,12 @@ const LABEL_COLUMN_WIDTH: usize = 12;
 
 fn label_padding(label_len: usize) -> String {
     " ".repeat(LABEL_COLUMN_WIDTH.saturating_sub(label_len))
+}
+
+fn write_test_result_line(printer: Printer, mut line: String) -> std::io::Result<()> {
+    line.push('\n');
+    let mut stdout = printer.stream_for_test_result().lock();
+    stdout.write_all(line.as_bytes())
 }
 
 /// Render the colored `module::function[params]` portion of a result line.
@@ -292,6 +422,8 @@ impl From<&IndividualTestResultKind> for ResultLabel {
 
 #[cfg(test)]
 mod tests {
+    use std::time::{Duration, Instant};
+
     use camino::Utf8PathBuf;
     use karva_logging::Printer;
     use karva_python_semantic::{ModulePath, QualifiedFunctionName};
@@ -308,17 +440,43 @@ mod tests {
         )
     }
 
+    fn wait_for_progress_body(path: &Utf8Path, matches: impl Fn(&str) -> bool) -> String {
+        let start = Instant::now();
+        while start.elapsed() < Duration::from_secs(1) {
+            let body = std::fs::read_to_string(path).expect("progress file should exist");
+            if matches(&body) {
+                return body;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        panic!("timed out waiting for progress file body");
+    }
+
+    fn wait_for_empty_progress_body(path: &Utf8Path) {
+        let start = Instant::now();
+        while start.elapsed() < Duration::from_secs(1) {
+            let body = std::fs::read_to_string(path).expect("progress file should exist");
+            if body.is_empty() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        panic!("timed out waiting for progress file to clear");
+    }
+
     #[test]
-    fn progress_file_is_written_and_removed() {
+    fn progress_file_is_written_and_cleared() {
         let temp_dir = tempfile::tempdir().expect("create temp dir");
         let path = Utf8PathBuf::try_from(temp_dir.path().join("current-test.json"))
             .expect("temp path should be UTF-8");
-        let reporter = TestCaseReporter::new(Printer::default()).with_progress_file(path.clone());
+        let reporter = TestCaseReporter::new(Printer::default())
+            .with_progress_file(&path)
+            .expect("progress file should open");
         let test_name = qualified_test_name();
 
         reporter.report_test_started(&test_name);
 
-        let body = std::fs::read_to_string(&path).expect("progress file should exist");
+        let body = wait_for_progress_body(&path, |body| !body.is_empty());
         let progress: serde_json::Value =
             serde_json::from_str(&body).expect("progress file should be valid JSON");
         assert_eq!(progress["name"], "test_module::test_example");
@@ -326,16 +484,38 @@ mod tests {
 
         reporter.report_test_finished(&test_name);
 
-        assert!(!path.exists());
+        wait_for_empty_progress_body(&path);
     }
 
     #[test]
-    fn progress_file_cleanup_allows_missing_marker() {
+    fn progress_file_reuses_marker_without_stale_content() {
         let temp_dir = tempfile::tempdir().expect("create temp dir");
         let path = Utf8PathBuf::try_from(temp_dir.path().join("current-test.json"))
             .expect("temp path should be UTF-8");
-        let reporter = TestCaseReporter::new(Printer::default()).with_progress_file(path);
+        let reporter = TestCaseReporter::new(Printer::default())
+            .with_progress_file(&path)
+            .expect("progress file should open");
+
+        reporter.report_test_started(&QualifiedTestName::new(
+            QualifiedFunctionName::new(
+                "test_example_with_a_much_longer_name".to_string(),
+                ModulePath::new_with_name("test_module.py", "test_module".to_string()),
+            ),
+            None,
+        ));
+        let body = wait_for_progress_body(&path, |body| {
+            body.contains("test_example_with_a_much_longer_name")
+        });
+        assert!(body.contains("test_example_with_a_much_longer_name"));
 
         reporter.report_test_finished(&qualified_test_name());
+        reporter.report_test_started(&qualified_test_name());
+
+        let body = wait_for_progress_body(&path, |body| {
+            body.contains(r#""name":"test_module::test_example""#)
+        });
+        let progress: serde_json::Value =
+            serde_json::from_str(&body).expect("progress file should be valid JSON");
+        assert_eq!(progress["name"], "test_module::test_example");
     }
 }

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
-use std::io::Write;
-use std::process::{Child, Stdio};
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, ChildStdout, Stdio};
+use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
@@ -27,6 +28,7 @@ use crate::worker_args::{WorkerSpawn, worker_command};
 /// Width that result labels (`PASS`, `FAIL`, `SIGINT`) are right-padded to so
 /// columns align. Mirrors the constant in `karva_diagnostic::reporter`.
 const LABEL_COLUMN_WIDTH: usize = 12;
+const CURRENT_TEST_SETTLE: Duration = Duration::from_millis(50);
 
 /// How `wait_for_completion` exited.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -45,14 +47,16 @@ enum WaitOutcome {
 struct Worker {
     id: usize,
     child: Child,
+    output: Option<WorkerOutputForwarder>,
     start_time: Instant,
 }
 
 impl Worker {
-    fn new(id: usize, child: Child) -> Self {
+    fn new(id: usize, child: Child, output: Option<WorkerOutputForwarder>) -> Self {
         Self {
             id,
             child,
+            output,
             start_time: Instant::now(),
         }
     }
@@ -60,11 +64,54 @@ impl Worker {
     fn duration(&self) -> Duration {
         self.start_time.elapsed()
     }
+
+    fn join_output(&mut self) {
+        if let Some(output) = self.output.take() {
+            output.join(self.id);
+        }
+    }
 }
 
 #[derive(Default, Debug)]
 struct WorkerManager {
     workers: Vec<Worker>,
+}
+
+#[derive(Debug)]
+struct WorkerOutputForwarder {
+    handle: JoinHandle<std::io::Result<()>>,
+}
+
+impl WorkerOutputForwarder {
+    fn spawn(stdout: ChildStdout) -> Self {
+        let handle = thread::spawn(move || forward_worker_stdout(stdout));
+        Self { handle }
+    }
+
+    fn join(self, worker_id: usize) {
+        match self.handle.join() {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) if err.kind() == std::io::ErrorKind::BrokenPipe => {}
+            Ok(Err(err)) => tracing::warn!(worker_id, "failed to forward worker stdout: {err}"),
+            Err(err) => tracing::warn!(worker_id, ?err, "worker stdout forwarder panicked"),
+        }
+    }
+}
+
+fn forward_worker_stdout(stdout: ChildStdout) -> std::io::Result<()> {
+    let mut reader = BufReader::new(stdout);
+    let mut line = Vec::new();
+
+    loop {
+        line.clear();
+        let bytes_read = reader.read_until(b'\n', &mut line)?;
+        if bytes_read == 0 {
+            return Ok(());
+        }
+
+        let mut stdout = std::io::stdout().lock();
+        stdout.write_all(&line)?;
+    }
 }
 
 struct InFlightTest {
@@ -79,8 +126,8 @@ struct InterruptedTest {
 }
 
 impl WorkerManager {
-    fn spawn(&mut self, worker_id: usize, child: Child) {
-        self.workers.push(Worker::new(worker_id, child));
+    fn spawn(&mut self, worker_id: usize, child: Child, output: Option<WorkerOutputForwarder>) {
+        self.workers.push(Worker::new(worker_id, child, output));
     }
 
     /// Wait for all workers to complete.
@@ -113,6 +160,7 @@ impl WorkerManager {
             self.workers
                 .retain_mut(|worker| match worker.child.try_wait() {
                     Ok(Some(status)) => {
+                        worker.join_output();
                         if status.success() {
                             tracing::info!(
                                 "Worker {} completed successfully in {}",
@@ -190,26 +238,27 @@ impl WorkerManager {
                     "failed to wait for worker process: {err}"
                 );
             }
+            worker.join_output();
         }
     }
 
     /// Stop remaining workers and emit nextest-style cancellation lines.
     ///
-    /// Each worker writes a `current_test.json` file at the start of every
-    /// test and removes it when the test finishes. We read those files
-    /// *before* killing — once we kill the worker, that file may be removed
-    /// by an in-flight finalizer or simply lost — and remember a
+    /// Each worker publishes a `current_test.json` file while a test is in
+    /// flight and clears it when the worker is between tests. We read those
+    /// files *before* killing — once we kill the worker, that file may be
+    /// removed by an in-flight finalizer or simply lost — and remember a
     /// `(worker_id, test name, test start time)` snapshot for each.
     ///
-    /// Workers are killed and reaped before we print so any in-flight
-    /// `PASS`/`FAIL` lines they were writing to the inherited stdout land
-    /// before our banner; otherwise the cancellation block interleaves
-    /// with worker output. A short settle pause lets any kernel-buffered
-    /// writes drain.
+    /// Workers are killed, reaped, and have their forwarded stdout drained
+    /// before we print so any in-flight `PASS`/`FAIL` lines land before the
+    /// cancellation block.
     fn cancel_and_kill(&mut self, printer: Printer, cache: &RunCache) -> Vec<InterruptedTest> {
         if self.workers.is_empty() {
             return Vec::new();
         }
+
+        std::thread::sleep(CURRENT_TEST_SETTLE);
 
         let now_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -260,8 +309,8 @@ impl WorkerManager {
                     "failed to wait for worker process: {err}"
                 );
             }
+            worker.join_output();
         }
-        std::thread::sleep(STDOUT_SETTLE);
 
         let mut stdout = printer.stream_for_test_result().lock();
         let cancel_label = "Cancelling".yellow().bold();
@@ -361,7 +410,11 @@ pub struct ParallelTestConfig {
 ///
 /// Creates a worker process for each non-empty partition, passing the appropriate
 /// subset of tests and command-line arguments to each worker.
-fn spawn_workers(spawn: &WorkerSpawn, partitions: &[Partition]) -> Result<WorkerManager> {
+fn spawn_workers(
+    spawn: &WorkerSpawn,
+    partitions: &[Partition],
+    forward_stdout: bool,
+) -> Result<WorkerManager> {
     let mut worker_manager = WorkerManager::default();
 
     for (worker_id, partition) in partitions.iter().enumerate() {
@@ -370,11 +423,22 @@ fn spawn_workers(spawn: &WorkerSpawn, partitions: &[Partition]) -> Result<Worker
             continue;
         }
 
-        let child = worker_command(spawn, worker_id, partition)
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit())
+        let mut command = worker_command(spawn, worker_id, partition);
+        command.stderr(Stdio::inherit());
+        if forward_stdout {
+            command.stdout(Stdio::piped());
+        } else {
+            command.stdout(Stdio::inherit());
+        }
+
+        let mut child = command
             .spawn()
             .context("Failed to spawn karva-worker process")?;
+        let output = if forward_stdout {
+            child.stdout.take().map(WorkerOutputForwarder::spawn)
+        } else {
+            None
+        };
 
         tracing::info!(
             "Worker {} spawned with {} tests",
@@ -382,7 +446,7 @@ fn spawn_workers(spawn: &WorkerSpawn, partitions: &[Partition]) -> Result<Worker
             partition.tests().len()
         );
 
-        worker_manager.spawn(worker_id, child);
+        worker_manager.spawn(worker_id, child, output);
     }
 
     Ok(worker_manager)
@@ -534,7 +598,8 @@ pub fn run_parallel_tests(
         worker_binary: &worker_binary,
         coverage_enabled: !project.settings().coverage().sources.is_empty(),
     };
-    let mut worker_manager = spawn_workers(&spawn, &partitions)?;
+    let forward_stdout = printer.stream_for_test_result().is_enabled();
+    let mut worker_manager = spawn_workers(&spawn, &partitions, forward_stdout)?;
 
     let max_fail_cache = project.settings().max_fail().has_limit().then_some(&cache);
 
@@ -572,10 +637,6 @@ pub fn run_parallel_tests(
 
 const MIN_TESTS_PER_WORKER: usize = 5;
 const WORKER_POLL_INTERVAL: Duration = Duration::from_millis(10);
-/// Pause after killing workers to let kernel-buffered output drain to
-/// stdout before we emit the cancellation banner.
-const STDOUT_SETTLE: Duration = Duration::from_millis(50);
-
 fn previous_durations(cache_dir: &Utf8Path, no_cache: bool) -> HashMap<String, Duration> {
     if no_cache {
         return HashMap::new();

--- a/crates/karva_runner/src/worker_args.rs
+++ b/crates/karva_runner/src/worker_args.rs
@@ -4,6 +4,7 @@ use camino::Utf8PathBuf;
 
 use karva_cache::{RunCache, RunHash};
 use karva_cli::SubTestCommand;
+use karva_logging::TerminalColor;
 use karva_metadata::ProjectSettings;
 use karva_project::Project;
 use karva_static::WorkerEnvVars;
@@ -90,7 +91,12 @@ fn inner_cli_args(settings: &ProjectSettings, args: &SubTestCommand) -> Vec<Stri
     cli_args.push("--final-status-level".to_string());
     cli_args.push(settings.terminal().final_status_level.as_str().to_string());
 
-    if let Some(color) = args.color {
+    let color = args.color.or_else(|| {
+        colored::control::SHOULD_COLORIZE
+            .should_colorize()
+            .then_some(TerminalColor::Always)
+    });
+    if let Some(color) = color {
         cli_args.push("--color".to_string());
         cli_args.push(color.as_str().to_string());
     }

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -159,7 +159,11 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
     let reporter: Box<dyn Reporter> = if matches!(printer.status_level(), StatusLevel::None) {
         Box::new(DummyReporter)
     } else {
-        Box::new(TestCaseReporter::new(printer).with_progress_file(progress_file))
+        Box::new(
+            TestCaseReporter::new(printer)
+                .with_progress_file(&progress_file)
+                .context("Failed to open worker progress file")?,
+        )
     };
 
     let result = karva_test_semantic::run_tests(


### PR DESCRIPTION
## Summary

Status output no longer writes and removes `current_test.json` for every passing test. Workers keep the current test in memory and publish progress through a low-rate background flusher for Ctrl-C reporting, which keeps SIGINT test names while avoiding the hot-path filesystem churn.

Worker stdout is now forwarded through the parent process when per-test status output is enabled, so result lines are emitted as complete lines from one process instead of racing across worker processes on the same terminal. The forwarding path preserves automatic color behavior by forcing worker color only when the parent would have colored output.

The CLI benchmark now warms the duration cache, then measures the normal cached invocation with default status output instead of forcing `--status-level none`, `--final-status-level none`, or `--no-cache`. Local serial runs of `uv run karva test tests` in `../karva-benchmark-1` stayed around the expected 2.5s range after warm-up, and captured output scans found no merged `PASS` lines.

Closes #502.

## Test Plan

`cargo test -p karva_runner -p karva_worker`, `cargo test -p karva_benchmark`, focused `karva` integration tests for Ctrl-C, multi-worker fail-fast, `-s` output, and worker counts, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `uvx prek run -a`, plus local benchmark output scans.
