### PR TITLE
Add Rust toolchain config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,9 @@ jobs:
 
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
 
+      - name: "Install Rust components"
+        run: rustup component add rustfmt clippy
+
       - uses: j178/prek-action@91fd7d7cf70ae1dee9f4f44e7dfa5d1073fe6623 # v1.0.11
 
   cargo-test:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.96.0"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2024"
+style_edition = "2024"


### PR DESCRIPTION
## Summary

Add the same minimal Rust toolchain configuration used by Ruff and uv: pin the development compiler to Rust 1.96.0 and set rustfmt to the 2024 edition and style edition. The CI pre-commit job now installs the Rust components required by the cargo hooks before running `prek`, so the pinned toolchain does not depend on runner defaults.

## Test Plan

`rustup show active-toolchain`

`cargo fmt -- --check`

`pinact run`

`uvx prek run -a`