### PR TITLE
Narrow release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,14 @@ on:
 env:
   PYTHON_VERSION: "3.14"
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   generate-release:
     name: Generate release metadata
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       release-metadata: ${{ steps.seal-generate.outputs.metadata }}
       tag: ${{ github.event.inputs.tag }}
@@ -57,6 +58,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [generate-release, build-wheels]
     if: github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -137,6 +140,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: create-release
     if: github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -3,8 +3,3 @@ rules:
     config:
       policies:
         dtolnay/rust-toolchain: any
-  excessive-permissions:
-    # it's hard to test what the impact of removing these ignores would be
-    # without actually running the release workflow...
-    ignore:
-      - release.yml


### PR DESCRIPTION
## Summary

The release workflow now defaults to no token permissions and grants `contents` access only to the jobs that need it. This removes the release workflow exception from `zizmor` so excessive permission checks apply to every workflow.

## Test Plan

Ran `pinact run`, `uvx prek run --files .github/workflows/release.yml .github/zizmor.yml`, and `uvx prek run -a`.