### PR TITLE
Add hash test partitioning

### DIFF
--- a/crates/karva/tests/it/partition.rs
+++ b/crates/karva/tests/it/partition.rs
@@ -100,6 +100,69 @@ fn slice_one_of_one_runs_everything() {
 }
 
 #[test]
+fn hash_first_of_three() {
+    let context = TestContext::with_file("test_mod.py", SIX_TESTS);
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().arg("--partition=hash:1/3"),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 6 tests across 1 worker
+            PASS [TIME] test_mod::test_c
+            PASS [TIME] test_mod::test_e
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
+fn hash_second_of_three() {
+    let context = TestContext::with_file("test_mod.py", SIX_TESTS);
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().arg("--partition=hash:2/3"),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 6 tests across 1 worker
+            PASS [TIME] test_mod::test_b
+            PASS [TIME] test_mod::test_d
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
+fn hash_third_of_three() {
+    let context = TestContext::with_file("test_mod.py", SIX_TESTS);
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().arg("--partition=hash:3/3"),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 6 tests across 1 worker
+            PASS [TIME] test_mod::test_a
+            PASS [TIME] test_mod::test_f
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
 fn invalid_partition_index_above_total_errors() {
     let context = TestContext::with_file("test_mod.py", SIX_TESTS);
 
@@ -123,14 +186,14 @@ fn invalid_partition_strategy_errors() {
     let context = TestContext::with_file("test_mod.py", SIX_TESTS);
 
     assert_cmd_snapshot!(
-        context.command_no_parallel().arg("--partition=hash:1/3"),
+        context.command_no_parallel().arg("--partition=random:1/3"),
         @r"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    error: invalid value 'hash:1/3' for '--partition <STRATEGY:M/N>': unknown partition strategy `hash`; supported strategies: `slice`
+    error: invalid value 'random:1/3' for '--partition <STRATEGY:M/N>': unknown partition strategy `random`; supported strategies: `slice`, `hash`
 
     For more information, try '--help'.
     "

--- a/crates/karva_cli/src/partition.rs
+++ b/crates/karva_cli/src/partition.rs
@@ -2,13 +2,14 @@ use std::fmt;
 use std::num::NonZeroU32;
 use std::str::FromStr;
 
-/// Selection of a single partition (slice) from the collected tests.
+/// Selection of a single partition from the collected tests.
 ///
-/// Used by `--partition slice:M/N` to run only the tests assigned to slice
-/// `M` of `N`. Slice indices are 1-indexed: `slice:1/3`, `slice:2/3`,
-/// `slice:3/3` together cover every collected test exactly once.
+/// Used by `--partition <strategy>:M/N` to run only the tests assigned to
+/// partition `M` of `N`. Partition indices are 1-indexed: `slice:1/3`,
+/// `slice:2/3`, `slice:3/3` together cover every collected test exactly once.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PartitionSelection {
+    strategy: PartitionStrategy,
     index: NonZeroU32,
     total: NonZeroU32,
 }
@@ -16,8 +17,20 @@ pub struct PartitionSelection {
 impl PartitionSelection {
     #[must_use]
     pub fn new(index: NonZeroU32, total: NonZeroU32) -> Option<Self> {
+        Self::with_strategy(PartitionStrategy::Slice, index, total)
+    }
+
+    fn with_strategy(
+        strategy: PartitionStrategy,
+        index: NonZeroU32,
+        total: NonZeroU32,
+    ) -> Option<Self> {
         if index <= total {
-            Some(Self { index, total })
+            Some(Self {
+                strategy,
+                index,
+                total,
+            })
         } else {
             None
         }
@@ -33,20 +46,72 @@ impl PartitionSelection {
         self.total
     }
 
-    /// Returns true if the test at `position` (0-indexed, in the deterministic
-    /// post-filter ordering) belongs to this slice.
+    /// Returns true if the zero-based test position belongs to this slice.
     #[must_use]
     pub fn contains(self, position: usize) -> bool {
+        self.contains_position(position)
+    }
+
+    #[must_use]
+    pub fn contains_test(self, position: usize, qualified_name: &str) -> bool {
+        match self.strategy {
+            PartitionStrategy::Slice => self.contains_position(position),
+            PartitionStrategy::Hash => self.contains_hash(qualified_name),
+        }
+    }
+
+    fn contains_position(self, position: usize) -> bool {
         // 1-indexed input -> 0-indexed modulo target.
         let target = (self.index.get() - 1) as usize;
         let total = self.total.get() as usize;
         position % total == target
     }
+
+    fn contains_hash(self, qualified_name: &str) -> bool {
+        let target = u64::from(self.index.get() - 1);
+        let total = u64::from(self.total.get());
+        stable_hash(qualified_name.as_bytes()) % total == target
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PartitionStrategy {
+    Slice,
+    Hash,
+}
+
+impl PartitionStrategy {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Slice => "slice",
+            Self::Hash => "hash",
+        }
+    }
+}
+
+impl FromStr for PartitionStrategy {
+    type Err = String;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        match raw {
+            "slice" => Ok(Self::Slice),
+            "hash" => Ok(Self::Hash),
+            _ => Err(format!(
+                "unknown partition strategy `{raw}`; supported strategies: `slice`, `hash`"
+            )),
+        }
+    }
 }
 
 impl fmt::Display for PartitionSelection {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "slice:{}/{}", self.index, self.total)
+        write!(
+            f,
+            "{}:{}/{}",
+            self.strategy.as_str(),
+            self.index,
+            self.total
+        )
     }
 }
 
@@ -58,15 +123,11 @@ impl FromStr for PartitionSelection {
             format!("expected `<strategy>:<M>/<N>` (e.g. `slice:1/3`), got `{raw}`")
         })?;
 
-        if kind != "slice" {
-            return Err(format!(
-                "unknown partition strategy `{kind}`; supported strategies: `slice`"
-            ));
-        }
+        let strategy = kind.parse::<PartitionStrategy>()?;
 
         let (m, n) = body
             .split_once('/')
-            .ok_or_else(|| format!("expected `slice:<M>/<N>`, got `slice:{body}`"))?;
+            .ok_or_else(|| format!("expected `{kind}:<M>/<N>`, got `{kind}:{body}`"))?;
 
         let index: u32 = m
             .parse()
@@ -88,8 +149,24 @@ impl FromStr for PartitionSelection {
             ));
         }
 
-        Ok(Self { index, total })
+        Ok(Self {
+            strategy,
+            index,
+            total,
+        })
     }
+}
+
+fn stable_hash(bytes: &[u8]) -> u64 {
+    const FNV_OFFSET_BASIS: u64 = 14_695_981_039_346_656_037;
+    const FNV_PRIME: u64 = 1_099_511_628_211;
+
+    let mut hash = FNV_OFFSET_BASIS;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
 }
 
 #[cfg(test)]
@@ -113,6 +190,18 @@ mod tests {
     }
 
     #[test]
+    fn parses_valid_hash() {
+        assert_eq!(
+            "hash:1/3".parse::<PartitionSelection>().unwrap(),
+            hash_selection(1, 3),
+        );
+        assert_eq!(
+            "hash:3/3".parse::<PartitionSelection>().unwrap(),
+            hash_selection(3, 3),
+        );
+    }
+
+    #[test]
     fn rejects_zero_total() {
         assert!("slice:1/0".parse::<PartitionSelection>().is_err());
     }
@@ -129,7 +218,7 @@ mod tests {
 
     #[test]
     fn rejects_unknown_strategy() {
-        assert!("hash:1/3".parse::<PartitionSelection>().is_err());
+        assert!("random:1/3".parse::<PartitionSelection>().is_err());
     }
 
     #[test]
@@ -155,10 +244,49 @@ mod tests {
     }
 
     #[test]
+    fn contains_hash_bucket() {
+        let p = hash_selection(1, 3);
+        let q = hash_selection(2, 3);
+        let r = hash_selection(3, 3);
+
+        for name in [
+            "test_module::test_a",
+            "test_module::test_b",
+            "test_module::test_c",
+            "test_module::test_d",
+        ] {
+            let matches = [
+                p.contains_test(0, name),
+                q.contains_test(0, name),
+                r.contains_test(0, name),
+            ];
+            assert_eq!(
+                matches.into_iter().filter(|matched| *matched).count(),
+                1,
+                "`{name}` should belong to exactly one hash partition",
+            );
+        }
+    }
+
+    #[test]
+    fn hash_partition_is_independent_of_position() {
+        let p = hash_selection(2, 3);
+
+        assert_eq!(
+            p.contains_test(0, "test_module::test_a"),
+            p.contains_test(42, "test_module::test_a"),
+        );
+    }
+
+    #[test]
     fn display_round_trip() {
         let p = selection(2, 5);
         assert_eq!(p.to_string(), "slice:2/5");
         assert_eq!(p.to_string().parse::<PartitionSelection>().unwrap(), p);
+
+        let q = hash_selection(2, 5);
+        assert_eq!(q.to_string(), "hash:2/5");
+        assert_eq!(q.to_string().parse::<PartitionSelection>().unwrap(), q);
     }
 
     #[test]
@@ -181,5 +309,16 @@ mod tests {
             panic!("test partition total should be non-zero");
         };
         PartitionSelection::new(index, total).expect("valid partition selection")
+    }
+
+    fn hash_selection(index: u32, total: u32) -> PartitionSelection {
+        let Some(index) = NonZeroU32::new(index) else {
+            panic!("test partition index should be non-zero");
+        };
+        let Some(total) = NonZeroU32::new(total) else {
+            panic!("test partition total should be non-zero");
+        };
+        PartitionSelection::with_strategy(PartitionStrategy::Hash, index, total)
+            .expect("valid partition selection")
     }
 }

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -285,7 +285,7 @@ pub struct TestCommand {
     #[clap(long, alias = "lf", help_heading = "Filter options")]
     pub last_failed: bool,
 
-    /// Run only a slice of the collected tests, distributed round-robin.
+    /// Run only one partition of the collected tests.
     ///
     /// Accepts `slice:M/N` where this run executes slice `M` of `N` total
     /// slices (1-indexed). Tests are sorted by qualified name and then
@@ -294,9 +294,9 @@ pub struct TestCommand {
     /// `slice:1/N` through `slice:N/N` together covers every collected test
     /// exactly once.
     ///
-    /// Useful for splitting a test run across CI jobs. Slice membership
-    /// shifts when tests are added or removed, so it gives less stable
-    /// per-test placement than a hash-based scheme.
+    /// Also accepts `hash:M/N`, which assigns each test to a stable bucket
+    /// based on its qualified name. Hash partitioning is less balanced than
+    /// `slice`, but adding or removing a test only changes that test's bucket.
     #[clap(long, value_name = "STRATEGY:M/N", help_heading = "Filter options")]
     pub partition: Option<PartitionSelection>,
 

--- a/crates/karva_runner/src/partition.rs
+++ b/crates/karva_runner/src/partition.rs
@@ -125,14 +125,15 @@ pub fn partition_collected_tests(
         test_infos.retain(|info| last_failed.contains(&info.qualified_name));
     }
 
-    // Slice partitioning runs on a deterministic ordering of the post-filter
-    // test set so that `slice:M/N` is stable across runs and machines (modulo
-    // changes to the test set itself).
+    // Explicit partitioning runs on a deterministic ordering of the
+    // post-filter test set so that `slice:M/N` is stable across runs and
+    // machines. `hash:M/N` does not depend on the position, but sharing the
+    // same ordering keeps the selected worker input stable too.
     if let Some(selection) = partition_selection {
         test_infos.sort_by(|a, b| a.qualified_name.cmp(&b.qualified_name));
         let mut position = 0usize;
-        test_infos.retain(|_| {
-            let keep = selection.contains(position);
+        test_infos.retain(|info| {
+            let keep = selection.contains_test(position, &info.qualified_name);
             position += 1;
             keep
         });

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -108,9 +108,9 @@ karva test [OPTIONS] [PATH]...
 <ul>
 <li><code>full</code>:  Print diagnostics verbosely, with context and helpful hints (default)</li>
 <li><code>concise</code>:  Print diagnostics concisely, one per line</li>
-</ul></dd><dt id="karva-test--partition"><a href="#karva-test--partition"><code>--partition</code></a> <i>strategy:m/n</i></dt><dd><p>Run only a slice of the collected tests, distributed round-robin.</p>
+</ul></dd><dt id="karva-test--partition"><a href="#karva-test--partition"><code>--partition</code></a> <i>strategy:m/n</i></dt><dd><p>Run only one partition of the collected tests.</p>
 <p>Accepts <code>slice:M/N</code> where this run executes slice <code>M</code> of <code>N</code> total slices (1-indexed). Tests are sorted by qualified name and then distributed by cycling through slices: test 1 to slice 1, test 2 to slice 2, ..., test N+1 to slice 1, and so on. Running every <code>slice:1/N</code> through <code>slice:N/N</code> together covers every collected test exactly once.</p>
-<p>Useful for splitting a test run across CI jobs. Slice membership shifts when tests are added or removed, so it gives less stable per-test placement than a hash-based scheme.</p>
+<p>Also accepts <code>hash:M/N</code>, which assigns each test to a stable bucket based on its qualified name. Hash partitioning is less balanced than <code>slice</code>, but adding or removing a test only changes that test's bucket.</p>
 </dd><dt id="karva-test--profile"><a href="#karva-test--profile"><code>--profile</code></a>, <code>-P</code> <i>name</i></dt><dd><p>Configuration profile to use.</p>
 <p>Profiles are defined as <code>&#91;profile.&lt;name&gt;&#93;</code> sections in <code>karva.toml</code> (or <code>&#91;tool.karva.profile.&lt;name&gt;&#93;</code> in <code>pyproject.toml</code>) and may override any of the <code>&#91;src&#93;</code>, <code>&#91;terminal&#93;</code>, and <code>&#91;test&#93;</code> settings. The selected profile is layered on top of any <code>&#91;profile.default&#93;</code> overrides, which themselves layer on top of the top-level options.</p>
 <p>Defaults to <code>default</code>.</p>


### PR DESCRIPTION
## Summary

Add `hash:M/N` as a stable test partition strategy alongside existing `slice:M/N`. Hash partitioning assigns tests by qualified-name hash so adding or removing a test does not reshuffle unrelated tests. Closes #586.

## Test Plan

Ran `just test`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test -p karva_cli partition`, and `uvx prek run -a`.