### PR TITLE
Use nextest CI profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
           PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
           KARVA_MAX_PARALLELISM: 2
         run: |
-          cargo nextest run
+          cargo nextest run --profile ci
 
   build-windows-tests:
     name: "build tests archive | windows"
@@ -268,7 +268,7 @@ jobs:
           PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
           KARVA_MAX_PARALLELISM: 2
         run: |
-          cargo nextest run --archive-file nextest-archive.tar.zst --partition hash:${{ matrix.partition }}/5
+          cargo nextest run --profile ci --archive-file nextest-archive.tar.zst --partition hash:${{ matrix.partition }}/5
 
   build-docs:
     name: "Build docs"


### PR DESCRIPTION
## Summary

Run CI nextest jobs with the existing `ci` profile so the repository's configured retries, failure output, fail-fast behavior, and slow-test reporting are actually applied. This makes the existing nextest configuration effective without changing test code.

## Test Plan

`pinact run`, `cargo nextest run --profile ci --no-run`, `uvx prek run --files .github/workflows/ci.yml`, and `uvx prek run -a`.