### PR TITLE
Use zensical shadcn docs theme

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,10 @@ karva-worker = "karva._karva:karva_worker_run"
 
 [dependency-groups]
 dev = ["ruff", "ty"]
-docs = ["zensical==0.0.45"]
+docs = [
+    "zensical==0.0.45",
+    "zensical-shadcn @ git+https://github.com/MatthewMckee4/zensical-shadcn.git@19c2a0425582dab9e3e1ea4f9e74a5e731ba5fb0",
+]
 release = ["tbump"]
 
 [project.urls]

--- a/zensical.toml
+++ b/zensical.toml
@@ -57,6 +57,7 @@ nav = [
 ]
 
 [project.theme]
+name = "shadcn"
 language = "en"
 features = [
     "navigation.instant",


### PR DESCRIPTION
## Summary

Switch the docs theme to `shadcn` and add `zensical-shadcn` as a git-pinned docs dependency so this branch can test the theme without waiting for a package release. The pinned commit is from MatthewMckee4/zensical-shadcn#13 and includes the dark-mode readability, tighter article spacing, compact header/nav shell, and mobile overflow fixes.

## Test Plan

`uv run -s scripts/prepare_docs.py`; `uv run --isolated --only-group docs zensical build`; `uvx prek run -a`