### PR TITLE
Improve issue template routing

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yaml
@@ -1,5 +1,6 @@
 name: Bug report
 description: Report an error or unexpected behavior
+labels: ["bug"]
 body:
   - type: markdown
     attributes:
@@ -21,8 +22,24 @@ body:
 
   - type: input
     attributes:
+      label: Platform
+      description: What operating system and architecture are you using? (see `uname -orsm`)
+      placeholder: e.g., macOS 15 arm64, Windows 11 x86_64, Ubuntu 24.04 amd64
+    validations:
+      required: true
+
+  - type: input
+    attributes:
       label: Version
       description: What version of Karva are you using? (see `karva --version`)
       placeholder: e.g., Karva 0.1.0
     validations:
-      required: false
+      required: true
+
+  - type: input
+    attributes:
+      label: Python version
+      description: What version of Python are you using? (see `python --version`)
+      placeholder: e.g., Python 3.12.6
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,6 @@ contact_links:
   - name: Documentation
     url: https://matthewmckee4.github.io/karva/
     about: Please consult the documentation before creating an issue.
+  - name: Community
+    url: https://discord.gg/XG95vNz4Zu
+    about: Join the Discord community to ask questions and collaborate.


### PR DESCRIPTION
## Summary

Tighten the bug report template by applying the bug label and collecting platform, Karva version, and Python version up front. Also add the existing Discord community link to the issue chooser so support questions have a clearer route.

## Test Plan

uvx prek run -a