### PR TITLE
Add graceful worker termination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,6 +1323,7 @@ dependencies = [
  "karva_project",
  "karva_static",
  "karva_version",
+ "libc",
  "ruff_python_ast",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ ignore = { version = "0.4.25" }
 insta = { version = "1.47.1" }
 insta-cmd = { version = "0.7.0" }
 itertools = { version = "0.15.0" }
+libc = { version = "0.2.178" }
 markdown = { version = "1.0.0" }
 notify-debouncer-mini = { version = "0.7" }
 pretty_assertions = { version = "1.4.1" }

--- a/crates/karva/tests/it/run_timeout.rs
+++ b/crates/karva/tests/it/run_timeout.rs
@@ -68,6 +68,52 @@ def test_slow():
     ");
 }
 
+/// A timed-out run sends SIGTERM before force-killing the worker, giving the
+/// running test process a chance to clean up.
+#[cfg(unix)]
+#[test]
+fn test_run_timeout_sends_sigterm_before_force_kill() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import os
+from pathlib import Path
+import signal
+import time
+
+def handle_sigterm(signum, frame):
+    Path('terminated').write_text('1')
+    os._exit(0)
+
+signal.signal(signal.SIGTERM, handle_sigterm)
+
+def test_slow():
+    time.sleep(30)
+        ",
+    );
+
+    assert_cmd_snapshot!(
+        context
+            .command()
+            .arg("--run-timeout=1")
+            .arg("--termination-grace-period=2"),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+    ────────────
+         Summary [TIME] 0 tests run: 0 passed, 0 skipped
+
+    error: run timed out before all tests completed
+
+    ----- stderr -----
+    "
+    );
+
+    assert!(context.root().join("terminated").exists());
+}
+
 /// A run that finishes within `--run-timeout` is unaffected.
 #[test]
 fn test_run_timeout_allows_fast_run() {

--- a/crates/karva/tests/it/show_config.rs
+++ b/crates/karva/tests/it/show_config.rs
@@ -147,6 +147,7 @@ fn show_config_emits_set_timeouts_and_coverage() {
 [profile.default.test]
 slow-timeout = 0.5
 timeout = 120
+termination-grace-period = 2
 
 [profile.default.coverage]
 sources = ["src"]
@@ -178,6 +179,7 @@ fail-under = 90
     no-tests = "auto"
     slow-timeout = 0.5
     timeout = 120.0
+    termination-grace-period = 2.0
 
     [coverage]
     sources = ["src"]

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -5,7 +5,8 @@ use clap::Parser;
 use karva_logging::{FinalStatusLevel, StatusLevel, TerminalColor};
 use karva_metadata::{
     CovFailUnder, CoverageOptions, MaxFail, Options, OverrideOptions, RunTimeoutSecs,
-    SlowTimeoutSecs, SrcOptions, TerminalOptions, TestOptions, TestTimeoutSecs,
+    SlowTimeoutSecs, SrcOptions, TerminalOptions, TerminationGracePeriodSecs, TestOptions,
+    TestTimeoutSecs,
 };
 use karva_static::EnvVars;
 
@@ -312,6 +313,15 @@ pub struct TestCommand {
     #[clap(long, value_name = "SECONDS", help_heading = "Runner options")]
     pub run_timeout: Option<f64>,
 
+    /// Grace period before force-killing workers during shutdown, in seconds.
+    ///
+    /// When karva stops workers because of Ctrl+C, fail-fast, or
+    /// `--run-timeout`, it first asks them to terminate gracefully. If they
+    /// are still running after this period, karva force-kills them. Pass `0`
+    /// to force-kill immediately after graceful termination.
+    #[clap(long, value_name = "SECONDS", help_heading = "Runner options")]
+    pub termination_grace_period: Option<f64>,
+
     /// Disable parallel execution (equivalent to `--num-workers 1`)
     #[clap(long, default_missing_value = "true", num_args=0..1, help_heading = "Runner options")]
     pub no_parallel: Option<bool>,
@@ -417,6 +427,7 @@ impl SubTestCommand {
                 // than this worker-shared struct. `TestCommand::into_options`
                 // sets the real value.
                 run_timeout: None,
+                termination_grace_period: None,
             }),
             coverage: Some(CoverageOptions {
                 sources: (!self.cov.is_empty()).then(|| self.cov.clone()),
@@ -442,6 +453,7 @@ impl SubTestCommand {
 impl TestCommand {
     pub fn into_options(self) -> Options {
         let run_timeout = self.run_timeout;
+        let termination_grace_period = self.termination_grace_period;
         let mut sub_command = self.sub_command;
         if self.no_capture {
             sub_command.show_output = Some(true);
@@ -449,6 +461,8 @@ impl TestCommand {
         let mut options = sub_command.into_options();
         if let Some(test) = options.test.as_mut() {
             test.run_timeout = run_timeout.map(RunTimeoutSecs);
+            test.termination_grace_period =
+                termination_grace_period.map(TerminationGracePeriodSecs);
         }
         options
     }

--- a/crates/karva_metadata/src/lib.rs
+++ b/crates/karva_metadata/src/lib.rs
@@ -19,7 +19,7 @@ pub use options::{
 pub use pyproject::{PyProject, PyProjectError};
 pub use settings::{
     CovFailUnder, CoverageSettings, JunitSettings, NoTestsMode, OverrideSettings, ProjectSettings,
-    RunIgnoredMode, RunTimeoutSecs, SlowTimeoutSecs, TestTimeoutSecs,
+    RunIgnoredMode, RunTimeoutSecs, SlowTimeoutSecs, TerminationGracePeriodSecs, TestTimeoutSecs,
 };
 
 use crate::options::KarvaTomlError;

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -16,8 +16,8 @@ use crate::filter::{FiltersetSet, ValidatedFilter};
 use crate::max_fail::MaxFail;
 use crate::settings::{
     CovFailUnder, CoverageSettings, JunitSettings, NoTestsMode, OverrideSettings, ProjectSettings,
-    RunIgnoredMode, RunTimeoutSecs, SlowTimeoutSecs, SrcSettings, TerminalSettings, TestSettings,
-    TestTimeoutSecs,
+    RunIgnoredMode, RunTimeoutSecs, SlowTimeoutSecs, SrcSettings, TerminalSettings,
+    TerminationGracePeriodSecs, TestSettings, TestTimeoutSecs,
 };
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, OptionsMetadata)]
@@ -391,6 +391,24 @@ pub struct TestOptions {
         "#
     )]
     pub run_timeout: Option<RunTimeoutSecs>,
+
+    /// Grace period (in seconds) between graceful worker termination and
+    /// force-kill.
+    ///
+    /// Karva uses this when stopping workers because of Ctrl+C, fail-fast, or
+    /// `run-timeout`. Set to `0` to send the force-kill signal immediately
+    /// after the graceful termination signal.
+    ///
+    /// Defaults to 10 seconds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"10.0"#,
+        value_type = "float (seconds)",
+        example = r#"
+            termination-grace-period = 10.0
+        "#
+    )]
+    pub termination_grace_period: Option<TerminationGracePeriodSecs>,
 }
 
 impl TestOptions {
@@ -414,6 +432,9 @@ impl TestOptions {
             slow_timeout: self.slow_timeout.and_then(SlowTimeoutSecs::as_duration),
             timeout: self.timeout.and_then(TestTimeoutSecs::as_duration),
             run_timeout: self.run_timeout.and_then(RunTimeoutSecs::as_duration),
+            termination_grace_period: self
+                .termination_grace_period
+                .and_then(TerminationGracePeriodSecs::as_duration),
         }
     }
 }
@@ -794,7 +815,7 @@ nonsense = 42
           |
         4 | nonsense = 42
           | ^^^^^^^^
-        unknown field `nonsense`, expected one of `test-function-prefix`, `fail-fast`, `max-fail`, `try-import-fixtures`, `retry`, `no-tests`, `slow-timeout`, `timeout`, `run-timeout`
+        unknown field `nonsense`, expected one of `test-function-prefix`, `fail-fast`, `max-fail`, `try-import-fixtures`, `retry`, `no-tests`, `slow-timeout`, `timeout`, `run-timeout`, `termination-grace-period`
         "
         );
     }
@@ -895,6 +916,7 @@ max-fail = 0
             slow_timeout: None,
             timeout: None,
             run_timeout: None,
+            termination_grace_period: None,
         }
         "#);
     }
@@ -925,6 +947,7 @@ max-fail = 0
             slow_timeout: None,
             timeout: None,
             run_timeout: None,
+            termination_grace_period: None,
         }
         "#);
     }
@@ -988,6 +1011,7 @@ retry = 2
                 slow_timeout: None,
                 timeout: None,
                 run_timeout: None,
+                termination_grace_period: None,
             },
         )
         "#);
@@ -1045,6 +1069,7 @@ retry = 5
                 slow_timeout: None,
                 timeout: None,
                 run_timeout: None,
+                termination_grace_period: None,
             },
         )
         "#);

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -126,6 +126,33 @@ impl Combine for RunTimeoutSecs {
     }
 }
 
+/// Grace period between graceful termination and force-kill, in seconds.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TerminationGracePeriodSecs(pub f64);
+
+impl Eq for TerminationGracePeriodSecs {}
+
+impl TerminationGracePeriodSecs {
+    pub fn as_duration(self) -> Option<Duration> {
+        if self.0.is_finite() && self.0 >= 0.0 {
+            Some(Duration::from_secs_f64(self.0))
+        } else {
+            None
+        }
+    }
+}
+
+impl Combine for TerminationGracePeriodSecs {
+    #[inline(always)]
+    fn combine_with(&mut self, _other: Self) {}
+
+    #[inline]
+    fn combine(self, _other: Self) -> Self {
+        self
+    }
+}
+
 /// A coverage threshold expressed as a percentage (`0..=100`).
 ///
 /// Wraps `f64` for the same reason as [`SlowTimeoutSecs`]: keeps the
@@ -379,4 +406,22 @@ pub struct TestSettings {
     /// duration, the remaining workers are stopped and the run fails.
     /// `None` disables the limit.
     pub run_timeout: Option<Duration>,
+    /// Grace period between graceful termination and force-kill when karva
+    /// stops workers because of Ctrl+C, fail-fast, or run timeout.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_duration_secs"
+    )]
+    pub termination_grace_period: Option<Duration>,
+}
+
+impl TestSettings {
+    pub fn termination_grace_period(&self) -> Duration {
+        self.termination_grace_period
+            .unwrap_or_else(default_termination_grace_period)
+    }
+}
+
+pub fn default_termination_grace_period() -> Duration {
+    Duration::from_secs(10)
 }

--- a/crates/karva_runner/Cargo.toml
+++ b/crates/karva_runner/Cargo.toml
@@ -28,6 +28,7 @@ crossbeam-channel = { workspace = true }
 ctrlc = { workspace = true }
 fastrand = { workspace = true }
 ignore = { workspace = true }
+libc = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 which = { workspace = true }

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -130,6 +130,37 @@ impl WorkerManager {
         self.workers.push(Worker::new(worker_id, child, output));
     }
 
+    fn reap_finished(&mut self, log_completion: bool) {
+        self.workers
+            .retain_mut(|worker| match worker.child.try_wait() {
+                Ok(Some(status)) => {
+                    worker.join_output();
+                    if log_completion {
+                        if status.success() {
+                            tracing::info!(
+                                "Worker {} completed successfully in {}",
+                                worker.id,
+                                format_duration(worker.duration()),
+                            );
+                        } else {
+                            tracing::error!(
+                                "Worker {} failed with exit code {} in {}",
+                                worker.id,
+                                status.code().unwrap_or(-1),
+                                format_duration(worker.duration()),
+                            );
+                        }
+                    }
+                    false
+                }
+                Ok(None) => true,
+                Err(e) => {
+                    tracing::error!("Error waiting on worker {}: {}", worker.id, e);
+                    false
+                }
+            });
+    }
+
     /// Wait for all workers to complete.
     ///
     /// Returns early if a message is received on `shutdown_rx`, if the cache
@@ -157,32 +188,7 @@ impl WorkerManager {
         );
 
         loop {
-            self.workers
-                .retain_mut(|worker| match worker.child.try_wait() {
-                    Ok(Some(status)) => {
-                        worker.join_output();
-                        if status.success() {
-                            tracing::info!(
-                                "Worker {} completed successfully in {}",
-                                worker.id,
-                                format_duration(worker.duration()),
-                            );
-                        } else {
-                            tracing::error!(
-                                "Worker {} failed with exit code {} in {}",
-                                worker.id,
-                                status.code().unwrap_or(-1),
-                                format_duration(worker.duration()),
-                            );
-                        }
-                        false
-                    }
-                    Ok(None) => true,
-                    Err(e) => {
-                        tracing::error!("Error waiting on worker {}: {}", worker.id, e);
-                        false
-                    }
-                });
+            self.reap_finished(true);
 
             if self.workers.is_empty() {
                 tracing::info!("All workers completed");
@@ -217,21 +223,70 @@ impl WorkerManager {
         }
     }
 
-    /// Kill and wait on any remaining worker processes.
+    /// Terminate and wait on any remaining worker processes.
     ///
-    /// Uses two separate loops: the first sends kill signals to all workers
-    /// immediately, and the second reaps them. This ensures every worker
-    /// receives the signal without waiting for earlier ones to exit first.
-    fn kill_remaining(&mut self) {
+    /// Uses separate phases: send graceful termination to all workers, wait
+    /// for the configured grace period, then force-kill anything that remains.
+    fn terminate_remaining(&mut self, grace_period: Duration) {
+        if self.workers.is_empty() {
+            return;
+        }
+
+        let processes: Vec<_> = self
+            .workers
+            .iter()
+            .map(|worker| WorkerProcess {
+                worker_id: worker.id,
+                process_id: worker.child.id(),
+            })
+            .collect();
+
         for worker in &mut self.workers {
-            if let Err(err) = worker.child.kill() {
+            #[cfg(unix)]
+            let terminate_result = process_control::terminate(&worker.child);
+            #[cfg(not(unix))]
+            let terminate_result = process_control::terminate(&mut worker.child);
+            if let Err(err) = terminate_result {
                 tracing::warn!(
                     worker_id = worker.id,
-                    "failed to kill worker process: {err}"
+                    "failed to terminate worker process: {err}"
                 );
             }
         }
+
+        let deadline = Instant::now() + grace_period;
+        loop {
+            self.reap_finished(false);
+            if self.workers.is_empty()
+                && !processes
+                    .iter()
+                    .any(|process| process_control::is_running(process.process_id))
+            {
+                return;
+            }
+            if grace_period.is_zero() || Instant::now() >= deadline {
+                break;
+            }
+            std::thread::sleep(WORKER_POLL_INTERVAL);
+        }
+
+        for process in &processes {
+            if let Err(err) = process_control::force_kill(process.process_id) {
+                tracing::warn!(
+                    worker_id = process.worker_id,
+                    "failed to force-kill worker process group: {err}"
+                );
+            }
+        }
+
         for worker in &mut self.workers {
+            #[cfg(not(unix))]
+            if let Err(err) = process_control::force_kill_child(&mut worker.child) {
+                tracing::warn!(
+                    worker_id = worker.id,
+                    "failed to force-kill worker process: {err}"
+                );
+            }
             if let Err(err) = worker.child.wait() {
                 tracing::warn!(
                     worker_id = worker.id,
@@ -240,6 +295,7 @@ impl WorkerManager {
             }
             worker.join_output();
         }
+        self.workers.clear();
     }
 
     /// Stop remaining workers and emit nextest-style cancellation lines.
@@ -253,7 +309,12 @@ impl WorkerManager {
     /// Workers are killed, reaped, and have their forwarded stdout drained
     /// before we print so any in-flight `PASS`/`FAIL` lines land before the
     /// cancellation block.
-    fn cancel_and_kill(&mut self, printer: Printer, cache: &RunCache) -> Vec<InterruptedTest> {
+    fn cancel_and_kill(
+        &mut self,
+        printer: Printer,
+        cache: &RunCache,
+        grace_period: Duration,
+    ) -> Vec<InterruptedTest> {
         if self.workers.is_empty() {
             return Vec::new();
         }
@@ -294,23 +355,7 @@ impl WorkerManager {
         let running_tests = in_flight.iter().filter(|test| test.name.is_some()).count();
         let test_label = if running_tests == 1 { "test" } else { "tests" };
 
-        for worker in &mut self.workers {
-            if let Err(err) = worker.child.kill() {
-                tracing::warn!(
-                    worker_id = worker.id,
-                    "failed to kill worker process: {err}"
-                );
-            }
-        }
-        for worker in &mut self.workers {
-            if let Err(err) = worker.child.wait() {
-                tracing::warn!(
-                    worker_id = worker.id,
-                    "failed to wait for worker process: {err}"
-                );
-            }
-            worker.join_output();
-        }
+        self.terminate_remaining(grace_period);
 
         let mut stdout = printer.stream_for_test_result().lock();
         let cancel_label = "Cancelling".yellow().bold();
@@ -356,6 +401,12 @@ impl WorkerManager {
             })
             .collect()
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct WorkerProcess {
+    worker_id: usize,
+    process_id: u32,
 }
 
 fn elapsed_since_start(now_ms: u64, start_ms: u64, worker_id: usize) -> Duration {
@@ -425,6 +476,7 @@ fn spawn_workers(
 
         let mut command = worker_command(spawn, worker_id, partition);
         command.stderr(Stdio::inherit());
+        process_control::configure_worker_command(&mut command);
         if forward_stdout {
             command.stdout(Stdio::piped());
         } else {
@@ -604,10 +656,11 @@ pub fn run_parallel_tests(
     let max_fail_cache = project.settings().max_fail().has_limit().then_some(&cache);
 
     let outcome = worker_manager.wait_for_completion(shutdown_rx, max_fail_cache, run_deadline);
+    let termination_grace_period = project.settings().test().termination_grace_period();
     let interrupted_tests = if outcome == WaitOutcome::Cancelled {
-        worker_manager.cancel_and_kill(printer, &cache)
+        worker_manager.cancel_and_kill(printer, &cache, termination_grace_period)
     } else {
-        worker_manager.kill_remaining();
+        worker_manager.terminate_remaining(termination_grace_period);
         Vec::new()
     };
 
@@ -668,6 +721,89 @@ fn last_failed_set(cache_dir: &Utf8Path, enabled: bool) -> HashSet<String> {
 fn write_last_failed(cache_dir: &Utf8Path, failed_tests: &[String]) {
     if let Err(err) = persist_last_failed(cache_dir, failed_tests) {
         tracing::warn!("Failed to write last-failed cache: {err}");
+    }
+}
+
+#[cfg(unix)]
+mod process_control {
+    use std::io;
+    use std::os::unix::process::CommandExt;
+    use std::process::{Child, Command};
+
+    pub(super) fn configure_worker_command(command: &mut Command) {
+        command.process_group(0);
+    }
+
+    pub(super) fn terminate(child: &Child) -> io::Result<()> {
+        signal_process_group(child.id(), libc::SIGTERM)
+    }
+
+    pub(super) fn force_kill(process_id: u32) -> io::Result<()> {
+        signal_process_group(process_id, libc::SIGKILL)
+    }
+
+    pub(super) fn is_running(process_id: u32) -> bool {
+        let Ok(process_group_id) = process_group_id(process_id) else {
+            return false;
+        };
+        #[expect(
+            unsafe_code,
+            reason = "checking Unix process groups requires libc::kill"
+        )]
+        let result = unsafe { libc::kill(-process_group_id, 0) };
+        result == 0
+    }
+
+    fn signal_process_group(process_id: u32, signal: libc::c_int) -> io::Result<()> {
+        let process_group_id = process_group_id(process_id)?;
+        #[expect(
+            unsafe_code,
+            reason = "signalling Unix process groups requires libc::kill"
+        )]
+        let result = unsafe { libc::kill(-process_group_id, signal) };
+        if result == 0 {
+            return Ok(());
+        }
+
+        let err = io::Error::last_os_error();
+        if err.raw_os_error() == Some(libc::ESRCH) {
+            Ok(())
+        } else {
+            Err(err)
+        }
+    }
+
+    fn process_group_id(process_id: u32) -> io::Result<libc::pid_t> {
+        libc::pid_t::try_from(process_id).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("process id {process_id} cannot be represented as pid_t"),
+            )
+        })
+    }
+}
+
+#[cfg(not(unix))]
+mod process_control {
+    use std::io;
+    use std::process::{Child, Command};
+
+    pub(super) fn configure_worker_command(_command: &mut Command) {}
+
+    pub(super) fn terminate(child: &mut Child) -> io::Result<()> {
+        child.kill()
+    }
+
+    pub(super) fn force_kill(_process_id: u32) -> io::Result<()> {
+        Ok(())
+    }
+
+    pub(super) fn force_kill_child(child: &mut Child) -> io::Result<()> {
+        child.kill()
+    }
+
+    pub(super) fn is_running(_process_id: u32) -> bool {
+        false
     }
 }
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -516,6 +516,30 @@ slow-timeout = 60.0
 
 ---
 
+### `termination-grace-period`
+
+Grace period (in seconds) between graceful worker termination and
+force-kill.
+
+Karva uses this when stopping workers because of Ctrl+C, fail-fast, or
+`run-timeout`. Set to `0` to send the force-kill signal immediately
+after the graceful termination signal.
+
+Defaults to 10 seconds.
+
+**Default value**: `10.0`
+
+**Type**: `float (seconds)`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.karva.profile.default.test]
+termination-grace-period = 10.0
+```
+
+---
+
 ### `test-function-prefix`
 
 The prefix to use for test functions.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -137,7 +137,9 @@ karva test [OPTIONS] [PATH]...
 <li><code>pass</code>:  Display failed, retried, slow, and passing test results (default)</li>
 <li><code>skip</code>:  Additionally display skipped test results</li>
 <li><code>all</code>:  Display all test result statuses</li>
-</ul></dd><dt id="karva-test--test-prefix"><a href="#karva-test--test-prefix"><code>--test-prefix</code></a> <i>test-prefix</i></dt><dd><p>The prefix of the test functions</p>
+</ul></dd><dt id="karva-test--termination-grace-period"><a href="#karva-test--termination-grace-period"><code>--termination-grace-period</code></a> <i>seconds</i></dt><dd><p>Grace period before force-killing workers during shutdown, in seconds.</p>
+<p>When karva stops workers because of Ctrl+C, fail-fast, or <code>--run-timeout</code>, it first asks them to terminate gracefully. If they are still running after this period, karva force-kills them. Pass <code>0</code> to force-kill immediately after graceful termination.</p>
+</dd><dt id="karva-test--test-prefix"><a href="#karva-test--test-prefix"><code>--test-prefix</code></a> <i>test-prefix</i></dt><dd><p>The prefix of the test functions</p>
 </dd><dt id="karva-test--timeout"><a href="#karva-test--timeout"><code>--timeout</code></a> <i>seconds</i></dt><dd><p>Hard per-test timeout, in seconds.</p>
 <p>Tests that run longer than this duration are killed and reported as failures. A test-level &#91;<code>@karva.tags.timeout</code>&#93; decorator overrides the default for that specific test.</p>
 <p>Accepts fractional seconds such as <code>--timeout=120</code> or <code>--timeout=0.5</code>.</p>


### PR DESCRIPTION
## Summary

Add two-stage worker shutdown for cancellation, fail-fast, and run-timeout paths. Unix workers now run in their own process group so karva sends SIGTERM to the group, waits for the configurable `termination-grace-period`, then sends SIGKILL; non-Unix keeps immediate force-kill behavior. Closes #561.

## Test Plan

Ran `just test`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `uvx prek run -a`.