### PR TITLE
Add uv cache keys

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,17 @@ module-name = "karva._karva"
 python-source = "python"
 features = ["pyo3/extension-module"]
 
+[tool.uv]
+cache-keys = [
+    { file = "pyproject.toml" },
+    { file = "Cargo.toml" },
+    { file = "Cargo.lock" },
+    { file = ".cargo/config.toml" },
+    { file = "rust-toolchain.toml" },
+    { file = "crates/**/*.rs" },
+    { file = "crates/**/Cargo.toml" },
+]
+
 [tool.ruff]
 fix = true
 target-version = "py311"


### PR DESCRIPTION
## Summary

Add explicit uv cache keys for Karva's Rust-backed Python build, following uv's maturin project setup. This makes uv invalidate cached local builds when Cargo metadata, the Rust toolchain/config, or Rust source files change.

## Test Plan

`uvx prek run --files pyproject.toml`, `uv check --verbose --preview-features=check-command --ty-version=0.0.48 --isolated --no-project`, and `uvx prek run -a`.