### PR TITLE
Add branch coverage

### DIFF
--- a/crates/karva/tests/it/coverage.rs
+++ b/crates/karva/tests/it/coverage.rs
@@ -96,6 +96,189 @@ def test_pos():
 }
 
 #[test]
+fn test_cov_branch_reports_partial_branch() {
+    let context = TestContext::with_file(
+        "test_branch.py",
+        r"
+def choose(flag):
+    if flag:
+        return 'yes'
+    return 'no'
+
+def test_yes():
+    assert choose(True) == 'yes'
+",
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel()
+            .arg("--cov")
+            .arg("--cov-branch")
+            .arg("--cov-report=term-missing")
+            .arg("--status-level=none")
+            .arg("test_branch.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    Name             Stmts   Miss   Branch   BrPart   Cover   Missing
+    [LONG-LINE]
+    test_branch.py       6      1        2        1     75%   5
+    [LONG-LINE]
+    TOTAL                6      1        2        1     75%
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
+fn test_cov_branch_json_reports_branch_arcs() {
+    let context = TestContext::with_file(
+        "test_branch_json.py",
+        r"
+def choose(flag):
+    if flag:
+        return 'yes'
+    return 'no'
+
+def test_yes():
+    assert choose(True) == 'yes'
+",
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel()
+            .arg("--cov")
+            .arg("--cov-branch")
+            .arg("--cov-report=json")
+            .arg("--status-level=none")
+            .arg("test_branch_json.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+
+    let json = context.read_file("coverage.json");
+    insta::assert_snapshot!(json, @r#"
+    {
+      "meta": {
+        "format": 2,
+        "version": "karva"
+      },
+      "files": {
+        "test_branch_json.py": {
+          "executed_lines": [
+            2,
+            3,
+            4,
+            7,
+            8
+          ],
+          "summary": {
+            "covered_lines": 5,
+            "num_statements": 6,
+            "percent_covered": 75.0,
+            "missing_lines": [
+              5
+            ],
+            "excluded_lines": [],
+            "num_branches": 2,
+            "num_partial_branches": 1,
+            "covered_branches": 1,
+            "missing_branches": 1,
+            "percent_branches_covered": 50.0
+          },
+          "missing_lines": [
+            5
+          ],
+          "excluded_lines": [],
+          "executed_branches": [
+            [
+              3,
+              4
+            ]
+          ],
+          "missing_branches": [
+            [
+              3,
+              5
+            ]
+          ]
+        }
+      },
+      "totals": {
+        "covered_lines": 5,
+        "num_statements": 6,
+        "percent_covered": 75.0,
+        "num_branches": 2,
+        "num_partial_branches": 1,
+        "covered_branches": 1,
+        "missing_branches": 1,
+        "percent_branches_covered": 50.0
+      }
+    }
+    "#);
+}
+
+#[test]
+fn test_cov_branch_can_be_enabled_from_config() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.default.coverage]
+sources = [""]
+branch = true
+"#,
+        ),
+        (
+            "test_branch_config.py",
+            r"
+def choose(flag):
+    if flag:
+        return 'yes'
+    return 'no'
+
+def test_yes():
+    assert choose(True) == 'yes'
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel()
+            .arg("--cov-report=term-missing")
+            .arg("--status-level=none")
+            .arg("test_branch_config.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    Name                    Stmts   Miss   Branch   BrPart   Cover   Missing
+    [LONG-LINE]
+    test_branch_config.py       6      1        2        1     75%   5
+    [LONG-LINE]
+    TOTAL                       6      1        2        1     75%
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
 fn test_cov_saves_on_test_failure() {
     let context = TestContext::with_file(
         "test_failing.py",

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -208,6 +208,10 @@ pub struct SubTestCommand {
     )]
     pub cov_context: Option<crate::CovContext>,
 
+    /// Measure branch coverage in addition to line coverage.
+    #[clap(long = "cov-branch", action = clap::ArgAction::SetTrue, help_heading = "Coverage options")]
+    pub cov_branch: bool,
+
     /// Disable coverage measurement for this run.
     ///
     /// Overrides any `--cov` flag and any `[coverage] sources` configured in
@@ -425,6 +429,7 @@ impl SubTestCommand {
                     | CovReport::Html { path } => path.as_ref().map(ToString::to_string),
                     CovReport::Term | CovReport::TermMissing => None,
                 }),
+                branch: self.cov_branch.then_some(true),
                 fail_under: self.cov_fail_under.map(CovFailUnder),
                 disabled: self.no_cov.then_some(true),
             }),

--- a/crates/karva_coverage/src/branches.rs
+++ b/crates/karva_coverage/src/branches.rs
@@ -1,0 +1,328 @@
+//! Compute branch destinations for Python source files.
+
+use std::collections::{BTreeSet, HashSet};
+use std::io;
+use std::path::Path;
+
+use fs_err as fs;
+use ruff_python_ast::helpers::is_docstring_stmt;
+use ruff_python_ast::{
+    ElifElseClause, ExceptHandler, MatchCase, Stmt, StmtClassDef, StmtFunctionDef, StmtIf,
+    StmtMatch,
+};
+use ruff_python_parser::{Mode, ParseOptions, parse_unchecked};
+use ruff_source_file::LineIndex;
+use ruff_text_size::{Ranged, TextSize};
+
+use crate::data::BranchArc;
+use crate::executable::pragma_no_cover_lines;
+
+#[expect(
+    clippy::redundant_pub_crate,
+    reason = "sibling modules use this helper, while unreachable_pub rejects `pub` here"
+)]
+pub(crate) fn branch_arcs(path: &Path) -> io::Result<BTreeSet<BranchArc>> {
+    let source = fs::read_to_string(path)?;
+    Ok(branch_arcs_for_source(&source))
+}
+
+fn branch_arcs_for_source(source: &str) -> BTreeSet<BranchArc> {
+    let Some(parsed) = parse_unchecked(source, ParseOptions::from(Mode::Module)).try_into_module()
+    else {
+        return BTreeSet::new();
+    };
+    let line_index = LineIndex::from_source_text(source);
+    let pragma_lines = pragma_no_cover_lines(&parsed, source, &line_index);
+    let module = parsed.into_syntax();
+    let executable = crate::executable::executable_lines_for_source(source);
+    let mut collector = BranchCollector {
+        line_index: &line_index,
+        pragma_lines: &pragma_lines,
+        executable: &executable,
+        arcs: BTreeSet::new(),
+    };
+    collector.visit_body(&module.body, None);
+    collector.arcs
+}
+
+struct BranchCollector<'a> {
+    line_index: &'a LineIndex,
+    pragma_lines: &'a HashSet<u32>,
+    executable: &'a HashSet<u32>,
+    arcs: BTreeSet<BranchArc>,
+}
+
+impl BranchCollector<'_> {
+    fn visit_body(&mut self, body: &[Stmt], next: Option<i32>) {
+        let body = skip_docstring(body);
+        for (idx, stmt) in body.iter().enumerate() {
+            let stmt_next = self
+                .first_executable_in_body(&body[idx + 1..])
+                .map(line_to_i32)
+                .or(next);
+            self.visit_stmt(stmt, stmt_next);
+        }
+    }
+
+    fn visit_stmt(&mut self, stmt: &Stmt, next: Option<i32>) {
+        if self.line_has_pragma(stmt_line_offset(stmt)) {
+            return;
+        }
+
+        match stmt {
+            Stmt::FunctionDef(stmt) => self.visit_function_def(stmt),
+            Stmt::ClassDef(stmt) => self.visit_class_def(stmt),
+            Stmt::If(stmt) => self.visit_if(stmt, next),
+            Stmt::For(stmt) => {
+                let line = self.line(stmt.range().start());
+                self.add_branch(line, [self.first_executable_i32(&stmt.body), next]);
+                self.visit_body(&stmt.body, line.map(line_to_i32));
+                self.visit_body(&stmt.orelse, next);
+            }
+            Stmt::While(stmt) => {
+                let line = self.line(stmt.range().start());
+                if !is_constant_true_while(stmt) {
+                    self.add_branch(line, [self.first_executable_i32(&stmt.body), next]);
+                }
+                self.visit_body(&stmt.body, line.map(line_to_i32));
+                self.visit_body(&stmt.orelse, next);
+            }
+            Stmt::Try(stmt) => {
+                self.visit_body(&stmt.body, next);
+                for handler in &stmt.handlers {
+                    self.visit_except_handler(handler, next);
+                }
+                self.visit_body(&stmt.orelse, next);
+                self.visit_body(&stmt.finalbody, next);
+            }
+            Stmt::Match(stmt) => self.visit_match(stmt, next),
+            _ => {}
+        }
+    }
+
+    fn visit_function_def(&mut self, stmt: &StmtFunctionDef) {
+        let exit = self
+            .line(stmt.name.range().start())
+            .map(|line| -line_to_i32(line));
+        self.visit_body(&stmt.body, exit);
+    }
+
+    fn visit_class_def(&mut self, stmt: &StmtClassDef) {
+        let exit = self
+            .line(stmt.name.range().start())
+            .map(|line| -line_to_i32(line));
+        self.visit_body(&stmt.body, exit);
+    }
+
+    fn visit_if(&mut self, stmt: &StmtIf, next: Option<i32>) {
+        let line = self.line(stmt.range().start());
+        let alternate = self.if_alternate_target(stmt, next);
+        self.add_branch(line, [self.first_executable_i32(&stmt.body), alternate]);
+        self.visit_body(&stmt.body, next);
+
+        for (idx, clause) in stmt.elif_else_clauses.iter().enumerate() {
+            if self.line_has_pragma(clause.range().start()) {
+                continue;
+            }
+            if clause.test.is_some() {
+                let clause_line = self.line(clause.range().start());
+                let alternate = self.next_clause_target(&stmt.elif_else_clauses[idx + 1..], next);
+                self.add_branch(
+                    clause_line,
+                    [self.first_executable_i32(&clause.body), alternate],
+                );
+            }
+            self.visit_body(&clause.body, next);
+        }
+    }
+
+    fn visit_match(&mut self, stmt: &StmtMatch, next: Option<i32>) {
+        for (idx, case) in stmt.cases.iter().enumerate() {
+            if self.line_has_pragma(case.range().start()) {
+                continue;
+            }
+            if !case.pattern.is_irrefutable() || case.guard.is_some() {
+                let line = self.line(case.range().start());
+                let alternate = self.next_match_case_target(&stmt.cases[idx + 1..], next);
+                self.add_branch(line, [self.first_executable_i32(&case.body), alternate]);
+            }
+            self.visit_body(&case.body, next);
+        }
+    }
+
+    fn visit_except_handler(&mut self, handler: &ExceptHandler, next: Option<i32>) {
+        match handler {
+            ExceptHandler::ExceptHandler(handler) => self.visit_body(&handler.body, next),
+        }
+    }
+
+    fn if_alternate_target(&self, stmt: &StmtIf, next: Option<i32>) -> Option<i32> {
+        self.next_clause_target(&stmt.elif_else_clauses, next)
+    }
+
+    fn next_clause_target(&self, clauses: &[ElifElseClause], next: Option<i32>) -> Option<i32> {
+        if clauses.is_empty() {
+            next
+        } else {
+            clauses.iter().find_map(|clause| self.clause_target(clause))
+        }
+    }
+
+    fn clause_target(&self, clause: &ElifElseClause) -> Option<i32> {
+        if self.line_has_pragma(clause.range().start()) {
+            return None;
+        }
+        if clause.test.is_some() {
+            self.line(clause.range().start()).map(line_to_i32)
+        } else {
+            self.first_executable_i32(&clause.body)
+        }
+    }
+
+    fn match_case_target(&self, case: &MatchCase) -> Option<i32> {
+        if self.line_has_pragma(case.range().start()) {
+            return None;
+        }
+        self.line(case.range().start()).map(line_to_i32)
+    }
+
+    fn next_match_case_target(&self, cases: &[MatchCase], next: Option<i32>) -> Option<i32> {
+        if cases.is_empty() {
+            next
+        } else {
+            cases.iter().find_map(|case| self.match_case_target(case))
+        }
+    }
+
+    fn first_executable_i32(&self, body: &[Stmt]) -> Option<i32> {
+        self.first_executable_in_body(body).map(line_to_i32)
+    }
+
+    fn first_executable_in_body(&self, body: &[Stmt]) -> Option<u32> {
+        skip_docstring(body)
+            .iter()
+            .filter(|stmt| !self.line_has_pragma(stmt_line_offset(stmt)))
+            .find_map(|stmt| self.line(stmt_line_offset(stmt)))
+            .filter(|line| self.executable.contains(line))
+    }
+
+    fn add_branch<const N: usize>(&mut self, from: Option<u32>, targets: [Option<i32>; N]) {
+        let Some(from) = from else {
+            return;
+        };
+        let targets: BTreeSet<i32> = targets.into_iter().flatten().collect();
+        if targets.len() < 2 {
+            return;
+        }
+        for to in targets {
+            self.arcs.insert(BranchArc {
+                from: line_to_i32(from),
+                to,
+            });
+        }
+    }
+
+    fn line(&self, offset: TextSize) -> Option<u32> {
+        u32::try_from(self.line_index.line_index(offset).get()).ok()
+    }
+
+    fn line_has_pragma(&self, offset: TextSize) -> bool {
+        self.line(offset)
+            .is_some_and(|line| self.pragma_lines.contains(&line))
+    }
+}
+
+fn stmt_line_offset(stmt: &Stmt) -> TextSize {
+    match stmt {
+        Stmt::FunctionDef(stmt) => stmt.name.range().start(),
+        Stmt::ClassDef(stmt) => stmt.name.range().start(),
+        _ => stmt.range().start(),
+    }
+}
+
+fn skip_docstring(body: &[Stmt]) -> &[Stmt] {
+    let start = usize::from(body.first().is_some_and(is_docstring_stmt));
+    &body[start..]
+}
+
+fn line_to_i32(line: u32) -> i32 {
+    i32::try_from(line).unwrap_or(i32::MAX)
+}
+
+fn is_constant_true_while(stmt: &ruff_python_ast::StmtWhile) -> bool {
+    matches!(&*stmt.test, ruff_python_ast::Expr::BooleanLiteral(value) if value.value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn arcs(source: &str) -> Vec<(i32, i32)> {
+        branch_arcs_for_source(source)
+            .into_iter()
+            .map(|arc| (arc.from, arc.to))
+            .collect()
+    }
+
+    #[test]
+    fn if_else_arcs_point_to_bodies() {
+        let source = "\
+def f(x):
+    if x:
+        return 1
+    return 0
+";
+
+        assert_eq!(arcs(source), vec![(2, 3), (2, 4)]);
+    }
+
+    #[test]
+    fn if_without_fallthrough_uses_function_exit() {
+        let source = "\
+def f(x):
+    if x:
+        return 1
+";
+
+        assert_eq!(arcs(source), vec![(2, -1), (2, 3)]);
+    }
+
+    #[test]
+    fn loop_arcs_point_to_body_and_exit() {
+        let source = "\
+def f(items):
+    for item in items:
+        print(item)
+    return None
+";
+
+        assert_eq!(arcs(source), vec![(2, 3), (2, 4)]);
+    }
+
+    #[test]
+    fn match_case_arcs_point_to_body_and_next_case() {
+        let source = "\
+def f(x):
+    match x:
+        case 1:
+            return 1
+        case _:
+            return 0
+";
+
+        assert_eq!(arcs(source), vec![(3, 4), (3, 5)]);
+    }
+
+    #[test]
+    fn pragma_excluded_choice_removes_branch() {
+        let source = "\
+def f(x):
+    if x:
+        return 1
+    else:  # pragma: no cover
+        return 0
+";
+
+        assert!(arcs(source).is_empty());
+    }
+}

--- a/crates/karva_coverage/src/data.rs
+++ b/crates/karva_coverage/src/data.rs
@@ -16,4 +16,26 @@ pub struct FileEntry {
     pub executed: Vec<u32>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub contexts: BTreeMap<u32, BTreeSet<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branches: Option<BranchEntry>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+pub struct BranchArc {
+    pub from: i32,
+    pub to: i32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BranchEntry {
+    pub possible: Vec<BranchArc>,
+    pub executed: Vec<BranchArc>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub contexts: Vec<BranchContextEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BranchContextEntry {
+    pub arc: BranchArc,
+    pub contexts: BTreeSet<String>,
 }

--- a/crates/karva_coverage/src/executable.rs
+++ b/crates/karva_coverage/src/executable.rs
@@ -51,7 +51,7 @@ pub fn executable_lines_for_source(source: &str) -> HashSet<u32> {
 /// Collect the set of line numbers carrying a `# pragma: no cover` comment.
 /// Match is case-insensitive and tolerant of surrounding whitespace, mirroring
 /// coverage.py's default `exclude_lines` regex.
-fn pragma_no_cover_lines<T>(
+pub(crate) fn pragma_no_cover_lines<T>(
     parsed: &ruff_python_parser::Parsed<T>,
     source: &str,
     line_index: &LineIndex,

--- a/crates/karva_coverage/src/lib.rs
+++ b/crates/karva_coverage/src/lib.rs
@@ -15,6 +15,7 @@
 
 #![warn(unreachable_pub)]
 
+pub(crate) mod branches;
 pub mod data;
 pub mod executable;
 pub mod report;

--- a/crates/karva_coverage/src/report/coveragepy.rs
+++ b/crates/karva_coverage/src/report/coveragepy.rs
@@ -21,6 +21,7 @@ const SQLITE_WRITER: &str = include_str!("../../../../python/karva/_coverage_sql
 
 #[derive(Serialize)]
 struct SqlitePayload {
+    has_arcs: bool,
     files: Vec<SqliteFileRow>,
 }
 
@@ -28,12 +29,19 @@ struct SqlitePayload {
 struct SqliteFileRow {
     path: String,
     contexts: Vec<SqliteContextRow>,
+    arcs: Vec<SqliteArcContextRow>,
 }
 
 #[derive(Serialize)]
 struct SqliteContextRow {
     context: String,
     numbits: Vec<u8>,
+}
+
+#[derive(Serialize)]
+struct SqliteArcContextRow {
+    context: String,
+    arcs: Vec<[i32; 2]>,
 }
 
 pub fn write_coveragepy_sqlite(
@@ -128,6 +136,7 @@ fn python_writer_error(output_status: &Output) -> Result<()> {
 
 fn sqlite_payload(rows: &[FileRow]) -> SqlitePayload {
     SqlitePayload {
+        has_arcs: rows.iter().any(|row| row.branches_enabled),
         files: rows
             .iter()
             .map(|row| SqliteFileRow {
@@ -138,6 +147,14 @@ fn sqlite_payload(rows: &[FileRow]) -> SqlitePayload {
                     .map(|(context, lines)| SqliteContextRow {
                         context,
                         numbits: nums_to_numbits(&lines),
+                    })
+                    .collect(),
+                arcs: arcs_by_context(row)
+                    .into_iter()
+                    .filter(|(_, arcs)| !arcs.is_empty())
+                    .map(|(context, arcs)| SqliteArcContextRow {
+                        context,
+                        arcs: arcs.into_iter().map(|arc| [arc.from, arc.to]).collect(),
                     })
                     .collect(),
             })
@@ -214,6 +231,30 @@ fn lines_by_context(row: &FileRow) -> BTreeMap<String, BTreeSet<u32>> {
     lines_by_context
 }
 
+fn arcs_by_context(row: &FileRow) -> BTreeMap<String, BTreeSet<crate::data::BranchArc>> {
+    let mut arcs_by_context: BTreeMap<String, BTreeSet<crate::data::BranchArc>> = BTreeMap::new();
+
+    for arc in &row.arcs {
+        if let Some(contexts) = row.arc_contexts.get(arc)
+            && !contexts.is_empty()
+        {
+            for context in contexts {
+                arcs_by_context
+                    .entry(context.clone())
+                    .or_default()
+                    .insert(*arc);
+            }
+        } else {
+            arcs_by_context
+                .entry(String::new())
+                .or_default()
+                .insert(*arc);
+        }
+    }
+
+    arcs_by_context
+}
+
 fn nums_to_numbits(lines: &BTreeSet<u32>) -> Vec<u8> {
     let Some(max_line) = lines.iter().next_back() else {
         return Vec::new();
@@ -234,7 +275,7 @@ mod tests {
     use pyo3::types::PyDict;
 
     use super::*;
-    use crate::data::{FileEntry, WorkerFile};
+    use crate::data::{BranchArc, BranchEntry, FileEntry, WorkerFile};
 
     type CoverageData = (u32, String, u32, Vec<(String, String)>);
 
@@ -275,6 +316,7 @@ mod tests {
                             ),
                             (6, BTreeSet::from(["test_mod::test_one".to_string()])),
                         ]),
+                        branches: None,
                     },
                 ),
                 (
@@ -283,6 +325,7 @@ mod tests {
                         executable: vec![1, 2],
                         executed: Vec::new(),
                         contexts: BTreeMap::new(),
+                        branches: None,
                     },
                 ),
             ]),
@@ -317,6 +360,48 @@ mod tests {
         );
     }
 
+    #[test]
+    fn write_coveragepy_sqlite_writes_branch_arcs() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).expect("utf8 temp dir");
+        let worker_file = root.join("worker.json");
+        let output = root.join(".coverage");
+        let app = root.join("src/app.py");
+        let worker = WorkerFile {
+            files: BTreeMap::from([(
+                app.to_string(),
+                FileEntry {
+                    executable: vec![1, 2, 3, 4],
+                    executed: vec![1, 2, 3],
+                    contexts: BTreeMap::new(),
+                    branches: Some(BranchEntry {
+                        possible: vec![BranchArc { from: 2, to: 3 }, BranchArc { from: 2, to: 4 }],
+                        executed: vec![
+                            BranchArc { from: -1, to: 1 },
+                            BranchArc { from: 1, to: 2 },
+                            BranchArc { from: 2, to: 3 },
+                            BranchArc { from: 3, to: -1 },
+                        ],
+                        contexts: Vec::new(),
+                    }),
+                },
+            )]),
+        };
+        fs::write(
+            &worker_file,
+            serde_json::to_vec(&worker).expect("serialize worker file"),
+        )
+        .expect("write worker file");
+
+        write_coveragepy_sqlite(&root, &[worker_file], &output, &CoverageFilters::default())
+            .expect("write coverage.py sqlite");
+
+        let (has_arcs, arcs) = query_arc_data(&output, &app).expect("query arc data");
+
+        assert_eq!(has_arcs, "1");
+        assert_eq!(arcs, vec![(-1, 1), (1, 2), (2, 3), (3, -1)]);
+    }
+
     fn query_coverage_data(output: &Utf8Path, app: &Utf8Path) -> PyResult<CoverageData> {
         Python::initialize();
         Python::attach(|py| {
@@ -341,6 +426,44 @@ try:
                 JOIN file ON file.id = line_bits.file_id
                 WHERE file.path = ?
                 ORDER BY context.context
+                """,
+            (app,),
+        )),
+    )
+finally:
+    conn.close()
+"#,
+                None,
+                Some(&locals),
+            )?;
+            locals
+                .get_item("result")?
+                .expect("result should be set")
+                .extract()
+        })
+    }
+
+    fn query_arc_data(output: &Utf8Path, app: &Utf8Path) -> PyResult<(String, Vec<(i32, i32)>)> {
+        Python::initialize();
+        Python::attach(|py| {
+            let locals = PyDict::new(py);
+            locals.set_item("output", output.as_str())?;
+            locals.set_item("app", app.as_str())?;
+            py.run(
+                cr#"
+import sqlite3
+
+conn = sqlite3.connect(output)
+try:
+    result = (
+        conn.execute("SELECT value FROM meta WHERE key = 'has_arcs'").fetchone()[0],
+        list(conn.execute(
+            """
+                SELECT arc.fromno, arc.tono
+                FROM arc
+                JOIN file ON file.id = arc.file_id
+                WHERE file.path = ?
+                ORDER BY arc.fromno, arc.tono
                 """,
             (app,),
         )),

--- a/crates/karva_coverage/src/report/html.rs
+++ b/crates/karva_coverage/src/report/html.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use super::shared::{FileRow, escape_html, format_percent, totals_row};
+use super::shared::{FileRow, escape_html, format_percent, row_percent, totals_row};
 
 pub(super) fn build_html_report(rows: &[FileRow]) -> String {
     HtmlReport { rows }.to_string()
@@ -30,39 +30,73 @@ impl fmt::Display for HtmlReport<'_> {
         writeln!(html, "  <h1>Coverage report</h1>")?;
 
         let total = totals_row(self.rows);
+        let show_branches = total.branches_enabled;
         writeln!(
             html,
-            "  <p>Total coverage: <strong>{}</strong> ({}/{})</p>",
-            format_percent(total.stmts, total.miss),
+            "  <p>Total coverage: <strong>{:.0}%</strong> ({}/{})</p>",
+            row_percent(&total),
             total.hit,
             total.stmts
         )?;
         writeln!(html, "  <table>")?;
         writeln!(html, "    <thead>")?;
-        writeln!(
-            html,
-            "      <tr><th>Name</th><th>Stmts</th><th>Miss</th><th>Cover</th><th>Missing</th></tr>"
-        )?;
+        if show_branches {
+            writeln!(
+                html,
+                "      <tr><th>Name</th><th>Stmts</th><th>Miss</th><th>Branch</th><th>BrPart</th><th>Cover</th><th>Missing</th></tr>"
+            )?;
+        } else {
+            writeln!(
+                html,
+                "      <tr><th>Name</th><th>Stmts</th><th>Miss</th><th>Cover</th><th>Missing</th></tr>"
+            )?;
+        }
         writeln!(html, "    </thead>")?;
         writeln!(html, "    <tbody>")?;
         for row in self.rows {
+            if show_branches {
+                writeln!(
+                    html,
+                    "      <tr><td><code>{}</code></td><td class=\"num\">{}</td><td class=\"num\">{}</td><td class=\"num\">{}</td><td class=\"num\">{}</td><td class=\"num\">{:.0}%</td><td><code>{}</code></td></tr>",
+                    escape_html(&row.name),
+                    row.stmts,
+                    row.miss,
+                    row.branches,
+                    row.branch_partial,
+                    row_percent(row),
+                    escape_html(&row.missing)
+                )?;
+            } else {
+                writeln!(
+                    html,
+                    "      <tr><td><code>{}</code></td><td class=\"num\">{}</td><td class=\"num\">{}</td><td class=\"num\">{}</td><td><code>{}</code></td></tr>",
+                    escape_html(&row.name),
+                    row.stmts,
+                    row.miss,
+                    format_percent(row.stmts, row.miss),
+                    escape_html(&row.missing)
+                )?;
+            }
+        }
+        if show_branches {
             writeln!(
                 html,
-                "      <tr><td><code>{}</code></td><td class=\"num\">{}</td><td class=\"num\">{}</td><td class=\"num\">{}</td><td><code>{}</code></td></tr>",
-                escape_html(&row.name),
-                row.stmts,
-                row.miss,
-                format_percent(row.stmts, row.miss),
-                escape_html(&row.missing)
+                "      <tr><td><strong>TOTAL</strong></td><td class=\"num\"><strong>{}</strong></td><td class=\"num\"><strong>{}</strong></td><td class=\"num\"><strong>{}</strong></td><td class=\"num\"><strong>{}</strong></td><td class=\"num\"><strong>{:.0}%</strong></td><td></td></tr>",
+                total.stmts,
+                total.miss,
+                total.branches,
+                total.branch_partial,
+                row_percent(&total)
+            )?;
+        } else {
+            writeln!(
+                html,
+                "      <tr><td><strong>TOTAL</strong></td><td class=\"num\"><strong>{}</strong></td><td class=\"num\"><strong>{}</strong></td><td class=\"num\"><strong>{}</strong></td><td></td></tr>",
+                total.stmts,
+                total.miss,
+                format_percent(total.stmts, total.miss)
             )?;
         }
-        writeln!(
-            html,
-            "      <tr><td><strong>TOTAL</strong></td><td class=\"num\"><strong>{}</strong></td><td class=\"num\"><strong>{}</strong></td><td class=\"num\"><strong>{}</strong></td><td></td></tr>",
-            total.stmts,
-            total.miss,
-            format_percent(total.stmts, total.miss)
-        )?;
         writeln!(html, "    </tbody>")?;
         writeln!(html, "  </table>")?;
         writeln!(html, "</body>")?;

--- a/crates/karva_coverage/src/report/json.rs
+++ b/crates/karva_coverage/src/report/json.rs
@@ -4,7 +4,9 @@ use std::collections::BTreeSet;
 use anyhow::{Context, Result};
 use serde::Serialize;
 
-use super::shared::{FileRow, missing_lines, percent, totals_row};
+use crate::data::BranchArc;
+
+use super::shared::{FileRow, missing_lines, percent, row_percent, totals_row};
 
 #[derive(Serialize)]
 struct JsonFileSummary {
@@ -13,6 +15,16 @@ struct JsonFileSummary {
     percent_covered: f64,
     missing_lines: Vec<u32>,
     excluded_lines: Vec<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    num_branches: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    num_partial_branches: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    covered_branches: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    missing_branches: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    percent_branches_covered: Option<f64>,
 }
 
 #[derive(Serialize)]
@@ -23,6 +35,10 @@ struct JsonFileReport {
     excluded_lines: Vec<u32>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     contexts: BTreeMap<u32, BTreeSet<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    executed_branches: Option<Vec<[i32; 2]>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    missing_branches: Option<Vec<[i32; 2]>>,
 }
 
 #[derive(Serialize)]
@@ -30,6 +46,16 @@ struct JsonTotalsSummary {
     covered_lines: u32,
     num_statements: u32,
     percent_covered: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    num_branches: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    num_partial_branches: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    covered_branches: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    missing_branches: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    percent_branches_covered: Option<f64>,
 }
 
 #[derive(Serialize)]
@@ -67,6 +93,12 @@ pub(super) fn build_json_report(rows: &[FileRow]) -> Result<String> {
                     missing_lines: missing_lines(row),
                     excluded_lines: Vec::new(),
                     contexts: row.contexts.clone(),
+                    executed_branches: row
+                        .branches_enabled
+                        .then(|| branch_pairs(&row.branch_executed)),
+                    missing_branches: row
+                        .branches_enabled
+                        .then(|| branch_pairs(&row.branch_missing)),
                 },
             )
         })
@@ -91,9 +123,16 @@ fn json_summary(row: &FileRow) -> JsonFileSummary {
     JsonFileSummary {
         covered_lines: row.hit,
         num_statements: row.stmts,
-        percent_covered: percent(row.stmts, row.miss),
+        percent_covered: row_percent(row),
         missing_lines: missing_lines(row),
         excluded_lines: Vec::new(),
+        num_branches: row.branches_enabled.then_some(row.branches),
+        num_partial_branches: row.branches_enabled.then_some(row.branch_partial),
+        covered_branches: row.branches_enabled.then_some(row.branch_hit),
+        missing_branches: row.branches_enabled.then_some(row.branch_miss),
+        percent_branches_covered: row
+            .branches_enabled
+            .then(|| percent(row.branches, row.branch_miss)),
     }
 }
 
@@ -101,6 +140,17 @@ fn json_totals_summary(row: &FileRow) -> JsonTotalsSummary {
     JsonTotalsSummary {
         covered_lines: row.hit,
         num_statements: row.stmts,
-        percent_covered: percent(row.stmts, row.miss),
+        percent_covered: row_percent(row),
+        num_branches: row.branches_enabled.then_some(row.branches),
+        num_partial_branches: row.branches_enabled.then_some(row.branch_partial),
+        covered_branches: row.branches_enabled.then_some(row.branch_hit),
+        missing_branches: row.branches_enabled.then_some(row.branch_miss),
+        percent_branches_covered: row
+            .branches_enabled
+            .then(|| percent(row.branches, row.branch_miss)),
     }
+}
+
+fn branch_pairs(arcs: &[BranchArc]) -> Vec<[i32; 2]> {
+    arcs.iter().map(|arc| [arc.from, arc.to]).collect()
 }

--- a/crates/karva_coverage/src/report/shared.rs
+++ b/crates/karva_coverage/src/report/shared.rs
@@ -4,13 +4,17 @@ use anyhow::{Context, Result};
 use camino::Utf8Path;
 use fs_err as fs;
 
-use crate::data::WorkerFile;
+use crate::data::{BranchArc, WorkerFile};
 
 #[derive(Debug, Default)]
 pub(super) struct CombinedFile {
     executable: BTreeSet<u32>,
     executed: BTreeSet<u32>,
     contexts: BTreeMap<u32, BTreeSet<String>>,
+    branches_enabled: bool,
+    branch_possible: BTreeSet<BranchArc>,
+    branch_executed: BTreeSet<BranchArc>,
+    arc_contexts: BTreeMap<BranchArc, BTreeSet<String>>,
 }
 
 pub(super) struct FileRow {
@@ -23,6 +27,16 @@ pub(super) struct FileRow {
     pub executable: Vec<u32>,
     pub executed: Vec<u32>,
     pub contexts: BTreeMap<u32, BTreeSet<String>>,
+    pub branches_enabled: bool,
+    pub branches: u32,
+    pub branch_hit: u32,
+    pub branch_miss: u32,
+    pub branch_partial: u32,
+    pub branch_possible: Vec<BranchArc>,
+    pub branch_executed: Vec<BranchArc>,
+    pub branch_missing: Vec<BranchArc>,
+    pub arcs: Vec<BranchArc>,
+    pub arc_contexts: BTreeMap<BranchArc, BTreeSet<String>>,
 }
 
 pub(super) fn combine(files: &[impl AsRef<Utf8Path>]) -> Result<BTreeMap<String, CombinedFile>> {
@@ -41,6 +55,18 @@ pub(super) fn combine(files: &[impl AsRef<Utf8Path>]) -> Result<BTreeMap<String,
             bucket.executed.extend(file_entry.executed);
             for (line, contexts) in file_entry.contexts {
                 bucket.contexts.entry(line).or_default().extend(contexts);
+            }
+            if let Some(branches) = file_entry.branches {
+                bucket.branches_enabled = true;
+                bucket.branch_possible.extend(branches.possible);
+                bucket.branch_executed.extend(branches.executed);
+                for entry in branches.contexts {
+                    bucket
+                        .arc_contexts
+                        .entry(entry.arc)
+                        .or_default()
+                        .extend(entry.contexts);
+                }
             }
         }
     }
@@ -62,13 +88,27 @@ pub(super) fn build_rows(
             let stmts = u32::try_from(executable.len()).unwrap_or(u32::MAX);
             let hit = u32::try_from(executed.len()).unwrap_or(u32::MAX);
             let miss = stmts.saturating_sub(hit);
+            let branch_executed: BTreeSet<BranchArc> = data
+                .branch_executed
+                .intersection(&data.branch_possible)
+                .copied()
+                .collect();
+            let branch_missing: BTreeSet<BranchArc> = data
+                .branch_possible
+                .difference(&branch_executed)
+                .copied()
+                .collect();
+            let branches = u32::try_from(data.branch_possible.len()).unwrap_or(u32::MAX);
+            let branch_hit = u32::try_from(branch_executed.len()).unwrap_or(u32::MAX);
+            let branch_miss = branches.saturating_sub(branch_hit);
+            let branch_partial = partial_branch_count(&data.branch_possible, &branch_executed);
             let missing = if show_missing {
                 let uncovered: BTreeSet<u32> = data
                     .executable
                     .difference(&data.executed)
                     .copied()
                     .collect();
-                collapse_ranges(&uncovered)
+                collapse_missing(&uncovered, &branch_missing)
             } else {
                 String::new()
             };
@@ -82,6 +122,16 @@ pub(super) fn build_rows(
                 executable,
                 executed,
                 contexts: data.contexts.clone(),
+                branches_enabled: data.branches_enabled,
+                branches,
+                branch_hit,
+                branch_miss,
+                branch_partial,
+                branch_possible: data.branch_possible.iter().copied().collect(),
+                branch_executed: branch_executed.iter().copied().collect(),
+                branch_missing: branch_missing.iter().copied().collect(),
+                arcs: data.branch_executed.iter().copied().collect(),
+                arc_contexts: data.arc_contexts.clone(),
             }
         })
         .collect()
@@ -94,7 +144,16 @@ pub(super) fn total_percent(rows: &[FileRow]) -> f64 {
     let total_miss = rows
         .iter()
         .fold(0_u32, |acc, row| acc.saturating_add(row.miss));
-    percent(total_stmts, total_miss)
+    let total_branches = rows
+        .iter()
+        .fold(0_u32, |acc, row| acc.saturating_add(row.branches));
+    let total_branch_miss = rows
+        .iter()
+        .fold(0_u32, |acc, row| acc.saturating_add(row.branch_miss));
+    percent(
+        total_stmts.saturating_add(total_branches),
+        total_miss.saturating_add(total_branch_miss),
+    )
 }
 
 pub(super) fn totals_row(rows: &[FileRow]) -> FileRow {
@@ -108,6 +167,18 @@ pub(super) fn totals_row(rows: &[FileRow]) -> FileRow {
         .iter()
         .fold(0_u32, |acc, row| acc.saturating_add(row.miss));
     let missing = rows.iter().flat_map(missing_lines).collect::<Vec<_>>();
+    let branches = rows
+        .iter()
+        .fold(0_u32, |acc, row| acc.saturating_add(row.branches));
+    let branch_hit = rows
+        .iter()
+        .fold(0_u32, |acc, row| acc.saturating_add(row.branch_hit));
+    let branch_miss = rows
+        .iter()
+        .fold(0_u32, |acc, row| acc.saturating_add(row.branch_miss));
+    let branch_partial = rows
+        .iter()
+        .fold(0_u32, |acc, row| acc.saturating_add(row.branch_partial));
     FileRow {
         name: "TOTAL".to_string(),
         absolute_name: String::new(),
@@ -118,6 +189,16 @@ pub(super) fn totals_row(rows: &[FileRow]) -> FileRow {
         executable: Vec::new(),
         executed: Vec::new(),
         contexts: BTreeMap::new(),
+        branches_enabled: rows.iter().any(|row| row.branches_enabled),
+        branches,
+        branch_hit,
+        branch_miss,
+        branch_partial,
+        branch_possible: Vec::new(),
+        branch_executed: Vec::new(),
+        branch_missing: Vec::new(),
+        arcs: Vec::new(),
+        arc_contexts: BTreeMap::new(),
     }
 }
 
@@ -154,6 +235,13 @@ pub(super) fn rate(hit: u32, total: u32) -> f64 {
     }
 }
 
+pub(super) fn row_percent(row: &FileRow) -> f64 {
+    percent(
+        row.stmts.saturating_add(row.branches),
+        row.miss.saturating_add(row.branch_miss),
+    )
+}
+
 pub(super) fn format_percent(total: u32, miss: u32) -> String {
     let pct = percent(total, miss);
     format!("{pct:.0}%")
@@ -183,6 +271,49 @@ fn format_range(start: u32, end: u32) -> String {
     } else {
         format!("{start}-{end}")
     }
+}
+
+fn partial_branch_count(possible: &BTreeSet<BranchArc>, executed: &BTreeSet<BranchArc>) -> u32 {
+    let mut by_source: BTreeMap<i32, (u32, u32)> = BTreeMap::new();
+    for arc in possible {
+        let entry = by_source.entry(arc.from).or_default();
+        entry.0 = entry.0.saturating_add(1);
+        if executed.contains(arc) {
+            entry.1 = entry.1.saturating_add(1);
+        }
+    }
+    u32::try_from(
+        by_source
+            .values()
+            .filter(|(possible, executed)| *executed > 0 && executed < possible)
+            .count(),
+    )
+    .unwrap_or(u32::MAX)
+}
+
+fn collapse_missing(lines: &BTreeSet<u32>, branches: &BTreeSet<BranchArc>) -> String {
+    let mut parts = Vec::new();
+    let lines_collapsed = collapse_ranges(lines);
+    if !lines_collapsed.is_empty() {
+        parts.push(lines_collapsed);
+    }
+    parts.extend(
+        branches
+            .iter()
+            .copied()
+            .filter(|arc| arc.to <= 0 || !lines.contains(&(u32::try_from(arc.to).unwrap_or(0))))
+            .map(format_branch_arc),
+    );
+    parts.join(", ")
+}
+
+pub(super) fn format_branch_arc(arc: BranchArc) -> String {
+    let to = if arc.to < 0 {
+        "exit".to_string()
+    } else {
+        arc.to.to_string()
+    };
+    format!("{}->{to}", arc.from)
 }
 
 fn simplify_path(path: &str) -> String {
@@ -330,6 +461,16 @@ mod tests {
             executable: Vec::new(),
             executed: Vec::new(),
             contexts: BTreeMap::new(),
+            branches_enabled: false,
+            branches: 0,
+            branch_hit: 0,
+            branch_miss: 0,
+            branch_partial: 0,
+            branch_possible: Vec::new(),
+            branch_executed: Vec::new(),
+            branch_missing: Vec::new(),
+            arcs: Vec::new(),
+            arc_contexts: BTreeMap::new(),
         };
 
         assert_eq!(

--- a/crates/karva_coverage/src/report/terminal.rs
+++ b/crates/karva_coverage/src/report/terminal.rs
@@ -9,7 +9,7 @@ use super::CoverageFilters;
 use super::combined_rows;
 use super::html::build_html_report;
 use super::json::build_json_report;
-use super::shared::{FileRow, format_percent, total_percent};
+use super::shared::{FileRow, row_percent, total_percent};
 use super::xml::build_cobertura_xml;
 
 pub fn combine_and_report(
@@ -101,11 +101,14 @@ struct Row<'a> {
     name: &'a str,
     stmts: &'a str,
     miss: &'a str,
+    branches: &'a str,
+    branch_partial: &'a str,
     cover: &'a str,
     missing: &'a str,
 }
 
 fn print_report(rows: &[FileRow], show_missing: bool, out: &mut dyn Write) -> Result<f64> {
+    let show_branches = rows.iter().any(|row| row.branches_enabled);
     let name_width = rows
         .iter()
         .map(|row| row.name.len())
@@ -117,10 +120,13 @@ fn print_report(rows: &[FileRow], show_missing: bool, out: &mut dyn Write) -> Re
     let header = format_row(
         name_width,
         show_missing,
+        show_branches,
         &Row {
             name: "Name",
             stmts: "Stmts",
             miss: "Miss",
+            branches: "Branch",
+            branch_partial: "BrPart",
             cover: "Cover",
             missing: "Missing",
         },
@@ -134,21 +140,29 @@ fn print_report(rows: &[FileRow], show_missing: bool, out: &mut dyn Write) -> Re
 
     let mut total_stmts: u32 = 0;
     let mut total_miss: u32 = 0;
+    let mut total_branches: u32 = 0;
+    let mut total_branch_miss: u32 = 0;
+    let mut total_branch_partial: u32 = 0;
 
     for row in rows {
-        let cover = format_percent(row.stmts, row.miss);
+        let cover = format!("{:.0}%", row_percent(row));
         let stmts_str = row.stmts.to_string();
         let miss_str = row.miss.to_string();
+        let branches_str = row.branches.to_string();
+        let branch_partial_str = row.branch_partial.to_string();
         writeln!(
             out,
             "{}",
             format_row(
                 name_width,
                 show_missing,
+                show_branches,
                 &Row {
                     name: &row.name,
                     stmts: &stmts_str,
                     miss: &miss_str,
+                    branches: &branches_str,
+                    branch_partial: &branch_partial_str,
                     cover: &cover,
                     missing: &row.missing,
                 },
@@ -156,23 +170,37 @@ fn print_report(rows: &[FileRow], show_missing: bool, out: &mut dyn Write) -> Re
         )?;
         total_stmts = total_stmts.saturating_add(row.stmts);
         total_miss = total_miss.saturating_add(row.miss);
+        total_branches = total_branches.saturating_add(row.branches);
+        total_branch_miss = total_branch_miss.saturating_add(row.branch_miss);
+        total_branch_partial = total_branch_partial.saturating_add(row.branch_partial);
     }
 
     writeln!(out, "{rule}")?;
     let total_pct = total_percent(rows);
-    let total_cover = format_percent(total_stmts, total_miss);
+    let total_cover = format!(
+        "{:.0}%",
+        super::shared::percent(
+            total_stmts.saturating_add(total_branches),
+            total_miss.saturating_add(total_branch_miss),
+        )
+    );
     let total_stmts_str = total_stmts.to_string();
     let total_miss_str = total_miss.to_string();
+    let total_branches_str = total_branches.to_string();
+    let total_branch_partial_str = total_branch_partial.to_string();
     writeln!(
         out,
         "{}",
         format_row(
             name_width,
             show_missing,
+            show_branches,
             &Row {
                 name: "TOTAL",
                 stmts: &total_stmts_str,
                 miss: &total_miss_str,
+                branches: &total_branches_str,
+                branch_partial: &total_branch_partial_str,
                 cover: &total_cover,
                 missing: "",
             },
@@ -182,17 +210,34 @@ fn print_report(rows: &[FileRow], show_missing: bool, out: &mut dyn Write) -> Re
     Ok(total_pct)
 }
 
-fn format_row(name_width: usize, show_missing: bool, row: &Row<'_>) -> String {
-    let base = format!(
-        "{name:<name_width$}   {stmts:>stmts_w$}   {miss:>miss_w$}   {cover:>cover_w$}",
-        name = row.name,
-        stmts = row.stmts,
-        miss = row.miss,
-        cover = row.cover,
-        stmts_w = "Stmts".len(),
-        miss_w = "Miss".len(),
-        cover_w = "Cover".len(),
-    );
+fn format_row(name_width: usize, show_missing: bool, show_branches: bool, row: &Row<'_>) -> String {
+    let base = if show_branches {
+        format!(
+            "{name:<name_width$}   {stmts:>stmts_w$}   {miss:>miss_w$}   {branches:>branches_w$}   {branch_partial:>branch_partial_w$}   {cover:>cover_w$}",
+            name = row.name,
+            stmts = row.stmts,
+            miss = row.miss,
+            branches = row.branches,
+            branch_partial = row.branch_partial,
+            cover = row.cover,
+            stmts_w = "Stmts".len(),
+            miss_w = "Miss".len(),
+            branches_w = "Branch".len(),
+            branch_partial_w = "BrPart".len(),
+            cover_w = "Cover".len(),
+        )
+    } else {
+        format!(
+            "{name:<name_width$}   {stmts:>stmts_w$}   {miss:>miss_w$}   {cover:>cover_w$}",
+            name = row.name,
+            stmts = row.stmts,
+            miss = row.miss,
+            cover = row.cover,
+            stmts_w = "Stmts".len(),
+            miss_w = "Miss".len(),
+            cover_w = "Cover".len(),
+        )
+    };
     if show_missing && !row.missing.is_empty() {
         format!("{base}   {missing}", missing = row.missing)
     } else {
@@ -217,6 +262,16 @@ mod tests {
             executable: Vec::new(),
             executed: Vec::new(),
             contexts: BTreeMap::new(),
+            branches_enabled: false,
+            branches: 0,
+            branch_hit: 0,
+            branch_miss: 0,
+            branch_partial: 0,
+            branch_possible: Vec::new(),
+            branch_executed: Vec::new(),
+            branch_missing: Vec::new(),
+            arcs: Vec::new(),
+            arc_contexts: BTreeMap::new(),
         }
     }
 

--- a/crates/karva_coverage/src/report/xml.rs
+++ b/crates/karva_coverage/src/report/xml.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::fmt::Write as _;
 use std::time::UNIX_EPOCH;
@@ -20,6 +21,18 @@ pub(super) fn build_cobertura_xml(
         .iter()
         .fold(0_u32, |acc, row| acc.saturating_add(row.hit));
     let line_rate = rate(total_hit, total_stmts);
+    let total_branches = rows
+        .iter()
+        .fold(0_u32, |acc, row| acc.saturating_add(row.branches));
+    let total_branch_hit = rows
+        .iter()
+        .fold(0_u32, |acc, row| acc.saturating_add(row.branch_hit));
+    let branch_mode = rows.iter().any(|row| row.branches_enabled);
+    let branch_rate = if branch_mode {
+        rate(total_branch_hit, total_branches)
+    } else {
+        0.0
+    };
     let timestamp = fs::metadata(cwd)
         .with_context(|| format!("failed to read coverage root metadata {cwd}"))?
         .modified()
@@ -33,7 +46,7 @@ pub(super) fn build_cobertura_xml(
     xml.push_str("<?xml version=\"1.0\" ?>\n");
     writeln!(
         xml,
-        "<coverage version=\"1.0\" timestamp=\"{timestamp}\" lines-valid=\"{total_stmts}\" lines-covered=\"{total_hit}\" line-rate=\"{line_rate:.4}\" branches-covered=\"0\" branches-valid=\"0\" branch-rate=\"0.0000\" complexity=\"0.0\">"
+        "<coverage version=\"1.0\" timestamp=\"{timestamp}\" lines-valid=\"{total_stmts}\" lines-covered=\"{total_hit}\" line-rate=\"{line_rate:.4}\" branches-covered=\"{total_branch_hit}\" branches-valid=\"{total_branches}\" branch-rate=\"{branch_rate:.4}\" complexity=\"0.0\">"
     )?;
     xml.push_str("  <sources>\n");
     writeln!(xml, "    <source>{}</source>", escape_xml(&source_root))?;
@@ -41,7 +54,7 @@ pub(super) fn build_cobertura_xml(
     xml.push_str("  <packages>\n");
     writeln!(
         xml,
-        "    <package name=\".\" line-rate=\"{line_rate:.4}\" branch-rate=\"0.0000\" complexity=\"0.0\">",
+        "    <package name=\".\" line-rate=\"{line_rate:.4}\" branch-rate=\"{branch_rate:.4}\" complexity=\"0.0\">",
     )?;
     xml.push_str("      <classes>\n");
 
@@ -49,20 +62,34 @@ pub(super) fn build_cobertura_xml(
         let filename = class_filename(row, cwd_real);
         writeln!(
             xml,
-            "        <class name=\"{}\" filename=\"{}\" line-rate=\"{:.4}\" branch-rate=\"0.0000\" complexity=\"0.0\">",
+            "        <class name=\"{}\" filename=\"{}\" line-rate=\"{:.4}\" branch-rate=\"{:.4}\" complexity=\"0.0\">",
             escape_xml(&row.name),
             escape_xml(&filename),
-            rate(row.hit, row.stmts)
+            rate(row.hit, row.stmts),
+            if row.branches_enabled {
+                rate(row.branch_hit, row.branches)
+            } else {
+                0.0
+            }
         )?;
         xml.push_str("          <methods/>\n");
         xml.push_str("          <lines>\n");
         let executed: BTreeSet<u32> = row.executed.iter().copied().collect();
+        let branch_lines = branch_lines(row);
         for line in &row.executable {
             let hits = i32::from(executed.contains(line));
-            writeln!(
-                xml,
-                "            <line number=\"{line}\" hits=\"{hits}\" branch=\"false\"/>"
-            )?;
+            if let Some((covered, total)) = branch_lines.get(line) {
+                let pct = rate(*covered, *total) * 100.0;
+                writeln!(
+                    xml,
+                    "            <line number=\"{line}\" hits=\"{hits}\" branch=\"true\" condition-coverage=\"{pct:.0}% ({covered}/{total})\"/>"
+                )?;
+            } else {
+                writeln!(
+                    xml,
+                    "            <line number=\"{line}\" hits=\"{hits}\" branch=\"false\"/>"
+                )?;
+            }
         }
         xml.push_str("          </lines>\n");
         xml.push_str("        </class>\n");
@@ -73,6 +100,22 @@ pub(super) fn build_cobertura_xml(
     xml.push_str("  </packages>\n");
     xml.push_str("</coverage>\n");
     Ok(xml)
+}
+
+fn branch_lines(row: &FileRow) -> BTreeMap<u32, (u32, u32)> {
+    let executed: BTreeSet<_> = row.branch_executed.iter().copied().collect();
+    let mut lines: BTreeMap<u32, (u32, u32)> = BTreeMap::new();
+    for arc in &row.branch_possible {
+        let Ok(line) = u32::try_from(arc.from) else {
+            continue;
+        };
+        let entry = lines.entry(line).or_default();
+        if executed.contains(arc) {
+            entry.0 = entry.0.saturating_add(1);
+        }
+        entry.1 = entry.1.saturating_add(1);
+    }
+    lines
 }
 
 #[cfg(test)]

--- a/crates/karva_coverage/src/tracer.rs
+++ b/crates/karva_coverage/src/tracer.rs
@@ -13,7 +13,8 @@ use camino::{Utf8Path, Utf8PathBuf};
 use fs_err as fs;
 use pyo3::prelude::*;
 
-use crate::data::{FileEntry, WorkerFile};
+use crate::branches::branch_arcs;
+use crate::data::{BranchArc, BranchContextEntry, BranchEntry, FileEntry, WorkerFile};
 use crate::executable::executable_lines;
 
 /// Configuration for a single worker's coverage measurement.
@@ -28,6 +29,9 @@ pub struct CoverageConfig {
 
     /// Whether to record the current test context for each executed line.
     pub contexts: bool,
+
+    /// Whether to record branch arcs in addition to executed lines.
+    pub branches: bool,
 }
 
 /// Path components inside a source root that suppress tracking. These match
@@ -62,6 +66,7 @@ impl CoverageSession {
             CoverageTracer {
                 roots,
                 contexts: config.contexts,
+                branches: config.branches,
                 state: Mutex::new(TracerState::default()),
                 monitoring_tool_id: OnceLock::new(),
                 monitoring_disable: OnceLock::new(),
@@ -96,22 +101,36 @@ impl CoverageSession {
         }
 
         let borrowed = bound.borrow();
-        let (executed, contexts) = match borrowed.state.lock() {
+        let (executed, contexts, arcs, arc_contexts) = match borrowed.state.lock() {
             Ok(mut state) => (
                 std::mem::take(&mut state.executed),
                 std::mem::take(&mut state.contexts),
+                std::mem::take(&mut state.arcs),
+                std::mem::take(&mut state.arc_contexts),
             ),
             Err(poisoned) => {
                 let mut state = poisoned.into_inner();
                 (
                     std::mem::take(&mut state.executed),
                     std::mem::take(&mut state.contexts),
+                    std::mem::take(&mut state.arcs),
+                    std::mem::take(&mut state.arc_contexts),
                 )
             }
         };
         let roots = borrowed.roots.clone();
+        let branches = borrowed.branches;
         drop(borrowed);
-        save_data(&data_file, executed, contexts, &roots).map_err(|err| {
+        save_data(
+            &data_file,
+            executed,
+            contexts,
+            arcs,
+            arc_contexts,
+            branches,
+            &roots,
+        )
+        .map_err(|err| {
             pyo3::exceptions::PyOSError::new_err(format!(
                 "failed to write coverage data to {data_file}: {err}"
             ))
@@ -130,17 +149,34 @@ struct TracerState {
     executed: HashMap<PathBuf, HashSet<u32>>,
     /// Per-line test contexts for files with executed lines.
     contexts: HashMap<PathBuf, HashMap<u32, HashSet<String>>>,
+    /// Line-to-line arcs executed in each file.
+    arcs: HashMap<PathBuf, HashSet<BranchArc>>,
+    /// Per-arc test contexts for files with executed arcs.
+    arc_contexts: HashMap<PathBuf, HashMap<BranchArc, HashSet<String>>>,
     /// Current test context, if `--cov-context=test` is active and a test is running.
     current_context: Option<String>,
     /// Memoized result of [`compute_tracked_path`] per filename string.
     track_cache: HashMap<String, Option<PathBuf>>,
     /// Memoized result of [`compute_tracked_path`] per live Python code object.
     code_cache: HashMap<usize, TrackedCode>,
+    /// Last executed line per live Python code object for `sys.monitoring` arcs.
+    monitoring_last_lines: HashMap<usize, u32>,
+    /// Last executed line per traced frame for `sys.settrace` arcs.
+    frame_last_lines: HashMap<usize, u32>,
 }
 
 struct TrackedCode {
     code: Py<PyAny>,
     path: Option<PathBuf>,
+    first_line: i32,
+    line_ranges: Vec<CodeLineRange>,
+}
+
+#[derive(Clone)]
+struct CodeLineRange {
+    start: u32,
+    end: u32,
+    line: Option<u32>,
 }
 
 /// Thread-safe because the trace callbacks fire on whichever Python thread
@@ -153,6 +189,7 @@ struct TrackedCode {
 struct CoverageTracer {
     roots: Vec<PathBuf>,
     contexts: bool,
+    branches: bool,
     state: Mutex<TracerState>,
     monitoring_tool_id: OnceLock<u8>,
     /// Cached `sys.monitoring.DISABLE` sentinel. Populated when the
@@ -175,14 +212,54 @@ impl CoverageTracer {
         code: &Bound<'_, PyAny>,
         lineno: u32,
     ) -> PyResult<Option<Py<PyAny>>> {
-        if let Some(path) = self.tracked_code_path(code)? {
-            self.record_line(path, lineno);
+        if let Some(info) = self.tracked_code_info(code)? {
+            self.record_monitoring_line(code.as_ptr() as usize, info.path, info.first_line, lineno);
+        }
+        if self.contexts || self.branches {
+            Ok(None)
+        } else {
+            Ok(self.monitoring_disable.get().map(|d| d.clone_ref(py)))
+        }
+    }
+
+    fn branch_cb(
+        &self,
+        py: Python<'_>,
+        code: &Bound<'_, PyAny>,
+        offset: u32,
+        destination: u32,
+    ) -> PyResult<Option<Py<PyAny>>> {
+        if let Some(info) = self.tracked_code_info(code)?
+            && let Some(from) = line_for_offset(&info.line_ranges, offset)
+        {
+            let to = line_for_offset(&info.line_ranges, destination)
+                .map(line_to_i32)
+                .unwrap_or_else(|| -info.first_line);
+            self.record_arc(
+                info.path,
+                BranchArc {
+                    from: line_to_i32(from),
+                    to,
+                },
+            );
         }
         if self.contexts {
             Ok(None)
         } else {
             Ok(self.monitoring_disable.get().map(|d| d.clone_ref(py)))
         }
+    }
+
+    fn return_cb(
+        &self,
+        code: &Bound<'_, PyAny>,
+        _offset: u32,
+        _value: &Bound<'_, PyAny>,
+    ) -> PyResult<()> {
+        if let Some(info) = self.tracked_code_info(code)? {
+            self.record_monitoring_return(code.as_ptr() as usize, info.path, info.first_line);
+        }
+        Ok(())
     }
 
     /// `sys.settrace` global trace function. Returns the per-frame
@@ -219,11 +296,23 @@ impl CoverageTracer {
         _arg: &Bound<'py, PyAny>,
     ) -> PyResult<Py<PyAny>> {
         if event == "line" {
-            let filename: String = frame.getattr("f_code")?.getattr("co_filename")?.extract()?;
+            let code = frame.getattr("f_code")?;
+            let filename: String = code.getattr("co_filename")?.extract()?;
             let path = slf.borrow().tracked_path(&filename);
             if let Some(path) = path {
                 let lineno: u32 = frame.getattr("f_lineno")?.extract()?;
-                slf.borrow().record_line(path, lineno);
+                let first_line: i32 = code.getattr("co_firstlineno")?.extract()?;
+                slf.borrow()
+                    .record_frame_line(frame.as_ptr() as usize, path, first_line, lineno);
+            }
+        } else if event == "return" {
+            let code = frame.getattr("f_code")?;
+            let filename: String = code.getattr("co_filename")?.extract()?;
+            let path = slf.borrow().tracked_path(&filename);
+            if let Some(path) = path {
+                let first_line: i32 = code.getattr("co_firstlineno")?.extract()?;
+                slf.borrow()
+                    .record_frame_return(frame.as_ptr() as usize, path, first_line);
             }
         }
         Ok(slf.getattr("local_trace")?.unbind())
@@ -240,42 +329,113 @@ impl CoverageTracer {
         }
     }
 
-    fn record_line(&self, path: PathBuf, lineno: u32) {
+    fn record_monitoring_line(&self, code_id: usize, path: PathBuf, first_line: i32, lineno: u32) {
         if let Ok(mut state) = self.state.lock() {
-            if self.contexts
-                && let Some(context) = state.current_context.clone()
-            {
-                state
-                    .executed
-                    .entry(path.clone())
-                    .or_default()
-                    .insert(lineno);
-                state
-                    .contexts
-                    .entry(path)
-                    .or_default()
-                    .entry(lineno)
-                    .or_default()
-                    .insert(context);
-            } else {
-                state.executed.entry(path).or_default().insert(lineno);
+            if self.branches {
+                let arc = state
+                    .monitoring_last_lines
+                    .insert(code_id, lineno)
+                    .map_or_else(
+                        || BranchArc {
+                            from: -first_line,
+                            to: line_to_i32(lineno),
+                        },
+                        |from| BranchArc {
+                            from: line_to_i32(from),
+                            to: line_to_i32(lineno),
+                        },
+                    );
+                record_arc_in_state(&mut state, self.contexts, path.clone(), arc);
             }
+            record_line_in_state(&mut state, self.contexts, path, lineno);
+        }
+    }
+
+    fn record_monitoring_return(&self, code_id: usize, path: PathBuf, first_line: i32) {
+        if !self.branches {
+            return;
+        }
+        if let Ok(mut state) = self.state.lock()
+            && let Some(from) = state.monitoring_last_lines.remove(&code_id)
+        {
+            record_arc_in_state(
+                &mut state,
+                self.contexts,
+                path,
+                BranchArc {
+                    from: line_to_i32(from),
+                    to: -first_line,
+                },
+            );
+        }
+    }
+
+    fn record_frame_line(&self, frame_id: usize, path: PathBuf, first_line: i32, lineno: u32) {
+        if let Ok(mut state) = self.state.lock() {
+            if self.branches {
+                let arc = state.frame_last_lines.insert(frame_id, lineno).map_or_else(
+                    || BranchArc {
+                        from: -first_line,
+                        to: line_to_i32(lineno),
+                    },
+                    |from| BranchArc {
+                        from: line_to_i32(from),
+                        to: line_to_i32(lineno),
+                    },
+                );
+                record_arc_in_state(&mut state, self.contexts, path.clone(), arc);
+            }
+            record_line_in_state(&mut state, self.contexts, path, lineno);
+        }
+    }
+
+    fn record_frame_return(&self, frame_id: usize, path: PathBuf, first_line: i32) {
+        if !self.branches {
+            return;
+        }
+        if let Ok(mut state) = self.state.lock()
+            && let Some(from) = state.frame_last_lines.remove(&frame_id)
+        {
+            record_arc_in_state(
+                &mut state,
+                self.contexts,
+                path,
+                BranchArc {
+                    from: line_to_i32(from),
+                    to: -first_line,
+                },
+            );
+        }
+    }
+
+    fn record_arc(&self, path: PathBuf, arc: BranchArc) {
+        if !self.branches || arc.from == arc.to {
+            return;
+        }
+        if let Ok(mut state) = self.state.lock() {
+            record_arc_in_state(&mut state, self.contexts, path, arc);
         }
     }
 
     /// Resolve a live Python code object without extracting `co_filename`
     /// after the first line callback for that object.
-    fn tracked_code_path(&self, code: &Bound<'_, PyAny>) -> PyResult<Option<PathBuf>> {
+    fn tracked_code_info(&self, code: &Bound<'_, PyAny>) -> PyResult<Option<TrackedCodeInfo>> {
         let code_id = code.as_ptr() as usize;
         if let Ok(state) = self.state.lock()
             && let Some(cached) = state.code_cache.get(&code_id)
         {
             debug_assert!(cached.code.is(code));
-            return Ok(cached.path.clone());
+            return Ok(cached.path.clone().map(|path| TrackedCodeInfo {
+                path,
+                first_line: cached.first_line,
+                line_ranges: cached.line_ranges.clone(),
+            }));
         }
 
         let filename: String = code.getattr("co_filename")?.extract()?;
         let path = self.tracked_path(&filename);
+        let first_line = code.getattr("co_firstlineno")?.extract()?;
+        let line_ranges = code_line_ranges(code)?;
 
         if let Ok(mut state) = self.state.lock() {
             state.code_cache.insert(
@@ -283,11 +443,17 @@ impl CoverageTracer {
                 TrackedCode {
                     code: code.clone().unbind(),
                     path: path.clone(),
+                    first_line,
+                    line_ranges: line_ranges.clone(),
                 },
             );
         }
 
-        Ok(path)
+        Ok(path.map(|path| TrackedCodeInfo {
+            path,
+            first_line,
+            line_ranges,
+        }))
     }
 
     /// Resolve `filename` against the source roots. Returns the canonical
@@ -307,6 +473,80 @@ impl CoverageTracer {
         }
         resolved
     }
+}
+
+struct TrackedCodeInfo {
+    path: PathBuf,
+    first_line: i32,
+    line_ranges: Vec<CodeLineRange>,
+}
+
+fn record_line_in_state(
+    state: &mut TracerState,
+    contexts_enabled: bool,
+    path: PathBuf,
+    lineno: u32,
+) {
+    if contexts_enabled && let Some(context) = state.current_context.clone() {
+        state
+            .executed
+            .entry(path.clone())
+            .or_default()
+            .insert(lineno);
+        state
+            .contexts
+            .entry(path)
+            .or_default()
+            .entry(lineno)
+            .or_default()
+            .insert(context);
+    } else {
+        state.executed.entry(path).or_default().insert(lineno);
+    }
+}
+
+fn record_arc_in_state(
+    state: &mut TracerState,
+    contexts_enabled: bool,
+    path: PathBuf,
+    arc: BranchArc,
+) {
+    if arc.from == arc.to {
+        return;
+    }
+    if contexts_enabled && let Some(context) = state.current_context.clone() {
+        state.arcs.entry(path.clone()).or_default().insert(arc);
+        state
+            .arc_contexts
+            .entry(path)
+            .or_default()
+            .entry(arc)
+            .or_default()
+            .insert(context);
+    } else {
+        state.arcs.entry(path).or_default().insert(arc);
+    }
+}
+
+fn code_line_ranges(code: &Bound<'_, PyAny>) -> PyResult<Vec<CodeLineRange>> {
+    let mut ranges = Vec::new();
+    let co_lines = code.call_method0("co_lines")?;
+    for item in co_lines.try_iter()? {
+        let (start, end, line): (u32, u32, Option<u32>) = item?.extract()?;
+        ranges.push(CodeLineRange { start, end, line });
+    }
+    Ok(ranges)
+}
+
+fn line_for_offset(ranges: &[CodeLineRange], offset: u32) -> Option<u32> {
+    ranges
+        .iter()
+        .find(|range| range.start <= offset && offset < range.end)
+        .and_then(|range| range.line)
+}
+
+fn line_to_i32(line: u32) -> i32 {
+    i32::try_from(line).unwrap_or(i32::MAX)
 }
 
 fn compute_tracked_path(filename: &str, roots: &[PathBuf]) -> Option<PathBuf> {
@@ -337,7 +577,9 @@ fn py_version_at_least(py: Python<'_>, major: u8, minor: u8) -> PyResult<bool> {
 
 fn install_monitoring(py: Python<'_>, tracer: &Py<CoverageTracer>) -> PyResult<()> {
     let mon = py.import("sys")?.getattr("monitoring")?;
-    let line_event = mon.getattr("events")?.getattr("LINE")?;
+    let events = mon.getattr("events")?;
+    let line_event = events.getattr("LINE")?;
+    let line_event_value: u32 = line_event.extract()?;
     let disable = mon.getattr("DISABLE")?.unbind();
 
     let tool_id = (0u8..6u8)
@@ -349,11 +591,28 @@ fn install_monitoring(py: Python<'_>, tracer: &Py<CoverageTracer>) -> PyResult<(
         })?;
 
     let install_result = (|| -> PyResult<()> {
-        let callback = tracer.bind(py).getattr("line_cb")?;
+        let tracer_bound = tracer.bind(py);
+        let callback = tracer_bound.getattr("line_cb")?;
         mon.call_method1("register_callback", (tool_id, &line_event, callback))?;
-        mon.call_method1("set_events", (tool_id, &line_event))?;
+
+        let mut event_mask = line_event_value;
+        if tracer_bound.borrow().branches {
+            let branch_callback = tracer_bound.getattr("branch_cb")?;
+            for event in branch_events(&events)? {
+                mon.call_method1("register_callback", (tool_id, event, &branch_callback))?;
+                event_mask |= event;
+            }
+            let return_callback = tracer_bound.getattr("return_cb")?;
+            for event_name in ["PY_RETURN", "PY_UNWIND"] {
+                let event: u32 = events.getattr(event_name)?.extract()?;
+                mon.call_method1("register_callback", (tool_id, event, &return_callback))?;
+                event_mask |= event;
+            }
+        }
+
+        mon.call_method1("set_events", (tool_id, event_mask))?;
         {
-            let bound = tracer.bind(py).borrow();
+            let bound = tracer_bound.borrow();
             bound.monitoring_tool_id.set(tool_id).map_err(|_| {
                 pyo3::exceptions::PyRuntimeError::new_err(
                     "coverage monitoring tool id was already initialized",
@@ -374,6 +633,15 @@ fn install_monitoring(py: Python<'_>, tracer: &Py<CoverageTracer>) -> PyResult<(
     }
 
     Ok(())
+}
+
+fn branch_events(events: &Bound<'_, PyAny>) -> PyResult<Vec<u32>> {
+    let left = events.getattr("BRANCH_LEFT");
+    let right = events.getattr("BRANCH_RIGHT");
+    if let (Ok(left), Ok(right)) = (left, right) {
+        return Ok(vec![left.extract()?, right.extract()?]);
+    }
+    Ok(vec![events.getattr("BRANCH")?.extract()?])
 }
 
 fn release_monitoring_tool(
@@ -487,6 +755,9 @@ fn save_data(
     data_file: &Utf8Path,
     mut executed: HashMap<PathBuf, HashSet<u32>>,
     mut contexts: HashMap<PathBuf, HashMap<u32, HashSet<String>>>,
+    mut arcs: HashMap<PathBuf, HashSet<BranchArc>>,
+    mut arc_contexts: HashMap<PathBuf, HashMap<BranchArc, HashSet<String>>>,
+    branches: bool,
     roots: &[PathBuf],
 ) -> std::io::Result<()> {
     for path in walk_source_files(roots) {
@@ -510,12 +781,38 @@ fn save_data(
             .filter(|(line, _)| executed_lines.binary_search(line).is_ok())
             .map(|(line, contexts)| (line, contexts.into_iter().collect::<BTreeSet<_>>()))
             .collect();
+        let branches = if branches {
+            let possible = branch_arcs(&path)?;
+            let executed_arcs = arcs.remove(&path).unwrap_or_default();
+            let mut possible_vec: Vec<BranchArc> = possible.iter().copied().collect();
+            possible_vec.sort_unstable();
+            let mut executed_vec: Vec<BranchArc> = executed_arcs.iter().copied().collect();
+            executed_vec.sort_unstable();
+            let contexts = arc_contexts
+                .remove(&path)
+                .unwrap_or_default()
+                .into_iter()
+                .filter(|(arc, _)| executed_arcs.contains(arc))
+                .map(|(arc, contexts)| BranchContextEntry {
+                    arc,
+                    contexts: contexts.into_iter().collect(),
+                })
+                .collect();
+            Some(BranchEntry {
+                possible: possible_vec,
+                executed: executed_vec,
+                contexts,
+            })
+        } else {
+            None
+        };
         files.insert(
             path.to_string_lossy().into_owned(),
             FileEntry {
                 executable: executable_lines_vec,
                 executed: executed_lines,
                 contexts: context_lines,
+                branches,
             },
         );
     }
@@ -549,6 +846,7 @@ mod tests {
             let tracer = CoverageTracer {
                 roots: vec![root],
                 contexts: false,
+                branches: false,
                 state: Mutex::new(TracerState::default()),
                 monitoring_tool_id: OnceLock::new(),
                 monitoring_disable: OnceLock::new(),
@@ -569,6 +867,13 @@ class Code:
             raise AssertionError("co_filename should be cached")
         return filename
 
+    @property
+    def co_firstlineno(self):
+        return 1
+
+    def co_lines(self):
+        return iter([(0, 2, 1)])
+
 code = Code()
 "#
                 ),
@@ -577,8 +882,14 @@ code = Code()
             )?;
             let code = locals.get_item("code")?.expect("code object");
 
-            assert_eq!(tracer.tracked_code_path(&code)?, expected);
-            assert_eq!(tracer.tracked_code_path(&code)?, expected);
+            assert_eq!(
+                tracer.tracked_code_info(&code)?.map(|info| info.path),
+                expected
+            );
+            assert_eq!(
+                tracer.tracked_code_info(&code)?.map(|info| info.path),
+                expected
+            );
 
             let calls: u32 = code.getattr("calls")?.extract()?;
             assert_eq!(calls, 1);
@@ -604,8 +915,16 @@ code = Code()
         let missing = dir.path().join("missing.py");
         let executed = HashMap::from([(missing, HashSet::from([1]))]);
 
-        let err = save_data(&data_file, executed, HashMap::new(), &[])
-            .expect_err("missing source should fail");
+        let err = save_data(
+            &data_file,
+            executed,
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            false,
+            &[],
+        )
+        .expect_err("missing source should fail");
 
         assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
         assert!(err.to_string().contains("missing.py"), "{err}");

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -491,6 +491,17 @@ pub struct CoverageOptions {
     )]
     pub report_path: Option<String>,
 
+    /// Whether to measure branch coverage in addition to line coverage.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"false"#,
+        value_type = r#"true | false"#,
+        example = r#"
+            branch = true
+        "#
+    )]
+    pub branch: Option<bool>,
+
     /// Minimum total coverage percentage required for the run to succeed.
     ///
     /// When set, the test command exits with a non-zero status if the
@@ -529,6 +540,7 @@ impl Combine for CoverageOptions {
         } else {
             self.report_path.take().combine(other.report_path)
         };
+        self.branch = self.branch.combine(other.branch);
         self.fail_under = self.fail_under.combine(other.fail_under);
         self.disabled = self.disabled.combine(other.disabled);
     }
@@ -547,6 +559,7 @@ impl CoverageOptions {
             omit: self.omit.clone().unwrap_or_default(),
             report: self.report.unwrap_or_default(),
             report_path: self.report_path.clone(),
+            branch: self.branch.unwrap_or_default(),
             fail_under: self.fail_under.map(|t| t.0),
         }
     }
@@ -1101,6 +1114,7 @@ report-path = "build/coverage.xml"
                 report_path: Some(
                     "build/coverage.xml",
                 ),
+                branch: None,
                 fail_under: None,
                 disabled: None,
             },
@@ -1135,6 +1149,7 @@ report-path = "build/coverage.xml"
                 TermMissing,
             ),
             report_path: None,
+            branch: None,
             fail_under: None,
             disabled: None,
         }
@@ -1171,6 +1186,7 @@ report-path = "build/coverage.xml"
             ),
             report: None,
             report_path: None,
+            branch: None,
             fail_under: None,
             disabled: None,
         }
@@ -1232,6 +1248,7 @@ report-path = "build/coverage.xml"
                 Json,
             ),
             report_path: None,
+            branch: None,
             fail_under: None,
             disabled: None,
         }
@@ -1268,7 +1285,7 @@ disabled = true
           |
         3 | disabled = true
           | ^^^^^^^^
-        unknown field `disabled`, expected one of `sources`, `include`, `omit`, `report`, `report-path`, `fail-under`
+        unknown field `disabled`, expected one of `sources`, `include`, `omit`, `report`, `report-path`, `branch`, `fail-under`
         "
         );
     }
@@ -1287,7 +1304,7 @@ nonsense = 1
           |
         4 | nonsense = 1
           | ^^^^^^^^
-        unknown field `nonsense`, expected one of `sources`, `include`, `omit`, `report`, `report-path`, `fail-under`
+        unknown field `nonsense`, expected one of `sources`, `include`, `omit`, `report`, `report-path`, `branch`, `fail-under`
         "
         );
     }

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -299,11 +299,21 @@ pub struct CoverageSettings {
     pub omit: Vec<String>,
     pub report: CovReport,
     pub report_path: Option<String>,
+    #[serde(skip_serializing_if = "is_false")]
+    pub branch: bool,
     /// Minimum total coverage percentage (`0..=100`). When set and the
     /// reported `TOTAL` coverage is below this value, the test command
     /// exits with a non-zero status even if every test passed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fail_under: Option<f64>,
+}
+
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "serde skip_serializing_if passes a reference to the field"
+)]
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 #[derive(Default, Debug, Clone, Serialize)]

--- a/crates/karva_runner/src/worker_args.rs
+++ b/crates/karva_runner/src/worker_args.rs
@@ -143,6 +143,10 @@ fn inner_cli_args(settings: &ProjectSettings, args: &SubTestCommand) -> Vec<Stri
         cli_args.push(context.as_str().to_string());
     }
 
+    if settings.coverage().branch {
+        cli_args.push("--cov-branch".to_string());
+    }
+
     for ovr in settings.overrides() {
         let json = serde_json::json!({
             "filter": ovr.filter.as_str(),

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -231,6 +231,7 @@ fn worker_coverage_config(
         sources: sub_command.cov.clone(),
         data_file,
         contexts: sub_command.cov_context == Some(karva_cli::CovContext::Test),
+        branches: sub_command.cov_branch,
     }))
 }
 
@@ -282,6 +283,7 @@ mod tests {
         assert_eq!(coverage.sources, vec![String::new(), "pkg".to_string()]);
         assert_eq!(coverage.data_file, data_file);
         assert!(!coverage.contexts);
+        assert!(!coverage.branches);
     }
 
     #[test]
@@ -299,5 +301,22 @@ mod tests {
             .expect("coverage should be enabled");
 
         assert!(coverage.contexts);
+    }
+
+    #[test]
+    fn coverage_config_preserves_branch_mode() {
+        let data_file = Utf8PathBuf::from(".coverage.worker-0");
+        let sub_command = SubTestCommand {
+            cov: vec!["pkg".to_string()],
+            cov_branch: true,
+            cov_data_file: Some(data_file),
+            ..SubTestCommand::default()
+        };
+
+        let coverage = worker_coverage_config(&sub_command)
+            .expect("coverage config")
+            .expect("coverage should be enabled");
+
+        assert!(coverage.branches);
     }
 }

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -35,6 +35,23 @@ required-version = ">=0.5.0"
 
 ## `coverage`
 
+### `branch`
+
+Whether to measure branch coverage in addition to line coverage.
+
+**Default value**: `false`
+
+**Type**: `true | false`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.karva.profile.default.coverage]
+branch = true
+```
+
+---
+
 ### `fail-under`
 
 Minimum total coverage percentage required for the run to succeed.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -49,6 +49,7 @@ karva test [OPTIONS] [PATH]...
 <p>While karva configuration can be included in a <code>pyproject.toml</code> file, it is not allowed in this context.</p>
 <p>May also be set with the <code>KARVA_CONFIG_FILE</code> environment variable.</p></dd><dt id="karva-test--cov"><a href="#karva-test--cov"><code>--cov</code></a> <i>source</i></dt><dd><p>Measure code coverage for the given source path.</p>
 <p>May be passed multiple times to measure several sources. Pass without a value (<code>--cov</code>) to measure the current working directory.</p>
+</dd><dt id="karva-test--cov-branch"><a href="#karva-test--cov-branch"><code>--cov-branch</code></a></dt><dd><p>Measure branch coverage in addition to line coverage</p>
 </dd><dt id="karva-test--cov-context"><a href="#karva-test--cov-context"><code>--cov-context</code></a> <i>context</i></dt><dd><p>Record per-test coverage contexts.</p>
 <p>Currently supports <code>test</code>, which records the qualified test name for each line executed while that test is running. Contexts are emitted in JSON coverage reports.</p>
 <p>Possible values:</p>

--- a/docs/usage/writing-tests/coverage.md
+++ b/docs/usage/writing-tests/coverage.md
@@ -38,6 +38,32 @@ sources = ["src"]
 
 An empty entry (`""`) measures the cwd, matching `pytest-cov`'s bare `--cov`.
 
+## Branch coverage
+
+Pass `--cov-branch` to measure branch destinations as well as lines:
+
+```bash
+karva test --cov --cov-branch --cov-report=term-missing
+```
+
+```text
+Name             Stmts   Miss   Branch   BrPart   Cover   Missing
+──────────────────────────────────────────────────────────────────
+test_branch.py       6      1        2        1     75%   5
+──────────────────────────────────────────────────────────────────
+TOTAL                6      1        2        1     75%
+```
+
+Branch coverage records line-to-line arcs for conditional control flow and compares them with statically possible branch destinations. The `Cover` percentage includes both statement and branch opportunities, matching coverage.py's branch coverage model. JSON, XML, HTML, and the `.coverage` SQLite file include branch data when branch mode is enabled.
+
+Equivalent configuration:
+
+```toml
+[tool.karva.profile.default.coverage]
+sources = ["src"]
+branch = true
+```
+
 ## Reports
 
 `--cov-report=term` (the default) prints the compact table above. `--cov-report=term-missing` adds a `Missing` column listing the uncovered line numbers per file:

--- a/python/karva/_coverage_sqlite.py
+++ b/python/karva/_coverage_sqlite.py
@@ -67,10 +67,26 @@ def main() -> int:
                 "INSERT INTO meta (key, value) VALUES (?, ?)", ("version", "karva")
             )
             conn.execute(
-                "INSERT INTO meta (key, value) VALUES (?, ?)", ("has_arcs", "0")
+                "INSERT INTO meta (key, value) VALUES (?, ?)",
+                ("has_arcs", "1" if payload.get("has_arcs") else "0"),
             )
 
             context_ids: dict[str, int] = {}
+
+            def context_id_for(context: str) -> int:
+                context_id = context_ids.get(context)
+                if context_id is not None:
+                    return context_id
+                cursor = conn.execute(
+                    "INSERT INTO context (context) VALUES (?)",
+                    (context,),
+                )
+                context_id = cursor.lastrowid
+                if context_id is None:
+                    raise RuntimeError("sqlite did not return a context id")
+                context_ids[context] = context_id
+                return context_id
+
             for file_row in payload["files"]:
                 cursor = conn.execute(
                     "INSERT INTO file (path) VALUES (?)", (file_row["path"],)
@@ -79,23 +95,22 @@ def main() -> int:
                 if file_id is None:
                     raise RuntimeError("sqlite did not return a file id")
                 for context_row in file_row["contexts"]:
-                    context = context_row["context"]
-                    context_id = context_ids.get(context)
-                    if context_id is None:
-                        cursor = conn.execute(
-                            "INSERT INTO context (context) VALUES (?)",
-                            (context,),
-                        )
-                        context_id = cursor.lastrowid
-                        if context_id is None:
-                            raise RuntimeError("sqlite did not return a context id")
-                        context_ids[context] = context_id
+                    context_id = context_id_for(context_row["context"])
                     conn.execute(
                         "INSERT INTO line_bits (file_id, context_id, numbits) VALUES (?, ?, ?)",
                         (
                             file_id,
                             context_id,
                             sqlite3.Binary(bytes(context_row["numbits"])),
+                        ),
+                    )
+                for context_row in file_row.get("arcs", ()):
+                    context_id = context_id_for(context_row["context"])
+                    conn.executemany(
+                        "INSERT INTO arc (file_id, context_id, fromno, tono) VALUES (?, ?, ?, ?)",
+                        (
+                            (file_id, context_id, arc[0], arc[1])
+                            for arc in context_row["arcs"]
                         ),
                     )
     finally:


### PR DESCRIPTION
## Summary

Closes #706.

This adds opt-in branch coverage via `--cov-branch` and `coverage.branch = true`. Karva now records executed arcs in workers, compares them with static branch opportunities, and includes branch totals in terminal, JSON, XML, HTML, and coverage.py-compatible `.coverage` output while keeping line-only coverage unchanged by default.

## Test Plan

Ran `just test`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `uvx prek run -a`. Also verified coverage.py can read a Karva-produced branch `.coverage` file with `coverage json`.