### PR TITLE
Write cache artifacts atomically

### DIFF
--- a/crates/karva_cache/Cargo.toml
+++ b/crates/karva_cache/Cargo.toml
@@ -19,13 +19,13 @@ ruff_db = { workspace = true }
 ruff_notebook = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tempfile = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
 ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }
-tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/karva_cache/src/artifact.rs
+++ b/crates/karva_cache/src/artifact.rs
@@ -7,11 +7,13 @@
 //! artifact is a single-place change and read/write helpers can't drift.
 
 use std::fs;
+use std::io::Write;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
+use tempfile::NamedTempFile;
 
 /// One of the well-known files in the cache directory hierarchy.
 #[derive(Clone, Copy)]
@@ -62,8 +64,30 @@ impl CacheFile {
 
 /// Pretty-prints `value` as JSON and writes it to `dir/<file>`.
 pub fn write_json<T: Serialize>(dir: &Utf8Path, file: CacheFile, value: &T) -> Result<()> {
-    let json = serde_json::to_string_pretty(value)?;
-    fs::write(file.path_in(dir), json)?;
+    let json = serde_json::to_vec_pretty(value)?;
+    write_bytes(dir, file, &json)
+}
+
+/// Writes `content` to `dir/<file>`.
+pub fn write_text(dir: &Utf8Path, file: CacheFile, content: impl AsRef<[u8]>) -> Result<()> {
+    write_bytes(dir, file, content.as_ref())
+}
+
+fn write_bytes(dir: &Utf8Path, file: CacheFile, content: &[u8]) -> Result<()> {
+    let path = file.path_in(dir);
+    let parent = path
+        .parent()
+        .with_context(|| format!("cache artifact `{path}` has no parent directory"))?;
+
+    let mut temp =
+        NamedTempFile::new_in(parent).with_context(|| format!("failed to create `{path}`"))?;
+    temp.write_all(content)
+        .with_context(|| format!("failed to write `{path}`"))?;
+    temp.flush()
+        .with_context(|| format!("failed to flush `{path}`"))?;
+    temp.persist(path.as_std_path())
+        .map_err(|err| err.error)
+        .with_context(|| format!("failed to replace `{path}`"))?;
     Ok(())
 }
 
@@ -99,4 +123,23 @@ pub fn read_text(dir: &Utf8Path, file: CacheFile) -> Result<Option<String>> {
         return Ok(None);
     }
     Ok(Some(fs::read_to_string(&path)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_text_replaces_existing_artifact() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let cache_dir =
+            Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf()).expect("UTF-8 temp path");
+
+        write_text(&cache_dir, CacheFile::LastFailed, "old").expect("write old artifact");
+        write_text(&cache_dir, CacheFile::LastFailed, "new").expect("replace artifact");
+
+        let body = std::fs::read_to_string(CacheFile::LastFailed.path_in(&cache_dir))
+            .expect("read artifact");
+        assert_eq!(body, "new");
+    }
 }

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -9,7 +9,9 @@ use karva_diagnostic::{FlakyTest, TestResultKind, TestResultStats, TestRunResult
 use ruff_db::diagnostic::DisplayDiagnosticConfig;
 use serde::{Deserialize, Serialize};
 
-use crate::artifact::{CacheFile, read_json, read_text, write_json, write_json_if_nonempty};
+use crate::artifact::{
+    CacheFile, read_json, read_text, write_json, write_json_if_nonempty, write_text,
+};
 use crate::diagnostics::write_diagnostics;
 use crate::{RUN_PREFIX, RunHash, WORKER_PREFIX, worker_folder};
 
@@ -62,8 +64,7 @@ impl RunCache {
     /// Writes a fail-fast signal file to indicate a worker encountered a test failure.
     pub fn write_fail_fast_signal(&self) -> Result<()> {
         fs::create_dir_all(&self.run_dir)?;
-        fs::write(CacheFile::FailFastSignal.path_in(&self.run_dir), "")?;
-        Ok(())
+        write_text(&self.run_dir, CacheFile::FailFastSignal, "")
     }
 
     /// Checks whether any worker has written a fail-fast signal file.

--- a/crates/karva_cache/src/diagnostics.rs
+++ b/crates/karva_cache/src/diagnostics.rs
@@ -10,7 +10,7 @@ use ruff_db::diagnostic::{
 use ruff_db::files::File;
 use ruff_notebook::NotebookIndex;
 
-use crate::artifact::CacheFile;
+use crate::artifact::{CacheFile, write_text};
 
 /// Renders diagnostics into the worker directory.
 ///
@@ -32,11 +32,7 @@ pub fn write_diagnostics(
 
     let resolver = DiagnosticFileResolver::new(cwd);
     let output = DisplayDiagnostics::new(&resolver, config, result.diagnostics());
-    std::fs::write(
-        CacheFile::Diagnostics.path_in(worker_dir),
-        output.to_string(),
-    )?;
-    Ok(())
+    write_text(worker_dir, CacheFile::Diagnostics, output.to_string())
 }
 
 fn ensure_source_file_spans(result: &TestRunResult) -> Result<()> {


### PR DESCRIPTION
## Summary

Write cache JSON and text artifacts through a temporary file and atomic replacement, matching the safer write pattern used in Ruff tooling. This keeps cache readers from observing partially written result files and routes diagnostics plus fail-fast sentinels through the same artifact helper.

This is stacked on #845.

## Test Plan

cargo test -p karva_cache; cargo clippy --workspace --all-targets --all-features -- -D warnings; just test; uvx prek run -a