### PR TITLE
Enforce coverage visibility

### DIFF
--- a/crates/karva_coverage/src/lib.rs
+++ b/crates/karva_coverage/src/lib.rs
@@ -13,6 +13,8 @@
 //! The two halves communicate only through the JSON file format, defined
 //! in [`data`].
 
+#![warn(unreachable_pub)]
+
 pub mod data;
 pub mod executable;
 pub mod report;

--- a/crates/karva_coverage/src/report/html.rs
+++ b/crates/karva_coverage/src/report/html.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use super::shared::{FileRow, escape_html, format_percent, totals_row};
 
-pub fn build_html_report(rows: &[FileRow]) -> String {
+pub(super) fn build_html_report(rows: &[FileRow]) -> String {
     HtmlReport { rows }.to_string()
 }
 

--- a/crates/karva_coverage/src/report/json.rs
+++ b/crates/karva_coverage/src/report/json.rs
@@ -42,7 +42,7 @@ struct JsonMeta {
     version: &'static str,
 }
 
-pub fn build_json_report(rows: &[FileRow]) -> Result<String> {
+pub(super) fn build_json_report(rows: &[FileRow]) -> Result<String> {
     let files = rows
         .iter()
         .map(|row| {

--- a/crates/karva_coverage/src/report/mod.rs
+++ b/crates/karva_coverage/src/report/mod.rs
@@ -1,10 +1,10 @@
 //! Combine per-worker JSON files and produce terminal or machine-readable reports.
 
-mod html;
-mod json;
-mod shared;
+pub(crate) mod html;
+pub(crate) mod json;
+pub(crate) mod shared;
 mod terminal;
-mod xml;
+pub(crate) mod xml;
 
 use anyhow::Result;
 use camino::Utf8Path;
@@ -17,7 +17,7 @@ pub use terminal::write_json_report;
 
 use self::shared::combine;
 
-pub(crate) fn combined_rows(
+fn combined_rows(
     cwd: &Utf8Path,
     files: &[impl AsRef<Utf8Path>],
     show_missing: bool,

--- a/crates/karva_coverage/src/report/shared.rs
+++ b/crates/karva_coverage/src/report/shared.rs
@@ -7,12 +7,12 @@ use fs_err as fs;
 use crate::data::WorkerFile;
 
 #[derive(Debug, Default)]
-pub struct CombinedFile {
-    pub executable: BTreeSet<u32>,
-    pub executed: BTreeSet<u32>,
+pub(super) struct CombinedFile {
+    executable: BTreeSet<u32>,
+    executed: BTreeSet<u32>,
 }
 
-pub struct FileRow {
+pub(super) struct FileRow {
     pub name: String,
     pub absolute_name: String,
     pub stmts: u32,
@@ -23,7 +23,7 @@ pub struct FileRow {
     pub executed: Vec<u32>,
 }
 
-pub fn combine(files: &[impl AsRef<Utf8Path>]) -> Result<BTreeMap<String, CombinedFile>> {
+pub(super) fn combine(files: &[impl AsRef<Utf8Path>]) -> Result<BTreeMap<String, CombinedFile>> {
     let mut combined: BTreeMap<String, CombinedFile> = BTreeMap::new();
 
     for path in files {
@@ -43,7 +43,7 @@ pub fn combine(files: &[impl AsRef<Utf8Path>]) -> Result<BTreeMap<String, Combin
     Ok(combined)
 }
 
-pub fn build_rows(
+pub(super) fn build_rows(
     cwd_real: &std::path::Path,
     combined: &BTreeMap<String, CombinedFile>,
     show_missing: bool,
@@ -81,7 +81,7 @@ pub fn build_rows(
         .collect()
 }
 
-pub fn total_percent(rows: &[FileRow]) -> f64 {
+pub(super) fn total_percent(rows: &[FileRow]) -> f64 {
     let total_stmts = rows
         .iter()
         .fold(0_u32, |acc, row| acc.saturating_add(row.stmts));
@@ -91,7 +91,7 @@ pub fn total_percent(rows: &[FileRow]) -> f64 {
     percent(total_stmts, total_miss)
 }
 
-pub fn totals_row(rows: &[FileRow]) -> FileRow {
+pub(super) fn totals_row(rows: &[FileRow]) -> FileRow {
     let stmts = rows
         .iter()
         .fold(0_u32, |acc, row| acc.saturating_add(row.stmts));
@@ -114,7 +114,7 @@ pub fn totals_row(rows: &[FileRow]) -> FileRow {
     }
 }
 
-pub fn missing_lines(row: &FileRow) -> Vec<u32> {
+pub(super) fn missing_lines(row: &FileRow) -> Vec<u32> {
     let executed: BTreeSet<u32> = row.executed.iter().copied().collect();
     row.executable
         .iter()
@@ -123,7 +123,7 @@ pub fn missing_lines(row: &FileRow) -> Vec<u32> {
         .collect()
 }
 
-pub fn class_filename(row: &FileRow, cwd_real: &std::path::Path) -> String {
+pub(super) fn class_filename(row: &FileRow, cwd_real: &std::path::Path) -> String {
     if let Ok(relative) = std::path::Path::new(&row.absolute_name).strip_prefix(cwd_real) {
         normalize_report_path(&relative.to_string_lossy())
     } else {
@@ -131,7 +131,7 @@ pub fn class_filename(row: &FileRow, cwd_real: &std::path::Path) -> String {
     }
 }
 
-pub fn percent(total: u32, miss: u32) -> f64 {
+pub(super) fn percent(total: u32, miss: u32) -> f64 {
     if total == 0 {
         return 100.0;
     }
@@ -139,7 +139,7 @@ pub fn percent(total: u32, miss: u32) -> f64 {
     f64::from(hit) / f64::from(total) * 100.0
 }
 
-pub fn rate(hit: u32, total: u32) -> f64 {
+pub(super) fn rate(hit: u32, total: u32) -> f64 {
     if total == 0 {
         1.0
     } else {
@@ -147,12 +147,12 @@ pub fn rate(hit: u32, total: u32) -> f64 {
     }
 }
 
-pub fn format_percent(total: u32, miss: u32) -> String {
+pub(super) fn format_percent(total: u32, miss: u32) -> String {
     let pct = percent(total, miss);
     format!("{pct:.0}%")
 }
 
-pub fn collapse_ranges(lines: &BTreeSet<u32>) -> String {
+pub(super) fn collapse_ranges(lines: &BTreeSet<u32>) -> String {
     let mut parts: Vec<String> = Vec::new();
     let mut iter = lines.iter().copied();
     let Some(mut start) = iter.next() else {
@@ -197,7 +197,7 @@ fn normalize_report_path(path: &str) -> String {
     path.replace('\\', "/")
 }
 
-pub fn escape_xml(value: &str) -> String {
+pub(super) fn escape_xml(value: &str) -> String {
     value
         .replace('&', "&amp;")
         .replace('<', "&lt;")
@@ -206,7 +206,7 @@ pub fn escape_xml(value: &str) -> String {
         .replace('\'', "&apos;")
 }
 
-pub fn escape_html(value: &str) -> String {
+pub(super) fn escape_html(value: &str) -> String {
     value
         .replace('&', "&amp;")
         .replace('<', "&lt;")

--- a/crates/karva_coverage/src/report/xml.rs
+++ b/crates/karva_coverage/src/report/xml.rs
@@ -8,7 +8,7 @@ use fs_err as fs;
 
 use super::shared::{FileRow, class_filename, escape_xml, rate};
 
-pub fn build_cobertura_xml(
+pub(super) fn build_cobertura_xml(
     cwd: &Utf8Path,
     cwd_real: &std::path::Path,
     rows: &[FileRow],


### PR DESCRIPTION
## Summary

Starts adopting the ruff/uv `unreachable_pub` practice inside `karva_coverage` by enabling the lint for that crate and narrowing report helpers to module-local visibility. This keeps the public coverage API limited to the re-exported report entry points.

## Test Plan

`cargo clippy -p karva_coverage --all-targets --all-features -- -D warnings`; `just test -p karva_coverage`; `uvx prek run -a`