### PR TITLE
Add Dependabot development updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,17 @@ updates:
     cooldown:
       default-days: 7
 
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      pre-commit-hooks:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7
+
   - package-ecosystem: "cargo" # See documentation for possible values
 
     directory: "/" # Location of package manifests

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,13 @@ updates:
     cooldown:
       default-days: 7
 
+  - package-ecosystem: "rust-toolchain"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
   - package-ecosystem: "cargo" # See documentation for possible values
 
     directory: "/" # Location of package manifests

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,17 @@
 version: 2
 
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7
+
   - package-ecosystem: "cargo" # See documentation for possible values
 
     directory: "/" # Location of package manifests

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,17 @@ updates:
     cooldown:
       default-days: 7
 
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      python-dev-dependencies:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7
+
   - package-ecosystem: "cargo" # See documentation for possible values
 
     directory: "/" # Location of package manifests


### PR DESCRIPTION
## Summary

Extend Dependabot to update GitHub Actions, Python development dependencies, pre-commit hooks, and the pinned Rust toolchain weekly. Each ecosystem is grouped where useful and uses the same cooldown as Cargo updates, keeping repository tooling from drifting without replacing the existing Dependabot setup.

## Test Plan

`uvx prek run -a`