### PR TITLE
Modernize Python license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,14 @@
 [build-system]
 build-backend = "maturin"
-requires = ["maturin>=1.7,<2.0"]
+requires = ["maturin>=1.9.3,<2.0"]
 
 [project]
 name = "karva"
 version = "0.0.1-alpha.6"
 description = "A Python test framework, written in Rust."
 authors = [{ name = "Matthew Mckee", email = "matthewmckee04@yahoo.co.uk" }]
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.10,<3.15"
 classifiers = [


### PR DESCRIPTION
## Summary

Switch the Python package metadata to the modern SPDX license form used by Ruff and uv, with an explicit LICENSE file entry. Bump the maturin build-system floor to 1.9.3 because older maturin versions reject `license-files`.

## Test Plan

`uv run --no-project --with maturin==1.9.3 maturin build --out /tmp/karva-license-maturin193`, `uv run --no-project --with twine twine check /tmp/karva-license-maturin193/*.whl`, and `uvx prek run -a`.