### PR TITLE
Enforce macro visibility

### DIFF
--- a/crates/karva_macros/src/combine.rs
+++ b/crates/karva_macros/src/combine.rs
@@ -2,7 +2,11 @@ use quote::{quote, quote_spanned};
 use syn::spanned::Spanned;
 use syn::{Data, DataStruct, DeriveInput};
 
-pub fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
+#[expect(
+    clippy::redundant_pub_crate,
+    reason = "parent module calls this helper while unreachable_pub rejects plain pub"
+)]
+pub(super) fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     let DeriveInput { ident, data, .. } = input;
 
     match data {

--- a/crates/karva_macros/src/combine_options.rs
+++ b/crates/karva_macros/src/combine_options.rs
@@ -1,7 +1,11 @@
 use quote::{quote, quote_spanned};
 use syn::{Data, DataStruct, DeriveInput, Field, Fields, Path, PathSegment, Type, TypePath};
 
-pub fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
+#[expect(
+    clippy::redundant_pub_crate,
+    reason = "parent module calls this helper while unreachable_pub rejects plain pub"
+)]
+pub(super) fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     let DeriveInput { ident, data, .. } = input;
 
     match data {

--- a/crates/karva_macros/src/config.rs
+++ b/crates/karva_macros/src/config.rs
@@ -8,7 +8,11 @@ use syn::{
     Fields, Lit, LitStr, Meta, Path, PathArguments, PathSegment, Type, TypePath,
 };
 
-pub fn derive_impl(input: DeriveInput) -> syn::Result<TokenStream> {
+#[expect(
+    clippy::redundant_pub_crate,
+    reason = "parent module calls this helper while unreachable_pub rejects plain pub"
+)]
+pub(super) fn derive_impl(input: DeriveInput) -> syn::Result<TokenStream> {
     let DeriveInput {
         ident,
         data,

--- a/crates/karva_macros/src/lib.rs
+++ b/crates/karva_macros/src/lib.rs
@@ -1,9 +1,11 @@
+#![warn(unreachable_pub)]
+
 use proc_macro::TokenStream;
 use syn::{DeriveInput, parse_macro_input};
 
-mod combine;
-mod combine_options;
-mod config;
+pub(crate) mod combine;
+pub(crate) mod combine_options;
+pub(crate) mod config;
 
 #[proc_macro_derive(OptionsMetadata, attributes(option, option_group))]
 pub fn derive_options_metadata(input: TokenStream) -> TokenStream {


### PR DESCRIPTION
## Summary

Continues adopting the ruff/uv `unreachable_pub` practice by enabling it for `karva_macros` and narrowing proc-macro helper entry points to parent-module visibility. The three targeted Clippy expectations document the current `redundant_pub_crate` interaction for private implementation modules.

## Test Plan

`cargo clippy -p karva_macros --all-targets --all-features -- -D warnings`; `just test -p karva_macros --no-tests pass`; `uvx prek run -a`