### PR TITLE
Add JUnit XML reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,6 +1066,7 @@ dependencies = [
  "karva_cache",
  "karva_cli",
  "karva_coverage",
+ "karva_diagnostic",
  "karva_logging",
  "karva_metadata",
  "karva_project",

--- a/crates/karva/Cargo.toml
+++ b/crates/karva/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 karva_cache = { workspace = true }
 karva_cli = { workspace = true }
 karva_coverage = { workspace = true }
+karva_diagnostic = { workspace = true }
 karva_logging = { workspace = true }
 karva_metadata = { workspace = true }
 karva_project = { workspace = true }

--- a/crates/karva/src/commands/test/junit.rs
+++ b/crates/karva/src/commands/test/junit.rs
@@ -1,0 +1,198 @@
+use std::collections::{BTreeMap, HashMap};
+use std::fmt::Write as _;
+
+use anyhow::{Context as _, Result};
+use camino::Utf8Path;
+use karva_cache::AggregatedResults;
+use karva_diagnostic::{CapturedTestOutput, TestCaseOutcome, TestCaseResult};
+use karva_metadata::JunitSettings;
+use karva_project::path::absolute;
+
+pub(super) fn write_junit_report(
+    settings: &JunitSettings,
+    results: &AggregatedResults,
+    project_root: &Utf8Path,
+) -> Result<()> {
+    let Some(path) = settings.path.as_deref() else {
+        return Ok(());
+    };
+
+    let output_path = absolute(path, project_root);
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create JUnit report directory `{parent}`"))?;
+    }
+
+    let xml = build_junit_xml(settings, results)?;
+    std::fs::write(&output_path, xml)
+        .with_context(|| format!("failed to write JUnit report `{output_path}`"))?;
+
+    Ok(())
+}
+
+fn build_junit_xml(settings: &JunitSettings, results: &AggregatedResults) -> Result<String> {
+    let captured_outputs = captured_outputs_by_test(results);
+    let suites = test_cases_by_module(&results.test_cases);
+    let total_time = results
+        .test_cases
+        .iter()
+        .map(|case| case.duration().as_secs_f64())
+        .sum::<f64>();
+
+    let mut xml = String::new();
+    xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    writeln!(
+        xml,
+        "<testsuites name=\"{}\" tests=\"{}\" failures=\"{}\" skipped=\"{}\" errors=\"0\" time=\"{total_time:.6}\">",
+        escape_xml(&settings.report_name),
+        results.stats.total(),
+        results.stats.failed(),
+        results.stats.skipped(),
+    )?;
+
+    for (module_name, cases) in suites {
+        write_suite(&mut xml, settings, &captured_outputs, module_name, cases)?;
+    }
+
+    xml.push_str("</testsuites>\n");
+    Ok(xml)
+}
+
+fn write_suite(
+    xml: &mut String,
+    settings: &JunitSettings,
+    captured_outputs: &HashMap<&str, &CapturedTestOutput>,
+    module_name: &str,
+    cases: Vec<&TestCaseResult>,
+) -> Result<()> {
+    let tests = cases.len();
+    let failures = cases
+        .iter()
+        .filter(|case| case.outcome().is_failed())
+        .count();
+    let skipped = cases
+        .iter()
+        .filter(|case| case.outcome().is_skipped())
+        .count();
+    let time = cases
+        .iter()
+        .map(|case| case.duration().as_secs_f64())
+        .sum::<f64>();
+
+    writeln!(
+        xml,
+        "  <testsuite name=\"{}\" tests=\"{tests}\" failures=\"{failures}\" skipped=\"{skipped}\" errors=\"0\" time=\"{time:.6}\">",
+        escape_xml(module_name),
+    )?;
+
+    for case in cases {
+        write_case(xml, settings, captured_outputs, case)?;
+    }
+
+    xml.push_str("  </testsuite>\n");
+    Ok(())
+}
+
+fn write_case(
+    xml: &mut String,
+    settings: &JunitSettings,
+    captured_outputs: &HashMap<&str, &CapturedTestOutput>,
+    case: &TestCaseResult,
+) -> Result<()> {
+    let time = case.duration().as_secs_f64();
+    let output = captured_outputs.get(case.full_name()).copied();
+    let include_output = match case.outcome() {
+        TestCaseOutcome::Passed => settings.store_success_output,
+        TestCaseOutcome::Failed => settings.store_failure_output,
+        TestCaseOutcome::Skipped { .. } => false,
+    };
+    let has_output = include_output
+        && output.is_some_and(|output| !output.stdout().is_empty() || !output.stderr().is_empty());
+    let is_self_closing = matches!(case.outcome(), TestCaseOutcome::Passed) && !has_output;
+
+    write!(
+        xml,
+        "    <testcase classname=\"{}\" name=\"{}\" time=\"{time:.6}\"",
+        escape_xml(case.module_name()),
+        escape_xml(case.name()),
+    )?;
+
+    if is_self_closing {
+        xml.push_str("/>\n");
+        return Ok(());
+    }
+
+    xml.push_str(">\n");
+    match case.outcome() {
+        TestCaseOutcome::Passed => {}
+        TestCaseOutcome::Failed => {
+            xml.push_str("      <failure message=\"test failed\"/>\n");
+        }
+        TestCaseOutcome::Skipped { reason } => {
+            if let Some(reason) = reason {
+                writeln!(xml, "      <skipped message=\"{}\"/>", escape_xml(reason))?;
+            } else {
+                xml.push_str("      <skipped/>\n");
+            }
+        }
+    }
+
+    if has_output && let Some(output) = output {
+        write_captured_stream(xml, "system-out", output.stdout())?;
+        write_captured_stream(xml, "system-err", output.stderr())?;
+    }
+
+    xml.push_str("    </testcase>\n");
+    Ok(())
+}
+
+fn write_captured_stream(xml: &mut String, element: &str, content: &str) -> Result<()> {
+    if content.is_empty() {
+        return Ok(());
+    }
+
+    writeln!(xml, "      <{element}>{}</{element}>", escape_xml(content))?;
+    Ok(())
+}
+
+fn test_cases_by_module(cases: &[TestCaseResult]) -> BTreeMap<&str, Vec<&TestCaseResult>> {
+    let mut by_module = BTreeMap::new();
+    for case in cases {
+        by_module
+            .entry(case.module_name())
+            .or_insert_with(Vec::new)
+            .push(case);
+    }
+    by_module
+}
+
+fn captured_outputs_by_test(results: &AggregatedResults) -> HashMap<&str, &CapturedTestOutput> {
+    results
+        .captured_outputs
+        .iter()
+        .map(|output| (output.test_name(), output))
+        .collect()
+}
+
+fn escape_xml(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for c in value.chars() {
+        match c {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&apos;"),
+            c if is_xml_char(c) => escaped.push(c),
+            _ => escaped.push_str("&#xFFFD;"),
+        }
+    }
+    escaped
+}
+
+fn is_xml_char(c: char) -> bool {
+    matches!(
+        u32::from(c),
+        0x09 | 0x0A | 0x0D | 0x20..=0xD7FF | 0xE000..=0xFFFD | 0x1_0000..=0x10_FFFF
+    )
+}

--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -1,3 +1,4 @@
+mod junit;
 mod watch;
 
 use std::collections::HashMap;
@@ -99,6 +100,7 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
     } = karva_runner::run_parallel_tests(&project, &config, &sub_command, printer)?;
 
     print_test_output(printer, start_time, &result, durations)?;
+    junit::write_junit_report(project.settings().junit(), &result, project.cwd())?;
 
     if timed_out {
         print_run_timed_out(printer)?;

--- a/crates/karva/tests/it/junit.rs
+++ b/crates/karva/tests/it/junit.rs
@@ -1,0 +1,86 @@
+use insta::assert_snapshot;
+use regex::Regex;
+
+use crate::common::TestContext;
+
+fn normalize_junit_xml(xml: &str) -> String {
+    Regex::new(r#"time="[0-9.]+""#)
+        .expect("valid time regex")
+        .replace_all(xml, r#"time="[TIME]""#)
+        .to_string()
+}
+
+#[test]
+fn writes_junit_xml_report() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.ci.junit]
+path = "reports/test-results.xml"
+report-name = "karva-ci"
+store-success-output = true
+store-failure-output = true
+"#,
+        ),
+        (
+            "test_alpha.py",
+            r#"
+import sys
+
+def test_pass():
+    print("pass <stdout>")
+    print("pass & stderr", file=sys.stderr)
+
+def test_fail():
+    print("fail stdout")
+    print("fail stderr", file=sys.stderr)
+    assert False
+"#,
+        ),
+        (
+            "test_beta.py",
+            r#"
+import karva
+
+@karva.tags.skip("skip & wait")
+def test_skip():
+    assert False
+"#,
+        ),
+    ]);
+
+    let output = context
+        .command_no_parallel()
+        .args(["--profile=ci", "--status-level=none"])
+        .output()
+        .expect("run karva");
+    assert_eq!(output.status.code(), Some(1));
+
+    let xml = normalize_junit_xml(&context.read_file("reports/test-results.xml"));
+    assert_snapshot!(xml, @r#"
+    <?xml version="1.0" encoding="UTF-8"?>
+    <testsuites name="karva-ci" tests="3" failures="1" skipped="1" errors="0" time="[TIME]">
+      <testsuite name="test_alpha" tests="2" failures="1" skipped="0" errors="0" time="[TIME]">
+        <testcase classname="test_alpha" name="test_fail" time="[TIME]">
+          <failure message="test failed"/>
+          <system-out>fail stdout
+    </system-out>
+          <system-err>fail stderr
+    </system-err>
+        </testcase>
+        <testcase classname="test_alpha" name="test_pass" time="[TIME]">
+          <system-out>pass &lt;stdout&gt;
+    </system-out>
+          <system-err>pass &amp; stderr
+    </system-err>
+        </testcase>
+      </testsuite>
+      <testsuite name="test_beta" tests="1" failures="0" skipped="1" errors="0" time="[TIME]">
+        <testcase classname="test_beta" name="test_skip" time="[TIME]">
+          <skipped message="skip &amp; wait"/>
+        </testcase>
+      </testsuite>
+    </testsuites>
+    "#);
+}

--- a/crates/karva/tests/it/main.rs
+++ b/crates/karva/tests/it/main.rs
@@ -10,6 +10,7 @@ mod discovery;
 mod durations;
 mod extensions;
 mod filterset;
+mod junit;
 mod last_failed;
 mod partition;
 mod run_ignored;

--- a/crates/karva/tests/it/show_config.rs
+++ b/crates/karva/tests/it/show_config.rs
@@ -32,6 +32,10 @@ fn show_config_default_profile() {
     omit = []
     report = "term"
 
+    [junit]
+    report-name = "karva-tests"
+    store-failure-output = true
+
     ----- stderr -----
     "#);
 }
@@ -76,6 +80,10 @@ output-format = "concise"
     include = []
     omit = []
     report = "term"
+
+    [junit]
+    report-name = "karva-tests"
+    store-failure-output = true
 
     ----- stderr -----
     "#);
@@ -122,6 +130,10 @@ output-format = "concise"
     include = []
     omit = []
     report = "term"
+
+    [junit]
+    report-name = "karva-tests"
+    store-failure-output = true
 
     ----- stderr -----
     "#);
@@ -174,6 +186,10 @@ fail-under = 90
     report = "term-missing"
     fail-under = 90.0
 
+    [junit]
+    report-name = "karva-tests"
+    store-failure-output = true
+
     ----- stderr -----
     "#);
 }
@@ -219,6 +235,10 @@ slow-timeout = 0.5
     include = []
     omit = []
     report = "term"
+
+    [junit]
+    report-name = "karva-tests"
+    store-failure-output = true
 
     [[overrides]]
     filter = "tag(network)"

--- a/crates/karva_cache/src/artifact.rs
+++ b/crates/karva_cache/src/artifact.rs
@@ -28,6 +28,8 @@ pub enum CacheFile {
     FailedTests,
     /// Per-worker JSON: list of `FlakyTest` records.
     FlakyTests,
+    /// Per-worker JSON: final result records for executed test variants.
+    TestCases,
     /// Per-worker JSON: captured Python stdout/stderr records by exact test name.
     CapturedOutput,
     /// Per-worker JSON: line-coverage data for sources tracked during the run.
@@ -51,6 +53,7 @@ impl CacheFile {
             Self::Durations => "durations.json",
             Self::FailedTests => "failed_tests.json",
             Self::FlakyTests => "flaky_tests.json",
+            Self::TestCases => "test_cases.json",
             Self::CapturedOutput => "captured_output.json",
             Self::Coverage => "coverage.json",
             Self::FailFastSignal => "fail-fast",

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -6,7 +6,8 @@ use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
 use fs_err as fs;
 use karva_diagnostic::{
-    CapturedTestOutput, FlakyTest, TestResultKind, TestResultStats, TestRunResult,
+    CapturedTestOutput, FlakyTest, TestCaseOutcome, TestCaseResult, TestResultKind,
+    TestResultStats, TestRunResult,
 };
 use ruff_db::diagnostic::DisplayDiagnosticConfig;
 use serde::{Deserialize, Serialize};
@@ -37,6 +38,7 @@ pub struct AggregatedResults {
     pub diagnostics: String,
     pub failed_tests: Vec<String>,
     pub flaky_tests: Vec<FlakyTest>,
+    pub test_cases: Vec<TestCaseResult>,
     pub captured_outputs: Vec<CapturedTestOutput>,
     pub durations: HashMap<String, Duration>,
 }
@@ -48,6 +50,11 @@ impl AggregatedResults {
             .map_or_else(|| name.to_string(), |(base, _)| base.to_string());
         self.stats.add(TestResultKind::Failed);
         self.failed_tests.push(function_name.clone());
+        self.test_cases.push(TestCaseResult::from_display_name(
+            name,
+            TestCaseOutcome::Failed,
+            duration,
+        ));
         self.durations.insert(function_name, duration);
     }
 }
@@ -156,6 +163,7 @@ impl RunCache {
             .collect();
         write_json_if_nonempty(&worker_dir, CacheFile::FailedTests, &failed_names)?;
         write_json_if_nonempty(&worker_dir, CacheFile::FlakyTests, result.flaky_tests())?;
+        write_json_if_nonempty(&worker_dir, CacheFile::TestCases, result.test_cases())?;
         write_json_if_nonempty(
             &worker_dir,
             CacheFile::CapturedOutput,
@@ -182,6 +190,10 @@ fn read_worker_results(worker_dir: &Utf8Path, results: &mut AggregatedResults) -
 
     if let Some(flaky) = read_json::<Vec<FlakyTest>>(worker_dir, CacheFile::FlakyTests)? {
         results.flaky_tests.extend(flaky);
+    }
+
+    if let Some(cases) = read_json::<Vec<TestCaseResult>>(worker_dir, CacheFile::TestCases)? {
+        results.test_cases.extend(cases);
     }
 
     if let Some(outputs) =

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -433,6 +433,7 @@ impl SubTestCommand {
                 fail_under: self.cov_fail_under.map(CovFailUnder),
                 disabled: self.no_cov.then_some(true),
             }),
+            junit: None,
             overrides: self.override_json,
         }
     }

--- a/crates/karva_diagnostic/src/lib.rs
+++ b/crates/karva_diagnostic/src/lib.rs
@@ -6,7 +6,8 @@ mod traceback;
 pub use reporter::{DummyReporter, Reporter, TestCaseReporter};
 pub use result::{
     CapturedTestOutcome, CapturedTestOutput, DisplayFlakyTest, DisplayFlakyTests, FlakyTest,
-    IndividualTestResultKind, TestResultKind, TestResultStats, TestRunResult,
+    IndividualTestResultKind, TestCaseOutcome, TestCaseResult, TestResultKind, TestResultStats,
+    TestRunResult,
 };
 
 #[cfg(feature = "traceback")]

--- a/crates/karva_diagnostic/src/result/case.rs
+++ b/crates/karva_diagnostic/src/result/case.rs
@@ -1,0 +1,110 @@
+use std::time::Duration;
+
+use karva_python_semantic::QualifiedTestName;
+use serde::{Deserialize, Serialize};
+
+use super::kind::IndividualTestResultKind;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TestCaseResult {
+    module_name: String,
+    name: String,
+    full_name: String,
+    outcome: TestCaseOutcome,
+    duration: Duration,
+}
+
+impl TestCaseResult {
+    pub fn new(
+        test_case_name: &QualifiedTestName,
+        outcome: TestCaseOutcome,
+        duration: Duration,
+    ) -> Self {
+        let function_name = test_case_name.function_name();
+        let module_name = function_name.module_path().module_name().to_string();
+        let full_name = test_case_name.to_string();
+        let prefix = format!("{module_name}::");
+        let name = full_name
+            .strip_prefix(&prefix)
+            .unwrap_or(&full_name)
+            .to_string();
+
+        Self {
+            module_name,
+            name,
+            full_name,
+            outcome,
+            duration,
+        }
+    }
+
+    pub fn from_display_name(
+        full_name: &str,
+        outcome: TestCaseOutcome,
+        duration: Duration,
+    ) -> Self {
+        let (module_name, name) = full_name
+            .split_once("::")
+            .map_or(("unknown", full_name), |(module_name, name)| {
+                (module_name, name)
+            });
+
+        Self {
+            module_name: module_name.to_string(),
+            name: name.to_string(),
+            full_name: full_name.to_string(),
+            outcome,
+            duration,
+        }
+    }
+
+    pub fn module_name(&self) -> &str {
+        &self.module_name
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn full_name(&self) -> &str {
+        &self.full_name
+    }
+
+    pub fn outcome(&self) -> &TestCaseOutcome {
+        &self.outcome
+    }
+
+    pub fn duration(&self) -> Duration {
+        self.duration
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TestCaseOutcome {
+    Passed,
+    Failed,
+    Skipped { reason: Option<String> },
+}
+
+impl TestCaseOutcome {
+    pub fn is_failed(&self) -> bool {
+        matches!(self, Self::Failed)
+    }
+
+    pub fn is_skipped(&self) -> bool {
+        matches!(self, Self::Skipped { .. })
+    }
+}
+
+impl From<&IndividualTestResultKind> for TestCaseOutcome {
+    fn from(value: &IndividualTestResultKind) -> Self {
+        match value {
+            IndividualTestResultKind::Passed => Self::Passed,
+            IndividualTestResultKind::Failed => Self::Failed,
+            IndividualTestResultKind::Skipped { reason } => Self::Skipped {
+                reason: reason.clone(),
+            },
+        }
+    }
+}

--- a/crates/karva_diagnostic/src/result/mod.rs
+++ b/crates/karva_diagnostic/src/result/mod.rs
@@ -1,3 +1,4 @@
+mod case;
 mod flaky;
 mod kind;
 mod output;
@@ -10,6 +11,7 @@ use ruff_db::diagnostic::Diagnostic;
 
 use crate::reporter::Reporter;
 
+pub use case::{TestCaseOutcome, TestCaseResult};
 pub use flaky::{DisplayFlakyTest, DisplayFlakyTests, FlakyTest};
 pub use kind::{IndividualTestResultKind, TestResultKind};
 pub use output::{CapturedTestOutcome, CapturedTestOutput};
@@ -35,6 +37,9 @@ pub struct TestRunResult {
 
     /// Tests that passed only after at least one retry.
     flaky_tests: Vec<FlakyTest>,
+
+    /// Final outcome for each executed test variant.
+    test_cases: Vec<TestCaseResult>,
 
     /// Captured Python stdout/stderr for individual test variants.
     captured_outputs: Vec<CapturedTestOutput>,
@@ -81,6 +86,11 @@ impl TestRunResult {
         self.stats.add(result.clone().into());
 
         let function_name = test_case_name.function_name().clone();
+        self.test_cases.push(TestCaseResult::new(
+            test_case_name,
+            TestCaseOutcome::from(&result),
+            duration,
+        ));
 
         if matches!(result, IndividualTestResultKind::Failed) {
             self.failed_tests.push(function_name.clone());
@@ -118,6 +128,11 @@ impl TestRunResult {
         self.stats.add(result.clone().into());
 
         let function_name = test_case_name.function_name().clone();
+        self.test_cases.push(TestCaseResult::new(
+            test_case_name,
+            TestCaseOutcome::from(result),
+            duration,
+        ));
 
         if matches!(result, IndividualTestResultKind::Failed) {
             self.failed_tests.push(function_name.clone());
@@ -171,6 +186,11 @@ impl TestRunResult {
     #[must_use]
     pub fn into_sorted(mut self) -> Self {
         self.diagnostics.sort_by(Diagnostic::ruff_start_ordering);
+        self.test_cases.sort_by(|a, b| {
+            a.module_name()
+                .cmp(b.module_name())
+                .then_with(|| a.name().cmp(b.name()))
+        });
         self.captured_outputs
             .sort_by(|a, b| a.test_name().cmp(b.test_name()));
         self
@@ -186,6 +206,10 @@ impl TestRunResult {
 
     pub fn flaky_tests(&self) -> &[FlakyTest] {
         &self.flaky_tests
+    }
+
+    pub fn test_cases(&self) -> &[TestCaseResult] {
+        &self.test_cases
     }
 
     pub fn captured_outputs(&self) -> &[CapturedTestOutput] {

--- a/crates/karva_metadata/src/lib.rs
+++ b/crates/karva_metadata/src/lib.rs
@@ -12,14 +12,14 @@ mod settings;
 
 pub use max_fail::MaxFail;
 pub use options::{
-    Config, CovReport, CoverageOptions, DEFAULT_PROFILE, IncompatibleVersionError, Options,
-    OutputFormat, OverrideOptions, ProjectOptionsOverrides, SrcOptions, TerminalOptions,
+    Config, CovReport, CoverageOptions, DEFAULT_PROFILE, IncompatibleVersionError, JunitOptions,
+    Options, OutputFormat, OverrideOptions, ProjectOptionsOverrides, SrcOptions, TerminalOptions,
     TestOptions, UnknownProfile,
 };
 pub use pyproject::{PyProject, PyProjectError};
 pub use settings::{
-    CovFailUnder, CoverageSettings, NoTestsMode, OverrideSettings, ProjectSettings, RunIgnoredMode,
-    RunTimeoutSecs, SlowTimeoutSecs, TestTimeoutSecs,
+    CovFailUnder, CoverageSettings, JunitSettings, NoTestsMode, OverrideSettings, ProjectSettings,
+    RunIgnoredMode, RunTimeoutSecs, SlowTimeoutSecs, TestTimeoutSecs,
 };
 
 use crate::options::KarvaTomlError;

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -15,8 +15,9 @@ pub use overrides::ProjectOptionsOverrides;
 use crate::filter::{FiltersetSet, ValidatedFilter};
 use crate::max_fail::MaxFail;
 use crate::settings::{
-    CovFailUnder, CoverageSettings, NoTestsMode, OverrideSettings, ProjectSettings, RunIgnoredMode,
-    RunTimeoutSecs, SlowTimeoutSecs, SrcSettings, TerminalSettings, TestSettings, TestTimeoutSecs,
+    CovFailUnder, CoverageSettings, JunitSettings, NoTestsMode, OverrideSettings, ProjectSettings,
+    RunIgnoredMode, RunTimeoutSecs, SlowTimeoutSecs, SrcSettings, TerminalSettings, TestSettings,
+    TestTimeoutSecs,
 };
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, OptionsMetadata)]
@@ -34,6 +35,9 @@ pub struct Options {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[option_group]
     pub coverage: Option<CoverageOptions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option_group]
+    pub junit: Option<JunitOptions>,
 
     /// Per-test configuration overrides.
     ///
@@ -52,6 +56,7 @@ impl Combine for Options {
         Combine::combine_with(&mut self.terminal, other.terminal);
         Combine::combine_with(&mut self.test, other.test);
         Combine::combine_with(&mut self.coverage, other.coverage);
+        Combine::combine_with(&mut self.junit, other.junit);
         // Overrides obey "first match wins"; higher-precedence entries
         // (i.e. those from `self`) must come first, so prepend rather
         // than using the default `Vec::combine_with` which appends.
@@ -66,6 +71,7 @@ impl Options {
             src: self.src.clone().unwrap_or_default().to_settings(),
             test: self.test.clone().unwrap_or_default().to_settings(),
             coverage: self.coverage.clone().unwrap_or_default().to_settings(),
+            junit: self.junit.clone().unwrap_or_default().to_settings(),
             overrides: self
                 .overrides
                 .iter()
@@ -561,6 +567,72 @@ impl CoverageOptions {
             report_path: self.report_path.clone(),
             branch: self.branch.unwrap_or_default(),
             fail_under: self.fail_under.map(|t| t.0),
+        }
+    }
+}
+
+#[derive(
+    Debug, Default, Clone, Eq, PartialEq, Combine, Serialize, Deserialize, OptionsMetadata,
+)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct JunitOptions {
+    /// Output path for the `JUnit` XML report.
+    ///
+    /// When unset, no `JUnit` report is written.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"null"#,
+        value_type = r#"path"#,
+        example = r#"
+            path = "reports/test-results.xml"
+        "#
+    )]
+    pub path: Option<String>,
+
+    /// Name of the top-level `JUnit` test suite collection.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#""karva-tests""#,
+        value_type = r#"string"#,
+        example = r#"
+            report-name = "karva-tests"
+        "#
+    )]
+    pub report_name: Option<String>,
+
+    /// Whether to include captured stdout and stderr for passing tests.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"false"#,
+        value_type = r#"true | false"#,
+        example = r#"
+            store-success-output = true
+        "#
+    )]
+    pub store_success_output: Option<bool>,
+
+    /// Whether to include captured stdout and stderr for failing tests.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"true"#,
+        value_type = r#"true | false"#,
+        example = r#"
+            store-failure-output = true
+        "#
+    )]
+    pub store_failure_output: Option<bool>,
+}
+
+impl JunitOptions {
+    pub fn to_settings(&self) -> JunitSettings {
+        JunitSettings {
+            path: self.path.clone(),
+            report_name: self
+                .report_name
+                .clone()
+                .unwrap_or_else(|| "karva-tests".to_string()),
+            store_success_output: self.store_success_output.unwrap_or_default(),
+            store_failure_output: self.store_failure_output.unwrap_or(true),
         }
     }
 }
@@ -1117,6 +1189,39 @@ report-path = "build/coverage.xml"
                 branch: None,
                 fail_under: None,
                 disabled: None,
+            },
+        )
+        "#);
+    }
+
+    #[test]
+    fn parse_junit_section() {
+        let toml = r#"
+[profile.ci.junit]
+path = "reports/test-results.xml"
+report-name = "karva-ci"
+store-success-output = true
+store-failure-output = false
+"#;
+        let resolved = Config::from_toml_str(toml)
+            .expect("parse")
+            .resolve_profile(Some("ci"))
+            .expect("resolves");
+        assert_debug_snapshot!(resolved.junit, @r#"
+        Some(
+            JunitOptions {
+                path: Some(
+                    "reports/test-results.xml",
+                ),
+                report_name: Some(
+                    "karva-ci",
+                ),
+                store_success_output: Some(
+                    true,
+                ),
+                store_failure_output: Some(
+                    false,
+                ),
             },
         )
         "#);

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -155,6 +155,7 @@ pub struct ProjectSettings {
     pub(crate) terminal: TerminalSettings,
     pub(crate) test: TestSettings,
     pub(crate) coverage: CoverageSettings,
+    pub(crate) junit: JunitSettings,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub(crate) overrides: Vec<OverrideSettings>,
 }
@@ -194,6 +195,10 @@ impl ProjectSettings {
 
     pub fn coverage(&self) -> &CoverageSettings {
         &self.coverage
+    }
+
+    pub fn junit(&self) -> &JunitSettings {
+        &self.junit
     }
 
     pub fn max_fail(&self) -> MaxFail {
@@ -306,6 +311,28 @@ pub struct CoverageSettings {
     /// exits with a non-zero status even if every test passed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fail_under: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct JunitSettings {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    pub report_name: String,
+    #[serde(skip_serializing_if = "is_false")]
+    pub store_success_output: bool,
+    pub store_failure_output: bool,
+}
+
+impl Default for JunitSettings {
+    fn default() -> Self {
+        Self {
+            path: None,
+            report_name: "karva-tests".to_string(),
+            store_success_output: false,
+            store_failure_output: true,
+        }
+    }
 }
 
 #[expect(

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -180,6 +180,78 @@ sources = ["src"]
 
 ---
 
+## `junit`
+
+### `path`
+
+Output path for the `JUnit` XML report.
+
+When unset, no `JUnit` report is written.
+
+**Default value**: `null`
+
+**Type**: `path`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.karva.profile.default.junit]
+path = "reports/test-results.xml"
+```
+
+---
+
+### `report-name`
+
+Name of the top-level `JUnit` test suite collection.
+
+**Default value**: `"karva-tests"`
+
+**Type**: `string`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.karva.profile.default.junit]
+report-name = "karva-tests"
+```
+
+---
+
+### `store-failure-output`
+
+Whether to include captured stdout and stderr for failing tests.
+
+**Default value**: `true`
+
+**Type**: `true | false`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.karva.profile.default.junit]
+store-failure-output = true
+```
+
+---
+
+### `store-success-output`
+
+Whether to include captured stdout and stderr for passing tests.
+
+**Default value**: `false`
+
+**Type**: `true | false`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.karva.profile.default.junit]
+store-success-output = true
+```
+
+---
+
 ## `src`
 
 ### `include`


### PR DESCRIPTION
## Summary

Add `[profile.<name>.junit]` configuration for writing JUnit XML reports, including report naming and captured stdout/stderr controls for passing and failing tests. The main process now persists final per-test-case outcomes from worker caches and writes one `<testsuite>` per module with `<testcase>` entries for CI consumers. Closes #568.

## Test Plan

Ran `just test`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `uvx prek run -a`.
