### PR TITLE
Improve issue template prompts

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yaml
@@ -16,6 +16,10 @@ body:
         A clear and concise description of the bug, including a minimal reproducible example.
 
         Be sure to include the command you invoked (e.g., `karva test /path/to/file.py`)
+        and the full output, including the complete error message.
+
+        If the behavior depends on configuration, include the relevant section from
+        your `pyproject.toml`.
 
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/3_question.yaml
+++ b/.github/ISSUE_TEMPLATE/3_question.yaml
@@ -11,6 +11,14 @@ body:
 
   - type: input
     attributes:
+      label: Platform
+      description: What operating system and architecture are you using? (see `uname -orsm`)
+      placeholder: e.g., macOS 15 arm64, Windows 11 x86_64, Ubuntu 24.04 amd64
+    validations:
+      required: false
+
+  - type: input
+    attributes:
       label: Version
       description: What version of Karva are you using? (see `karva --version`)
       placeholder: e.g., Karva 0.1.0


### PR DESCRIPTION
## Summary

Ask bug reporters for full command output and relevant configuration, and add optional platform context to questions. This follows the Ruff and uv pattern of collecting enough environment and reproduction detail up front.

## Test Plan

`uvx prek run --files .github/ISSUE_TEMPLATE/1_bug_report.yaml .github/ISSUE_TEMPLATE/3_question.yaml` and `uvx prek run -a`.