### PR TITLE
Test installed wheel against Karva project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,39 @@ jobs:
         run: |
           cargo nextest run --profile ci
 
+  wheel-smoke:
+    name: "wheel smoke"
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    needs: determine_changes
+    if: ${{ (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: "Install Rust toolchain"
+        run: rustup show
+
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.10"
+
+      - name: Build wheel
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          command: build
+
+      - name: Run wheel smoke project
+        working-directory: crates/karva/tests/projects/wheel-smoke
+        run: |
+          python -m pip install ../../../../../target/wheels/karva-*.whl --force-reinstall
+          karva test --no-parallel --status-level=skip --final-status-level=skip
+
   build-windows-tests:
     name: "build tests archive | windows"
 

--- a/crates/karva/tests/projects/wheel-smoke/.gitignore
+++ b/crates/karva/tests/projects/wheel-smoke/.gitignore
@@ -1,0 +1,3 @@
+.karva_cache/
+__pycache__/
+*.py[cod]

--- a/crates/karva/tests/projects/wheel-smoke/checks/test_karva_features.py
+++ b/crates/karva/tests/projects/wheel-smoke/checks/test_karva_features.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import os
+
+import karva
+from karva_wheel_smoke.calculator import Calculator, legacy_label, normalize_name
+
+
+@karva.fixture
+def calculator() -> Calculator:
+    return Calculator(offset=2)
+
+
+@karva.tags.parametrize(
+    "left,right,expected",
+    [
+        (1, 2, 5),
+        karva.param(3, 4, 9),
+    ],
+)
+def test_parametrized_addition(
+    calculator: Calculator,
+    left: int,
+    right: int,
+    expected: int,
+) -> None:
+    assert calculator.add(left, right) == expected
+
+
+def test_tmp_path_and_output_capture(tmp_path, capsys) -> None:
+    message_file = tmp_path / "message.txt"
+    message_file.write_text("hello from wheel smoke", encoding="utf-8")
+
+    print(message_file.read_text(encoding="utf-8"))
+
+    captured = capsys.readouterr()
+    assert captured.out == "hello from wheel smoke\n"
+    assert captured.err == ""
+
+
+def test_warning_capture(recwarn) -> None:
+    assert legacy_label("  Example  ") == "legacy:example"
+
+    warning = recwarn.pop(DeprecationWarning)
+    assert str(warning.message) == "legacy_label is deprecated"
+
+
+def test_monkeypatch(monkeypatch) -> None:
+    monkeypatch.setenv("KARVA_WHEEL_SMOKE", "installed")
+
+    assert os.environ["KARVA_WHEEL_SMOKE"] == "installed"
+
+
+def test_raises_helper() -> None:
+    with karva.raises(ValueError, match="empty"):
+        normalize_name("  ")
+
+
+@karva.tags.expect_fail(reason="exercise expected failure handling")
+def test_expected_failure_tag() -> None:
+    raise AssertionError("expected failure")
+
+
+@karva.tags.skip(reason="exercise skip handling")
+def test_skip_tag() -> None:
+    raise AssertionError("skip tag did not skip this test")

--- a/crates/karva/tests/projects/wheel-smoke/karva_wheel_smoke/__init__.py
+++ b/crates/karva/tests/projects/wheel-smoke/karva_wheel_smoke/__init__.py
@@ -1,0 +1,1 @@
+"""Small project used to smoke test the installed Karva wheel."""

--- a/crates/karva/tests/projects/wheel-smoke/karva_wheel_smoke/calculator.py
+++ b/crates/karva/tests/projects/wheel-smoke/karva_wheel_smoke/calculator.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Calculator:
+    offset: int = 0
+
+    def add(self, left: int, right: int) -> int:
+        return left + right + self.offset
+
+
+def normalize_name(name: str) -> str:
+    normalized = name.strip().lower()
+    if not normalized:
+        raise ValueError("name cannot be empty")
+    return normalized
+
+
+def legacy_label(name: str) -> str:
+    warnings.warn("legacy_label is deprecated", DeprecationWarning, stacklevel=2)
+    return f"legacy:{normalize_name(name)}"

--- a/crates/karva/tests/projects/wheel-smoke/pyproject.toml
+++ b/crates/karva/tests/projects/wheel-smoke/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "karva-wheel-smoke"
+version = "0.1.0"
+requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Closes #821.

This adds a small Karva project under `crates/karva/tests/projects/wheel-smoke` that exercises the installed wheel through Karva APIs only. CI now has a separate `wheel smoke` job that builds the wheel, installs it, and runs `karva test` inside that project.

## Test Plan

Built the wheel with `uvx maturin build`, installed it into a clean venv, ran the wheel-smoke project with the installed `karva` CLI, and ran `uvx prek run --files ...` plus `uvx prek run -a`.
