### PR TITLE
Test distribution artifacts

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -12,6 +12,10 @@ on:
 
 permissions: {}
 
+env:
+  PACKAGE_NAME: karva
+  MODULE_NAME: karva
+
 jobs:
   linux:
     name: build wheels (Linux, ${{ matrix.platform.target }})
@@ -41,6 +45,14 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
           manylinux: auto
+
+      - name: Test wheel
+        if: ${{ matrix.platform.target == 'x86_64' }}
+        run: |
+          python -m pip install dist/"${PACKAGE_NAME}"-*.whl --force-reinstall
+          "${MODULE_NAME}" --help
+          python -m "${MODULE_NAME}" --help
+          karva-worker --help
 
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -108,6 +120,14 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
 
+      - name: Test wheel
+        shell: bash
+        run: |
+          python -m pip install dist/"${PACKAGE_NAME}"-*.whl --force-reinstall
+          "${MODULE_NAME}" --help
+          python -m "${MODULE_NAME}" --help
+          karva-worker --help
+
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -141,6 +161,13 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
 
+      - name: Test wheel
+        run: |
+          python -m pip install dist/"${PACKAGE_NAME}"-*.whl --force-reinstall
+          "${MODULE_NAME}" --help
+          python -m "${MODULE_NAME}" --help
+          karva-worker --help
+
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -165,6 +192,13 @@ jobs:
         with:
           command: sdist
           args: --out dist
+
+      - name: Test sdist
+        run: |
+          python -m pip install dist/"${PACKAGE_NAME}"-*.tar.gz --force-reinstall
+          "${MODULE_NAME}" --help
+          python -m "${MODULE_NAME}" --help
+          karva-worker --help
 
       - name: Upload sdist
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary

Build Wheels now installs generated distribution artifacts before uploading them. Native wheels are smoke-tested on the runners that can install them, and the source distribution is rebuilt through pip; each path verifies `karva`, `python -m karva`, and `karva-worker --help`.

This follows the artifact smoke test pattern used by Ruff and uv so broken release artifacts fail in CI instead of at publish time.

## Test Plan

Built and installed local wheel and sdist artifacts in clean venvs, ran the workflow-style help commands, then ran `pinact run`, `uvx prek run --files .github/workflows/build-wheels.yml`, and `uvx prek run -a`.