### PR TITLE
Remove unused Cargo dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,28 @@ jobs:
 
       - uses: j178/prek-action@91fd7d7cf70ae1dee9f4f44e7dfa5d1073fe6623 # v1.0.11
 
+  cargo-shear:
+    name: "cargo shear"
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    needs: determine_changes
+    if: ${{ (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: "Install cargo shear"
+        uses: taiki-e/install-action@a416ddeedbd372e614cc1386e8b642692f66865e # v2.57.1
+        with:
+          tool: cargo-shear@1.12.4
+
+      - name: "Check unused dependencies"
+        run: cargo shear --deny-warnings
+
   cargo-test:
     name: "cargo test (${{ matrix.os }})"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,7 +1055,6 @@ dependencies = [
  "insta-cmd",
  "karva_cache",
  "karva_cli",
- "karva_collector",
  "karva_coverage",
  "karva_logging",
  "karva_metadata",
@@ -1280,7 +1279,6 @@ dependencies = [
  "pyo3",
  "ruff_python_ast",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1297,7 +1295,6 @@ dependencies = [
  "karva_cache",
  "karva_cli",
  "karva_collector",
- "karva_coverage",
  "karva_logging",
  "karva_metadata",
  "karva_project",
@@ -1347,7 +1344,6 @@ dependencies = [
  "ruff_python_ast",
  "ruff_python_parser",
  "ruff_source_file",
- "tempfile",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ argfile = { version = "1.0.0" }
 camino = { version = "1.2", features = ["serde1"] }
 chrono = { version = "0.4.44", default-features = false, features = ["clock"] }
 clap = { version = "4.6.1", features = ["derive", "wrap_help"] }
-codspeed-criterion-compat = { version = "4.3.0", default-features = false }
 colored = { version = "3.1.1" }
 console = { version = "0.16" }
 crossbeam-channel = "0.5.15"

--- a/crates/karva/Cargo.toml
+++ b/crates/karva/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/main.rs"
 [dependencies]
 karva_cache = { workspace = true }
 karva_cli = { workspace = true }
-karva_collector = { workspace = true }
 karva_coverage = { workspace = true }
 karva_logging = { workspace = true }
 karva_metadata = { workspace = true }

--- a/crates/karva_python_semantic/Cargo.toml
+++ b/crates/karva_python_semantic/Cargo.toml
@@ -15,8 +15,5 @@ pyo3 = { workspace = true }
 ruff_python_ast = { workspace = true }
 serde = { workspace = true }
 
-[dev-dependencies]
-serde_json = { workspace = true }
-
 [lints]
 workspace = true

--- a/crates/karva_runner/Cargo.toml
+++ b/crates/karva_runner/Cargo.toml
@@ -14,7 +14,6 @@ license = { workspace = true }
 karva_cache = { workspace = true }
 karva_cli = { workspace = true }
 karva_collector = { workspace = true }
-karva_coverage = { workspace = true }
 karva_logging = { workspace = true }
 karva_metadata = { workspace = true }
 karva_project = { workspace = true }

--- a/crates/karva_test_semantic/Cargo.toml
+++ b/crates/karva_test_semantic/Cargo.toml
@@ -27,7 +27,6 @@ ruff_macros = { workspace = true }
 ruff_python_ast = { workspace = true }
 ruff_python_parser = { workspace = true }
 ruff_source_file = { workspace = true }
-tempfile = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

Remove Cargo dependencies reported unused by `cargo shear` and add a CI job that runs `cargo shear --deny-warnings` for code changes. This follows the dependency-hygiene checks used by Ruff and uv so unused Cargo dependencies are caught automatically.

## Test Plan

`pinact run`, `cargo shear`, `cargo check --workspace --all-targets --all-features`, `uvx prek run --files .github/workflows/ci.yml`, `uvx prek run --files Cargo.toml crates/karva/Cargo.toml crates/karva_python_semantic/Cargo.toml crates/karva_runner/Cargo.toml crates/karva_test_semantic/Cargo.toml Cargo.lock`, and `uvx prek run -a`.