### PR TITLE
Include Rust toolchain in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ manifest-path = "crates/karva_python/Cargo.toml"
 module-name = "karva._karva"
 python-source = "python"
 features = ["pyo3/extension-module"]
+include = [
+    { path = "rust-toolchain.toml", format = "sdist" },
+]
 
 [tool.ruff]
 fix = true


### PR DESCRIPTION
## Summary

Include the existing `rust-toolchain.toml` file in source distributions so source builds preserve the Rust toolchain pin. This mirrors uv's explicit sdist include for the toolchain file and avoids adding any new repository files.

## Test Plan

`uv run --no-project --with maturin maturin sdist --out /tmp/karva-toolchain-sdist`, `tar -tf /tmp/karva-toolchain-sdist/karva-0.0.1a6.tar.gz | rg rust-toolchain.toml`, and `uvx prek run -a`.