### PR TITLE
Improve CI change detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
             . \
             ':!.gitattributes' \
             ':!.github/CODEOWNERS' \
+            ':!.github/CODE_OF_CONDUCT.md' \
             ':!.github/FUNDING.yml' \
             ':!.github/ISSUE_TEMPLATE/**' \
             ':!.github/PULL_REQUEST_TEMPLATE.md' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,6 @@ jobs:
         run: |
           if git diff --quiet "${MERGE_BASE}...HEAD" -- \
             . \
-            ':!.editorconfig' \
             ':!.gitattributes' \
             ':!.github/CODEOWNERS' \
             ':!.github/FUNDING.yml' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,6 @@ jobs:
             . \
             ':!.editorconfig' \
             ':!.gitattributes' \
-            ':!.ignore' \
             ':!.github/CODEOWNERS' \
             ':!.github/FUNDING.yml' \
             ':!.github/ISSUE_TEMPLATE/**' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,6 @@ jobs:
             ':!.pre-commit-config.yaml' \
             ':!AGENTS.md' \
             ':!CHANGELOG.md' \
-            ':!CLAUDE.md' \
             ':!CODE_OF_CONDUCT.md' \
             ':!CONTRIBUTING.md' \
             ':!justfile' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
             . \
             ':!.editorconfig' \
             ':!.gitattributes' \
+            ':!.ignore' \
             ':!.github/CODEOWNERS' \
             ':!.github/FUNDING.yml' \
             ':!.github/ISSUE_TEMPLATE/**' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,19 @@ jobs:
         run: |
           if git diff --quiet "${MERGE_BASE}...HEAD" -- \
             . \
+            ':!.editorconfig' \
+            ':!.gitattributes' \
+            ':!.github/CODEOWNERS' \
+            ':!.github/FUNDING.yml' \
+            ':!.github/ISSUE_TEMPLATE/**' \
+            ':!.github/PULL_REQUEST_TEMPLATE.md' \
+            ':!.github/actionlint.yaml' \
+            ':!.github/dependabot.yml' \
+            ':!.github/zizmor.yml' \
             ':!docs/' \
             ':!.markdownlint.yaml' \
             ':!.pre-commit-config.yaml' \
+            ':!AGENTS.md' \
             ':!CHANGELOG.md' \
             ':!CLAUDE.md' \
             ':!CODE_OF_CONDUCT.md' \
@@ -64,6 +74,8 @@ jobs:
             ':!justfile' \
             ':!LICENSE' \
             ':!README.md' \
+            ':!SECURITY.md' \
+            ':!STYLE.md' \
             ':!seal.toml' \
             ':!zensical.toml' \
           ; then


### PR DESCRIPTION
## Summary

Exclude repository metadata and contributor-facing files from the CI code-change detector. This keeps pre-commit and docs validation in place while avoiding the full Rust/Python test matrix for changes that cannot affect runtime behavior.

## Test Plan

pinact run
uvx prek run -a