### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+Karva is a Python test framework. By design, it imports and executes Python test
+files, fixtures, and the code those tests exercise.
+
+Running an untrusted test suite is therefore equivalent to running untrusted
+Python code. Arbitrary behavior caused by test code, fixture setup or teardown,
+imports during discovery, subprocesses, native extensions, or the code under test
+is not considered a vulnerability in Karva.
+
+If you think Karva can make one of those areas clearer or harder to misuse,
+please open a feature request instead.
+
+Please report vulnerabilities in Karva itself privately by emailing
+<matthewmckee04@yahoo.co.uk>. Include the affected version, a minimal
+reproduction, and the impact you expect.
+
+Security fixes target the latest released version and the `main` branch.


### PR DESCRIPTION
## Summary

Add a security policy that explains Karva's trusted-code boundary as a Python test framework. The policy gives users a private reporting path while making clear that executing untrusted test suites is out of scope as a vulnerability.

## Test Plan

uvx prek run -a