### PR TITLE
Add workflow schema pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,12 @@ repos:
       - id: zizmor
         priority: 0
 
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.37.2
+    hooks:
+      - id: check-github-workflows
+        priority: 0
+
   - repo: https://github.com/executablebooks/mdformat
     rev: 1.0.0
     hooks:


### PR DESCRIPTION
## Summary

Add the `check-github-workflows` pre-commit hook from `check-jsonschema` to validate workflow files against the GitHub Actions schema. This mirrors Ruff's workflow schema guard alongside the existing actionlint and zizmor checks.

## Test Plan

`uvx prek run check-github-workflows --files .github/workflows/ci.yml .github/workflows/build-wheels.yml .github/workflows/pr-benchmarks.yml .github/workflows/release.yml` and `uvx prek run -a`.