### PR TITLE
Report imported fixture source read errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1333,6 +1333,7 @@ name = "karva_test_semantic"
 version = "0.0.0"
 dependencies = [
  "camino",
+ "fs-err",
  "karva_collector",
  "karva_coverage",
  "karva_diagnostic",

--- a/crates/karva/tests/it/extensions/fixtures/basic.rs
+++ b/crates/karva/tests/it/extensions/fixtures/basic.rs
@@ -739,3 +739,64 @@ def invoke():
     ----- stderr -----
     ");
 }
+
+#[test]
+#[cfg(unix)]
+fn test_imported_fixture_missing_source_is_reported() {
+    let context = TestContext::with_files([
+        ("mypackage/__init__.py", ""),
+        (
+            "mypackage/fixtures.py",
+            r"
+import pytest
+
+@pytest.fixture
+def invoke():
+    return 'invoked'
+",
+        ),
+        (
+            "conftest.py",
+            r"from pathlib import Path
+
+from mypackage.fixtures import invoke
+
+Path(__file__).with_name('mypackage').joinpath('fixtures.py').unlink()
+",
+        ),
+        (
+            "test_invoke.py",
+            "def test_invoke(invoke): assert invoke == 'invoked'",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test_invoke::test_invoke
+
+    diagnostics:
+
+    error[failed-to-discover-imported-fixture]: Failed to discover imported fixture `invoke` from `<temp_dir>/mypackage/fixtures.py`: failed to open file `<temp_dir>/mypackage/fixtures.py`: No such file or directory (os error 2)
+     --> conftest.py:1:1
+      |
+    1 | from pathlib import Path
+      | ^
+      |
+
+    error[missing-fixtures]: Test `test_invoke` has missing fixtures
+     --> test_invoke.py:1:5
+      |
+    1 | def test_invoke(invoke): assert invoke == 'invoked'
+      |     ^^^^^^^^^^^
+      |
+    info: Missing fixtures: `invoke`
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}

--- a/crates/karva_test_semantic/Cargo.toml
+++ b/crates/karva_test_semantic/Cargo.toml
@@ -13,6 +13,7 @@ license = { workspace = true }
 
 [dependencies]
 camino = { workspace = true }
+fs-err = { workspace = true }
 karva_collector = { workspace = true }
 karva_coverage = { workspace = true }
 karva_diagnostic = { workspace = true, features = ["traceback"] }

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -6,6 +6,7 @@
 
 use std::collections::HashMap;
 
+use camino::Utf8Path;
 use karva_collector::CollectionError;
 use karva_diagnostic::Traceback;
 use karva_python_semantic::FunctionKind;
@@ -46,6 +47,18 @@ declare_diagnostic_type! {
     /// exits non-zero.
     pub static FAILED_TO_IMPORT_MODULE = {
         summary: "Failed to import python module",
+        severity: Severity::Error,
+    }
+}
+
+declare_diagnostic_type! {
+    /// ## Failed to discover imported fixture
+    ///
+    /// Raised when karva finds a fixture object imported into a test module or
+    /// `conftest.py`, but cannot read the original source file needed to locate
+    /// the fixture definition.
+    pub static FAILED_TO_DISCOVER_IMPORTED_FIXTURE = {
+        summary: "Failed to discover imported fixture",
         severity: Severity::Error,
     }
 }
@@ -163,6 +176,22 @@ pub fn report_failed_to_import_module(context: &Context, module_name: &str, erro
     builder.into_diagnostic(format!(
         "Failed to import python module `{module_name}`: {error}"
     ));
+}
+
+pub fn report_failed_to_discover_imported_fixture(
+    context: &Context,
+    fixture_name: &str,
+    importing_source_file: SourceFile,
+    source_path: &Utf8Path,
+    error: &std::io::Error,
+) {
+    let builder = context.report_diagnostic(&FAILED_TO_DISCOVER_IMPORTED_FIXTURE);
+
+    let mut diagnostic = builder.into_diagnostic(format!(
+        "Failed to discover imported fixture `{fixture_name}` from `{source_path}`: {error}"
+    ));
+
+    diagnostic.annotate(Annotation::primary(Span::from(importing_source_file)));
 }
 
 pub fn report_invalid_fixture(

--- a/crates/karva_test_semantic/src/discovery/visitor.rs
+++ b/crates/karva_test_semantic/src/discovery/visitor.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::rc::Rc;
 
 use camino::Utf8Path;
+use fs_err as fs;
 use karva_python_semantic::ModulePath;
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
@@ -11,7 +12,10 @@ use ruff_python_parser::{Mode, ParseOptions, parse_unchecked};
 use ruff_source_file::SourceFileBuilder;
 
 use crate::Context;
-use crate::diagnostic::{report_failed_to_import_module, report_invalid_fixture};
+use crate::diagnostic::{
+    report_failed_to_discover_imported_fixture, report_failed_to_import_module,
+    report_invalid_fixture,
+};
 use crate::discovery::{DiscoveredModule, DiscoveredTestFunction};
 use crate::extensions::fixtures::DiscoveredFixture;
 use crate::extensions::fixtures::python::FixtureFunctionDefinition;
@@ -207,7 +211,6 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
             .ok()?;
         let utf8_file_name = Utf8Path::from_path(Path::new(&file_name))?;
         let module_path = ModulePath::new(utf8_file_name, &self.context.cwd().to_path_buf())?;
-        let source_text = std::fs::read_to_string(utf8_file_name).ok()?;
 
         // Use the function's own __name__ to find its definition in the source, since the
         // conftest symbol name may differ when the fixture is imported under an alias.
@@ -216,6 +219,20 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
             .ok()
             .and_then(|n| n.extract::<String>().ok())
             .unwrap_or_else(|| name.to_string());
+
+        let source_text = match fs::read_to_string(utf8_file_name) {
+            Ok(source_text) => source_text,
+            Err(err) => {
+                report_failed_to_discover_imported_fixture(
+                    self.context,
+                    name,
+                    self.module.source_file(),
+                    utf8_file_name,
+                    &err,
+                );
+                return None;
+            }
+        };
 
         let stmt_function_def =
             find_function_statement(&func_name, &source_text, self.context.python_version())?;


### PR DESCRIPTION
## Summary

Imported fixture discovery now reports a diagnostic when Karva finds a fixture object but cannot read the source file needed to locate its definition. This replaces a silent drop with a path-aware error while preserving the existing missing-fixture diagnostic for the affected test.

## Test Plan

Ran `cargo fmt --check`, `git diff --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `just test`, and `uvx prek run -a`.