### PR TITLE
Statically link Windows CRT

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,8 @@
 [alias]
 dev = "run --package karva_dev --bin karva_dev"
 benchmark = "bench -p karva_benchmark --bench karva_benchmark_walltime --"
+
+# Statically link the C runtime so Windows wheels do not depend on the
+# shared/dynamic MSVC runtime.
+[target.'cfg(all(target_env = "msvc", target_os = "windows"))']
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -5,6 +5,13 @@ on:
 
   pull_request:
     paths:
+      # Rust build inputs can change the native extension or the release
+      # toolchain used by maturin.
+      - .cargo/config.toml
+      - Cargo.lock
+      - Cargo.toml
+      - crates/**/Cargo.toml
+      - rust-toolchain.toml
       # When we change pyproject.toml, we want to ensure that the maturin builds still work.
       - pyproject.toml
       # And when we change this workflow itself...


### PR DESCRIPTION
## Summary

Configure MSVC Windows builds to statically link the C runtime, matching the Ruff and uv Cargo configuration. This makes Windows wheels less dependent on the shared MSVC runtime being present on user machines, and the wheel-build workflow now runs when Rust packaging inputs like Cargo metadata, `.cargo/config.toml`, or `rust-toolchain.toml` change.

## Test Plan

`pinact run`

`uvx prek run -a`