### PR TITLE
Add coverage.py data file

### DIFF
--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -121,6 +121,15 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
                 coverage.report.as_str()
             )?;
         }
+        let coverage_data_path = project.cwd().join(".coverage");
+        if let Err(err) = karva_coverage::write_coveragepy_sqlite(
+            project.cwd(),
+            &coverage_files,
+            &coverage_data_path,
+            &coverage_filters,
+        ) {
+            tracing::error!("Coverage data file failed: {err:#}");
+        }
         let coverage_result = match coverage.report {
             CovReport::Term => karva_coverage::combine_and_report(
                 project.cwd(),

--- a/crates/karva/tests/it/coverage.rs
+++ b/crates/karva/tests/it/coverage.rs
@@ -548,6 +548,48 @@ def test_only_covered():
 }
 
 #[test]
+fn test_cov_writes_coveragepy_sqlite_file() {
+    let context = TestContext::with_files([
+        (
+            "src/app.py",
+            "def covered():\n    return 1\n\ndef missed():\n    return 2\n",
+        ),
+        (
+            "test_sqlite.py",
+            r"
+import sys, os
+sys.path.insert(0, os.path.dirname(__file__))
+from src.app import covered
+
+def test_covered():
+    assert covered() == 1
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .arg("--cov=src")
+            .arg("--cov-report=json")
+            .arg("--status-level=none")
+            .arg("test_sqlite.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+
+    let bytes = std::fs::read(context.root().join(".coverage")).expect("read .coverage");
+    assert!(bytes.starts_with(b"SQLite format 3\0"));
+}
+
+#[test]
 fn test_cov_context_test_records_json_contexts() {
     let context = TestContext::with_files([
         (

--- a/crates/karva_coverage/src/lib.rs
+++ b/crates/karva_coverage/src/lib.rs
@@ -21,6 +21,7 @@ pub mod report;
 pub mod tracer;
 
 pub use report::{
-    CoverageFilters, combine_and_report, write_cobertura_xml, write_html_report, write_json_report,
+    CoverageFilters, combine_and_report, write_cobertura_xml, write_coveragepy_sqlite,
+    write_html_report, write_json_report,
 };
 pub use tracer::{CoverageConfig, CoverageSession};

--- a/crates/karva_coverage/src/report/coveragepy.rs
+++ b/crates/karva_coverage/src/report/coveragepy.rs
@@ -1,0 +1,360 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::Write;
+use std::process::{Command, Output, Stdio};
+
+use anyhow::{Context, Result, bail};
+use camino::Utf8Path;
+use fs_err as fs;
+use pyo3::types::PyAnyMethods;
+use pyo3::{PyResult, Python};
+use serde::Serialize;
+
+use super::CoverageFilters;
+use super::combined_rows;
+use super::shared::{FileRow, total_percent};
+
+const COVERAGE_SCHEMA_VERSION: u32 = 7;
+const SQLITE_MODULE: &str = "karva._coverage_sqlite";
+
+#[cfg(debug_assertions)]
+const SQLITE_WRITER: &str = include_str!("../../../../python/karva/_coverage_sqlite.py");
+
+#[derive(Serialize)]
+struct SqlitePayload {
+    files: Vec<SqliteFileRow>,
+}
+
+#[derive(Serialize)]
+struct SqliteFileRow {
+    path: String,
+    contexts: Vec<SqliteContextRow>,
+}
+
+#[derive(Serialize)]
+struct SqliteContextRow {
+    context: String,
+    numbits: Vec<u8>,
+}
+
+pub fn write_coveragepy_sqlite(
+    cwd: &Utf8Path,
+    files: &[impl AsRef<Utf8Path>],
+    output: &Utf8Path,
+    filters: &CoverageFilters,
+) -> Result<Option<f64>> {
+    let Some((_, rows)) = combined_rows(cwd, files, false, filters)? else {
+        return Ok(None);
+    };
+    let total_pct = total_percent(&rows);
+
+    if let Some(parent) = output.parent()
+        && !parent.as_str().is_empty()
+    {
+        fs::create_dir_all(parent.as_std_path())
+            .with_context(|| format!("failed to create coverage data directory {parent}"))?;
+    }
+    if output.exists() {
+        fs::remove_file(output.as_std_path())
+            .with_context(|| format!("failed to replace existing coverage data file {output}"))?;
+    }
+
+    write_sqlite_file(output, &rows)?;
+
+    Ok(Some(total_pct))
+}
+
+fn write_sqlite_file(output: &Utf8Path, rows: &[FileRow]) -> Result<()> {
+    let payload_json = serde_json::to_string(&sqlite_payload(rows))
+        .context("failed to serialize coverage.py data")?;
+    let python = python_executable().context("failed to locate Python for coverage data file")?;
+
+    let output_status =
+        run_python_sqlite_writer(&python, &["-m", SQLITE_MODULE], output, &payload_json)?;
+    if output_status.status.success() {
+        return Ok(());
+    }
+
+    #[cfg(debug_assertions)]
+    if module_not_found(&output_status.stderr) {
+        let output_status =
+            run_python_sqlite_writer(&python, &["-c", SQLITE_WRITER], output, &payload_json)?;
+        if output_status.status.success() {
+            return Ok(());
+        }
+        return python_writer_error(&output_status);
+    }
+
+    python_writer_error(&output_status)
+}
+
+fn run_python_sqlite_writer(
+    python: &str,
+    mode_args: &[&str],
+    output: &Utf8Path,
+    payload_json: &str,
+) -> Result<Output> {
+    let mut child = Command::new(python)
+        .args(mode_args)
+        .arg(output.as_str())
+        .arg(COVERAGE_SCHEMA_VERSION.to_string())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("failed to start Python sqlite writer `{python}`"))?;
+
+    let stdin = child
+        .stdin
+        .as_mut()
+        .context("failed to open Python sqlite writer stdin")?;
+    stdin
+        .write_all(payload_json.as_bytes())
+        .context("failed to send coverage.py data to Python sqlite writer")?;
+
+    child
+        .wait_with_output()
+        .context("failed to wait for Python sqlite writer")
+}
+
+#[cfg(debug_assertions)]
+fn module_not_found(stderr: &[u8]) -> bool {
+    String::from_utf8_lossy(stderr).contains("No module named")
+}
+
+fn python_writer_error(output_status: &Output) -> Result<()> {
+    let stderr = String::from_utf8_lossy(&output_status.stderr);
+    bail!("Python sqlite writer failed: {}", stderr.trim());
+}
+
+fn sqlite_payload(rows: &[FileRow]) -> SqlitePayload {
+    SqlitePayload {
+        files: rows
+            .iter()
+            .map(|row| SqliteFileRow {
+                path: row.absolute_name.clone(),
+                contexts: lines_by_context(row)
+                    .into_iter()
+                    .filter(|(_, lines)| !lines.is_empty())
+                    .map(|(context, lines)| SqliteContextRow {
+                        context,
+                        numbits: nums_to_numbits(&lines),
+                    })
+                    .collect(),
+            })
+            .collect(),
+    }
+}
+
+fn python_executable() -> Result<String> {
+    Python::initialize();
+    let executable = Python::attach(|py| -> PyResult<String> {
+        py.import("sys")?.getattr("executable")?.extract()
+    })?;
+    if is_python_executable(&executable) && python_has_sqlite(&executable) {
+        return Ok(executable);
+    }
+
+    for candidate in python_candidates() {
+        if python_has_sqlite(candidate) {
+            return Ok((*candidate).to_string());
+        }
+    }
+
+    Ok(executable)
+}
+
+fn is_python_executable(executable: &str) -> bool {
+    Utf8Path::new(executable)
+        .file_stem()
+        .is_some_and(|stem| stem.starts_with("python"))
+}
+
+fn python_has_sqlite(executable: &str) -> bool {
+    Command::new(executable)
+        .arg("-c")
+        .arg("import sqlite3")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+#[cfg(windows)]
+fn python_candidates() -> &'static [&'static str] {
+    &["python", "py"]
+}
+
+#[cfg(not(windows))]
+fn python_candidates() -> &'static [&'static str] {
+    &["python3", "python"]
+}
+
+fn lines_by_context(row: &FileRow) -> BTreeMap<String, BTreeSet<u32>> {
+    let mut lines_by_context: BTreeMap<String, BTreeSet<u32>> = BTreeMap::new();
+
+    for line in &row.executed {
+        if let Some(contexts) = row.contexts.get(line)
+            && !contexts.is_empty()
+        {
+            for context in contexts {
+                lines_by_context
+                    .entry(context.clone())
+                    .or_default()
+                    .insert(*line);
+            }
+        } else {
+            lines_by_context
+                .entry(String::new())
+                .or_default()
+                .insert(*line);
+        }
+    }
+
+    lines_by_context
+}
+
+fn nums_to_numbits(lines: &BTreeSet<u32>) -> Vec<u8> {
+    let Some(max_line) = lines.iter().next_back() else {
+        return Vec::new();
+    };
+    let byte_len = usize::try_from((max_line / 8) + 1).expect("u32 line numbers fit into usize");
+    let mut bits = vec![0_u8; byte_len];
+    for line in lines {
+        let byte_index = usize::try_from(line / 8).expect("u32 line numbers fit into usize");
+        bits[byte_index] |= 1_u8 << (line % 8);
+    }
+    bits
+}
+
+#[cfg(test)]
+mod tests {
+    use camino::Utf8PathBuf;
+    use pyo3::prelude::*;
+    use pyo3::types::PyDict;
+
+    use super::*;
+    use crate::data::{FileEntry, WorkerFile};
+
+    type CoverageData = (u32, String, u32, Vec<(String, String)>);
+
+    #[test]
+    fn nums_to_numbits_matches_coverage_py_format() {
+        assert_eq!(nums_to_numbits(&BTreeSet::from([1, 2, 3, 7])), [0x8e]);
+    }
+
+    #[test]
+    fn write_coveragepy_sqlite_writes_schema_and_contexts() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).expect("utf8 temp dir");
+        let worker_file = root.join("worker.json");
+        let output = root.join(".coverage");
+        let app = root.join("src/app.py");
+        let unused = root.join("src/unused.py");
+        let worker = WorkerFile {
+            files: BTreeMap::from([
+                (
+                    app.to_string(),
+                    FileEntry {
+                        executable: vec![1, 2, 3, 6],
+                        executed: vec![1, 2, 3, 6],
+                        contexts: BTreeMap::from([
+                            (
+                                2,
+                                BTreeSet::from([
+                                    "test_mod::test_one".to_string(),
+                                    "test_mod::test_two".to_string(),
+                                ]),
+                            ),
+                            (
+                                3,
+                                BTreeSet::from([
+                                    "test_mod::test_one".to_string(),
+                                    "test_mod::test_two".to_string(),
+                                ]),
+                            ),
+                            (6, BTreeSet::from(["test_mod::test_one".to_string()])),
+                        ]),
+                    },
+                ),
+                (
+                    unused.to_string(),
+                    FileEntry {
+                        executable: vec![1, 2],
+                        executed: Vec::new(),
+                        contexts: BTreeMap::new(),
+                    },
+                ),
+            ]),
+        };
+        fs::write(
+            &worker_file,
+            serde_json::to_vec(&worker).expect("serialize worker file"),
+        )
+        .expect("write worker file");
+
+        write_coveragepy_sqlite(&root, &[worker_file], &output, &CoverageFilters::default())
+            .expect("write coverage.py sqlite");
+
+        let (schema_version, has_arcs, file_count, rows) =
+            query_coverage_data(&output, &app).expect("query coverage data");
+
+        assert_eq!(schema_version, COVERAGE_SCHEMA_VERSION);
+
+        assert_eq!(has_arcs, "0");
+
+        assert_eq!(file_count, 2);
+
+        let rows: BTreeMap<_, _> = rows.into_iter().collect();
+
+        assert_eq!(
+            rows,
+            BTreeMap::from([
+                (String::new(), "02".to_string()),
+                ("test_mod::test_one".to_string(), "4C".to_string()),
+                ("test_mod::test_two".to_string(), "0C".to_string()),
+            ])
+        );
+    }
+
+    fn query_coverage_data(output: &Utf8Path, app: &Utf8Path) -> PyResult<CoverageData> {
+        Python::initialize();
+        Python::attach(|py| {
+            let locals = PyDict::new(py);
+            locals.set_item("output", output.as_str())?;
+            locals.set_item("app", app.as_str())?;
+            py.run(
+                cr#"
+import sqlite3
+
+conn = sqlite3.connect(output)
+try:
+    result = (
+        conn.execute("SELECT version FROM coverage_schema").fetchone()[0],
+        conn.execute("SELECT value FROM meta WHERE key = 'has_arcs'").fetchone()[0],
+        conn.execute("SELECT COUNT(*) FROM file").fetchone()[0],
+        list(conn.execute(
+            """
+                SELECT context.context, hex(line_bits.numbits)
+                FROM line_bits
+                JOIN context ON context.id = line_bits.context_id
+                JOIN file ON file.id = line_bits.file_id
+                WHERE file.path = ?
+                ORDER BY context.context
+                """,
+            (app,),
+        )),
+    )
+finally:
+    conn.close()
+"#,
+                None,
+                Some(&locals),
+            )?;
+            locals
+                .get_item("result")?
+                .expect("result should be set")
+                .extract()
+        })
+    }
+}

--- a/crates/karva_coverage/src/report/mod.rs
+++ b/crates/karva_coverage/src/report/mod.rs
@@ -1,5 +1,6 @@
 //! Combine per-worker JSON files and produce terminal or machine-readable reports.
 
+pub(crate) mod coveragepy;
 pub(crate) mod html;
 pub(crate) mod json;
 pub(crate) mod shared;
@@ -11,6 +12,7 @@ use camino::Utf8Path;
 use fs_err as fs;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 
+pub use coveragepy::write_coveragepy_sqlite;
 pub use terminal::combine_and_report;
 pub use terminal::write_cobertura_xml;
 pub use terminal::write_html_report;

--- a/docs/usage/writing-tests/coverage.md
+++ b/docs/usage/writing-tests/coverage.md
@@ -4,6 +4,8 @@ Karva measures line coverage natively. There is no plugin to install, no `.cover
 
 The implementation runs in the test worker on top of `sys.monitoring` (Python 3.12+) or `sys.settrace` (older versions), records every executed line under the configured source roots, and prints a `Name / Stmts / Miss / Cover` table at the end of the run.
 
+Every coverage run also writes a coverage.py-compatible `.coverage` SQLite file in the project root. Tools such as `coverage html`, `coverage xml`, Codecov uploaders, IDE gutters, and `diff-cover` can consume that artifact directly.
+
 ## Quick start
 
 Pass `--cov` to measure the current working directory:

--- a/python/karva/_coverage_sqlite.py
+++ b/python/karva/_coverage_sqlite.py
@@ -1,0 +1,108 @@
+"""Write Karva coverage data as a coverage.py-compatible SQLite database."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from typing import Any
+
+
+def main() -> int:
+    output = sys.argv[1]
+    schema_version = int(sys.argv[2])
+    payload: dict[str, Any] = json.load(sys.stdin)
+
+    conn = sqlite3.connect(output)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE coverage_schema (
+                version integer
+            );
+            CREATE TABLE meta (
+                key text,
+                value text,
+                unique (key)
+            );
+            CREATE TABLE file (
+                id integer primary key,
+                path text,
+                unique (path)
+            );
+            CREATE TABLE context (
+                id integer primary key,
+                context text,
+                unique (context)
+            );
+            CREATE TABLE line_bits (
+                file_id integer,
+                context_id integer,
+                numbits blob,
+                foreign key (file_id) references file (id),
+                foreign key (context_id) references context (id),
+                unique (file_id, context_id)
+            );
+            CREATE TABLE arc (
+                file_id integer,
+                context_id integer,
+                fromno integer,
+                tono integer,
+                foreign key (file_id) references file (id),
+                foreign key (context_id) references context (id),
+                unique (file_id, context_id, fromno, tono)
+            );
+            CREATE TABLE tracer (
+                file_id integer primary key,
+                tracer text,
+                foreign key (file_id) references file (id)
+            );
+            """
+        )
+        with conn:
+            conn.execute(
+                "INSERT INTO coverage_schema (version) VALUES (?)", (schema_version,)
+            )
+            conn.execute(
+                "INSERT INTO meta (key, value) VALUES (?, ?)", ("version", "karva")
+            )
+            conn.execute(
+                "INSERT INTO meta (key, value) VALUES (?, ?)", ("has_arcs", "0")
+            )
+
+            context_ids: dict[str, int] = {}
+            for file_row in payload["files"]:
+                cursor = conn.execute(
+                    "INSERT INTO file (path) VALUES (?)", (file_row["path"],)
+                )
+                file_id = cursor.lastrowid
+                if file_id is None:
+                    raise RuntimeError("sqlite did not return a file id")
+                for context_row in file_row["contexts"]:
+                    context = context_row["context"]
+                    context_id = context_ids.get(context)
+                    if context_id is None:
+                        cursor = conn.execute(
+                            "INSERT INTO context (context) VALUES (?)",
+                            (context,),
+                        )
+                        context_id = cursor.lastrowid
+                        if context_id is None:
+                            raise RuntimeError("sqlite did not return a context id")
+                        context_ids[context] = context_id
+                    conn.execute(
+                        "INSERT INTO line_bits (file_id, context_id, numbits) VALUES (?, ?, ?)",
+                        (
+                            file_id,
+                            context_id,
+                            sqlite3.Binary(bytes(context_row["numbits"])),
+                        ),
+                    )
+    finally:
+        conn.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #725.

This writes a coverage.py-compatible `.coverage` SQLite database in the project root for every coverage-enabled run. The writer uses coverage.py schema 7, stores file rows, empty and test contexts, and packed `line_bits` from Karva's combined worker data, while leaving the existing terminal, XML, JSON, and HTML reports unchanged. The SQLite file is written through Python's stdlib `sqlite3` in a subprocess, so SQLite is loaded only for coverage output and no new native dependency is added to the normal CLI startup path.

Test plan:

`just test`; `cargo clippy --workspace --all-targets --all-features -- -D warnings`; `uvx prek run -a`. Also verified `coverage json --show-contexts` from coverage.py 7.15.0 can read a Karva-produced `.coverage` file.
