### PR TITLE
Capture output per test

### DIFF
--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -259,15 +259,21 @@ pub fn print_test_output(
     let mut details = printer.stream_for_details().lock();
 
     let has_diagnostics = !result.diagnostics.is_empty();
+    let has_captured_output = has_failed_captured_output(result);
     let has_preceding_test_lines = result.stats.total() > 0;
 
     write_diagnostics_block(&mut details, result, has_preceding_test_lines)?;
+    write_captured_output_block(
+        &mut details,
+        result,
+        has_preceding_test_lines && !has_diagnostics,
+    )?;
 
     write_durations_block(
         &mut details,
         &result.durations,
         durations,
-        has_preceding_test_lines && !has_diagnostics,
+        has_preceding_test_lines && !has_diagnostics && !has_captured_output,
     )?;
 
     drop(details);
@@ -280,6 +286,13 @@ pub fn print_test_output(
     write!(summary, "{}", DisplayFlakyTests::new(&result.flaky_tests))?;
 
     Ok(())
+}
+
+fn has_failed_captured_output(result: &AggregatedResults) -> bool {
+    result
+        .captured_outputs
+        .iter()
+        .any(|output| output.outcome().is_failed() && !output.is_empty())
 }
 
 fn write_diagnostics_block(
@@ -297,6 +310,54 @@ fn write_diagnostics_block(
     writeln!(stdout, "diagnostics:")?;
     writeln!(stdout)?;
     write!(stdout, "{}", result.diagnostics)?;
+
+    Ok(())
+}
+
+fn write_captured_output_block(
+    stdout: &mut Stdout,
+    result: &AggregatedResults,
+    needs_leading_blank: bool,
+) -> Result<()> {
+    let mut failed_outputs: Vec<_> = result
+        .captured_outputs
+        .iter()
+        .filter(|output| output.outcome().is_failed() && !output.is_empty())
+        .collect();
+    if failed_outputs.is_empty() {
+        return Ok(());
+    }
+
+    failed_outputs.sort_by_key(|output| output.test_name());
+
+    if needs_leading_blank && stdout.is_enabled() {
+        writeln!(stdout)?;
+    }
+
+    for output in failed_outputs {
+        write_captured_stream(stdout, "stdout", output.test_name(), output.stdout())?;
+        write_captured_stream(stdout, "stderr", output.test_name(), output.stderr())?;
+    }
+    writeln!(stdout)?;
+
+    Ok(())
+}
+
+fn write_captured_stream(
+    stdout: &mut Stdout,
+    stream_name: &str,
+    test_name: &str,
+    content: &str,
+) -> Result<()> {
+    if content.is_empty() {
+        return Ok(());
+    }
+
+    writeln!(stdout, "captured {stream_name} for {test_name}:")?;
+    write!(stdout, "{content}")?;
+    if !content.ends_with('\n') {
+        writeln!(stdout)?;
+    }
 
     Ok(())
 }

--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -466,6 +466,58 @@ fn test_stdout() {
 }
 
 #[test]
+fn test_failed_output_is_captured() {
+    let context = TestContext::with_file(
+        "test_failed_output.py",
+        r"
+        import sys
+
+        def test_pass_with_output():
+            print('hidden pass output')
+
+        def test_fail_with_output():
+            print('stdout from failure')
+            print('stderr from failure', file=sys.stderr)
+            assert False
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            PASS [TIME] test_failed_output::test_pass_with_output
+            FAIL [TIME] test_failed_output::test_fail_with_output
+
+    diagnostics:
+
+    error[test-failure]: Test `test_fail_with_output` failed
+     --> test_failed_output.py:7:5
+      |
+    7 | def test_fail_with_output():
+      |     ^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: Test failed here
+      --> test_failed_output.py:10:5
+       |
+    10 |     assert False
+       |     ^^^^^^^^^^^^
+       |
+
+    captured stdout for test_failed_output::test_fail_with_output:
+    stdout from failure
+    captured stderr for test_failed_output::test_fail_with_output:
+    stderr from failure
+
+    ────────────
+         Summary [TIME] 2 tests run: 1 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_multiple_fixtures_not_found() {
     let context = TestContext::with_file(
         "test_multiple_fixtures_not_found.py",

--- a/crates/karva_cache/src/artifact.rs
+++ b/crates/karva_cache/src/artifact.rs
@@ -28,6 +28,8 @@ pub enum CacheFile {
     FailedTests,
     /// Per-worker JSON: list of `FlakyTest` records.
     FlakyTests,
+    /// Per-worker JSON: captured Python stdout/stderr records by exact test name.
+    CapturedOutput,
     /// Per-worker JSON: line-coverage data for sources tracked during the run.
     Coverage,
     /// Per-run empty sentinel marking that fail-fast was triggered.
@@ -49,6 +51,7 @@ impl CacheFile {
             Self::Durations => "durations.json",
             Self::FailedTests => "failed_tests.json",
             Self::FlakyTests => "flaky_tests.json",
+            Self::CapturedOutput => "captured_output.json",
             Self::Coverage => "coverage.json",
             Self::FailFastSignal => "fail-fast",
             Self::LastFailed => "last-failed.json",

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -5,7 +5,9 @@ use std::time::Duration;
 use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
 use fs_err as fs;
-use karva_diagnostic::{FlakyTest, TestResultKind, TestResultStats, TestRunResult};
+use karva_diagnostic::{
+    CapturedTestOutput, FlakyTest, TestResultKind, TestResultStats, TestRunResult,
+};
 use ruff_db::diagnostic::DisplayDiagnosticConfig;
 use serde::{Deserialize, Serialize};
 
@@ -35,6 +37,7 @@ pub struct AggregatedResults {
     pub diagnostics: String,
     pub failed_tests: Vec<String>,
     pub flaky_tests: Vec<FlakyTest>,
+    pub captured_outputs: Vec<CapturedTestOutput>,
     pub durations: HashMap<String, Duration>,
 }
 
@@ -131,7 +134,7 @@ impl RunCache {
         Ok(files)
     }
 
-    /// Persists a test run result (stats, diagnostics, durations, and failed tests) to disk.
+    /// Persists a test run result to disk.
     pub fn write_result(
         &self,
         worker_id: usize,
@@ -153,6 +156,11 @@ impl RunCache {
             .collect();
         write_json_if_nonempty(&worker_dir, CacheFile::FailedTests, &failed_names)?;
         write_json_if_nonempty(&worker_dir, CacheFile::FlakyTests, result.flaky_tests())?;
+        write_json_if_nonempty(
+            &worker_dir,
+            CacheFile::CapturedOutput,
+            result.captured_outputs(),
+        )?;
 
         Ok(())
     }
@@ -174,6 +182,12 @@ fn read_worker_results(worker_dir: &Utf8Path, results: &mut AggregatedResults) -
 
     if let Some(flaky) = read_json::<Vec<FlakyTest>>(worker_dir, CacheFile::FlakyTests)? {
         results.flaky_tests.extend(flaky);
+    }
+
+    if let Some(outputs) =
+        read_json::<Vec<CapturedTestOutput>>(worker_dir, CacheFile::CapturedOutput)?
+    {
+        results.captured_outputs.extend(outputs);
     }
 
     if let Some(durations) =
@@ -620,6 +634,64 @@ mod tests {
                 "mod::test_b",
                 20ms,
             ),
+        ]
+        "#);
+    }
+
+    #[test]
+    fn aggregate_results_merges_captured_output_across_workers() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let run_hash = RunHash::from_existing("run-710");
+
+        let run_dir = tmp.path().join(run_hash.dir_name());
+        let worker0 = run_dir.join("worker-0");
+        let worker1 = run_dir.join("worker-1");
+        fs::create_dir_all(&worker0).unwrap();
+        fs::create_dir_all(&worker1).unwrap();
+
+        let output0 = CapturedTestOutput::new(
+            "mod::test_a".to_string(),
+            karva_diagnostic::CapturedTestOutcome::Failed,
+            "worker 0 stdout\n".to_string(),
+            String::new(),
+        );
+        let output1 = CapturedTestOutput::new(
+            "mod::test_b".to_string(),
+            karva_diagnostic::CapturedTestOutcome::Passed,
+            String::new(),
+            "worker 1 stderr\n".to_string(),
+        );
+
+        fs::write(
+            worker0.join(CacheFile::CapturedOutput.filename()),
+            serde_json::to_string(&[output0]).unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            worker1.join(CacheFile::CapturedOutput.filename()),
+            serde_json::to_string(&[output1]).unwrap(),
+        )
+        .unwrap();
+
+        let cache = RunCache::new(&cache_dir, &run_hash);
+        let mut outputs = cache.aggregate_results().unwrap().captured_outputs;
+        outputs.sort_by(|a, b| a.test_name().cmp(b.test_name()));
+
+        assert_debug_snapshot!(outputs, @r#"
+        [
+            CapturedTestOutput {
+                test_name: "mod::test_a",
+                outcome: Failed,
+                stdout: "worker 0 stdout\n",
+                stderr: "",
+            },
+            CapturedTestOutput {
+                test_name: "mod::test_b",
+                outcome: Passed,
+                stdout: "",
+                stderr: "worker 1 stderr\n",
+            },
         ]
         "#);
     }

--- a/crates/karva_diagnostic/src/lib.rs
+++ b/crates/karva_diagnostic/src/lib.rs
@@ -5,8 +5,8 @@ mod traceback;
 
 pub use reporter::{DummyReporter, Reporter, TestCaseReporter};
 pub use result::{
-    DisplayFlakyTest, DisplayFlakyTests, FlakyTest, IndividualTestResultKind, TestResultKind,
-    TestResultStats, TestRunResult,
+    CapturedTestOutcome, CapturedTestOutput, DisplayFlakyTest, DisplayFlakyTests, FlakyTest,
+    IndividualTestResultKind, TestResultKind, TestResultStats, TestRunResult,
 };
 
 #[cfg(feature = "traceback")]

--- a/crates/karva_diagnostic/src/result/mod.rs
+++ b/crates/karva_diagnostic/src/result/mod.rs
@@ -1,5 +1,6 @@
 mod flaky;
 mod kind;
+mod output;
 mod stats;
 
 use std::collections::HashMap;
@@ -11,6 +12,7 @@ use crate::reporter::Reporter;
 
 pub use flaky::{DisplayFlakyTest, DisplayFlakyTests, FlakyTest};
 pub use kind::{IndividualTestResultKind, TestResultKind};
+pub use output::{CapturedTestOutcome, CapturedTestOutput};
 pub use stats::TestResultStats;
 
 /// Represents the result of a test run.
@@ -33,6 +35,9 @@ pub struct TestRunResult {
 
     /// Tests that passed only after at least one retry.
     flaky_tests: Vec<FlakyTest>,
+
+    /// Captured Python stdout/stderr for individual test variants.
+    captured_outputs: Vec<CapturedTestOutput>,
 }
 
 impl TestRunResult {
@@ -46,6 +51,24 @@ impl TestRunResult {
 
     pub fn stats(&self) -> &TestResultStats {
         &self.stats
+    }
+
+    pub fn register_captured_output(
+        &mut self,
+        test_case_name: &QualifiedTestName,
+        result: &IndividualTestResultKind,
+        stdout: String,
+        stderr: String,
+    ) {
+        let output = CapturedTestOutput::new(
+            test_case_name.to_string(),
+            CapturedTestOutcome::from(result),
+            stdout,
+            stderr,
+        );
+        if !output.is_empty() {
+            self.captured_outputs.push(output);
+        }
     }
 
     pub fn register_test_case_result(
@@ -148,6 +171,8 @@ impl TestRunResult {
     #[must_use]
     pub fn into_sorted(mut self) -> Self {
         self.diagnostics.sort_by(Diagnostic::ruff_start_ordering);
+        self.captured_outputs
+            .sort_by(|a, b| a.test_name().cmp(b.test_name()));
         self
     }
 
@@ -161,5 +186,9 @@ impl TestRunResult {
 
     pub fn flaky_tests(&self) -> &[FlakyTest] {
         &self.flaky_tests
+    }
+
+    pub fn captured_outputs(&self) -> &[CapturedTestOutput] {
+        &self.captured_outputs
     }
 }

--- a/crates/karva_diagnostic/src/result/output.rs
+++ b/crates/karva_diagnostic/src/result/output.rs
@@ -1,0 +1,71 @@
+use serde::{Deserialize, Serialize};
+
+use super::kind::IndividualTestResultKind;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapturedTestOutput {
+    test_name: String,
+    outcome: CapturedTestOutcome,
+    stdout: String,
+    stderr: String,
+}
+
+impl CapturedTestOutput {
+    pub fn new(
+        test_name: String,
+        outcome: CapturedTestOutcome,
+        stdout: String,
+        stderr: String,
+    ) -> Self {
+        Self {
+            test_name,
+            outcome,
+            stdout,
+            stderr,
+        }
+    }
+
+    pub fn test_name(&self) -> &str {
+        &self.test_name
+    }
+
+    pub fn outcome(&self) -> CapturedTestOutcome {
+        self.outcome
+    }
+
+    pub fn stdout(&self) -> &str {
+        &self.stdout
+    }
+
+    pub fn stderr(&self) -> &str {
+        &self.stderr
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.stdout.is_empty() && self.stderr.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CapturedTestOutcome {
+    Passed,
+    Failed,
+    Skipped,
+}
+
+impl CapturedTestOutcome {
+    pub fn is_failed(self) -> bool {
+        matches!(self, Self::Failed)
+    }
+}
+
+impl From<&IndividualTestResultKind> for CapturedTestOutcome {
+    fn from(value: &IndividualTestResultKind) -> Self {
+        match value {
+            IndividualTestResultKind::Passed => Self::Passed,
+            IndividualTestResultKind::Failed => Self::Failed,
+            IndividualTestResultKind::Skipped { .. } => Self::Skipped,
+        }
+    }
+}

--- a/crates/karva_test_semantic/src/context.rs
+++ b/crates/karva_test_semantic/src/context.rs
@@ -164,6 +164,17 @@ impl<'a> Context<'a> {
         passed
     }
 
+    pub fn register_captured_output(
+        &self,
+        test_case_name: &QualifiedTestName,
+        result: &IndividualTestResultKind,
+        stdout: String,
+        stderr: String,
+    ) {
+        self.result()
+            .register_captured_output(test_case_name, result, stdout, stderr);
+    }
+
     pub(crate) fn report_diagnostic<'ctx>(
         &'ctx self,
         rule: &'static DiagnosticType,

--- a/crates/karva_test_semantic/src/lib.rs
+++ b/crates/karva_test_semantic/src/lib.rs
@@ -3,6 +3,7 @@ mod context;
 pub(crate) mod diagnostic;
 pub(crate) mod discovery;
 pub(crate) mod extensions;
+mod output_capture;
 mod py_attach;
 mod python;
 mod runner;

--- a/crates/karva_test_semantic/src/output_capture.rs
+++ b/crates/karva_test_semantic/src/output_capture.rs
@@ -1,0 +1,75 @@
+use pyo3::prelude::*;
+
+pub struct PythonOutputCapture {
+    old_stdout: Py<PyAny>,
+    old_stderr: Py<PyAny>,
+    stdout: Py<PyAny>,
+    stderr: Py<PyAny>,
+}
+
+impl PythonOutputCapture {
+    pub fn start(py: Python<'_>) -> PyResult<Self> {
+        let sys = py.import("sys")?;
+        let string_io = py.import("io")?.getattr("StringIO")?;
+
+        let old_stdout = sys.getattr("stdout")?.unbind();
+        let old_stderr = sys.getattr("stderr")?.unbind();
+        let stdout = string_io.call0()?.unbind();
+        let stderr = string_io.call0()?.unbind();
+
+        sys.setattr("stdout", stdout.bind(py))?;
+        if let Err(err) = sys.setattr("stderr", stderr.bind(py)) {
+            if let Err(restore_err) = sys.setattr("stdout", old_stdout.bind(py)) {
+                tracing::warn!(
+                    "failed to restore Python stdout after capture setup error: {restore_err}"
+                );
+            }
+            return Err(err);
+        }
+
+        Ok(Self {
+            old_stdout,
+            old_stderr,
+            stdout,
+            stderr,
+        })
+    }
+
+    pub fn finish(self, py: Python<'_>) -> PyResult<CapturedPythonOutput> {
+        let sys = py.import("sys")?;
+        flush_current_streams(&sys);
+
+        let restore_result = restore_stdio(&sys, &self.old_stdout, &self.old_stderr, py);
+        let stdout = self.stdout.bind(py).call_method0("getvalue")?.extract()?;
+        let stderr = self.stderr.bind(py).call_method0("getvalue")?.extract()?;
+        restore_result?;
+
+        Ok(CapturedPythonOutput { stdout, stderr })
+    }
+}
+
+pub struct CapturedPythonOutput {
+    pub stdout: String,
+    pub stderr: String,
+}
+
+fn flush_current_streams(sys: &Bound<'_, PyModule>) {
+    for stream in ["stdout", "stderr"] {
+        if let Err(err) = sys
+            .getattr(stream)
+            .and_then(|stream| stream.call_method0("flush"))
+        {
+            tracing::warn!("failed to flush captured Python {stream}: {err}");
+        }
+    }
+}
+
+fn restore_stdio(
+    sys: &Bound<'_, PyModule>,
+    stdout: &Py<PyAny>,
+    stderr: &Py<PyAny>,
+    py: Python<'_>,
+) -> PyResult<()> {
+    sys.setattr("stdout", stdout.bind(py))?;
+    sys.setattr("stderr", stderr.bind(py))
+}

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -25,6 +25,7 @@ use crate::extensions::fixtures::{
 use crate::extensions::tags::expect_fail::ExpectFailTag;
 use crate::extensions::tags::skip::{extract_skip_reason, is_skip_exception};
 use crate::extensions::tags::timeout::TimeoutTag;
+use crate::output_capture::PythonOutputCapture;
 use crate::runner::fixture_resolver::RuntimeFixtureResolver;
 use crate::runner::test_iterator::{TestVariant, TestVariantIterator};
 use crate::runner::{FinalizerCache, FixtureArguments, FixtureCache};
@@ -99,6 +100,42 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         if !passed {
             self.failed_count
                 .set(self.failed_count.get().saturating_add(1));
+        }
+    }
+
+    fn start_output_capture(&self, py: Python<'_>) -> Option<PythonOutputCapture> {
+        if self.context.settings().terminal().show_python_output {
+            return None;
+        }
+
+        match PythonOutputCapture::start(py) {
+            Ok(capture) => Some(capture),
+            Err(err) => {
+                tracing::warn!("failed to start Python output capture: {err}");
+                None
+            }
+        }
+    }
+
+    fn register_captured_output(
+        &self,
+        py: Python<'_>,
+        capture: Option<PythonOutputCapture>,
+        test_name: &QualifiedTestName,
+        result: &IndividualTestResultKind,
+    ) {
+        let Some(capture) = capture else {
+            return;
+        };
+
+        match capture.finish(py) {
+            Ok(output) => self.context.register_captured_output(
+                test_name,
+                result,
+                output.stdout,
+                output.stderr,
+            ),
+            Err(err) => tracing::warn!("failed to finish Python output capture: {err}"),
         }
     }
 
@@ -489,6 +526,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             return result;
         }
 
+        let output_capture = self.start_output_capture(py);
         let start_time = std::time::Instant::now();
         let expect_fail_tag = tags.expect_fail_tag();
 
@@ -595,6 +633,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             self.context.settings().slow_timeout_for(&eval_ctx),
         );
 
+        let mut final_kind = None;
         let passed = if was_retried {
             let passed_on = attempt;
             // `total_attempts` mirrors nextest: the maximum number of attempts
@@ -603,6 +642,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             // out of an allowed T."
             let total_attempts = max_attempts;
             self.classify_test_result(py, test_result, fixture_call_errors, &report_ctx, |kind| {
+                final_kind = Some(kind.clone());
                 self.context.register_retried_result(
                     &qualified_test_name,
                     &kind,
@@ -613,6 +653,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             })
         } else {
             self.classify_test_result(py, test_result, fixture_call_errors, &report_ctx, |kind| {
+                final_kind = Some(kind.clone());
                 self.context
                     .register_test_case_result(&qualified_test_name, kind, total_duration)
             })
@@ -623,6 +664,20 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         }
 
         self.clean_up_scope(py, FixtureScope::Function);
+        match final_kind.as_ref() {
+            Some(kind) => {
+                self.register_captured_output(py, output_capture, &qualified_test_name, kind);
+            }
+            None => {
+                if let Some(capture) = output_capture
+                    && let Err(err) = capture.finish(py)
+                {
+                    tracing::warn!(
+                        "discarded Python output capture for `{qualified_test_name}` after missing result kind: {err}"
+                    );
+                }
+            }
+        }
         if let Some(coverage) = self.coverage {
             coverage.set_current_context(py, None);
         }

--- a/crates/karva_test_semantic/src/utils.rs
+++ b/crates/karva_test_semantic/src/utils.rs
@@ -138,8 +138,8 @@ fn rebrand_timeout_error(
 /// Returns `true` if the function was patched (caller should NOT apply `asyncio.run()`),
 /// or `false` if no patching was needed.
 pub(crate) fn patch_async_test_function(py: Python<'_>, function: &Py<PyAny>) -> PyResult<bool> {
-    let asyncio = py.import("asyncio")?;
-    let is_coroutine_fn = asyncio
+    let inspect = py.import("inspect")?;
+    let is_coroutine_fn = inspect
         .call_method1("iscoroutinefunction", (function,))?
         .extract::<bool>()?;
 
@@ -156,7 +156,7 @@ pub(crate) fn patch_async_test_function(py: Python<'_>, function: &Py<PyAny>) ->
         return Ok(false);
     };
 
-    let inner_is_async = asyncio
+    let inner_is_async = inspect
         .call_method1("iscoroutinefunction", (&inner_test,))?
         .extract::<bool>()?;
 


### PR DESCRIPTION
## Summary

Capture Python stdout and stderr per test variant, persist it through the worker cache, and render captured streams next to failing diagnostics. This closes #475 and keeps `--no-capture`/`-s` streaming behavior unchanged.

## Test Plan

Ran `just test`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `uvx prek run -a`.
