### PR TITLE
Add build wheels concurrency

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -10,6 +10,10 @@ on:
       # And when we change this workflow itself...
       - .github/workflows/build-wheels.yml
 
+concurrency:
+  group: build-wheels-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions: {}
 
 jobs:


### PR DESCRIPTION
## Summary

Add workflow-level concurrency to the build-wheels workflow so newer pull-request runs cancel stale wheel matrices. This mirrors the Ruff/uv pattern for expensive build workflows while leaving non-PR workflow-call behavior conservative.

## Test Plan

`pinact run`, `uvx prek run --files .github/workflows/build-wheels.yml`, and `uvx prek run -a`.