### PR TITLE
Add usage command for agents

### DIFF
--- a/crates/karva/src/commands/mod.rs
+++ b/crates/karva/src/commands/mod.rs
@@ -2,4 +2,5 @@ pub mod cache;
 pub mod show_config;
 pub mod snapshot;
 pub mod test;
+pub mod usage;
 pub mod version;

--- a/crates/karva/src/commands/usage.rs
+++ b/crates/karva/src/commands/usage.rs
@@ -1,0 +1,38 @@
+use std::io::Write;
+
+use anyhow::Result;
+use karva_logging::Printer;
+
+pub fn usage() -> Result<()> {
+    let mut stdout = Printer::default().stream_for_message().lock();
+    write!(
+        stdout,
+        "\
+Karva usage for agents
+
+Run tests:
+  karva test
+  karva test path/to/test_file.py
+  karva test path/to/test_file.py::test_name
+
+Focus while editing:
+  karva test path/to/test_file.py --status-level=fail
+  karva test --last-failed
+  karva test --filter 'test(~login)'
+
+Debug output:
+  karva test --no-parallel
+  karva test --no-capture
+  karva show-config
+
+Exit codes:
+  0  tests passed
+  1  tests failed, timed out, or no tests were allowed to run
+  2  configuration, discovery, or internal error
+
+Use `karva test --help` for all test options.
+"
+    )?;
+
+    Ok(())
+}

--- a/crates/karva/src/lib.rs
+++ b/crates/karva/src/lib.rs
@@ -41,6 +41,7 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
         Command::ShowConfig(show_config_args) => {
             commands::show_config::show_config(show_config_args)
         }
+        Command::Usage => commands::usage::usage().map(|()| ExitStatus::Success),
         Command::Version => commands::version::version().map(|()| ExitStatus::Success),
     }
 }

--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -2763,6 +2763,7 @@ fn test_no_subcommand_prints_help() {
       snapshot     Manage snapshots created by `karva.assert_snapshot()`
       cache        Manage the karva cache
       show-config  Print the resolved configuration karva would run with
+      usage        Print concise usage guidance for automation and coding agents
       version      Display Karva's version
       help         Print this message or the help of the given subcommand(s)
 

--- a/crates/karva/tests/it/common/mod.rs
+++ b/crates/karva/tests/it/common/mod.rs
@@ -198,6 +198,12 @@ impl TestContext {
         command.arg("show-config").current_dir(self.root());
         command
     }
+
+    pub fn usage(&self) -> Command {
+        let mut command = self.karva_command();
+        command.arg("usage").current_dir(self.root());
+        command
+    }
 }
 
 impl Default for TestContext {

--- a/crates/karva/tests/it/main.rs
+++ b/crates/karva/tests/it/main.rs
@@ -16,5 +16,6 @@ mod partition;
 mod run_ignored;
 mod run_timeout;
 mod show_config;
+mod usage;
 mod version;
 mod watch;

--- a/crates/karva/tests/it/usage.rs
+++ b/crates/karva/tests/it/usage.rs
@@ -1,0 +1,39 @@
+use insta_cmd::assert_cmd_snapshot;
+
+use crate::common::TestContext;
+
+#[test]
+fn usage_prints_agent_friendly_commands() {
+    let context = TestContext::default();
+
+    assert_cmd_snapshot!(context.usage(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Karva usage for agents
+
+    Run tests:
+      karva test
+      karva test path/to/test_file.py
+      karva test path/to/test_file.py::test_name
+
+    Focus while editing:
+      karva test path/to/test_file.py --status-level=fail
+      karva test --last-failed
+      karva test --filter 'test(~login)'
+
+    Debug output:
+      karva test --no-parallel
+      karva test --no-capture
+      karva show-config
+
+    Exit codes:
+      0  tests passed
+      1  tests failed, timed out, or no tests were allowed to run
+      2  configuration, discovery, or internal error
+
+    Use `karva test --help` for all test options.
+
+    ----- stderr -----
+    ");
+}

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -49,6 +49,9 @@ pub enum Command {
     /// Print the resolved configuration karva would run with.
     ShowConfig(ShowConfigCommand),
 
+    /// Print concise usage guidance for automation and coding agents.
+    Usage,
+
     /// Display Karva's version
     Version,
 }

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -231,6 +231,10 @@ impl WorkerManager {
         if self.workers.is_empty() {
             return;
         }
+        self.reap_finished(false);
+        if self.workers.is_empty() {
+            return;
+        }
 
         let processes: Vec<_> = self
             .workers

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -18,6 +18,7 @@ karva <COMMAND>
 <dt><a href="#karva-snapshot"><code>karva snapshot</code></a></dt><dd><p>Manage snapshots created by <code>karva.assert_snapshot()</code></p></dd>
 <dt><a href="#karva-cache"><code>karva cache</code></a></dt><dd><p>Manage the karva cache</p></dd>
 <dt><a href="#karva-show-config"><code>karva show-config</code></a></dt><dd><p>Print the resolved configuration karva would run with</p></dd>
+<dt><a href="#karva-usage"><code>karva usage</code></a></dt><dd><p>Print concise usage guidance for automation and coding agents</p></dd>
 <dt><a href="#karva-version"><code>karva version</code></a></dt><dd><p>Display Karva's version</p></dd>
 <dt><a href="#karva-help"><code>karva help</code></a></dt><dd><p>Print this message or the help of the given subcommand(s)</p></dd>
 </dl>
@@ -376,6 +377,21 @@ karva show-config [OPTIONS]
 </dd><dt id="karva-show-config--profile"><a href="#karva-show-config--profile"><code>--profile</code></a>, <code>-P</code> <i>name</i></dt><dd><p>Configuration profile to resolve.</p>
 <p>Defaults to <code>default</code>.</p>
 <p>May also be set with the <code>KARVA_PROFILE</code> environment variable.</p></dd></dl>
+
+## karva usage
+
+Print concise usage guidance for automation and coding agents
+
+<h3 class="cli-reference">Usage</h3>
+
+```
+karva usage
+```
+
+<h3 class="cli-reference">Options</h3>
+
+<dl class="cli-reference"><dt id="karva-usage--help"><a href="#karva-usage--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Print help</p>
+</dd></dl>
 
 ## karva version
 


### PR DESCRIPTION
## Summary

Add `karva usage`, a short command reference aimed at automation and coding agents, and include it in the generated CLI reference. This also reaps completed workers before shutdown termination so a fail-fast race does not emit a stale process warning. Closes #858.

## Test Plan

Ran `just test`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `uvx prek run -a`.