### PR TITLE
Use fs_err for cache IO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,6 +1100,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "camino",
+ "fs-err",
  "insta",
  "karva_diagnostic",
  "ruff_db",

--- a/crates/karva_cache/Cargo.toml
+++ b/crates/karva_cache/Cargo.toml
@@ -15,6 +15,7 @@ karva_diagnostic = { workspace = true }
 
 anyhow = { workspace = true }
 camino = { workspace = true }
+fs-err = { workspace = true }
 ruff_db = { workspace = true }
 ruff_notebook = { workspace = true }
 serde = { workspace = true }

--- a/crates/karva_cache/src/artifact.rs
+++ b/crates/karva_cache/src/artifact.rs
@@ -6,11 +6,11 @@
 //! pairing the filename with its serializer in one place means adding a new
 //! artifact is a single-place change and read/write helpers can't drift.
 
-use std::fs;
-use std::io::Write;
+use std::io::{ErrorKind, Write};
 
 use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
+use fs_err as fs;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tempfile::NamedTempFile;
@@ -109,25 +109,73 @@ pub fn write_json_if_nonempty<T: Serialize>(
 /// Reads `dir/<file>` as JSON, or returns `Ok(None)` when the file does not exist.
 pub fn read_json<T: DeserializeOwned>(dir: &Utf8Path, file: CacheFile) -> Result<Option<T>> {
     let path = file.path_in(dir);
-    if !path.exists() {
-        return Ok(None);
-    }
-    let content = fs::read_to_string(&path)?;
-    Ok(Some(serde_json::from_str(&content)?))
+    let content = match fs::read_to_string(&path) {
+        Ok(content) => content,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err.into()),
+    };
+    serde_json::from_str(&content)
+        .with_context(|| format!("failed to parse cache artifact `{path}`"))
+        .map(Some)
 }
 
 /// Reads `dir/<file>` as raw text, or returns `Ok(None)` when the file does not exist.
 pub fn read_text(dir: &Utf8Path, file: CacheFile) -> Result<Option<String>> {
     let path = file.path_in(dir);
-    if !path.exists() {
-        return Ok(None);
+    match fs::read_to_string(&path) {
+        Ok(content) => Ok(Some(content)),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err.into()),
     }
-    Ok(Some(fs::read_to_string(&path)?))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn read_text_missing_artifact_returns_none() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let cache_dir =
+            Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf()).expect("UTF-8 temp path");
+
+        let content = read_text(&cache_dir, CacheFile::LastFailed).expect("read artifact");
+
+        assert!(content.is_none());
+    }
+
+    #[test]
+    fn read_text_reports_artifact_path_on_read_error() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let cache_dir =
+            Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf()).expect("UTF-8 temp path");
+        let path = CacheFile::LastFailed.path_in(&cache_dir);
+        std::fs::create_dir(&path).expect("create directory at artifact path");
+
+        let error = read_text(&cache_dir, CacheFile::LastFailed).expect_err("read should fail");
+
+        assert!(
+            error.to_string().contains(path.as_str()),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn read_json_reports_artifact_path_on_parse_error() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let cache_dir =
+            Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf()).expect("UTF-8 temp path");
+        let path = CacheFile::LastFailed.path_in(&cache_dir);
+        std::fs::write(&path, "not-json").expect("write malformed artifact");
+
+        let error = read_json::<Vec<String>>(&cache_dir, CacheFile::LastFailed)
+            .expect_err("parse should fail");
+
+        assert!(
+            error.to_string().contains(path.as_str()),
+            "unexpected error: {error}"
+        );
+    }
 
     #[test]
     fn write_text_replaces_existing_artifact() {

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
-use std::fs;
 use std::io::ErrorKind;
 use std::time::Duration;
 
 use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
+use fs_err as fs;
 use karva_diagnostic::{FlakyTest, TestResultKind, TestResultStats, TestRunResult};
 use ruff_db::diagnostic::DisplayDiagnosticConfig;
 use serde::{Deserialize, Serialize};
@@ -205,12 +205,13 @@ pub fn read_last_failed(cache_dir: &Utf8Path) -> Result<Vec<String>> {
 /// Returns an empty vec if `parent` does not exist. Non-UTF-8 entries and
 /// non-directory entries are silently skipped.
 fn list_subdirs_with_prefix(parent: &Utf8Path, prefix: &str) -> Result<Vec<Utf8PathBuf>> {
-    if !parent.exists() {
-        return Ok(Vec::new());
-    }
-
     let mut dirs = Vec::new();
-    for entry in fs::read_dir(parent)? {
+    let entries = match fs::read_dir(parent) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => return Err(err.into()),
+    };
+    for entry in entries {
         let entry = entry?;
         let Ok(path) = Utf8PathBuf::try_from(entry.path()) else {
             continue;
@@ -273,12 +274,6 @@ pub struct PruneResult {
 
 /// Removes all but the most recent `run-*` directory from the cache.
 pub fn prune_cache(cache_dir: &Utf8Path) -> Result<PruneResult> {
-    if !cache_dir.exists() {
-        return Ok(PruneResult {
-            removed: Vec::new(),
-        });
-    }
-
     let mut run_dirs = collect_run_dirs(cache_dir)?;
 
     let to_remove = run_dirs.len().saturating_sub(1);
@@ -297,11 +292,10 @@ pub fn prune_cache(cache_dir: &Utf8Path) -> Result<PruneResult> {
 ///
 /// Returns `true` if the directory existed and was removed.
 pub fn clean_cache(cache_dir: &Utf8Path) -> Result<bool> {
-    if cache_dir.exists() {
-        fs::remove_dir_all(cache_dir)?;
-        Ok(true)
-    } else {
-        Ok(false)
+    match fs::remove_dir_all(cache_dir) {
+        Ok(()) => Ok(true),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(err.into()),
     }
 }
 
@@ -496,6 +490,22 @@ mod tests {
     }
 
     #[test]
+    fn prune_cache_reports_cache_dir_read_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = Utf8PathBuf::try_from(tmp.path().join("cache")).unwrap();
+        fs::write(&cache_dir, "").unwrap();
+
+        let Err(error) = prune_cache(&cache_dir) else {
+            panic!("file cache path should fail");
+        };
+
+        assert!(
+            error.to_string().contains(cache_dir.as_str()),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
     fn prune_cache_ignores_non_run_directories() {
         let tmp = tempfile::tempdir().unwrap();
         let cache_dir = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
@@ -644,6 +654,25 @@ mod tests {
         fs::write(progress_file, "").unwrap();
 
         assert!(cache.read_current_test(0).unwrap().is_none());
+    }
+
+    #[test]
+    fn read_current_test_reports_path_on_read_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let run_hash = RunHash::from_existing("run-760");
+        let cache = RunCache::new(&cache_dir, &run_hash);
+        let progress_file = cache.current_test_file(0);
+        fs::create_dir_all(&progress_file).unwrap();
+
+        let error = cache
+            .read_current_test(0)
+            .expect_err("directory progress file should fail");
+
+        assert!(
+            error.to_string().contains(progress_file.as_str()),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Cache artifact reads and cache directory operations now use `fs_err` for path-aware IO errors. Missing optional cache files and missing cache directories are still treated as absent, but real read and traversal failures now report the affected path.

## Test Plan

Ran `just test -p karva_cache`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `uvx prek run -a`.