### PR TITLE
Emit diagnostics explicitly

### DIFF
--- a/crates/karva_test_semantic/src/context.rs
+++ b/crates/karva_test_semantic/src/context.rs
@@ -8,7 +8,7 @@ use karva_metadata::ProjectSettings;
 use karva_python_semantic::QualifiedTestName;
 use ruff_python_ast::PythonVersion;
 
-use crate::diagnostic::{DiagnosticGuardBuilder, DiagnosticType};
+use crate::diagnostic::{DiagnosticBuilder, DiagnosticType};
 
 /// Central context object that holds shared state for a test run.
 ///
@@ -167,8 +167,8 @@ impl<'a> Context<'a> {
     pub(crate) fn report_diagnostic<'ctx>(
         &'ctx self,
         rule: &'static DiagnosticType,
-    ) -> DiagnosticGuardBuilder<'ctx, 'a> {
-        DiagnosticGuardBuilder::new(self, rule)
+    ) -> DiagnosticBuilder<'ctx, 'a> {
+        DiagnosticBuilder::new(self, rule)
     }
 
     pub fn python_version(&self) -> PythonVersion {

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -18,7 +18,8 @@ use ruff_source_file::SourceFile;
 
 mod metadata;
 
-pub use metadata::{DiagnosticGuardBuilder, DiagnosticType};
+pub use metadata::DiagnosticBuilder;
+pub use metadata::DiagnosticType;
 
 use crate::runner::{FixtureCallError, FixtureChainEntry};
 use crate::utils::truncate_string;
@@ -154,13 +155,13 @@ fn report_dependency_chain(
 pub fn report_collection_error(context: &Context, error: &CollectionError) {
     let builder = context.report_diagnostic(&FAILED_TO_COLLECT_MODULE);
 
-    builder.into_diagnostic(format!("Failed to collect python module: {error}"));
+    builder.emit(format!("Failed to collect python module: {error}"));
 }
 
 pub fn report_failed_to_import_module(context: &Context, module_name: &str, error: &str) {
     let builder = context.report_diagnostic(&FAILED_TO_IMPORT_MODULE);
 
-    builder.into_diagnostic(format!(
+    builder.emit(format!(
         "Failed to import python module `{module_name}`: {error}"
     ));
 }
@@ -174,18 +175,17 @@ pub fn report_invalid_fixture(
 ) {
     let builder = context.report_diagnostic(&INVALID_FIXTURE);
 
-    let mut diagnostic = builder.into_diagnostic(format!(
-        "Discovered an invalid fixture `{}`",
-        stmt_function_def.name
-    ));
+    builder.emit_with(
+        format!("Discovered an invalid fixture `{}`", stmt_function_def.name),
+        |diagnostic| {
+            annotate_function_name(diagnostic, source_file, stmt_function_def);
 
-    annotate_function_name(&mut diagnostic, source_file, stmt_function_def);
-
-    let error_string = error.value(py).to_string();
-
-    if !error_string.is_empty() {
-        diagnostic.info(indent_continuation_lines(&error_string));
-    }
+            let error_string = error.value(py).to_string();
+            if !error_string.is_empty() {
+                diagnostic.info(indent_continuation_lines(&error_string));
+            }
+        },
+    );
 }
 
 pub fn report_invalid_fixture_finalizer(
@@ -196,14 +196,16 @@ pub fn report_invalid_fixture_finalizer(
 ) {
     let builder = context.report_diagnostic(&INVALID_FIXTURE_FINALIZER);
 
-    let mut diagnostic = builder.into_diagnostic(format!(
-        "Discovered an invalid fixture finalizer `{}`",
-        stmt_function_def.name
-    ));
-
-    annotate_function_name(&mut diagnostic, source_file, stmt_function_def);
-
-    diagnostic.info(reason);
+    builder.emit_with(
+        format!(
+            "Discovered an invalid fixture finalizer `{}`",
+            stmt_function_def.name
+        ),
+        |diagnostic| {
+            annotate_function_name(diagnostic, source_file, stmt_function_def);
+            diagnostic.info(reason);
+        },
+    );
 }
 
 pub fn report_fixture_failure(context: &Context, py: Python, error: FixtureCallError) {
@@ -218,19 +220,19 @@ pub fn report_fixture_failure(context: &Context, py: Python, error: FixtureCallE
 
     let builder = context.report_diagnostic(&FIXTURE_FAILURE);
 
-    let mut diagnostic = builder.into_diagnostic(format!("Fixture `{fixture_name}` failed"));
+    builder.emit_with(format!("Fixture `{fixture_name}` failed"), |diagnostic| {
+        report_dependency_chain(diagnostic, &dependency_chain, &fixture_name);
 
-    report_dependency_chain(&mut diagnostic, &dependency_chain, &fixture_name);
-
-    handle_failed_function_call(
-        &mut diagnostic,
-        py,
-        &source_file,
-        &stmt_function_def,
-        &arguments,
-        FunctionKind::Fixture,
-        &error,
-    );
+        handle_failed_function_call(
+            diagnostic,
+            py,
+            &source_file,
+            &stmt_function_def,
+            &arguments,
+            FunctionKind::Fixture,
+            &error,
+        );
+    });
 }
 
 pub fn report_missing_fixtures(
@@ -244,62 +246,65 @@ pub fn report_missing_fixtures(
 ) {
     let builder = context.report_diagnostic(&MISSING_FIXTURES);
 
-    let mut diagnostic = builder.into_diagnostic(format!(
-        "{} `{}` has missing fixtures",
-        function_kind.capitalised(),
-        stmt_function_def.name
-    ));
-
-    annotate_function_name(&mut diagnostic, source_file, stmt_function_def);
-
     let missing_fixtures_string = missing_fixtures
         .iter()
         .map(|fixture| format!("`{}`", truncate_string(fixture)))
         .collect::<Vec<String>>()
         .join(", ");
 
-    diagnostic.info(format!("Missing fixtures: {missing_fixtures_string}"));
+    builder.emit_with(
+        format!(
+            "{} `{}` has missing fixtures",
+            function_kind.capitalised(),
+            stmt_function_def.name
+        ),
+        |diagnostic| {
+            annotate_function_name(diagnostic, source_file, stmt_function_def);
 
-    diagnostic.set_concise_message(format!(
-        "{} `{}` has missing fixtures: {missing_fixtures_string}",
-        function_kind.capitalised(),
-        stmt_function_def.name,
-    ));
+            diagnostic.info(format!("Missing fixtures: {missing_fixtures_string}"));
 
-    for FixtureCallError {
-        error,
-        fixture_name,
-        source_file,
-        dependency_chain,
-        ..
-    } in fixture_call_errors
-    {
-        report_dependency_chain(&mut diagnostic, &dependency_chain, &fixture_name);
+            diagnostic.set_concise_message(format!(
+                "{} `{}` has missing fixtures: {missing_fixtures_string}",
+                function_kind.capitalised(),
+                stmt_function_def.name,
+            ));
 
-        if let Some(Traceback {
-            lines: _,
-            error_source_file,
-            location,
-        }) = Traceback::from_error_with_source(py, &error, &source_file)
-        {
-            let mut sub = SubDiagnostic::new(
-                SubDiagnosticSeverity::Info,
-                format!("Fixture `{fixture_name}` failed here"),
-            );
+            for FixtureCallError {
+                error,
+                fixture_name,
+                source_file,
+                dependency_chain,
+                ..
+            } in fixture_call_errors
+            {
+                report_dependency_chain(diagnostic, &dependency_chain, &fixture_name);
 
-            let secondary_span = Span::from(error_source_file).with_range(location);
+                if let Some(Traceback {
+                    lines: _,
+                    error_source_file,
+                    location,
+                }) = Traceback::from_error_with_source(py, &error, &source_file)
+                {
+                    let mut sub = SubDiagnostic::new(
+                        SubDiagnosticSeverity::Info,
+                        format!("Fixture `{fixture_name}` failed here"),
+                    );
 
-            sub.annotate(Annotation::primary(secondary_span));
+                    let secondary_span = Span::from(error_source_file).with_range(location);
 
-            diagnostic.sub(sub);
-        }
+                    sub.annotate(Annotation::primary(secondary_span));
 
-        let error_string = error.value(py).to_string();
+                    diagnostic.sub(sub);
+                }
 
-        if !error_string.is_empty() {
-            diagnostic.info(indent_continuation_lines(&error_string));
-        }
-    }
+                let error_string = error.value(py).to_string();
+
+                if !error_string.is_empty() {
+                    diagnostic.info(indent_continuation_lines(&error_string));
+                }
+            }
+        },
+    );
 }
 
 pub fn report_test_pass_on_expect_failure(
@@ -310,16 +315,19 @@ pub fn report_test_pass_on_expect_failure(
 ) {
     let builder = context.report_diagnostic(&TEST_PASS_ON_EXPECT_FAILURE);
 
-    let mut diagnostic = builder.into_diagnostic(format!(
-        "Test `{}` passes when expected to fail",
-        stmt_function_def.name
-    ));
+    builder.emit_with(
+        format!(
+            "Test `{}` passes when expected to fail",
+            stmt_function_def.name
+        ),
+        |diagnostic| {
+            annotate_function_name(diagnostic, source_file, stmt_function_def);
 
-    annotate_function_name(&mut diagnostic, source_file, stmt_function_def);
-
-    if let Some(reason) = reason {
-        diagnostic.info(format!("Reason: {reason}"));
-    }
+            if let Some(reason) = reason {
+                diagnostic.info(format!("Reason: {reason}"));
+            }
+        },
+    );
 }
 
 pub fn report_test_failure(
@@ -332,17 +340,19 @@ pub fn report_test_failure(
 ) {
     let builder = context.report_diagnostic(&TEST_FAILURE);
 
-    let mut diagnostic =
-        builder.into_diagnostic(format!("Test `{}` failed", stmt_function_def.name));
-
-    handle_failed_function_call(
-        &mut diagnostic,
-        py,
-        source_file,
-        stmt_function_def,
-        arguments,
-        FunctionKind::Test,
-        error,
+    builder.emit_with(
+        format!("Test `{}` failed", stmt_function_def.name),
+        |diagnostic| {
+            handle_failed_function_call(
+                diagnostic,
+                py,
+                source_file,
+                stmt_function_def,
+                arguments,
+                FunctionKind::Test,
+                error,
+            );
+        },
     );
 }
 

--- a/crates/karva_test_semantic/src/diagnostic/metadata.rs
+++ b/crates/karva_test_semantic/src/diagnostic/metadata.rs
@@ -37,11 +37,10 @@ macro_rules! declare_diagnostic_type {
     };
 }
 
-/// Builder for creating diagnostic guards with the appropriate context.
+/// Builder for reporting diagnostics with the appropriate context.
 ///
-/// Used to construct diagnostics with the correct ID, severity, and context
-/// before they are finalized and reported.
-pub struct DiagnosticGuardBuilder<'ctx, 'a> {
+/// Used to construct diagnostics with the correct ID, severity, and context.
+pub struct DiagnosticBuilder<'ctx, 'a> {
     /// Reference to the test execution context.
     context: &'ctx Context<'a>,
 
@@ -52,61 +51,96 @@ pub struct DiagnosticGuardBuilder<'ctx, 'a> {
     severity: Severity,
 }
 
-impl<'ctx, 'a> DiagnosticGuardBuilder<'ctx, 'a> {
+impl<'ctx, 'a> DiagnosticBuilder<'ctx, 'a> {
     pub(crate) fn new(
         context: &'ctx Context<'a>,
         diagnostic_type: &'static DiagnosticType,
     ) -> Self {
-        DiagnosticGuardBuilder {
+        DiagnosticBuilder {
             context,
             id: DiagnosticId::Lint(diagnostic_type.name),
             severity: diagnostic_type.severity,
         }
     }
 
-    /// Build a diagnostic guard with the given message.
-    pub(crate) fn into_diagnostic(
+    /// Report a diagnostic with the given message.
+    pub(crate) fn emit(self, message: impl std::fmt::Display) {
+        self.emit_with(message, |_| {});
+    }
+
+    /// Report a diagnostic after applying additional annotations or notes.
+    pub(crate) fn emit_with(
         self,
         message: impl std::fmt::Display,
-    ) -> DiagnosticGuard<'ctx, 'a> {
-        DiagnosticGuard {
-            context: self.context,
-            diag: Some(Diagnostic::new(self.id, self.severity, message)),
+        configure: impl FnOnce(&mut Diagnostic),
+    ) {
+        let mut diagnostic = Diagnostic::new(self.id, self.severity, message);
+        configure(&mut diagnostic);
+        self.context.result().add_diagnostic(diagnostic);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use camino::Utf8Path;
+    use karva_diagnostic::DummyReporter;
+    use karva_metadata::ProjectSettings;
+    use ruff_python_ast::PythonVersion;
+
+    use super::*;
+    declare_diagnostic_type! {
+        /// Test diagnostic.
+        static TEST_DIAGNOSTIC = {
+            summary: "Test diagnostic",
+            severity: Severity::Error,
         }
     }
-}
 
-/// A guard that holds a diagnostic and reports it when dropped.
-///
-/// Allows mutation of the diagnostic before it is automatically
-/// reported to the test results when the guard goes out of scope.
-pub struct DiagnosticGuard<'ctx, 'a> {
-    /// Reference to the test execution context.
-    context: &'ctx Context<'a>,
+    #[test]
+    fn emit_records_diagnostic() {
+        let settings = ProjectSettings::default();
+        let reporter = DummyReporter;
+        let context = Context::new(
+            Utf8Path::new("."),
+            &settings,
+            PythonVersion::PY312,
+            &reporter,
+        );
 
-    /// The diagnostic being built, wrapped in Option for take-on-drop.
-    diag: Option<Diagnostic>,
-}
+        DiagnosticBuilder::new(&context, &TEST_DIAGNOSTIC).emit("plain diagnostic");
 
-/// Return a immutable borrow of the diagnostic in this guard.
-impl std::ops::Deref for DiagnosticGuard<'_, '_> {
-    type Target = Diagnostic;
-
-    fn deref(&self) -> &Diagnostic {
-        self.diag.as_ref().unwrap()
+        let result = context.into_result();
+        let [diagnostic] = result.diagnostics() else {
+            panic!("expected one diagnostic");
+        };
+        assert_eq!(diagnostic.primary_message(), "plain diagnostic");
     }
-}
 
-/// Return a mutable borrow of the diagnostic in this guard.
-impl std::ops::DerefMut for DiagnosticGuard<'_, '_> {
-    fn deref_mut(&mut self) -> &mut Diagnostic {
-        self.diag.as_mut().unwrap()
-    }
-}
+    #[test]
+    fn emit_with_configures_diagnostic_before_recording() {
+        let settings = ProjectSettings::default();
+        let reporter = DummyReporter;
+        let context = Context::new(
+            Utf8Path::new("."),
+            &settings,
+            PythonVersion::PY312,
+            &reporter,
+        );
 
-impl Drop for DiagnosticGuard<'_, '_> {
-    fn drop(&mut self) {
-        let diag = self.diag.take().unwrap();
-        self.context.result().add_diagnostic(diag);
+        DiagnosticBuilder::new(&context, &TEST_DIAGNOSTIC).emit_with(
+            "diagnostic with context",
+            |diagnostic| {
+                diagnostic.info("extra context");
+                diagnostic.set_concise_message("concise context");
+            },
+        );
+
+        let result = context.into_result();
+        let [diagnostic] = result.diagnostics() else {
+            panic!("expected one diagnostic");
+        };
+        assert_eq!(diagnostic.primary_message(), "diagnostic with context");
+        assert_eq!(diagnostic.sub_diagnostics().len(), 1);
+        assert_eq!(diagnostic.concise_message().to_string(), "concise context");
     }
 }


### PR DESCRIPTION
## Summary

Replace the diagnostic drop guard with an explicit builder API that records diagnostics through `emit` and `emit_with`. This removes the guard's hidden drop side effect and its runtime `unwrap` paths while keeping diagnostic construction in one place.

## Test Plan

`just test -p karva_test_semantic`; `uvx prek run -a`