### PR TITLE
Add Cargo package descriptions

### DIFF
--- a/crates/karva/Cargo.toml
+++ b/crates/karva/Cargo.toml
@@ -5,6 +5,7 @@ default-run = "karva"
 
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "The main Karva CLI binary."
 homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }

--- a/crates/karva_cache/Cargo.toml
+++ b/crates/karva_cache/Cargo.toml
@@ -3,6 +3,7 @@ name = "karva_cache"
 version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
+description = "Cache directory layout, result serialization, and duration tracking for Karva."
 homepage.workspace = true
 documentation.workspace = true
 repository.workspace = true

--- a/crates/karva_cli/Cargo.toml
+++ b/crates/karva_cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "karva_cli"
 version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
+description = "Shared CLI types for Karva."
 homepage.workspace = true
 documentation.workspace = true
 repository.workspace = true

--- a/crates/karva_collector/Cargo.toml
+++ b/crates/karva_collector/Cargo.toml
@@ -3,6 +3,7 @@ name = "karva_collector"
 version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
+description = "File-level Python test collection for Karva."
 homepage.workspace = true
 documentation.workspace = true
 repository.workspace = true

--- a/crates/karva_combine/Cargo.toml
+++ b/crates/karva_combine/Cargo.toml
@@ -3,6 +3,7 @@ name = "karva_combine"
 version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
+description = "Result combination and summary output for Karva."
 homepage.workspace = true
 documentation.workspace = true
 repository.workspace = true

--- a/crates/karva_coverage/Cargo.toml
+++ b/crates/karva_coverage/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Coverage measurement and reporting for Karva."
 homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }

--- a/crates/karva_dev/Cargo.toml
+++ b/crates/karva_dev/Cargo.toml
@@ -5,6 +5,7 @@ publish = false
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Development tooling for Karva."
 homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }

--- a/crates/karva_diagnostic/Cargo.toml
+++ b/crates/karva_diagnostic/Cargo.toml
@@ -3,6 +3,7 @@ name = "karva_diagnostic"
 version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
+description = "Test result types and diagnostic reporting for Karva."
 homepage.workspace = true
 documentation.workspace = true
 repository.workspace = true

--- a/crates/karva_logging/Cargo.toml
+++ b/crates/karva_logging/Cargo.toml
@@ -3,6 +3,7 @@ name = "karva_logging"
 version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
+description = "Tracing setup, terminal output, and duration formatting for Karva."
 homepage.workspace = true
 documentation.workspace = true
 repository.workspace = true

--- a/crates/karva_macros/Cargo.toml
+++ b/crates/karva_macros/Cargo.toml
@@ -3,6 +3,7 @@ name = "karva_macros"
 version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
+description = "Procedural macros for Karva."
 homepage.workspace = true
 documentation.workspace = true
 repository.workspace = true

--- a/crates/karva_metadata/Cargo.toml
+++ b/crates/karva_metadata/Cargo.toml
@@ -3,6 +3,7 @@ name = "karva_metadata"
 version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
+description = "Project configuration and config file parsing for Karva."
 homepage.workspace = true
 documentation.workspace = true
 repository.workspace = true

--- a/crates/karva_project/Cargo.toml
+++ b/crates/karva_project/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Project metadata, test path resolution, and path utilities for Karva."
 homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }

--- a/crates/karva_python/Cargo.toml
+++ b/crates/karva_python/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.1-alpha.6"
 
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Python extension module and wheel bindings for Karva."
 homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }

--- a/crates/karva_python_semantic/Cargo.toml
+++ b/crates/karva_python_semantic/Cargo.toml
@@ -3,6 +3,7 @@ name = "karva_python_semantic"
 version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
+description = "Python version detection and AST-level semantic types for Karva."
 homepage.workspace = true
 documentation.workspace = true
 repository.workspace = true

--- a/crates/karva_runner/Cargo.toml
+++ b/crates/karva_runner/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Worker orchestration, partitioning, and parallel collection for Karva."
 homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }

--- a/crates/karva_snapshot/Cargo.toml
+++ b/crates/karva_snapshot/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Snapshot testing support for Karva."
 homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }

--- a/crates/karva_static/Cargo.toml
+++ b/crates/karva_static/Cargo.toml
@@ -3,6 +3,7 @@ name = "karva_static"
 version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
+description = "Environment variable constants and parallelism helpers for Karva."
 homepage.workspace = true
 documentation.workspace = true
 repository.workspace = true

--- a/crates/karva_test_semantic/Cargo.toml
+++ b/crates/karva_test_semantic/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Core Python test execution library for Karva."
 homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }

--- a/crates/karva_version/Cargo.toml
+++ b/crates/karva_version/Cargo.toml
@@ -3,6 +3,7 @@ name = "karva_version"
 version = "0.0.1-alpha.6"
 edition.workspace = true
 rust-version.workspace = true
+description = "Version metadata for Karva."
 homepage.workspace = true
 documentation.workspace = true
 repository.workspace = true

--- a/crates/karva_worker/Cargo.toml
+++ b/crates/karva_worker/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "The Karva worker subprocess binary."
 homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }


### PR DESCRIPTION
## Summary

Add explicit Cargo package descriptions to each workspace crate so packaging no longer emits one warning per internal crate. The descriptions mirror the crate responsibilities documented in CONTRIBUTING.md instead of using a generic shared description.

## Test Plan

`cargo package --workspace --list --allow-dirty`, `uv run --no-project --with maturin maturin sdist --out /tmp/karva-description-sdist-individual`, and `uvx prek run -a`.