### PR TITLE
Tighten fixture scope helpers

### DIFF
--- a/crates/karva_test_semantic/src/extensions/fixtures/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/mod.rs
@@ -255,7 +255,7 @@ pub fn get_auto_use_fixtures<'a>(
     current: &'a dyn HasFixtures<'a>,
     scope: FixtureScope,
 ) -> Vec<&'a DiscoveredFixture> {
-    let current_fixtures = current.auto_use_fixtures(&scope.scopes_above());
+    let current_fixtures = current.auto_use_fixtures(scope.scopes_above());
     let parent_fixtures = parents
         .iter()
         .flat_map(|parent| parent.auto_use_fixtures(&[scope]));

--- a/crates/karva_test_semantic/src/extensions/fixtures/scope.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/scope.rs
@@ -12,14 +12,14 @@ pub enum FixtureScope {
 
 impl FixtureScope {
     /// Returns a list of scopes above the current scope.
-    pub(crate) fn scopes_above(self) -> Vec<Self> {
+    pub(crate) fn scopes_above(self) -> &'static [Self] {
         use FixtureScope::{Function, Module, Package, Session};
 
         match self {
-            Function => vec![Function, Module, Package, Session],
-            Module => vec![Module, Package, Session],
-            Package => vec![Package, Session],
-            Session => vec![Session],
+            Function => &[Function, Module, Package, Session],
+            Module => &[Module, Package, Session],
+            Package => &[Package, Session],
+            Session => &[Session],
         }
     }
 }
@@ -76,5 +76,21 @@ pub fn fixture_scope(
         FixtureScope::try_from(scope_str)
     } else {
         Err("Scope must be either a string or a callable".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FixtureScope::{Function, Module, Package, Session};
+
+    #[test]
+    fn scopes_above_returns_current_scope_through_session() {
+        assert_eq!(
+            Function.scopes_above(),
+            &[Function, Module, Package, Session]
+        );
+        assert_eq!(Module.scopes_above(), &[Module, Package, Session]);
+        assert_eq!(Package.scopes_above(), &[Package, Session]);
+        assert_eq!(Session.scopes_above(), &[Session]);
     }
 }

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -749,20 +749,14 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             fixture.scope(),
         );
 
-        // Handle finalizer based on scope
-        // Function-scoped finalizers are returned to be run immediately after the test
-        // Higher-scoped finalizers are added to the cache
-        let return_finalizer = finalizer.map_or_else(
-            || None,
-            |f| {
-                if f.scope == FixtureScope::Function {
-                    Some(f)
-                } else {
-                    self.finalizer_cache.add_finalizer(f);
-                    None
-                }
-            },
-        );
+        let return_finalizer = finalizer.and_then(|f| {
+            if f.scope == FixtureScope::Function {
+                Some(f)
+            } else {
+                self.finalizer_cache.add_finalizer(f);
+                None
+            }
+        });
 
         Ok((final_result, return_finalizer))
     }


### PR DESCRIPTION
## Summary

Fixture scope lookup now returns static slices instead of allocating a fresh vector, and fixture finalizer routing uses a direct `and_then` path. This keeps fixture internals a little tighter without changing behavior.

## Test Plan

`just test -p karva_test_semantic`, `just test -p karva --test it extensions::fixtures`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `uvx prek run -a`, and `just test`.
