### PR TITLE
Encode partition selection invariants

### DIFF
--- a/crates/karva_cli/src/partition.rs
+++ b/crates/karva_cli/src/partition.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::num::NonZeroU32;
 use std::str::FromStr;
 
 /// Selection of a single partition (slice) from the collected tests.
@@ -8,18 +9,37 @@ use std::str::FromStr;
 /// `slice:3/3` together cover every collected test exactly once.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PartitionSelection {
-    pub index: u32,
-    pub total: u32,
+    index: NonZeroU32,
+    total: NonZeroU32,
 }
 
 impl PartitionSelection {
+    #[must_use]
+    pub fn new(index: NonZeroU32, total: NonZeroU32) -> Option<Self> {
+        if index <= total {
+            Some(Self { index, total })
+        } else {
+            None
+        }
+    }
+
+    #[must_use]
+    pub fn index(self) -> NonZeroU32 {
+        self.index
+    }
+
+    #[must_use]
+    pub fn total(self) -> NonZeroU32 {
+        self.total
+    }
+
     /// Returns true if the test at `position` (0-indexed, in the deterministic
     /// post-filter ordering) belongs to this slice.
     #[must_use]
     pub fn contains(self, position: usize) -> bool {
         // 1-indexed input -> 0-indexed modulo target.
-        let target = (self.index - 1) as usize;
-        let total = self.total as usize;
+        let target = (self.index.get() - 1) as usize;
+        let total = self.total.get() as usize;
         position % total == target
     }
 }
@@ -55,12 +75,13 @@ impl FromStr for PartitionSelection {
             .parse()
             .map_err(|err| format!("`{n}` is not a valid partition count: {err}"))?;
 
-        if total == 0 {
-            return Err("partition count `N` must be at least 1".to_string());
-        }
-        if index == 0 {
+        let Some(index) = NonZeroU32::new(index) else {
             return Err("partition index `M` must be at least 1".to_string());
-        }
+        };
+        let Some(total) = NonZeroU32::new(total) else {
+            return Err("partition count `N` must be at least 1".to_string());
+        };
+
         if index > total {
             return Err(format!(
                 "partition index `M` ({index}) must not exceed partition count `N` ({total})"
@@ -79,15 +100,15 @@ mod tests {
     fn parses_valid_slice() {
         assert_eq!(
             "slice:1/3".parse::<PartitionSelection>().unwrap(),
-            PartitionSelection { index: 1, total: 3 },
+            selection(1, 3),
         );
         assert_eq!(
             "slice:3/3".parse::<PartitionSelection>().unwrap(),
-            PartitionSelection { index: 3, total: 3 },
+            selection(3, 3),
         );
         assert_eq!(
             "slice:1/1".parse::<PartitionSelection>().unwrap(),
-            PartitionSelection { index: 1, total: 1 },
+            selection(1, 1),
         );
     }
 
@@ -120,13 +141,13 @@ mod tests {
 
     #[test]
     fn contains_round_robin() {
-        let p = PartitionSelection { index: 1, total: 3 };
+        let p = selection(1, 3);
         assert!(p.contains(0));
         assert!(!p.contains(1));
         assert!(!p.contains(2));
         assert!(p.contains(3));
 
-        let q = PartitionSelection { index: 3, total: 3 };
+        let q = selection(3, 3);
         assert!(!q.contains(0));
         assert!(!q.contains(1));
         assert!(q.contains(2));
@@ -135,8 +156,30 @@ mod tests {
 
     #[test]
     fn display_round_trip() {
-        let p = PartitionSelection { index: 2, total: 5 };
+        let p = selection(2, 5);
         assert_eq!(p.to_string(), "slice:2/5");
         assert_eq!(p.to_string().parse::<PartitionSelection>().unwrap(), p);
+    }
+
+    #[test]
+    fn constructor_rejects_index_above_total() {
+        let Some(index) = NonZeroU32::new(3) else {
+            panic!("test constant should be non-zero");
+        };
+        let Some(total) = NonZeroU32::new(2) else {
+            panic!("test constant should be non-zero");
+        };
+
+        assert_eq!(PartitionSelection::new(index, total), None);
+    }
+
+    fn selection(index: u32, total: u32) -> PartitionSelection {
+        let Some(index) = NonZeroU32::new(index) else {
+            panic!("test partition index should be non-zero");
+        };
+        let Some(total) = NonZeroU32::new(total) else {
+            panic!("test partition total should be non-zero");
+        };
+        PartitionSelection::new(index, total).expect("valid partition selection")
     }
 }


### PR DESCRIPTION
## Summary

Make `PartitionSelection` hold private non-zero fields and expose validated construction/accessors so invalid slice selections cannot be built outside the parser. The CLI error messages stay the same, while the internal type now carries the same invariants the parser enforces.

## Test Plan

cargo test -p karva_cli partition; cargo clippy -p karva_cli --all-targets --all-features -- -D warnings; uvx prek run -a