### PR TITLE
Add structured result reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,6 +1079,8 @@ dependencies = [
  "regex",
  "rstest",
  "ruff_python_trivia",
+ "serde",
+ "serde_json",
  "tempfile",
  "toml",
  "tracing",

--- a/crates/karva/Cargo.toml
+++ b/crates/karva/Cargo.toml
@@ -37,6 +37,8 @@ clap = { workspace = true, features = ["wrap_help", "string", "env"] }
 colored = { workspace = true }
 crossbeam-channel = { workspace = true }
 notify-debouncer-mini = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true, features = ["release_max_level_debug"] }
 wild = { workspace = true }

--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -1,4 +1,5 @@
 mod junit;
+mod result_report;
 mod watch;
 
 use std::collections::HashMap;
@@ -47,6 +48,8 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
     let sub_command = args.sub_command.clone();
     let watch = args.watch;
     let durations = args.durations;
+    let result_output = args.result_output.clone();
+    let result_format = args.result_format.unwrap_or_default();
     let last_failed = args.last_failed;
     let partition = args.partition;
     let no_cache = args.no_cache.unwrap_or(false);
@@ -101,10 +104,22 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
 
     print_test_output(printer, start_time, &result, durations)?;
     junit::write_junit_report(project.settings().junit(), &result, project.cwd())?;
+    let write_result_report = |exit_status| {
+        result_report::write_result_report(
+            result_output.as_deref(),
+            result_format,
+            &result,
+            project.cwd(),
+            start_time.elapsed(),
+            exit_status,
+        )
+    };
 
     if timed_out {
         print_run_timed_out(printer)?;
-        return Ok(ExitStatus::Failure);
+        let exit_status = ExitStatus::Failure;
+        write_result_report(exit_status)?;
+        return Ok(exit_status);
     }
 
     let coverage_total = if coverage_files.is_empty() {
@@ -208,27 +223,44 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
     if no_tests_collected(&result) {
         let has_filters = !sub_command.filter_expressions.is_empty();
         match project.settings().test().no_tests {
-            NoTestsMode::Pass => return Ok(ExitStatus::Success),
-            NoTestsMode::Auto if has_filters => return Ok(ExitStatus::Success),
+            NoTestsMode::Pass => {
+                let exit_status = ExitStatus::Success;
+                write_result_report(exit_status)?;
+                return Ok(exit_status);
+            }
+            NoTestsMode::Auto if has_filters => {
+                let exit_status = ExitStatus::Success;
+                write_result_report(exit_status)?;
+                return Ok(exit_status);
+            }
             NoTestsMode::Warn => {
                 let mut stdout = printer.stream_for_message().lock();
                 writeln!(stdout, "warning: no tests to run")?;
-                return Ok(ExitStatus::Success);
+                let exit_status = ExitStatus::Success;
+                write_result_report(exit_status)?;
+                return Ok(exit_status);
             }
             NoTestsMode::Auto | NoTestsMode::Fail => {
                 let mut stdout = printer.stream_for_message().lock();
                 writeln!(stdout, "error: no tests to run")?;
                 writeln!(stdout, "(hint: use `--no-tests` to customize)")?;
-                return Ok(ExitStatus::Failure);
+                let exit_status = ExitStatus::Failure;
+                write_result_report(exit_status)?;
+                return Ok(exit_status);
             }
         }
     }
 
-    if result.stats.is_success() && result.diagnostics.is_empty() && !coverage_below_threshold {
-        Ok(ExitStatus::Success)
+    let exit_status = if result.stats.is_success()
+        && result.diagnostics.is_empty()
+        && !coverage_below_threshold
+    {
+        ExitStatus::Success
     } else {
-        Ok(ExitStatus::Failure)
-    }
+        ExitStatus::Failure
+    };
+    write_result_report(exit_status)?;
+    Ok(exit_status)
 }
 
 fn coverage_report_path(

--- a/crates/karva/src/commands/test/result_report.rs
+++ b/crates/karva/src/commands/test/result_report.rs
@@ -1,0 +1,274 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use anyhow::{Context as _, Result};
+use camino::Utf8Path;
+use karva_cache::AggregatedResults;
+use karva_cli::ResultFormat;
+use karva_diagnostic::{CapturedTestOutput, TestCaseOutcome, TestCaseResult, TestCaseRetry};
+use karva_project::path::absolute;
+use serde::Serialize;
+
+use crate::ExitStatus;
+
+const SCHEMA_VERSION: u8 = 1;
+
+pub(super) fn write_result_report(
+    path: Option<&Utf8Path>,
+    format: ResultFormat,
+    results: &AggregatedResults,
+    project_root: &Utf8Path,
+    elapsed: Duration,
+    exit_status: ExitStatus,
+) -> Result<()> {
+    let Some(path) = path else {
+        return Ok(());
+    };
+
+    let output_path = absolute(path, project_root);
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create result report directory `{parent}`"))?;
+    }
+
+    let report = RunReport::new(results, elapsed, RunStatus::from(exit_status));
+    let content = match format {
+        ResultFormat::Json => {
+            let mut content = serde_json::to_string_pretty(&report)?;
+            content.push('\n');
+            content
+        }
+        ResultFormat::Jsonl => build_jsonl_report(&report)?,
+    };
+
+    std::fs::write(&output_path, content)
+        .with_context(|| format!("failed to write result report `{output_path}`"))?;
+
+    Ok(())
+}
+
+fn build_jsonl_report(report: &RunReport<'_>) -> Result<String> {
+    let mut output = String::new();
+    for test in &report.tests {
+        push_jsonl_event(&mut output, "test", test)?;
+    }
+    if let Some(diagnostics) = report.diagnostics {
+        push_jsonl_event(
+            &mut output,
+            "diagnostics",
+            &DiagnosticsEvent { diagnostics },
+        )?;
+    }
+    push_jsonl_event(
+        &mut output,
+        "run_finished",
+        &RunFinishedEvent {
+            status: report.status,
+            elapsed_seconds: report.elapsed_seconds,
+            stats: report.stats,
+        },
+    )?;
+    Ok(output)
+}
+
+fn push_jsonl_event<T: Serialize>(output: &mut String, kind: &'static str, data: &T) -> Result<()> {
+    let event = JsonlEvent {
+        schema_version: SCHEMA_VERSION,
+        kind,
+        data,
+    };
+    output.push_str(&serde_json::to_string(&event)?);
+    output.push('\n');
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct JsonlEvent<'a, T> {
+    schema_version: u8,
+    #[serde(rename = "type")]
+    kind: &'a str,
+    #[serde(flatten)]
+    data: T,
+}
+
+#[derive(Serialize)]
+struct RunReport<'a> {
+    schema_version: u8,
+    status: RunStatus,
+    elapsed_seconds: f64,
+    stats: StatsReport,
+    tests: Vec<TestReport<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    diagnostics: Option<&'a str>,
+}
+
+impl<'a> RunReport<'a> {
+    fn new(results: &'a AggregatedResults, elapsed: Duration, status: RunStatus) -> Self {
+        let captured_outputs = captured_outputs_by_test(results);
+        let tests = results
+            .test_cases
+            .iter()
+            .map(|case| TestReport::new(case, captured_outputs.get(case.full_name()).copied()))
+            .collect();
+        let diagnostics = (!results.diagnostics.is_empty()).then_some(results.diagnostics.as_str());
+
+        Self {
+            schema_version: SCHEMA_VERSION,
+            status,
+            elapsed_seconds: elapsed.as_secs_f64(),
+            stats: StatsReport::new(results),
+            tests,
+            diagnostics,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum RunStatus {
+    Passed,
+    Failed,
+}
+
+impl From<ExitStatus> for RunStatus {
+    fn from(value: ExitStatus) -> Self {
+        match value {
+            ExitStatus::Success => Self::Passed,
+            ExitStatus::Failure | ExitStatus::Error => Self::Failed,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Serialize)]
+struct StatsReport {
+    total: usize,
+    passed: usize,
+    failed: usize,
+    skipped: usize,
+    flaky: usize,
+    slow: usize,
+}
+
+impl StatsReport {
+    fn new(results: &AggregatedResults) -> Self {
+        Self {
+            total: results.stats.total(),
+            passed: results.stats.passed(),
+            failed: results.stats.failed(),
+            skipped: results.stats.skipped(),
+            flaky: results.stats.flaky(),
+            slow: results.stats.slow(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct TestReport<'a> {
+    module: &'a str,
+    name: &'a str,
+    full_name: &'a str,
+    status: TestStatus,
+    duration_seconds: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    skip_reason: Option<&'a str>,
+    #[serde(skip_serializing_if = "is_false")]
+    flaky: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    retry: Option<RetryReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    captured_output: Option<CapturedOutputReport<'a>>,
+}
+
+impl<'a> TestReport<'a> {
+    fn new(case: &'a TestCaseResult, output: Option<&'a CapturedTestOutput>) -> Self {
+        let (status, skip_reason) = match case.outcome() {
+            TestCaseOutcome::Passed => (TestStatus::Passed, None),
+            TestCaseOutcome::Failed => (TestStatus::Failed, None),
+            TestCaseOutcome::Skipped { reason } => (TestStatus::Skipped, reason.as_deref()),
+        };
+        let retry = case.retry().map(RetryReport::new);
+        let flaky = matches!(case.outcome(), TestCaseOutcome::Passed) && retry.is_some();
+
+        Self {
+            module: case.module_name(),
+            name: case.name(),
+            full_name: case.full_name(),
+            status,
+            duration_seconds: case.duration().as_secs_f64(),
+            skip_reason,
+            flaky,
+            retry,
+            captured_output: output
+                .filter(|output| !output.is_empty())
+                .map(CapturedOutputReport::new),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum TestStatus {
+    Passed,
+    Failed,
+    Skipped,
+}
+
+#[derive(Clone, Copy, Serialize)]
+struct RetryReport {
+    attempts: u32,
+    max_attempts: u32,
+}
+
+impl RetryReport {
+    fn new(retry: &TestCaseRetry) -> Self {
+        Self {
+            attempts: retry.attempts(),
+            max_attempts: retry.max_attempts(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct CapturedOutputReport<'a> {
+    #[serde(skip_serializing_if = "str::is_empty")]
+    stdout: &'a str,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    stderr: &'a str,
+}
+
+impl<'a> CapturedOutputReport<'a> {
+    fn new(output: &'a CapturedTestOutput) -> Self {
+        Self {
+            stdout: output.stdout(),
+            stderr: output.stderr(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct DiagnosticsEvent<'a> {
+    diagnostics: &'a str,
+}
+
+#[derive(Serialize)]
+struct RunFinishedEvent {
+    status: RunStatus,
+    elapsed_seconds: f64,
+    stats: StatsReport,
+}
+
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "serde skip_serializing_if passes a reference to the field"
+)]
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+fn captured_outputs_by_test(results: &AggregatedResults) -> HashMap<&str, &CapturedTestOutput> {
+    results
+        .captured_outputs
+        .iter()
+        .map(|output| (output.test_name(), output))
+        .collect()
+}

--- a/crates/karva/tests/it/main.rs
+++ b/crates/karva/tests/it/main.rs
@@ -13,6 +13,7 @@ mod filterset;
 mod junit;
 mod last_failed;
 mod partition;
+mod result_report;
 mod run_ignored;
 mod run_timeout;
 mod show_config;

--- a/crates/karva/tests/it/result_report.rs
+++ b/crates/karva/tests/it/result_report.rs
@@ -1,0 +1,218 @@
+use insta::assert_snapshot;
+use serde_json::Value;
+
+use crate::common::TestContext;
+
+#[test]
+fn writes_json_result_report() {
+    let context = TestContext::with_file(
+        "test_report.py",
+        r#"
+        import pathlib
+        import sys
+
+        import karva
+
+        def test_pass():
+            print("pass stdout")
+
+        def test_fail():
+            print("fail stderr", file=sys.stderr)
+            assert False
+
+        @karva.tags.skip("skip reason")
+        def test_skip():
+            assert False
+
+        def test_flaky():
+            marker = pathlib.Path("flaky-count.txt")
+            count = int(marker.read_text()) if marker.exists() else 0
+            marker.write_text(str(count + 1))
+            print(f"flaky attempt {count + 1}")
+            assert count >= 1
+        "#,
+    );
+
+    let output = context
+        .command_no_parallel()
+        .args([
+            "--retry=1",
+            "--status-level=none",
+            "--result-output=reports/results.json",
+        ])
+        .output()
+        .expect("run karva");
+    assert_eq!(output.status.code(), Some(1));
+
+    assert_snapshot!(normalize_result_json(&context.read_file("reports/results.json")), @r#"
+    {
+      "diagnostics": "error[test-failure]: Test `test_fail` failed\n  --> test_report.py:10:5\n   |/n10 | def test_fail():\n   |     ^^^^^^^^^\n   |/ninfo: Test failed here\n  --> test_report.py:12:5\n   |/n12 |     assert False\n   |     ^^^^^^^^^^^^\n   |\n\n",
+      "elapsed_seconds": "[TIME]",
+      "schema_version": 1,
+      "stats": {
+        "failed": 1,
+        "flaky": 1,
+        "passed": 2,
+        "skipped": 1,
+        "slow": 0,
+        "total": 4
+      },
+      "status": "failed",
+      "tests": [
+        {
+          "captured_output": {
+            "stderr": "fail stderr/nfail stderr\n"
+          },
+          "duration_seconds": "[TIME]",
+          "full_name": "test_report::test_fail",
+          "module": "test_report",
+          "name": "test_fail",
+          "retry": {
+            "attempts": 2,
+            "max_attempts": 2
+          },
+          "status": "failed"
+        },
+        {
+          "captured_output": {
+            "stdout": "flaky attempt 1/nflaky attempt 2\n"
+          },
+          "duration_seconds": "[TIME]",
+          "flaky": true,
+          "full_name": "test_report::test_flaky",
+          "module": "test_report",
+          "name": "test_flaky",
+          "retry": {
+            "attempts": 2,
+            "max_attempts": 2
+          },
+          "status": "passed"
+        },
+        {
+          "captured_output": {
+            "stdout": "pass stdout\n"
+          },
+          "duration_seconds": "[TIME]",
+          "full_name": "test_report::test_pass",
+          "module": "test_report",
+          "name": "test_pass",
+          "status": "passed"
+        },
+        {
+          "duration_seconds": "[TIME]",
+          "full_name": "test_report::test_skip",
+          "module": "test_report",
+          "name": "test_skip",
+          "skip_reason": "skip reason",
+          "status": "skipped"
+        }
+      ]
+    }
+    "#);
+}
+
+#[test]
+fn writes_jsonl_result_events() {
+    let context = TestContext::with_file(
+        "test_events.py",
+        r"
+        def test_pass():
+            pass
+
+        def test_fail():
+            assert False
+        ",
+    );
+
+    let output = context
+        .command_no_parallel()
+        .args([
+            "--status-level=none",
+            "--result-output=reports/events.jsonl",
+            "--result-format=jsonl",
+        ])
+        .output()
+        .expect("run karva");
+    assert_eq!(output.status.code(), Some(1));
+
+    assert_snapshot!(normalize_result_jsonl(&context.read_file("reports/events.jsonl")), @r#"
+    {"duration_seconds":"[TIME]","full_name":"test_events::test_fail","module":"test_events","name":"test_fail","schema_version":1,"status":"failed","type":"test"}
+    {"duration_seconds":"[TIME]","full_name":"test_events::test_pass","module":"test_events","name":"test_pass","schema_version":1,"status":"passed","type":"test"}
+    {"diagnostics":"error[test-failure]: Test `test_fail` failed\n --> test_events.py:5:5\n  |/n5 | def test_fail():\n  |     ^^^^^^^^^\n  |/ninfo: Test failed here\n --> test_events.py:6:5\n  |/n6 |     assert False\n  |     ^^^^^^^^^^^^\n  |\n\n","schema_version":1,"type":"diagnostics"}
+    {"elapsed_seconds":"[TIME]","schema_version":1,"stats":{"failed":1,"flaky":0,"passed":1,"skipped":0,"slow":0,"total":2},"status":"failed","type":"run_finished"}
+    "#);
+}
+
+#[test]
+fn result_report_status_matches_no_tests_failure() {
+    let context = TestContext::new();
+
+    let output = context
+        .command_no_parallel()
+        .args([
+            "--status-level=none",
+            "--result-output=reports/no-tests.json",
+        ])
+        .output()
+        .expect("run karva");
+    assert_eq!(output.status.code(), Some(1));
+
+    assert_snapshot!(normalize_result_json(&context.read_file("reports/no-tests.json")), @r#"
+    {
+      "elapsed_seconds": "[TIME]",
+      "schema_version": 1,
+      "stats": {
+        "failed": 0,
+        "flaky": 0,
+        "passed": 0,
+        "skipped": 0,
+        "slow": 0,
+        "total": 0
+      },
+      "status": "failed",
+      "tests": []
+    }
+    "#);
+}
+
+fn normalize_result_json(raw: &str) -> String {
+    let mut value: Value = serde_json::from_str(raw).expect("parse result report");
+    redact_times(&mut value);
+    let mut output = serde_json::to_string_pretty(&value).expect("serialize result report");
+    output.push('\n');
+    output
+}
+
+fn normalize_result_jsonl(raw: &str) -> String {
+    let mut output = raw
+        .lines()
+        .map(|line| {
+            let mut value: Value = serde_json::from_str(line).expect("parse result event");
+            redact_times(&mut value);
+            serde_json::to_string(&value).expect("serialize result event")
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    output.push('\n');
+    output
+}
+
+fn redact_times(value: &mut Value) {
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                redact_times(value);
+            }
+        }
+        Value::Object(map) => {
+            for (key, value) in map {
+                if key == "duration_seconds" || key == "elapsed_seconds" {
+                    *value = Value::String("[TIME]".to_string());
+                } else {
+                    redact_times(value);
+                }
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}

--- a/crates/karva_cli/src/enums.rs
+++ b/crates/karva_cli/src/enums.rs
@@ -72,6 +72,19 @@ pub enum OutputFormat {
     Concise,
 }
 
+/// Machine-readable test result report format.
+#[derive(Copy, Clone, Hash, Debug, PartialEq, Eq, PartialOrd, Ord, Default, clap::ValueEnum)]
+pub enum ResultFormat {
+    /// Write one JSON document with the full run result.
+    #[default]
+    #[value(name = "json")]
+    Json,
+
+    /// Write newline-delimited JSON events.
+    #[value(name = "jsonl")]
+    Jsonl,
+}
+
 impl From<OutputFormat> for DiagnosticFormat {
     fn from(value: OutputFormat) -> Self {
         match value {

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -11,7 +11,7 @@ mod test;
 mod verbosity;
 
 pub use cache::{CacheAction, CacheCommand};
-pub use enums::{CovContext, CovReport, NoTests, OutputFormat, RunIgnored};
+pub use enums::{CovContext, CovReport, NoTests, OutputFormat, ResultFormat, RunIgnored};
 pub use partition::PartitionSelection;
 pub use show_config::ShowConfigCommand;
 pub use snapshot::{

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -10,7 +10,7 @@ use karva_metadata::{
 };
 use karva_static::EnvVars;
 
-use crate::enums::{CovReport, NoTests, OutputFormat, RunIgnored};
+use crate::enums::{CovReport, NoTests, OutputFormat, ResultFormat, RunIgnored};
 use crate::partition::PartitionSelection;
 use crate::verbosity::Verbosity;
 
@@ -346,6 +346,24 @@ pub struct TestCommand {
     /// Show the N slowest tests after the run completes.
     #[clap(long, value_name = "N", help_heading = "Reporter options")]
     pub durations: Option<usize>,
+
+    /// Write machine-readable test results to this path.
+    #[arg(
+        long,
+        value_name = "PATH",
+        conflicts_with = "watch",
+        help_heading = "Reporter options"
+    )]
+    pub result_output: Option<Utf8PathBuf>,
+
+    /// Machine-readable test result format.
+    #[arg(
+        long,
+        value_name = "FORMAT",
+        requires = "result_output",
+        help_heading = "Reporter options"
+    )]
+    pub result_format: Option<ResultFormat>,
 
     /// The path to a `karva.toml` file to use for configuration.
     ///

--- a/crates/karva_diagnostic/src/lib.rs
+++ b/crates/karva_diagnostic/src/lib.rs
@@ -6,8 +6,8 @@ mod traceback;
 pub use reporter::{DummyReporter, Reporter, TestCaseReporter};
 pub use result::{
     CapturedTestOutcome, CapturedTestOutput, DisplayFlakyTest, DisplayFlakyTests, FlakyTest,
-    IndividualTestResultKind, TestCaseOutcome, TestCaseResult, TestResultKind, TestResultStats,
-    TestRunResult,
+    IndividualTestResultKind, TestCaseOutcome, TestCaseResult, TestCaseRetry, TestResultKind,
+    TestResultStats, TestRunResult,
 };
 
 #[cfg(feature = "traceback")]

--- a/crates/karva_diagnostic/src/result/case.rs
+++ b/crates/karva_diagnostic/src/result/case.rs
@@ -12,6 +12,8 @@ pub struct TestCaseResult {
     full_name: String,
     outcome: TestCaseOutcome,
     duration: Duration,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    retry: Option<TestCaseRetry>,
 }
 
 impl TestCaseResult {
@@ -35,7 +37,19 @@ impl TestCaseResult {
             full_name,
             outcome,
             duration,
+            retry: None,
         }
+    }
+
+    pub fn retried(
+        test_case_name: &QualifiedTestName,
+        outcome: TestCaseOutcome,
+        duration: Duration,
+        retry: TestCaseRetry,
+    ) -> Self {
+        let mut result = Self::new(test_case_name, outcome, duration);
+        result.retry = Some(retry);
+        result
     }
 
     pub fn from_display_name(
@@ -55,6 +69,7 @@ impl TestCaseResult {
             full_name: full_name.to_string(),
             outcome,
             duration,
+            retry: None,
         }
     }
 
@@ -76,6 +91,33 @@ impl TestCaseResult {
 
     pub fn duration(&self) -> Duration {
         self.duration
+    }
+
+    pub fn retry(&self) -> Option<&TestCaseRetry> {
+        self.retry.as_ref()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TestCaseRetry {
+    attempts: u32,
+    max_attempts: u32,
+}
+
+impl TestCaseRetry {
+    pub fn new(attempts: u32, max_attempts: u32) -> Self {
+        Self {
+            attempts,
+            max_attempts,
+        }
+    }
+
+    pub fn attempts(&self) -> u32 {
+        self.attempts
+    }
+
+    pub fn max_attempts(&self) -> u32 {
+        self.max_attempts
     }
 }
 

--- a/crates/karva_diagnostic/src/result/mod.rs
+++ b/crates/karva_diagnostic/src/result/mod.rs
@@ -11,7 +11,7 @@ use ruff_db::diagnostic::Diagnostic;
 
 use crate::reporter::Reporter;
 
-pub use case::{TestCaseOutcome, TestCaseResult};
+pub use case::{TestCaseOutcome, TestCaseResult, TestCaseRetry};
 pub use flaky::{DisplayFlakyTest, DisplayFlakyTests, FlakyTest};
 pub use kind::{IndividualTestResultKind, TestResultKind};
 pub use output::{CapturedTestOutcome, CapturedTestOutput};
@@ -128,10 +128,11 @@ impl TestRunResult {
         self.stats.add(result.clone().into());
 
         let function_name = test_case_name.function_name().clone();
-        self.test_cases.push(TestCaseResult::new(
+        self.test_cases.push(TestCaseResult::retried(
             test_case_name,
             TestCaseOutcome::from(result),
             duration,
+            TestCaseRetry::new(passed_on, total_attempts),
         ));
 
         if matches!(result, IndividualTestResultKind::Failed) {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -114,7 +114,13 @@ karva test [OPTIONS] [PATH]...
 </dd><dt id="karva-test--profile"><a href="#karva-test--profile"><code>--profile</code></a>, <code>-P</code> <i>name</i></dt><dd><p>Configuration profile to use.</p>
 <p>Profiles are defined as <code>&#91;profile.&lt;name&gt;&#93;</code> sections in <code>karva.toml</code> (or <code>&#91;tool.karva.profile.&lt;name&gt;&#93;</code> in <code>pyproject.toml</code>) and may override any of the <code>&#91;src&#93;</code>, <code>&#91;terminal&#93;</code>, and <code>&#91;test&#93;</code> settings. The selected profile is layered on top of any <code>&#91;profile.default&#93;</code> overrides, which themselves layer on top of the top-level options.</p>
 <p>Defaults to <code>default</code>.</p>
-<p>May also be set with the <code>KARVA_PROFILE</code> environment variable.</p></dd><dt id="karva-test--retry"><a href="#karva-test--retry"><code>--retry</code></a> <i>retry</i></dt><dd><p>When set, the test will retry failed tests up to this number of times</p>
+<p>May also be set with the <code>KARVA_PROFILE</code> environment variable.</p></dd><dt id="karva-test--result-format"><a href="#karva-test--result-format"><code>--result-format</code></a> <i>format</i></dt><dd><p>Machine-readable test result format</p>
+<p>Possible values:</p>
+<ul>
+<li><code>json</code>:  Write one JSON document with the full run result</li>
+<li><code>jsonl</code>:  Write newline-delimited JSON events</li>
+</ul></dd><dt id="karva-test--result-output"><a href="#karva-test--result-output"><code>--result-output</code></a> <i>path</i></dt><dd><p>Write machine-readable test results to this path</p>
+</dd><dt id="karva-test--retry"><a href="#karva-test--retry"><code>--retry</code></a> <i>retry</i></dt><dd><p>When set, the test will retry failed tests up to this number of times</p>
 </dd><dt id="karva-test--run-ignored"><a href="#karva-test--run-ignored"><code>--run-ignored</code></a> <i>run-ignored</i></dt><dd><p>Run ignored tests</p>
 <p>Possible values:</p>
 <ul>


### PR DESCRIPTION
## Summary

Add `--result-output` and `--result-format` so test runs can write machine-readable JSON summaries or JSONL result events without reusing diagnostic `--output-format`. The reports include test statuses, durations, retry/flaky metadata, captured output, diagnostics, and the final command status. Refs #569.

## Test Plan

Ran focused result-report integration tests, `cargo run -p karva_dev generate-all`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `just test`, and `uvx prek run -a`.
