### PR TITLE
Tighten Rust lint baseline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ which = { version = "8.0" }
 wild = { version = "2" }
 
 [workspace.lints.rust]
+unsafe_code = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(codspeed)"] }
 
 [workspace.lints.clippy]

--- a/crates/karva_dev/Cargo.toml
+++ b/crates/karva_dev/Cargo.toml
@@ -24,3 +24,6 @@ itertools = { workspace = true }
 markdown = { workspace = true }
 pretty_assertions = { workspace = true }
 ruff_options_metadata = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/karva_dev/src/generate_cli_reference.rs
+++ b/crates/karva_dev/src/generate_cli_reference.rs
@@ -17,12 +17,12 @@ fn render_html(markdown_text: &str) -> String {
 }
 
 #[derive(clap::Args)]
-pub(crate) struct Args {
+pub struct Args {
     #[arg(long, default_value_t, value_enum)]
-    pub(crate) mode: Mode,
+    pub mode: Mode,
 }
 
-pub(crate) fn main(args: &Args) -> Result<()> {
+pub fn main(args: &Args) -> Result<()> {
     apply_mode(args.mode, "docs/reference/cli.md", &generate())
 }
 

--- a/crates/karva_dev/src/generate_env_vars.rs
+++ b/crates/karva_dev/src/generate_env_vars.rs
@@ -8,10 +8,10 @@ use karva_static::{EnvVarDoc, EnvVars, WorkerEnvVars};
 use crate::{Mode, apply_mode};
 
 #[derive(clap::Args)]
-pub(crate) struct Args {
+pub struct Args {
     /// Write the generated reference to stdout (rather than to `docs/reference/env-vars.md`).
     #[arg(long, default_value_t, value_enum)]
-    pub(crate) mode: Mode,
+    pub mode: Mode,
 }
 
 const FILE_NAME: &str = "docs/reference/env-vars.md";
@@ -19,7 +19,7 @@ const FILE_NAME: &str = "docs/reference/env-vars.md";
 const HEADER: &str = "<!-- WARNING: This file is auto-generated (cargo run -p karva_dev generate-all). Update the doc comments on the env-var structs in 'crates/karva_static/src/lib.rs' if you want to change anything here. -->\n\n# Environment Variables\n\nThis page lists every environment variable that Karva reads from the \
 environment, plus the variables the worker exposes to running tests.\n\n";
 
-pub(crate) fn main(args: &Args) -> anyhow::Result<()> {
+pub fn main(args: &Args) -> anyhow::Result<()> {
     apply_mode(args.mode, FILE_NAME, &generate())
 }
 

--- a/crates/karva_dev/src/generate_options.rs
+++ b/crates/karva_dev/src/generate_options.rs
@@ -9,13 +9,13 @@ use ruff_options_metadata::{OptionField, OptionSet, OptionsMetadata, Visit};
 use crate::{Mode, apply_mode};
 
 #[derive(clap::Args)]
-pub(crate) struct Args {
+pub struct Args {
     /// Write the generated table to stdout (rather than to `docs/configuration/configuration.md`).
     #[arg(long, default_value_t, value_enum)]
-    pub(crate) mode: Mode,
+    pub mode: Mode,
 }
 
-pub(crate) fn main(args: &Args) -> anyhow::Result<()> {
+pub fn main(args: &Args) -> anyhow::Result<()> {
     let mut output = String::new();
 
     output.push_str(
@@ -52,7 +52,7 @@ fn generate_set(output: &mut String, set: Set, parents: &mut Vec<Set>) {
                 .filter_map(|set| set.name())
                 .chain(std::iter::once(name.as_str()))
                 .join(".");
-            let _ = writeln!(output, "## `{title}`\n",);
+            let _ = writeln!(output, "## `{title}`\n");
         }
     }
 
@@ -182,9 +182,9 @@ fn emit_field(output: &mut String, name: &str, field: &OptionField, parents: &[S
 
 fn format_example(header: &str, content: &str) -> String {
     if header.is_empty() {
-        format!("```toml\n{content}\n```\n",)
+        format!("```toml\n{content}\n```\n")
     } else {
-        format!("```toml\n{header}\n{content}\n```\n",)
+        format!("```toml\n{header}\n{content}\n```\n")
     }
 }
 

--- a/crates/karva_static/src/lib.rs
+++ b/crates/karva_static/src/lib.rs
@@ -324,6 +324,7 @@ mod tests {
             }
         }
 
+        #[expect(unsafe_code, reason = "test env mutation is serialized by ENV_LOCK")]
         fn set(name: &str, value: &str) {
             // SAFETY: Tests in this module hold ENV_LOCK while mutating env vars.
             unsafe {
@@ -331,6 +332,7 @@ mod tests {
             }
         }
 
+        #[expect(unsafe_code, reason = "test env mutation is serialized by ENV_LOCK")]
         fn remove(name: &str) {
             // SAFETY: Tests in this module hold ENV_LOCK while mutating env vars.
             unsafe {
@@ -340,6 +342,7 @@ mod tests {
     }
 
     impl Drop for EnvRestore {
+        #[expect(unsafe_code, reason = "test env mutation is serialized by ENV_LOCK")]
         fn drop(&mut self) {
             for (name, value) in &self.values {
                 match value {

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -96,12 +96,8 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
 
     let args = Args::parse_from(args);
 
-    // SAFETY: This is called during single-threaded initialization before any
-    // concurrent work begins. The env var is read later by `assert_snapshot`.
     if args.sub_command.snapshot_update.unwrap_or(false) {
-        unsafe {
-            std::env::set_var(EnvVars::KARVA_SNAPSHOT_UPDATE, "1");
-        }
+        enable_snapshot_update_env_var();
     }
 
     let verbosity = args.verbosity().level();
@@ -195,6 +191,18 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
     }
 
     Ok(ExitStatus::Success)
+}
+
+#[expect(
+    unsafe_code,
+    reason = "worker startup sets this before concurrent test execution"
+)]
+fn enable_snapshot_update_env_var() {
+    // SAFETY: This is called during single-threaded initialization before any
+    // concurrent work begins. The env var is read later by `assert_snapshot`.
+    unsafe {
+        std::env::set_var(EnvVars::KARVA_SNAPSHOT_UPDATE, "1");
+    }
 }
 
 /// Get the current working directory as a UTF-8 path.


### PR DESCRIPTION
## Summary

Adopts the ruff/uv-style Rust unsafe-code baseline by warning on unsafe code at the workspace level, makes `karva_dev` inherit workspace lints, and fixes the lint fallout in developer tooling. Existing Rust 2024 environment mutations now have local `#[expect]` reasons.

## Test Plan

`cargo clippy --workspace --all-targets --all-features -- -D warnings`; `just test -p karva_static -p karva_worker -p karva_dev`; `uvx prek run -a`