### PR TITLE
Use fs_err for remaining path IO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,6 +1131,7 @@ name = "karva_collector"
 version = "0.0.0"
 dependencies = [
  "camino",
+ "fs-err",
  "karva_python_semantic",
  "ruff_python_ast",
  "ruff_python_parser",
@@ -1153,6 +1154,7 @@ dependencies = [
  "camino",
  "colored 3.1.1",
  "dunce",
+ "fs-err",
  "insta",
  "pyo3",
  "ruff_python_ast",
@@ -1234,6 +1236,7 @@ name = "karva_metadata"
 version = "0.0.0"
 dependencies = [
  "camino",
+ "fs-err",
  "globset",
  "insta",
  "karva_combine",
@@ -1258,6 +1261,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "camino",
+ "fs-err",
  "insta",
  "karva_metadata",
  "karva_python_semantic",
@@ -1333,6 +1337,7 @@ name = "karva_test_semantic"
 version = "0.0.0"
 dependencies = [
  "camino",
+ "fs-err",
  "karva_collector",
  "karva_coverage",
  "karva_diagnostic",
@@ -1364,6 +1369,7 @@ dependencies = [
  "camino",
  "clap",
  "colored 3.1.1",
+ "fs-err",
  "karva_cache",
  "karva_cli",
  "karva_diagnostic",

--- a/crates/karva/tests/it/configuration/mod.rs
+++ b/crates/karva/tests/it/configuration/mod.rs
@@ -1542,9 +1542,9 @@ fn test_config_file_flag_nonexistent_unix() {
 
     ----- stderr -----
     Karva failed
-      Cause: <temp_dir>/nonexistent.toml is not a valid `karva.toml`: Failed to read `<temp_dir>/nonexistent.toml`: No such file or directory (os error 2)
-      Cause: Failed to read `<temp_dir>/nonexistent.toml`: No such file or directory (os error 2)
-      Cause: No such file or directory (os error 2)
+      Cause: <temp_dir>/nonexistent.toml is not a valid `karva.toml`: Failed to read `<temp_dir>/nonexistent.toml`: failed to open file `<temp_dir>/nonexistent.toml`: No such file or directory (os error 2)
+      Cause: Failed to read `<temp_dir>/nonexistent.toml`: failed to open file `<temp_dir>/nonexistent.toml`: No such file or directory (os error 2)
+      Cause: failed to open file `<temp_dir>/nonexistent.toml`: No such file or directory (os error 2)
     ");
 }
 
@@ -1561,9 +1561,9 @@ fn test_discovered_karva_toml_read_error_unix() {
 
     ----- stderr -----
     Karva failed
-      Cause: <temp_dir>/karva.toml is not a valid `karva.toml`: Failed to read `<temp_dir>/karva.toml`: Is a directory (os error 21)
-      Cause: Failed to read `<temp_dir>/karva.toml`: Is a directory (os error 21)
-      Cause: Is a directory (os error 21)
+      Cause: <temp_dir>/karva.toml is not a valid `karva.toml`: Failed to read `<temp_dir>/karva.toml`: failed to read from file `<temp_dir>/karva.toml`: Is a directory (os error 21)
+      Cause: Failed to read `<temp_dir>/karva.toml`: failed to read from file `<temp_dir>/karva.toml`: Is a directory (os error 21)
+      Cause: failed to read from file `<temp_dir>/karva.toml`: Is a directory (os error 21)
     ");
 }
 
@@ -1579,8 +1579,8 @@ fn test_config_file_flag_nonexistent_windows() {
 
     ----- stderr -----
     Karva failed
-      Cause: <temp_dir>/nonexistent.toml is not a valid `karva.toml`: Failed to read `<temp_dir>/nonexistent.toml`: The system cannot find the file specified. (os error 2)
-      Cause: Failed to read `<temp_dir>/nonexistent.toml`: The system cannot find the file specified. (os error 2)
-      Cause: The system cannot find the file specified. (os error 2)
+      Cause: <temp_dir>/nonexistent.toml is not a valid `karva.toml`: Failed to read `<temp_dir>/nonexistent.toml`: failed to open file `<temp_dir>/nonexistent.toml`: The system cannot find the file specified. (os error 2)
+      Cause: Failed to read `<temp_dir>/nonexistent.toml`: failed to open file `<temp_dir>/nonexistent.toml`: The system cannot find the file specified. (os error 2)
+      Cause: failed to open file `<temp_dir>/nonexistent.toml`: The system cannot find the file specified. (os error 2)
     ");
 }

--- a/crates/karva_collector/Cargo.toml
+++ b/crates/karva_collector/Cargo.toml
@@ -14,6 +14,7 @@ license.workspace = true
 karva_python_semantic = { workspace = true }
 
 camino = { workspace = true }
+fs-err = { workspace = true }
 ruff_python_ast = { workspace = true }
 ruff_python_parser = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/karva_collector/src/lib.rs
+++ b/crates/karva_collector/src/lib.rs
@@ -1,4 +1,5 @@
 use camino::{Utf8Path, Utf8PathBuf};
+use fs_err as fs;
 use ruff_python_ast::{PythonVersion, Stmt};
 use ruff_python_parser::{Mode, ParseOptions, parse_unchecked};
 use thiserror::Error;
@@ -47,11 +48,10 @@ pub fn collect_file(
         return Ok(None);
     };
 
-    let source_text =
-        std::fs::read_to_string(path).map_err(|source| CollectionError::ReadSource {
-            path: path.clone(),
-            source,
-        })?;
+    let source_text = fs::read_to_string(path).map_err(|source| CollectionError::ReadSource {
+        path: path.clone(),
+        source,
+    })?;
 
     let module_type: ModuleType = path.into();
 

--- a/crates/karva_coverage/Cargo.toml
+++ b/crates/karva_coverage/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = { workspace = true }
 camino = { workspace = true }
 colored = { workspace = true }
 dunce = { workspace = true }
+fs-err = { workspace = true }
 pyo3 = { workspace = true }
 ruff_python_ast = { workspace = true }
 ruff_python_parser = { workspace = true }

--- a/crates/karva_coverage/src/report/shared.rs
+++ b/crates/karva_coverage/src/report/shared.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{Context, Result};
 use camino::Utf8Path;
+use fs_err as fs;
 
 use crate::data::WorkerFile;
 
@@ -27,8 +28,8 @@ pub fn combine(files: &[impl AsRef<Utf8Path>]) -> Result<BTreeMap<String, Combin
 
     for path in files {
         let path = path.as_ref();
-        let bytes = std::fs::read(path.as_std_path())
-            .with_context(|| format!("failed to read coverage file {path}"))?;
+        let bytes =
+            fs::read(path).with_context(|| format!("failed to read coverage file {path}"))?;
         let parsed: WorkerFile = serde_json::from_slice(&bytes)
             .with_context(|| format!("failed to parse coverage file {path}"))?;
 

--- a/crates/karva_coverage/src/report/xml.rs
+++ b/crates/karva_coverage/src/report/xml.rs
@@ -4,6 +4,7 @@ use std::time::UNIX_EPOCH;
 
 use anyhow::{Context, Result};
 use camino::Utf8Path;
+use fs_err as fs;
 
 use super::shared::{FileRow, class_filename, escape_xml, rate};
 
@@ -19,7 +20,7 @@ pub fn build_cobertura_xml(
         .iter()
         .fold(0_u32, |acc, row| acc.saturating_add(row.hit));
     let line_rate = rate(total_hit, total_stmts);
-    let timestamp = std::fs::metadata(cwd.as_std_path())
+    let timestamp = fs::metadata(cwd)
         .with_context(|| format!("failed to read coverage root metadata {cwd}"))?
         .modified()
         .with_context(|| format!("failed to read coverage root modification time {cwd}"))?

--- a/crates/karva_metadata/Cargo.toml
+++ b/crates/karva_metadata/Cargo.toml
@@ -20,6 +20,7 @@ karva_macros = { workspace = true }
 karva_version = { workspace = true }
 
 camino = { workspace = true }
+fs-err = { workspace = true }
 globset = { workspace = true }
 regex = { workspace = true }
 ruff_db = { workspace = true }

--- a/crates/karva_metadata/src/lib.rs
+++ b/crates/karva_metadata/src/lib.rs
@@ -1,4 +1,5 @@
 use camino::{Utf8Path, Utf8PathBuf};
+use fs_err as fs;
 use karva_combine::Combine;
 use ruff_python_ast::PythonVersion;
 use thiserror::Error;
@@ -225,7 +226,7 @@ impl ProjectMetadata {
 fn try_load_karva_toml(dir: &Utf8Path) -> Result<Option<Config>, ProjectMetadataError> {
     let path = dir.join("karva.toml");
 
-    let content = match std::fs::read_to_string(&path) {
+    let content = match fs::read_to_string(&path) {
         Ok(content) => content,
         Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(source) => {
@@ -253,7 +254,7 @@ fn try_load_karva_toml(dir: &Utf8Path) -> Result<Option<Config>, ProjectMetadata
 fn try_load_pyproject(dir: &Utf8Path) -> Result<Option<PyProject>, ProjectMetadataError> {
     let path = dir.join("pyproject.toml");
 
-    let content = match std::fs::read_to_string(&path) {
+    let content = match fs::read_to_string(&path) {
         Ok(content) => content,
         Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(source) => {

--- a/crates/karva_metadata/src/options/config.rs
+++ b/crates/karva_metadata/src/options/config.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use camino::{Utf8Path, Utf8PathBuf};
+use fs_err as fs;
 use karva_combine::Combine;
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
@@ -68,7 +69,7 @@ impl Config {
 
     pub(crate) fn from_karva_configuration_file(path: &Utf8Path) -> Result<Self, KarvaTomlError> {
         let karva_toml_str =
-            std::fs::read_to_string(path).map_err(|source| KarvaTomlError::FileReadError {
+            fs::read_to_string(path).map_err(|source| KarvaTomlError::FileReadError {
                 source,
                 path: path.to_path_buf(),
             })?;

--- a/crates/karva_project/Cargo.toml
+++ b/crates/karva_project/Cargo.toml
@@ -14,6 +14,7 @@ license = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 camino = { workspace = true }
+fs-err = { workspace = true }
 karva_metadata = { workspace = true }
 karva_python_semantic = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/karva_project/src/lib.rs
+++ b/crates/karva_project/src/lib.rs
@@ -2,6 +2,7 @@ pub mod path;
 
 use anyhow::Context;
 use camino::{Utf8Path, Utf8PathBuf};
+use fs_err as fs;
 use karva_metadata::{ProjectMetadata, ProjectSettings};
 
 use crate::path::{TestPath, TestPathError, absolute};
@@ -23,7 +24,7 @@ pub fn find_karva_wheel() -> anyhow::Result<Utf8PathBuf> {
 }
 
 fn find_karva_wheel_in(wheels_dir: &Utf8Path) -> anyhow::Result<Utf8PathBuf> {
-    let entries = std::fs::read_dir(wheels_dir)
+    let entries = fs::read_dir(wheels_dir)
         .with_context(|| format!("Could not read wheels directory: {wheels_dir}"))?;
 
     let mut newest: Option<(std::time::SystemTime, Utf8PathBuf)> = None;

--- a/crates/karva_test_semantic/Cargo.toml
+++ b/crates/karva_test_semantic/Cargo.toml
@@ -13,6 +13,7 @@ license = { workspace = true }
 
 [dependencies]
 camino = { workspace = true }
+fs-err = { workspace = true }
 karva_collector = { workspace = true }
 karva_coverage = { workspace = true }
 karva_diagnostic = { workspace = true, features = ["traceback"] }

--- a/crates/karva_test_semantic/src/discovery/discoverer.rs
+++ b/crates/karva_test_semantic/src/discovery/discoverer.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::rc::Rc;
 
 use camino::Utf8Path;
+use fs_err as fs;
 use karva_collector::{CollectedModule, CollectedPackage};
 use karva_project::path::{TestPath, TestPathError};
 use karva_python_semantic::ModulePath;
@@ -174,7 +175,7 @@ fn discover_framework_fixtures(
         return None;
     };
 
-    let source_text = match std::fs::read_to_string(utf8_path) {
+    let source_text = match fs::read_to_string(utf8_path) {
         Ok(text) => text,
         Err(err) => {
             tracing::warn!("Failed to read `karva._builtins` source at {utf8_path}: {err}");

--- a/crates/karva_worker/Cargo.toml
+++ b/crates/karva_worker/Cargo.toml
@@ -31,6 +31,7 @@ argfile = { workspace = true }
 camino = { workspace = true }
 clap = { workspace = true, features = ["wrap_help", "string", "env"] }
 colored = { workspace = true }
+fs-err = { workspace = true }
 ruff_db = { workspace = true }
 wild = { workspace = true }
 

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -4,6 +4,7 @@ use std::process::{ExitCode, Termination};
 use anyhow::Context as _;
 use camino::Utf8PathBuf;
 use clap::Parser;
+use fs_err as fs;
 use karva_cache::{RunCache, RunHash};
 use karva_cli::{SubTestCommand, Verbosity};
 use karva_diagnostic::{DummyReporter, Reporter, TestCaseReporter};
@@ -153,7 +154,7 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
     // Make sure the worker dir exists so the reporter can write the
     // progress file before the worker has otherwise touched it.
     if let Some(parent) = progress_file.parent() {
-        std::fs::create_dir_all(parent)
+        fs::create_dir_all(parent)
             .with_context(|| format!("Failed to create worker progress directory `{parent}`"))?;
     }
     let reporter: Box<dyn Reporter> = if matches!(printer.status_level(), StatusLevel::None) {


### PR DESCRIPTION
## Summary

Remaining production file reads and directory setup paths now use `fs_err`, matching the path-aware IO pattern used elsewhere in the stack. This keeps existing control flow while improving source errors for collection, configuration, project wheel lookup, coverage reports, framework fixture discovery, and worker progress setup.

## Test Plan

Ran focused package tests, `cargo fmt --check`, `git diff --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `just test --no-fail-fast`, and `uvx prek run -a`.