### PR TITLE
Report coverage source read errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,6 +1153,7 @@ dependencies = [
  "camino",
  "colored 3.1.1",
  "dunce",
+ "fs-err",
  "insta",
  "pyo3",
  "ruff_python_ast",

--- a/crates/karva_coverage/Cargo.toml
+++ b/crates/karva_coverage/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = { workspace = true }
 camino = { workspace = true }
 colored = { workspace = true }
 dunce = { workspace = true }
+fs-err = { workspace = true }
 pyo3 = { workspace = true }
 ruff_python_ast = { workspace = true }
 ruff_python_parser = { workspace = true }

--- a/crates/karva_coverage/src/executable.rs
+++ b/crates/karva_coverage/src/executable.rs
@@ -8,8 +8,10 @@
 //! bytecode constants rather than executable statements.
 
 use std::collections::HashSet;
+use std::io;
 use std::path::Path;
 
+use fs_err as fs;
 use ruff_python_ast::helpers::is_docstring_stmt;
 use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::visitor::source_order::{
@@ -22,11 +24,9 @@ use ruff_source_file::LineIndex;
 use ruff_text_size::{Ranged, TextSize};
 
 /// Parse `path` and return the set of line numbers that contain a statement.
-pub fn executable_lines(path: &Path) -> HashSet<u32> {
-    let Ok(source) = std::fs::read_to_string(path) else {
-        return HashSet::new();
-    };
-    executable_lines_for_source(&source)
+pub fn executable_lines(path: &Path) -> io::Result<HashSet<u32>> {
+    let source = fs::read_to_string(path)?;
+    Ok(executable_lines_for_source(&source))
 }
 
 /// Compute executable line numbers from a source string. Exposed separately
@@ -213,6 +213,17 @@ mod tests {
             })
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    #[test]
+    fn executable_lines_reports_read_errors() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("missing.py");
+
+        let err = executable_lines(&path).expect_err("missing source should fail");
+
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+        assert!(err.to_string().contains("missing.py"), "{err}");
     }
 
     #[test]

--- a/crates/karva_coverage/src/tracer.rs
+++ b/crates/karva_coverage/src/tracer.rs
@@ -405,7 +405,7 @@ fn save_data(
 
     let mut files = BTreeMap::new();
     for (path, hits) in executed {
-        let executable = executable_lines(&path);
+        let executable = executable_lines(&path)?;
         if executable.is_empty() {
             continue;
         }
@@ -429,4 +429,25 @@ fn save_data(
     }
     let bytes = serde_json::to_vec(&WorkerFile { files })?;
     std::fs::write(data_file.as_std_path(), bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn save_data_reports_missing_executed_source() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let data_file = Utf8Path::from_path(dir.path())
+            .expect("utf8 temp dir")
+            .join("coverage.json");
+        let missing = dir.path().join("missing.py");
+        let executed = HashMap::from([(missing, HashSet::from([1]))]);
+
+        let err = save_data(&data_file, executed, &[]).expect_err("missing source should fail");
+
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+        assert!(err.to_string().contains("missing.py"), "{err}");
+        assert!(!data_file.exists());
+    }
 }


### PR DESCRIPTION
## Summary

Stop treating unreadable coverage source files as having no executable lines. Coverage data generation now returns the source read error, preserving the path-aware IO context from the previous `fs_err` change, and unit tests cover both the helper and save path.

## Test Plan

`cargo test -p karva_coverage`; `cargo fmt --check`; `git diff --check`; `cargo clippy --workspace --all-targets --all-features -- -D warnings`; `just test`; `uvx prek run -a`.