### PR TITLE
Add coverage include and omit filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1167,6 +1167,7 @@ dependencies = [
  "colored 3.1.1",
  "dunce",
  "fs-err",
+ "globset",
  "insta",
  "pyo3",
  "ruff_python_ast",

--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -109,6 +109,8 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
         None
     } else {
         let coverage = project.settings().coverage();
+        let coverage_filters =
+            karva_coverage::CoverageFilters::new(&coverage.include, &coverage.omit)?;
         if coverage.report_path.is_some()
             && matches!(coverage.report, CovReport::Term | CovReport::TermMissing)
         {
@@ -120,19 +122,30 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
             )?;
         }
         let coverage_result = match coverage.report {
-            CovReport::Term => {
-                karva_coverage::combine_and_report(project.cwd(), &coverage_files, false)
-            }
-            CovReport::TermMissing => {
-                karva_coverage::combine_and_report(project.cwd(), &coverage_files, true)
-            }
+            CovReport::Term => karva_coverage::combine_and_report(
+                project.cwd(),
+                &coverage_files,
+                false,
+                &coverage_filters,
+            ),
+            CovReport::TermMissing => karva_coverage::combine_and_report(
+                project.cwd(),
+                &coverage_files,
+                true,
+                &coverage_filters,
+            ),
             CovReport::Xml => {
                 let output = coverage_report_path(
                     coverage.report_path.as_deref(),
                     "coverage.xml",
                     project.cwd(),
                 );
-                karva_coverage::write_cobertura_xml(project.cwd(), &coverage_files, &output)
+                karva_coverage::write_cobertura_xml(
+                    project.cwd(),
+                    &coverage_files,
+                    &output,
+                    &coverage_filters,
+                )
             }
             CovReport::Json => {
                 let output = coverage_report_path(
@@ -140,12 +153,22 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
                     "coverage.json",
                     project.cwd(),
                 );
-                karva_coverage::write_json_report(project.cwd(), &coverage_files, &output)
+                karva_coverage::write_json_report(
+                    project.cwd(),
+                    &coverage_files,
+                    &output,
+                    &coverage_filters,
+                )
             }
             CovReport::Html => {
                 let output =
                     coverage_report_path(coverage.report_path.as_deref(), "htmlcov", project.cwd());
-                karva_coverage::write_html_report(project.cwd(), &coverage_files, &output)
+                karva_coverage::write_html_report(
+                    project.cwd(),
+                    &coverage_files,
+                    &output,
+                    &coverage_filters,
+                )
             }
         };
         match coverage_result {

--- a/crates/karva/tests/it/coverage.rs
+++ b/crates/karva/tests/it/coverage.rs
@@ -1092,6 +1092,68 @@ def test_add():
 }
 
 #[test]
+fn test_cov_include_and_omit_filters_report_rows() {
+    let context = TestContext::with_files([
+        (
+            "src/app/service.py",
+            r"
+def used():
+    return 1
+",
+        ),
+        (
+            "src/app/generated.py",
+            r"
+def generated():
+    return 2
+",
+        ),
+        (
+            "src/other.py",
+            r"
+def outside():
+    return 3
+",
+        ),
+        (
+            "test_service.py",
+            r"
+import sys, os
+sys.path.insert(0, os.path.dirname(__file__))
+from src.app.service import used
+
+def test_used():
+    assert used() == 1
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel()
+            .arg("--cov=src")
+            .arg("--cov-include=src/app/*")
+            .arg("--cov-omit=src/app/generated.py")
+            .arg("--status-level=none")
+            .arg("test_service.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    Name                 Stmts   Miss   Cover
+    [LONG-LINE]
+    src/app/service.py       2      0    100%
+    [LONG-LINE]
+    TOTAL                    2      0    100%
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
 fn test_cov_sources_from_config() {
     let context = TestContext::with_files([
         (
@@ -1137,6 +1199,74 @@ def test_add():
     src/mymod.py       2      0    100%
     [LONG-LINE]
     TOTAL              2      0    100%
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
+fn test_cov_include_and_omit_from_config() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.default.coverage]
+sources = ["src"]
+include = ["src/app/*"]
+omit = ["src/app/generated.py"]
+"#,
+        ),
+        (
+            "src/app/service.py",
+            r"
+def used():
+    return 1
+",
+        ),
+        (
+            "src/app/generated.py",
+            r"
+def generated():
+    return 2
+",
+        ),
+        (
+            "src/other.py",
+            r"
+def outside():
+    return 3
+",
+        ),
+        (
+            "test_service.py",
+            r"
+import sys, os
+sys.path.insert(0, os.path.dirname(__file__))
+from src.app.service import used
+
+def test_used():
+    assert used() == 1
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel()
+            .arg("--status-level=none")
+            .arg("test_service.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    Name                 Stmts   Miss   Cover
+    [LONG-LINE]
+    src/app/service.py       2      0    100%
+    [LONG-LINE]
+    TOTAL                    2      0    100%
 
     ----- stderr -----
     "

--- a/crates/karva/tests/it/show_config.rs
+++ b/crates/karva/tests/it/show_config.rs
@@ -28,6 +28,8 @@ fn show_config_default_profile() {
 
     [coverage]
     sources = []
+    include = []
+    omit = []
     report = "term"
 
     ----- stderr -----
@@ -71,6 +73,8 @@ output-format = "concise"
 
     [coverage]
     sources = []
+    include = []
+    omit = []
     report = "term"
 
     ----- stderr -----
@@ -115,6 +119,8 @@ output-format = "concise"
 
     [coverage]
     sources = []
+    include = []
+    omit = []
     report = "term"
 
     ----- stderr -----
@@ -132,6 +138,8 @@ timeout = 120
 
 [profile.default.coverage]
 sources = ["src"]
+include = ["src/app/*"]
+omit = ["**/generated.py"]
 report = "term-missing"
 fail-under = 90
 "#,
@@ -161,6 +169,8 @@ fail-under = 90
 
     [coverage]
     sources = ["src"]
+    include = ["src/app/*"]
+    omit = ["**/generated.py"]
     report = "term-missing"
     fail-under = 90.0
 
@@ -206,6 +216,8 @@ slow-timeout = 0.5
 
     [coverage]
     sources = []
+    include = []
+    omit = []
     report = "term"
 
     [[overrides]]

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -174,6 +174,28 @@ pub struct SubTestCommand {
     )]
     pub cov: Vec<String>,
 
+    /// Exclude coverage report files whose project-relative path matches this glob.
+    ///
+    /// May be passed multiple times.
+    #[clap(
+        long = "cov-omit",
+        value_name = "GLOB",
+        action = clap::ArgAction::Append,
+        help_heading = "Coverage options"
+    )]
+    pub cov_omit: Vec<String>,
+
+    /// Include only coverage report files whose project-relative path matches this glob.
+    ///
+    /// May be passed multiple times.
+    #[clap(
+        long = "cov-include",
+        value_name = "GLOB",
+        action = clap::ArgAction::Append,
+        help_heading = "Coverage options"
+    )]
+    pub cov_include: Vec<String>,
+
     /// Disable coverage measurement for this run.
     ///
     /// Overrides any `--cov` flag and any `[coverage] sources` configured in
@@ -382,6 +404,8 @@ impl SubTestCommand {
             }),
             coverage: Some(CoverageOptions {
                 sources: (!self.cov.is_empty()).then(|| self.cov.clone()),
+                include: (!self.cov_include.is_empty()).then(|| self.cov_include.clone()),
+                omit: (!self.cov_omit.is_empty()).then(|| self.cov_omit.clone()),
                 report: cov_report.clone().map(Into::into),
                 report_path: cov_report.as_ref().and_then(|report| match report {
                     CovReport::Xml { path }

--- a/crates/karva_coverage/Cargo.toml
+++ b/crates/karva_coverage/Cargo.toml
@@ -17,6 +17,7 @@ camino = { workspace = true }
 colored = { workspace = true }
 dunce = { workspace = true }
 fs-err = { workspace = true }
+globset = { workspace = true }
 pyo3 = { workspace = true }
 ruff_python_ast = { workspace = true }
 ruff_python_parser = { workspace = true }

--- a/crates/karva_coverage/src/lib.rs
+++ b/crates/karva_coverage/src/lib.rs
@@ -20,5 +20,7 @@ pub mod executable;
 pub mod report;
 pub mod tracer;
 
-pub use report::{combine_and_report, write_cobertura_xml, write_html_report, write_json_report};
+pub use report::{
+    CoverageFilters, combine_and_report, write_cobertura_xml, write_html_report, write_json_report,
+};
 pub use tracer::{CoverageConfig, CoverageSession};

--- a/crates/karva_coverage/src/report/mod.rs
+++ b/crates/karva_coverage/src/report/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod xml;
 use anyhow::Result;
 use camino::Utf8Path;
 use fs_err as fs;
+use globset::{Glob, GlobSet, GlobSetBuilder};
 
 pub use terminal::combine_and_report;
 pub use terminal::write_cobertura_xml;
@@ -17,10 +18,49 @@ pub use terminal::write_json_report;
 
 use self::shared::combine;
 
+#[derive(Debug, Default)]
+pub struct CoverageFilters {
+    include: Option<GlobSet>,
+    omit: Option<GlobSet>,
+}
+
+impl CoverageFilters {
+    pub fn new(include: &[String], omit: &[String]) -> Result<Self> {
+        Ok(Self {
+            include: compile_globs("include", include)?,
+            omit: compile_globs("omit", omit)?,
+        })
+    }
+
+    fn matches(&self, path: &str) -> bool {
+        self.include
+            .as_ref()
+            .is_none_or(|include| include.is_match(path))
+            && !self.omit.as_ref().is_some_and(|omit| omit.is_match(path))
+    }
+}
+
+fn compile_globs(kind: &str, patterns: &[String]) -> Result<Option<GlobSet>> {
+    if patterns.is_empty() {
+        return Ok(None);
+    }
+
+    let mut builder = GlobSetBuilder::new();
+    for pattern in patterns {
+        builder.add(
+            Glob::new(pattern).map_err(|err| {
+                anyhow::anyhow!("invalid coverage {kind} glob `{pattern}`: {err}")
+            })?,
+        );
+    }
+    Ok(Some(builder.build()?))
+}
+
 fn combined_rows(
     cwd: &Utf8Path,
     files: &[impl AsRef<Utf8Path>],
     show_missing: bool,
+    filters: &CoverageFilters,
 ) -> Result<Option<(std::path::PathBuf, Vec<shared::FileRow>)>> {
     let combined = combine(files)?;
     if combined.is_empty() {
@@ -30,6 +70,37 @@ fn combined_rows(
     let cwd_real = fs::canonicalize(cwd.as_std_path())
         .map(|path| dunce::simplified(&path).to_path_buf())
         .unwrap_or_else(|_| cwd.into());
-    let rows = shared::build_rows(&cwd_real, &combined, show_missing);
+    let rows = shared::build_rows(&cwd_real, &combined, show_missing)
+        .into_iter()
+        .filter(|row| filters.matches(&row.name))
+        .collect();
     Ok(Some((cwd_real, rows)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CoverageFilters;
+
+    #[test]
+    fn filters_apply_include_then_omit() {
+        let include = vec!["src/**".to_string()];
+        let omit = vec!["**/generated.py".to_string()];
+        let filters = CoverageFilters::new(&include, &omit).expect("valid filters");
+
+        assert!(filters.matches("src/package/module.py"));
+        assert!(!filters.matches("tests/test_module.py"));
+        assert!(!filters.matches("src/package/generated.py"));
+    }
+
+    #[test]
+    fn filters_reject_invalid_globs() {
+        let include = vec!["[".to_string()];
+        let err = CoverageFilters::new(&include, &[]).expect_err("invalid glob");
+
+        assert!(
+            err.to_string()
+                .contains("invalid coverage include glob `[`"),
+            "{err:?}"
+        );
+    }
 }

--- a/crates/karva_coverage/src/report/terminal.rs
+++ b/crates/karva_coverage/src/report/terminal.rs
@@ -5,6 +5,7 @@ use camino::Utf8Path;
 use colored::Colorize;
 use fs_err as fs;
 
+use super::CoverageFilters;
 use super::combined_rows;
 use super::html::build_html_report;
 use super::json::build_json_report;
@@ -15,8 +16,9 @@ pub fn combine_and_report(
     cwd: &Utf8Path,
     files: &[impl AsRef<Utf8Path>],
     show_missing: bool,
+    filters: &CoverageFilters,
 ) -> Result<Option<f64>> {
-    let Some((_, rows)) = combined_rows(cwd, files, show_missing)? else {
+    let Some((_, rows)) = combined_rows(cwd, files, show_missing, filters)? else {
         return Ok(None);
     };
     let total = print_report(&rows, show_missing, &mut std::io::stdout().lock())?;
@@ -27,8 +29,9 @@ pub fn write_cobertura_xml(
     cwd: &Utf8Path,
     files: &[impl AsRef<Utf8Path>],
     output: &Utf8Path,
+    filters: &CoverageFilters,
 ) -> Result<Option<f64>> {
-    let Some((cwd_real, rows)) = combined_rows(cwd, files, false)? else {
+    let Some((cwd_real, rows)) = combined_rows(cwd, files, false, filters)? else {
         return Ok(None);
     };
     let total_pct = total_percent(&rows);
@@ -51,8 +54,9 @@ pub fn write_json_report(
     cwd: &Utf8Path,
     files: &[impl AsRef<Utf8Path>],
     output: &Utf8Path,
+    filters: &CoverageFilters,
 ) -> Result<Option<f64>> {
-    let Some((_, rows)) = combined_rows(cwd, files, false)? else {
+    let Some((_, rows)) = combined_rows(cwd, files, false, filters)? else {
         return Ok(None);
     };
     let total_pct = total_percent(&rows);
@@ -75,8 +79,9 @@ pub fn write_html_report(
     cwd: &Utf8Path,
     files: &[impl AsRef<Utf8Path>],
     output_dir: &Utf8Path,
+    filters: &CoverageFilters,
 ) -> Result<Option<f64>> {
-    let Some((_, rows)) = combined_rows(cwd, files, true)? else {
+    let Some((_, rows)) = combined_rows(cwd, files, true, filters)? else {
         return Ok(None);
     };
     let total_pct = total_percent(&rows);

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -430,6 +430,36 @@ pub struct CoverageOptions {
     )]
     pub sources: Option<Vec<String>>,
 
+    /// Include only coverage report files matching these globs.
+    ///
+    /// Globs are matched against the project-relative file path shown in the
+    /// coverage report, such as `src/package/module.py`. When unset, all files
+    /// under the configured coverage sources are included unless omitted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"null"#,
+        value_type = r#"list[str]"#,
+        example = r#"
+            include = ["src/**"]
+        "#
+    )]
+    pub include: Option<Vec<String>>,
+
+    /// Exclude coverage report files matching these globs.
+    ///
+    /// Globs are matched against the project-relative file path shown in the
+    /// coverage report, such as `src/package/module.py`. Omit filters are
+    /// applied after include filters.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"null"#,
+        value_type = r#"list[str]"#,
+        example = r#"
+            omit = ["**/migrations/*"]
+        "#
+    )]
+    pub omit: Option<Vec<String>>,
+
     /// Coverage report type.
     ///
     /// `term` (default) prints a compact terminal table.
@@ -491,6 +521,8 @@ impl Combine for CoverageOptions {
         let report_overridden = self.report.is_some();
 
         self.sources = self.sources.take().combine(other.sources);
+        self.include = self.include.take().combine(other.include);
+        self.omit = self.omit.take().combine(other.omit);
         self.report = self.report.combine(other.report);
         self.report_path = if report_overridden && self.report_path.is_none() {
             None
@@ -511,6 +543,8 @@ impl CoverageOptions {
         };
         CoverageSettings {
             sources,
+            include: self.include.clone().unwrap_or_default(),
+            omit: self.omit.clone().unwrap_or_default(),
             report: self.report.unwrap_or_default(),
             report_path: self.report_path.clone(),
             fail_under: self.fail_under.map(|t| t.0),
@@ -1033,6 +1067,8 @@ retry = 5
         let toml = r#"
 [profile.default.coverage]
 sources = ["src", "tests"]
+include = ["src/**"]
+omit = ["**/generated.py"]
 report = "term-missing"
 report-path = "build/coverage.xml"
 "#;
@@ -1047,6 +1083,16 @@ report-path = "build/coverage.xml"
                     [
                         "src",
                         "tests",
+                    ],
+                ),
+                include: Some(
+                    [
+                        "src/**",
+                    ],
+                ),
+                omit: Some(
+                    [
+                        "**/generated.py",
                     ],
                 ),
                 report: Some(
@@ -1083,9 +1129,47 @@ report-path = "build/coverage.xml"
                     "tests",
                 ],
             ),
+            include: None,
+            omit: None,
             report: Some(
                 TermMissing,
             ),
+            report_path: None,
+            fail_under: None,
+            disabled: None,
+        }
+        "#);
+    }
+
+    /// CLI filters accumulate with file filters, matching coverage sources.
+    #[test]
+    fn combine_appends_cli_coverage_filters_after_file() {
+        let cli = CoverageOptions {
+            include: Some(vec!["tests/**".to_string()]),
+            omit: Some(vec!["**/generated.py".to_string()]),
+            ..CoverageOptions::default()
+        };
+        let file = CoverageOptions {
+            include: Some(vec!["src/**".to_string()]),
+            omit: Some(vec!["**/migrations/*".to_string()]),
+            ..CoverageOptions::default()
+        };
+        assert_debug_snapshot!(cli.combine(file), @r#"
+        CoverageOptions {
+            sources: None,
+            include: Some(
+                [
+                    "src/**",
+                    "tests/**",
+                ],
+            ),
+            omit: Some(
+                [
+                    "**/migrations/*",
+                    "**/generated.py",
+                ],
+            ),
+            report: None,
             report_path: None,
             fail_under: None,
             disabled: None,
@@ -1142,6 +1226,8 @@ report-path = "build/coverage.xml"
         assert_debug_snapshot!(cli.combine(file), @r#"
         CoverageOptions {
             sources: None,
+            include: None,
+            omit: None,
             report: Some(
                 Json,
             ),
@@ -1182,7 +1268,7 @@ disabled = true
           |
         3 | disabled = true
           | ^^^^^^^^
-        unknown field `disabled`, expected one of `sources`, `report`, `report-path`, `fail-under`
+        unknown field `disabled`, expected one of `sources`, `include`, `omit`, `report`, `report-path`, `fail-under`
         "
         );
     }
@@ -1201,7 +1287,7 @@ nonsense = 1
           |
         4 | nonsense = 1
           | ^^^^^^^^
-        unknown field `nonsense`, expected one of `sources`, `report`, `report-path`, `fail-under`
+        unknown field `nonsense`, expected one of `sources`, `include`, `omit`, `report`, `report-path`, `fail-under`
         "
         );
     }

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -295,6 +295,8 @@ pub struct SrcSettings {
 #[serde(rename_all = "kebab-case")]
 pub struct CoverageSettings {
     pub sources: Vec<String>,
+    pub include: Vec<String>,
+    pub omit: Vec<String>,
     pub report: CovReport,
     pub report_path: Option<String>,
     /// Minimum total coverage percentage (`0..=100`). When set and the

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -57,6 +57,48 @@ fail-under = 90
 
 ---
 
+### `include`
+
+Include only coverage report files matching these globs.
+
+Globs are matched against the project-relative file path shown in the
+coverage report, such as `src/package/module.py`. When unset, all files
+under the configured coverage sources are included unless omitted.
+
+**Default value**: `null`
+
+**Type**: `list[str]`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.karva.profile.default.coverage]
+include = ["src/**"]
+```
+
+---
+
+### `omit`
+
+Exclude coverage report files matching these globs.
+
+Globs are matched against the project-relative file path shown in the
+coverage report, such as `src/package/module.py`. Omit filters are
+applied after include filters.
+
+**Default value**: `null`
+
+**Type**: `list[str]`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.karva.profile.default.coverage]
+omit = ["**/migrations/*"]
+```
+
+---
+
 ### `report`
 
 Coverage report type.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -51,6 +51,10 @@ karva test [OPTIONS] [PATH]...
 <p>May be passed multiple times to measure several sources. Pass without a value (<code>--cov</code>) to measure the current working directory.</p>
 </dd><dt id="karva-test--cov-fail-under"><a href="#karva-test--cov-fail-under"><code>--cov-fail-under</code></a> <i>percent</i></dt><dd><p>Fail the run if total coverage is below the given percentage.</p>
 <p>Accepts any value in <code>0..=100</code> (fractional values such as <code>90.5</code> are allowed). When the reported <code>TOTAL</code> percentage is below the threshold, the test command exits with a non-zero status even if every test passed. Has no effect when tests have already failed.</p>
+</dd><dt id="karva-test--cov-include"><a href="#karva-test--cov-include"><code>--cov-include</code></a> <i>glob</i></dt><dd><p>Include only coverage report files whose project-relative path matches this glob.</p>
+<p>May be passed multiple times.</p>
+</dd><dt id="karva-test--cov-omit"><a href="#karva-test--cov-omit"><code>--cov-omit</code></a> <i>glob</i></dt><dd><p>Exclude coverage report files whose project-relative path matches this glob.</p>
+<p>May be passed multiple times.</p>
 </dd><dt id="karva-test--cov-report"><a href="#karva-test--cov-report"><code>--cov-report</code></a> <i>type</i></dt><dd><p>Coverage report type.</p>
 <p><code>term</code> (default) prints a compact terminal table. <code>term-missing</code> extends it with a <code>Missing</code> column listing the uncovered line numbers per file. <code>xml&#91;:PATH&#93;</code>, <code>json&#91;:PATH&#93;</code>, and <code>html&#91;:DIR&#93;</code> write reports to disk.</p>
 </dd><dt id="karva-test--durations"><a href="#karva-test--durations"><code>--durations</code></a> <i>n</i></dt><dd><p>Show the N slowest tests after the run completes</p>

--- a/docs/usage/writing-tests/coverage.md
+++ b/docs/usage/writing-tests/coverage.md
@@ -84,6 +84,25 @@ karva test --cov=src --cov-report=html:build/htmlcov
 
 Files that were never imported during the run still appear, at `0%`, so dead modules under your source root show up rather than silently inflating the total.
 
+## Filtering report files
+
+Use `--cov-include` and `--cov-omit` to keep generated files, migrations, vendored code, or other non-target paths out of the report:
+
+```bash
+karva test --cov=src --cov-include='src/**' --cov-omit='**/migrations/*'
+```
+
+Globs match the project-relative file path shown in the coverage report. When include filters are set, only matching files are reported. Omit filters are applied after include filters.
+
+Equivalent configuration:
+
+```toml
+[tool.karva.profile.default.coverage]
+sources = ["src"]
+include = ["src/**"]
+omit = ["**/migrations/*"]
+```
+
 ## Failing on low coverage
 
 `--cov-fail-under=N` exits non-zero when total coverage drops below `N`, even if every test passed:


### PR DESCRIPTION
## Summary

Adds coverage include and omit glob filters for CLI and profile configuration, then applies them consistently across terminal, XML, JSON, and HTML coverage reports. Closes #723.

## Test Plan

Ran `just test`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `uvx prek run -a`.
