### PR TITLE
Use fixture argument wrapper

### DIFF
--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -4,13 +4,11 @@
 //!
 //! `ruff_db` diagnostics look great and have a great API.
 
-use std::collections::HashMap;
-
 use camino::Utf8Path;
 use karva_collector::CollectionError;
 use karva_diagnostic::Traceback;
 use karva_python_semantic::FunctionKind;
-use pyo3::{Py, PyAny, PyErr, Python};
+use pyo3::{PyErr, Python};
 use ruff_db::diagnostic::{
     Annotation, Diagnostic, Severity, Span, SubDiagnostic, SubDiagnosticSeverity,
 };
@@ -21,7 +19,7 @@ mod metadata;
 
 pub use metadata::{DiagnosticGuardBuilder, DiagnosticType};
 
-use crate::runner::{FixtureCallError, FixtureChainEntry};
+use crate::runner::{FixtureArguments, FixtureCallError, FixtureChainEntry};
 use crate::utils::truncate_string;
 use crate::{Context, declare_diagnostic_type};
 
@@ -356,7 +354,7 @@ pub fn report_test_failure(
     py: Python,
     source_file: &SourceFile,
     stmt_function_def: &StmtFunctionDef,
-    arguments: &HashMap<String, Py<PyAny>>,
+    arguments: &FixtureArguments,
     error: &PyErr,
 ) {
     let builder = context.report_diagnostic(&TEST_FAILURE);
@@ -380,7 +378,7 @@ fn handle_failed_function_call(
     py: Python,
     source_file: &SourceFile,
     stmt_function_def: &StmtFunctionDef,
-    arguments: &HashMap<String, Py<PyAny>>,
+    arguments: &FixtureArguments,
     function_kind: FunctionKind,
     error: &PyErr,
 ) {

--- a/crates/karva_test_semantic/src/extensions/fixtures/normalized_fixture.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/normalized_fixture.rs
@@ -1,14 +1,13 @@
-use std::collections::HashMap;
 use std::rc::Rc;
 
 use karva_python_semantic::QualifiedFunctionName;
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
 use ruff_python_ast::StmtFunctionDef;
 use ruff_source_file::SourceFile;
 
 use crate::extensions::fixtures::FixtureScope;
 use crate::extensions::tags::Tags;
+use crate::runner::FixtureArguments;
 use crate::utils::run_coroutine;
 
 /// A normalized fixture represents a concrete instance of a fixture ready for execution.
@@ -73,17 +72,12 @@ impl NormalizedFixture {
     pub(crate) fn call(
         &self,
         py: Python,
-        fixture_arguments: &HashMap<String, Py<PyAny>>,
+        fixture_arguments: &FixtureArguments,
     ) -> PyResult<Py<PyAny>> {
         let result = if fixture_arguments.is_empty() {
             self.py_function.call0(py)
         } else {
-            let kwargs_dict = PyDict::new(py);
-
-            for (key, value) in fixture_arguments {
-                kwargs_dict.set_item(key, value)?;
-            }
-
+            let kwargs_dict = fixture_arguments.to_kwargs(py)?;
             self.py_function.call(py, (), Some(&kwargs_dict))
         };
 

--- a/crates/karva_test_semantic/src/runner/fixture_arguments.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_arguments.rs
@@ -1,0 +1,70 @@
+use std::collections::HashMap;
+
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+/// Keyword arguments resolved for a test or fixture call.
+#[derive(Default)]
+pub struct FixtureArguments {
+    inner: HashMap<String, Py<PyAny>>,
+}
+
+impl FixtureArguments {
+    pub fn insert(&mut self, name: String, value: Py<PyAny>) -> Option<Py<PyAny>> {
+        self.inner.insert(name, value)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    pub fn iter(&self) -> std::collections::hash_map::Iter<'_, String, Py<PyAny>> {
+        self.inner.iter()
+    }
+
+    pub fn to_kwargs<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let kwargs = PyDict::new(py);
+        for (key, value) in self {
+            kwargs.set_item(key, value)?;
+        }
+        Ok(kwargs)
+    }
+}
+
+impl<'a> IntoIterator for &'a FixtureArguments {
+    type IntoIter = std::collections::hash_map::Iter<'a, String, Py<PyAny>>;
+    type Item = (&'a String, &'a Py<PyAny>);
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pyo3::IntoPyObjectExt;
+
+    use super::*;
+
+    #[test]
+    fn builds_python_kwargs() {
+        Python::initialize();
+        Python::attach(|py| {
+            let mut arguments = FixtureArguments::default();
+            arguments.insert(
+                "answer".to_string(),
+                42i32.into_py_any(py).expect("convert int"),
+            );
+
+            let kwargs = arguments.to_kwargs(py).expect("build kwargs");
+            let answer = kwargs
+                .get_item("answer")
+                .expect("lookup should succeed")
+                .expect("answer should exist")
+                .extract::<i32>()
+                .expect("answer should be an int");
+
+            assert_eq!(answer, 42);
+        });
+    }
+}

--- a/crates/karva_test_semantic/src/runner/mod.rs
+++ b/crates/karva_test_semantic/src/runner/mod.rs
@@ -1,4 +1,5 @@
 mod finalizer_cache;
+mod fixture_arguments;
 mod fixture_cache;
 mod fixture_resolver;
 mod package_runner;
@@ -6,5 +7,6 @@ mod scoped_storage;
 mod test_iterator;
 
 use finalizer_cache::FinalizerCache;
+pub use fixture_arguments::FixtureArguments;
 use fixture_cache::FixtureCache;
 pub use package_runner::{FixtureCallError, FixtureChainEntry, PackageRunner};

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -3,14 +3,12 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
 
-type FixtureArguments = HashMap<String, Py<PyAny>>;
-
 use karva_diagnostic::IndividualTestResultKind;
 use karva_metadata::RunIgnoredMode;
 use karva_metadata::filter::EvalContext;
 use karva_python_semantic::{FunctionKind, QualifiedFunctionName, QualifiedTestName};
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyIterator};
+use pyo3::types::PyIterator;
 use ruff_python_ast::StmtFunctionDef;
 use ruff_source_file::SourceFile;
 
@@ -28,7 +26,7 @@ use crate::extensions::tags::skip::{extract_skip_reason, is_skip_exception};
 use crate::extensions::tags::timeout::TimeoutTag;
 use crate::runner::fixture_resolver::RuntimeFixtureResolver;
 use crate::runner::test_iterator::{TestVariant, TestVariantIterator};
-use crate::runner::{FinalizerCache, FixtureCache};
+use crate::runner::{FinalizerCache, FixtureArguments, FixtureCache};
 use crate::utils::{
     full_test_name, run_coroutine, run_test_with_timeout, set_attempt_env, set_test_name_env,
 };
@@ -290,7 +288,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         let use_fixture_errors = self.run_fixtures(py, use_fixture_dependencies);
         fixture_call_errors.extend(use_fixture_errors);
 
-        let mut function_arguments: FixtureArguments = HashMap::new();
+        let mut function_arguments = FixtureArguments::default();
 
         for fixture in fixture_dependencies {
             match self.run_fixture(py, fixture) {
@@ -554,10 +552,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             let result = if function_arguments.is_empty() {
                 function.call0(py)
             } else {
-                let py_dict = PyDict::new(py);
-                for (key, value) in &function_arguments {
-                    py_dict.set_item(key, value.as_ref())?;
-                }
+                let py_dict = function_arguments.to_kwargs(py)?;
                 function.call(py, (), Some(&py_dict))
             };
             if is_async {
@@ -638,7 +633,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             return Ok((cached, None));
         }
 
-        let mut function_arguments: FixtureArguments = HashMap::new();
+        let mut function_arguments = FixtureArguments::default();
 
         for dep in fixture.dependencies() {
             match self.run_fixture(py, dep) {
@@ -678,7 +673,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             error: err,
             stmt_function_def: fixture.stmt_function_def.clone(),
             source_file: fixture.source_file.clone(),
-            arguments: HashMap::new(),
+            arguments: FixtureArguments::default(),
             dependency_chain: Vec::new(),
         })?;
 

--- a/crates/karva_test_semantic/src/utils.rs
+++ b/crates/karva_test_semantic/src/utils.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::fmt::Write;
 
 use camino::Utf8Path;
@@ -7,6 +6,8 @@ use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3::types::{PyAnyMethods, PyDict};
 use pyo3::{PyResult, Python};
+
+use crate::runner::FixtureArguments;
 
 const MAKE_SYNC_CODE: &std::ffi::CStr = c"
 def _make_sync(async_fn):
@@ -34,15 +35,11 @@ pub(crate) fn run_coroutine(py: Python<'_>, coroutine: Py<PyAny>) -> PyResult<Py
 pub(crate) fn run_test_with_timeout(
     py: Python<'_>,
     function: &Py<PyAny>,
-    kwargs: &HashMap<String, Py<PyAny>>,
+    kwargs: &FixtureArguments,
     is_async: bool,
     seconds: f64,
 ) -> PyResult<Py<PyAny>> {
-    let kwargs_dict = PyDict::new(py);
-    for (key, value) in kwargs {
-        kwargs_dict.set_item(key, value)?;
-    }
-
+    let kwargs_dict = kwargs.to_kwargs(py)?;
     if is_async {
         run_async_with_timeout(py, function, &kwargs_dict, seconds)
     } else {
@@ -209,11 +206,7 @@ pub(crate) fn add_to_sys_path(py: Python<'_>, path: &Utf8Path, index: isize) -> 
     Ok(())
 }
 
-pub(crate) fn full_test_name(
-    py: Python,
-    function: String,
-    kwargs: &HashMap<String, Py<PyAny>>,
-) -> String {
+pub(crate) fn full_test_name(py: Python, function: String, kwargs: &FixtureArguments) -> String {
     if kwargs.is_empty() {
         function
     } else {


### PR DESCRIPTION
## Summary

Fixture invocation now uses a dedicated `FixtureArguments` wrapper instead of threading raw `HashMap<String, Py<PyAny>>` values through runner, diagnostics, and timeout helpers. The wrapper owns kwargs construction for Python calls, removes duplicate `PyDict` assembly, and keeps fixture argument handling in one place.

## Test Plan

Ran `cargo test -p karva_test_semantic`, `just test -p karva_test_semantic`, `just test -p karva --test it extensions::fixtures`, workspace clippy, and `uvx prek run -a`.
