### PR TITLE
Add coverage test contexts

### DIFF
--- a/crates/karva/tests/it/coverage.rs
+++ b/crates/karva/tests/it/coverage.rs
@@ -548,6 +548,103 @@ def test_only_covered():
 }
 
 #[test]
+fn test_cov_context_test_records_json_contexts() {
+    let context = TestContext::with_files([
+        (
+            "src/app.py",
+            "def shared():\n    value = 1\n    return value\n\ndef only_one():\n    return shared() + 1\n\ndef only_two():\n    return shared() + 2\n",
+        ),
+        (
+            "test_context.py",
+            r"
+import sys, os
+sys.path.insert(0, os.path.dirname(__file__))
+from src.app import only_one, only_two
+
+def test_one():
+    assert only_one() == 2
+
+def test_two():
+    assert only_two() == 3
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .arg("--cov=src")
+            .arg("--cov-context=test")
+            .arg("--cov-report=json")
+            .arg("--status-level=none")
+            .arg("test_context.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+
+    let json = context.read_file("coverage.json");
+    insta::assert_snapshot!(json, @r#"
+    {
+      "meta": {
+        "format": 2,
+        "version": "karva",
+        "show_contexts": true
+      },
+      "files": {
+        "src/app.py": {
+          "executed_lines": [
+            1,
+            2,
+            3,
+            5,
+            6,
+            8,
+            9
+          ],
+          "summary": {
+            "covered_lines": 7,
+            "num_statements": 7,
+            "percent_covered": 100.0,
+            "missing_lines": [],
+            "excluded_lines": []
+          },
+          "missing_lines": [],
+          "excluded_lines": [],
+          "contexts": {
+            "2": [
+              "test_context::test_one",
+              "test_context::test_two"
+            ],
+            "3": [
+              "test_context::test_one",
+              "test_context::test_two"
+            ],
+            "6": [
+              "test_context::test_one"
+            ],
+            "9": [
+              "test_context::test_two"
+            ]
+          }
+        }
+      },
+      "totals": {
+        "covered_lines": 7,
+        "num_statements": 7,
+        "percent_covered": 100.0
+      }
+    }
+    "#);
+}
+
+#[test]
 fn test_cov_report_cli_override_uses_default_path_when_config_path_is_stale() {
     let context = TestContext::with_files([
         (

--- a/crates/karva_cli/src/enums.rs
+++ b/crates/karva_cli/src/enums.rs
@@ -102,6 +102,21 @@ impl From<CovReport> for karva_metadata::CovReport {
     }
 }
 
+/// Coverage context selection parsed from `--cov-context`.
+#[derive(Copy, Clone, Hash, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub enum CovContext {
+    /// Record the current test name for each covered line.
+    Test,
+}
+
+impl CovContext {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Test => "test",
+        }
+    }
+}
+
 /// Whether to run ignored/skipped tests.
 #[derive(Copy, Clone, Hash, Debug, PartialEq, Eq, clap::ValueEnum)]
 pub enum RunIgnored {

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -11,7 +11,7 @@ mod test;
 mod verbosity;
 
 pub use cache::{CacheAction, CacheCommand};
-pub use enums::{CovReport, NoTests, OutputFormat, RunIgnored};
+pub use enums::{CovContext, CovReport, NoTests, OutputFormat, RunIgnored};
 pub use partition::PartitionSelection;
 pub use show_config::ShowConfigCommand;
 pub use snapshot::{

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -196,6 +196,18 @@ pub struct SubTestCommand {
     )]
     pub cov_include: Vec<String>,
 
+    /// Record per-test coverage contexts.
+    ///
+    /// Currently supports `test`, which records the qualified test name for
+    /// each line executed while that test is running. Contexts are emitted in
+    /// JSON coverage reports.
+    #[clap(
+        long = "cov-context",
+        value_name = "CONTEXT",
+        help_heading = "Coverage options"
+    )]
+    pub cov_context: Option<crate::CovContext>,
+
     /// Disable coverage measurement for this run.
     ///
     /// Overrides any `--cov` flag and any `[coverage] sources` configured in

--- a/crates/karva_coverage/src/data.rs
+++ b/crates/karva_coverage/src/data.rs
@@ -1,7 +1,7 @@
 //! Per-worker JSON schema. Both the tracer and the report side use these
 //! types so the wire format stays in lockstep.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
@@ -14,4 +14,6 @@ pub struct WorkerFile {
 pub struct FileEntry {
     pub executable: Vec<u32>,
     pub executed: Vec<u32>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub contexts: BTreeMap<u32, BTreeSet<String>>,
 }

--- a/crates/karva_coverage/src/report/json.rs
+++ b/crates/karva_coverage/src/report/json.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 
 use anyhow::{Context, Result};
 use serde::Serialize;
@@ -20,6 +21,8 @@ struct JsonFileReport {
     summary: JsonFileSummary,
     missing_lines: Vec<u32>,
     excluded_lines: Vec<u32>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    contexts: BTreeMap<u32, BTreeSet<String>>,
 }
 
 #[derive(Serialize)]
@@ -40,6 +43,16 @@ struct JsonReport {
 struct JsonMeta {
     format: u32,
     version: &'static str,
+    #[serde(skip_serializing_if = "is_false")]
+    show_contexts: bool,
+}
+
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "serde skip_serializing_if passes a reference to the field"
+)]
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 pub(super) fn build_json_report(rows: &[FileRow]) -> Result<String> {
@@ -53,16 +66,19 @@ pub(super) fn build_json_report(rows: &[FileRow]) -> Result<String> {
                     summary: json_summary(row),
                     missing_lines: missing_lines(row),
                     excluded_lines: Vec::new(),
+                    contexts: row.contexts.clone(),
                 },
             )
         })
         .collect();
 
     let totals_row = totals_row(rows);
+    let show_contexts = rows.iter().any(|row| !row.contexts.is_empty());
     let report = JsonReport {
         meta: JsonMeta {
             format: 2,
             version: "karva",
+            show_contexts,
         },
         files,
         totals: json_totals_summary(&totals_row),

--- a/crates/karva_coverage/src/report/shared.rs
+++ b/crates/karva_coverage/src/report/shared.rs
@@ -10,6 +10,7 @@ use crate::data::WorkerFile;
 pub(super) struct CombinedFile {
     executable: BTreeSet<u32>,
     executed: BTreeSet<u32>,
+    contexts: BTreeMap<u32, BTreeSet<String>>,
 }
 
 pub(super) struct FileRow {
@@ -21,6 +22,7 @@ pub(super) struct FileRow {
     pub missing: String,
     pub executable: Vec<u32>,
     pub executed: Vec<u32>,
+    pub contexts: BTreeMap<u32, BTreeSet<String>>,
 }
 
 pub(super) fn combine(files: &[impl AsRef<Utf8Path>]) -> Result<BTreeMap<String, CombinedFile>> {
@@ -37,6 +39,9 @@ pub(super) fn combine(files: &[impl AsRef<Utf8Path>]) -> Result<BTreeMap<String,
             let bucket = combined.entry(filename).or_default();
             bucket.executable.extend(file_entry.executable);
             bucket.executed.extend(file_entry.executed);
+            for (line, contexts) in file_entry.contexts {
+                bucket.contexts.entry(line).or_default().extend(contexts);
+            }
         }
     }
 
@@ -76,6 +81,7 @@ pub(super) fn build_rows(
                 missing,
                 executable,
                 executed,
+                contexts: data.contexts.clone(),
             }
         })
         .collect()
@@ -111,6 +117,7 @@ pub(super) fn totals_row(rows: &[FileRow]) -> FileRow {
         missing: collapse_ranges(&missing.iter().copied().collect()),
         executable: Vec::new(),
         executed: Vec::new(),
+        contexts: BTreeMap::new(),
     }
 }
 
@@ -259,6 +266,39 @@ mod tests {
     }
 
     #[test]
+    fn combine_merges_contexts_for_same_line() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let first = dir.path().join("worker-0.json");
+        let second = dir.path().join("worker-1.json");
+        fs::write(
+            &first,
+            r#"{"files":{"/project/src/app.py":{"executable":[1,2],"executed":[2],"contexts":{"2":["test_a"]}}}}"#,
+        )
+        .expect("write first worker file");
+        fs::write(
+            &second,
+            r#"{"files":{"/project/src/app.py":{"executable":[1,2],"executed":[2],"contexts":{"2":["test_b"]}}}}"#,
+        )
+        .expect("write second worker file");
+
+        let first = camino::Utf8PathBuf::from_path_buf(first).expect("utf8 path");
+        let second = camino::Utf8PathBuf::from_path_buf(second).expect("utf8 path");
+        let combined = combine(&[first, second]).expect("combine coverage files");
+
+        assert_eq!(
+            combined
+                .get("/project/src/app.py")
+                .expect("combined file")
+                .contexts
+                .get(&2),
+            Some(&BTreeSet::from([
+                "test_a".to_string(),
+                "test_b".to_string()
+            ]))
+        );
+    }
+
+    #[test]
     #[cfg(windows)]
     fn simplify_path_strips_windows_verbatim_prefix() {
         assert_eq!(
@@ -289,6 +329,7 @@ mod tests {
             missing: String::new(),
             executable: Vec::new(),
             executed: Vec::new(),
+            contexts: BTreeMap::new(),
         };
 
         assert_eq!(

--- a/crates/karva_coverage/src/report/terminal.rs
+++ b/crates/karva_coverage/src/report/terminal.rs
@@ -202,6 +202,8 @@ fn format_row(name_width: usize, show_missing: bool, row: &Row<'_>) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::*;
 
     fn row(name: &str, stmts: u32, hit: u32, miss: u32, missing: &str) -> FileRow {
@@ -214,6 +216,7 @@ mod tests {
             missing: missing.to_string(),
             executable: Vec::new(),
             executed: Vec::new(),
+            contexts: BTreeMap::new(),
         }
     }
 

--- a/crates/karva_coverage/src/tracer.rs
+++ b/crates/karva_coverage/src/tracer.rs
@@ -5,7 +5,7 @@
 //! touched file and writes a per-worker JSON file at
 //! [`CoverageConfig::data_file`].
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
@@ -25,6 +25,9 @@ pub struct CoverageConfig {
 
     /// Per-worker data file path. The runner combines these after the run.
     pub data_file: Utf8PathBuf,
+
+    /// Whether to record the current test context for each executed line.
+    pub contexts: bool,
 }
 
 /// Path components inside a source root that suppress tracking. These match
@@ -58,6 +61,7 @@ impl CoverageSession {
             py,
             CoverageTracer {
                 roots,
+                contexts: config.contexts,
                 state: Mutex::new(TracerState::default()),
                 monitoring_tool_id: OnceLock::new(),
                 monitoring_disable: OnceLock::new(),
@@ -92,18 +96,31 @@ impl CoverageSession {
         }
 
         let borrowed = bound.borrow();
-        let executed = match borrowed.state.lock() {
-            Ok(mut state) => std::mem::take(&mut state.executed),
-            Err(poisoned) => std::mem::take(&mut poisoned.into_inner().executed),
+        let (executed, contexts) = match borrowed.state.lock() {
+            Ok(mut state) => (
+                std::mem::take(&mut state.executed),
+                std::mem::take(&mut state.contexts),
+            ),
+            Err(poisoned) => {
+                let mut state = poisoned.into_inner();
+                (
+                    std::mem::take(&mut state.executed),
+                    std::mem::take(&mut state.contexts),
+                )
+            }
         };
         let roots = borrowed.roots.clone();
         drop(borrowed);
-        save_data(&data_file, executed, &roots).map_err(|err| {
+        save_data(&data_file, executed, contexts, &roots).map_err(|err| {
             pyo3::exceptions::PyOSError::new_err(format!(
                 "failed to write coverage data to {data_file}: {err}"
             ))
         })?;
         Ok(())
+    }
+
+    pub fn set_current_context(&self, py: Python<'_>, context: Option<&str>) {
+        self.tracer.bind(py).borrow().set_current_context(context);
     }
 }
 
@@ -111,6 +128,10 @@ impl CoverageSession {
 struct TracerState {
     /// Files with the set of executed line numbers.
     executed: HashMap<PathBuf, HashSet<u32>>,
+    /// Per-line test contexts for files with executed lines.
+    contexts: HashMap<PathBuf, HashMap<u32, HashSet<String>>>,
+    /// Current test context, if `--cov-context=test` is active and a test is running.
+    current_context: Option<String>,
     /// Memoized result of [`compute_tracked_path`] per filename string.
     track_cache: HashMap<String, Option<PathBuf>>,
     /// Memoized result of [`compute_tracked_path`] per live Python code object.
@@ -131,6 +152,7 @@ struct TrackedCode {
 #[pyclass(module = "karva_coverage")]
 struct CoverageTracer {
     roots: Vec<PathBuf>,
+    contexts: bool,
     state: Mutex<TracerState>,
     monitoring_tool_id: OnceLock<u8>,
     /// Cached `sys.monitoring.DISABLE` sentinel. Populated when the
@@ -144,20 +166,23 @@ struct CoverageTracer {
 #[pymethods]
 impl CoverageTracer {
     /// `sys.monitoring` LINE event callback. Records the line if it's in a
-    /// tracked file, then always returns `sys.monitoring.DISABLE` so the
-    /// interpreter never calls us back for the same `(code, line)` pair.
+    /// tracked file, then returns `sys.monitoring.DISABLE` for normal coverage
+    /// so the interpreter never calls us back for the same `(code, line)` pair.
+    /// Context coverage keeps callbacks active so later tests can be attributed.
     fn line_cb(
         &self,
         py: Python<'_>,
         code: &Bound<'_, PyAny>,
         lineno: u32,
     ) -> PyResult<Option<Py<PyAny>>> {
-        if let Some(path) = self.tracked_code_path(code)?
-            && let Ok(mut state) = self.state.lock()
-        {
-            state.executed.entry(path).or_default().insert(lineno);
+        if let Some(path) = self.tracked_code_path(code)? {
+            self.record_line(path, lineno);
         }
-        Ok(self.monitoring_disable.get().map(|d| d.clone_ref(py)))
+        if self.contexts {
+            Ok(None)
+        } else {
+            Ok(self.monitoring_disable.get().map(|d| d.clone_ref(py)))
+        }
     }
 
     /// `sys.settrace` global trace function. Returns the per-frame
@@ -198,9 +223,7 @@ impl CoverageTracer {
             let path = slf.borrow().tracked_path(&filename);
             if let Some(path) = path {
                 let lineno: u32 = frame.getattr("f_lineno")?.extract()?;
-                if let Ok(mut state) = slf.borrow().state.lock() {
-                    state.executed.entry(path).or_default().insert(lineno);
-                }
+                slf.borrow().record_line(path, lineno);
             }
         }
         Ok(slf.getattr("local_trace")?.unbind())
@@ -208,6 +231,38 @@ impl CoverageTracer {
 }
 
 impl CoverageTracer {
+    fn set_current_context(&self, context: Option<&str>) {
+        if !self.contexts {
+            return;
+        }
+        if let Ok(mut state) = self.state.lock() {
+            state.current_context = context.map(ToOwned::to_owned);
+        }
+    }
+
+    fn record_line(&self, path: PathBuf, lineno: u32) {
+        if let Ok(mut state) = self.state.lock() {
+            if self.contexts
+                && let Some(context) = state.current_context.clone()
+            {
+                state
+                    .executed
+                    .entry(path.clone())
+                    .or_default()
+                    .insert(lineno);
+                state
+                    .contexts
+                    .entry(path)
+                    .or_default()
+                    .entry(lineno)
+                    .or_default()
+                    .insert(context);
+            } else {
+                state.executed.entry(path).or_default().insert(lineno);
+            }
+        }
+    }
+
     /// Resolve a live Python code object without extracting `co_filename`
     /// after the first line callback for that object.
     fn tracked_code_path(&self, code: &Bound<'_, PyAny>) -> PyResult<Option<PathBuf>> {
@@ -431,6 +486,7 @@ fn is_python_source(path: &Path) -> bool {
 fn save_data(
     data_file: &Utf8Path,
     mut executed: HashMap<PathBuf, HashSet<u32>>,
+    mut contexts: HashMap<PathBuf, HashMap<u32, HashSet<String>>>,
     roots: &[PathBuf],
 ) -> std::io::Result<()> {
     for path in walk_source_files(roots) {
@@ -447,11 +503,19 @@ fn save_data(
         executed_lines.sort_unstable();
         let mut executable_lines_vec: Vec<u32> = executable.into_iter().collect();
         executable_lines_vec.sort_unstable();
+        let context_lines = contexts
+            .remove(&path)
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|(line, _)| executed_lines.binary_search(line).is_ok())
+            .map(|(line, contexts)| (line, contexts.into_iter().collect::<BTreeSet<_>>()))
+            .collect();
         files.insert(
             path.to_string_lossy().into_owned(),
             FileEntry {
                 executable: executable_lines_vec,
                 executed: executed_lines,
+                contexts: context_lines,
             },
         );
     }
@@ -484,6 +548,7 @@ mod tests {
         Python::attach(|py| -> PyResult<()> {
             let tracer = CoverageTracer {
                 roots: vec![root],
+                contexts: false,
                 state: Mutex::new(TracerState::default()),
                 monitoring_tool_id: OnceLock::new(),
                 monitoring_disable: OnceLock::new(),
@@ -539,7 +604,8 @@ code = Code()
         let missing = dir.path().join("missing.py");
         let executed = HashMap::from([(missing, HashSet::from([1]))]);
 
-        let err = save_data(&data_file, executed, &[]).expect_err("missing source should fail");
+        let err = save_data(&data_file, executed, HashMap::new(), &[])
+            .expect_err("missing source should fail");
 
         assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
         assert!(err.to_string().contains("missing.py"), "{err}");

--- a/crates/karva_runner/src/worker_args.rs
+++ b/crates/karva_runner/src/worker_args.rs
@@ -138,6 +138,11 @@ fn inner_cli_args(settings: &ProjectSettings, args: &SubTestCommand) -> Vec<Stri
         cli_args.push(format!("--cov={source}"));
     }
 
+    if let Some(context) = args.cov_context {
+        cli_args.push("--cov-context".to_string());
+        cli_args.push(context.as_str().to_string());
+    }
+
     for ovr in settings.overrides() {
         let json = serde_json::json!({
             "filter": ovr.filter.as_str(),

--- a/crates/karva_test_semantic/src/lib.rs
+++ b/crates/karva_test_semantic/src/lib.rs
@@ -48,7 +48,7 @@ pub fn run_tests(
 
         let session = StandardDiscoverer::new(&context).discover_with_py(py, test_paths);
 
-        PackageRunner::new(&context).execute(py, &session);
+        PackageRunner::new(&context, cov_session.as_ref()).execute(py, &session);
 
         if let Some(cov_session) = cov_session
             && let Err(err) = cov_session.stop_and_save(py)

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
 
+use karva_coverage::CoverageSession;
 use karva_diagnostic::IndividualTestResultKind;
 use karva_metadata::RunIgnoredMode;
 use karva_metadata::filter::EvalContext;
@@ -46,6 +47,9 @@ pub struct PackageRunner<'ctx, 'a> {
     /// Cache for fixture finalizers to run cleanup at appropriate times.
     finalizer_cache: FinalizerCache,
 
+    /// Active coverage session, when coverage is enabled for this worker.
+    coverage: Option<&'ctx CoverageSession>,
+
     /// Running count of failed tests observed during this run.
     ///
     /// Used to enforce `--max-fail=N`: once this counter reaches the
@@ -54,11 +58,12 @@ pub struct PackageRunner<'ctx, 'a> {
 }
 
 impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
-    pub(crate) fn new(context: &'ctx Context<'a>) -> Self {
+    pub(crate) fn new(context: &'ctx Context<'a>, coverage: Option<&'ctx CoverageSession>) -> Self {
         Self {
             context,
             fixture_cache: FixtureCache::default(),
             finalizer_cache: FinalizerCache::default(),
+            coverage,
             failed_count: Cell::new(0),
         }
     }
@@ -564,6 +569,9 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
 
         let configured_retries = self.context.settings().retry_for(&eval_ctx);
         self.context.report_test_started(&qualified_test_name);
+        if let Some(coverage) = self.coverage {
+            coverage.set_current_context(py, Some(&qualified_name_str));
+        }
         let RetryOutcome {
             test_result,
             attempt,
@@ -615,6 +623,9 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         }
 
         self.clean_up_scope(py, FixtureScope::Function);
+        if let Some(coverage) = self.coverage {
+            coverage.set_current_context(py, None);
+        }
 
         passed
     }

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -230,6 +230,7 @@ fn worker_coverage_config(
     Ok(Some(karva_test_semantic::CoverageConfig {
         sources: sub_command.cov.clone(),
         data_file,
+        contexts: sub_command.cov_context == Some(karva_cli::CovContext::Test),
     }))
 }
 
@@ -280,5 +281,23 @@ mod tests {
 
         assert_eq!(coverage.sources, vec![String::new(), "pkg".to_string()]);
         assert_eq!(coverage.data_file, data_file);
+        assert!(!coverage.contexts);
+    }
+
+    #[test]
+    fn coverage_config_preserves_context_mode() {
+        let data_file = Utf8PathBuf::from(".coverage.worker-0");
+        let sub_command = SubTestCommand {
+            cov: vec!["pkg".to_string()],
+            cov_context: Some(karva_cli::CovContext::Test),
+            cov_data_file: Some(data_file),
+            ..SubTestCommand::default()
+        };
+
+        let coverage = worker_coverage_config(&sub_command)
+            .expect("coverage config")
+            .expect("coverage should be enabled");
+
+        assert!(coverage.contexts);
     }
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -49,7 +49,12 @@ karva test [OPTIONS] [PATH]...
 <p>While karva configuration can be included in a <code>pyproject.toml</code> file, it is not allowed in this context.</p>
 <p>May also be set with the <code>KARVA_CONFIG_FILE</code> environment variable.</p></dd><dt id="karva-test--cov"><a href="#karva-test--cov"><code>--cov</code></a> <i>source</i></dt><dd><p>Measure code coverage for the given source path.</p>
 <p>May be passed multiple times to measure several sources. Pass without a value (<code>--cov</code>) to measure the current working directory.</p>
-</dd><dt id="karva-test--cov-fail-under"><a href="#karva-test--cov-fail-under"><code>--cov-fail-under</code></a> <i>percent</i></dt><dd><p>Fail the run if total coverage is below the given percentage.</p>
+</dd><dt id="karva-test--cov-context"><a href="#karva-test--cov-context"><code>--cov-context</code></a> <i>context</i></dt><dd><p>Record per-test coverage contexts.</p>
+<p>Currently supports <code>test</code>, which records the qualified test name for each line executed while that test is running. Contexts are emitted in JSON coverage reports.</p>
+<p>Possible values:</p>
+<ul>
+<li><code>test</code>:  Record the current test name for each covered line</li>
+</ul></dd><dt id="karva-test--cov-fail-under"><a href="#karva-test--cov-fail-under"><code>--cov-fail-under</code></a> <i>percent</i></dt><dd><p>Fail the run if total coverage is below the given percentage.</p>
 <p>Accepts any value in <code>0..=100</code> (fractional values such as <code>90.5</code> are allowed). When the reported <code>TOTAL</code> percentage is below the threshold, the test command exits with a non-zero status even if every test passed. Has no effect when tests have already failed.</p>
 </dd><dt id="karva-test--cov-include"><a href="#karva-test--cov-include"><code>--cov-include</code></a> <i>glob</i></dt><dd><p>Include only coverage report files whose project-relative path matches this glob.</p>
 <p>May be passed multiple times.</p>

--- a/docs/usage/writing-tests/coverage.md
+++ b/docs/usage/writing-tests/coverage.md
@@ -75,6 +75,12 @@ karva test --cov=src --cov-report=json
 karva test --cov=src --cov-report=json:build/coverage.json
 ```
 
+Pass `--cov-context=test` with JSON reports to include a `contexts` map from executed source lines to the qualified test names that covered them:
+
+```bash
+karva test --cov=src --cov-context=test --cov-report=json
+```
+
 `--cov-report=html[:DIR]` writes a simple browsable HTML report. If `DIR` is omitted, karva writes `htmlcov/` in the project root:
 
 ```bash


### PR DESCRIPTION
Closes #726.

This adds `--cov-context=test`, forwards it to workers, and records qualified test names for each covered source line while a test is running. The data is merged across workers and emitted in JSON reports as a file-level `contexts` map that matches coverage.py's `coverage json --show-contexts` shape. Terminal, XML, and HTML reports stay unchanged.

Test plan:

`just test`; `cargo clippy --workspace --all-targets --all-features -- -D warnings`; `uvx prek run -a`.