### PR TITLE
Strip wheel binaries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ manifest-path = "crates/karva_python/Cargo.toml"
 module-name = "karva._karva"
 python-source = "python"
 features = ["pyo3/extension-module"]
+strip = true
 
 [tool.ruff]
 fix = true


### PR DESCRIPTION
## Summary

Enable maturin's `strip` option so built Karva wheels strip Rust binary symbols, matching the Ruff and uv packaging setup. This should keep published wheel artifacts smaller without changing source behavior.

## Test Plan

`uv run --no-project --with maturin maturin build --out /tmp/karva-strip-wheel-test`, `uvx prek run --files pyproject.toml`, and `uvx prek run -a`.