### PR TITLE
Use fs_err for progress file IO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,6 +1187,7 @@ version = "0.0.0"
 dependencies = [
  "camino",
  "colored 3.1.1",
+ "fs-err",
  "insta",
  "karva_logging",
  "karva_python_semantic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ directories = "6.0.0"
 divan = { package = "codspeed-divan-compat", version = "4.3.0" }
 dunce = { version = "1.0.5" }
 fastrand = { version = "2.4" }
+fs-err = { version = "3.2.2" }
 globset = { version = "0.4" }
 ignore = { version = "0.4.25" }
 insta = { version = "1.47.1" }

--- a/crates/karva_diagnostic/Cargo.toml
+++ b/crates/karva_diagnostic/Cargo.toml
@@ -19,6 +19,7 @@ karva_python_semantic = { workspace = true }
 
 camino = { workspace = true }
 colored = { workspace = true }
+fs-err = { workspace = true }
 pyo3 = { workspace = true, optional = true }
 ruff_db = { workspace = true }
 ruff_source_file = { workspace = true }

--- a/crates/karva_diagnostic/src/reporter.rs
+++ b/crates/karva_diagnostic/src/reporter.rs
@@ -1,4 +1,3 @@
-use std::fs::{File, OpenOptions};
 use std::io::{Seek, SeekFrom, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -7,6 +6,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use camino::Utf8Path;
 use colored::Colorize;
+use fs_err::{File, OpenOptions};
 use karva_logging::time::format_duration_bracketed;
 use karva_logging::{Printer, StatusLevel};
 use karva_python_semantic::QualifiedTestName;
@@ -524,5 +524,26 @@ mod tests {
             progress["name"] == "test_module::test_example"
         });
         assert_eq!(progress["name"], "test_module::test_example");
+    }
+
+    #[test]
+    fn progress_file_open_error_includes_path() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let path = Utf8PathBuf::try_from(
+            temp_dir
+                .path()
+                .join("missing-parent")
+                .join("current-test.json"),
+        )
+        .expect("temp path should be UTF-8");
+
+        let Err(error) = TestCaseReporter::new(Printer::default()).with_progress_file(&path) else {
+            panic!("missing parent should fail");
+        };
+
+        assert!(
+            error.to_string().contains(path.as_str()),
+            "unexpected error: {error}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

The test progress reporter now opens its current-test file through `fs_err`, so startup failures include the exact path that could not be created. A regression test covers the missing-parent case for the progress file.

## Test Plan

Ran `just test -p karva_diagnostic`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `uvx prek run -a`.