### PR TITLE
Use ty pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,6 +77,10 @@ repos:
     hooks:
       - id: ty
         args: [--isolated, --no-project]
+        files: ^python/
+        types: [file]
+        types_or: [python, pyi]
+        always_run: false
         priority: 2
 
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,12 +71,12 @@ repos:
         types: [rust]
         pass_filenames: false
         priority: 1
+
+  - repo: https://github.com/astral-sh/ty-pre-commit
+    rev: v0.0.48
+    hooks:
       - id: ty
-        name: ty
-        entry: uvx ty check python/
-        language: system
-        types: [python]
-        pass_filenames: false
+        args: [--isolated]
         priority: 2
 
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,7 +76,7 @@ repos:
     rev: v0.0.48
     hooks:
       - id: ty
-        args: [--isolated]
+        args: [--isolated, --no-project]
         priority: 2
 
   - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
## Summary

Replace the local `uvx ty check python/` hook with the official `astral-sh/ty-pre-commit` hook. The hook is scoped to files under `python/` and runs with `--isolated` and `--no-project` so `uv check` uses ty without creating local uv state or building Karva through maturin.

## Test Plan

`uvx prek run ty --files README.md`, `uvx prek run ty --files python/karva/__main__.py`, and `uvx prek run ty --files python/karva/_karva/__init__.pyi` with `cargo`, `rustc`, and `maturin` shadowed for Python-file runs. `uvx prek run -a`.