### PR TITLE
Check generated docs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,9 +255,19 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+
+      - name: "Install Rust toolchain"
+        run: rustup show
+
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Check generated docs
+        run: |
+          cargo run -p karva_dev generate-all
+          git diff --exit-code -- docs/configuration/configuration.md docs/reference/cli.md docs/reference/env-vars.md
 
       - name: Prepare docs
         run: uv run --script scripts/prepare_docs.py


### PR DESCRIPTION
## Summary

Add a docs CI guard that runs `karva_dev generate-all` before building the docs and fails if the generated reference docs differ from what is committed. This follows uv's generated-file check pattern and keeps CLI, environment-variable, and configuration reference docs from drifting.

## Test Plan

`cargo run -p karva_dev generate-all && git diff --exit-code -- docs/configuration/configuration.md docs/reference/cli.md docs/reference/env-vars.md`, docs build, and `uvx prek run -a`.