### PR TITLE
Cover verbosity mappings

### DIFF
--- a/crates/karva_cli/src/verbosity.rs
+++ b/crates/karva_cli/src/verbosity.rs
@@ -24,3 +24,23 @@ impl Verbosity {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verbosity_count_maps_to_level() {
+        assert_eq!(Verbosity { verbose: 0 }.level(), VerbosityLevel::Default);
+        assert_eq!(Verbosity { verbose: 1 }.level(), VerbosityLevel::Verbose);
+        assert_eq!(
+            Verbosity { verbose: 2 }.level(),
+            VerbosityLevel::ExtraVerbose
+        );
+        assert_eq!(Verbosity { verbose: 3 }.level(), VerbosityLevel::Trace);
+        assert_eq!(
+            Verbosity { verbose: u8::MAX }.level(),
+            VerbosityLevel::Trace
+        );
+    }
+}

--- a/crates/karva_logging/src/verbosity.rs
+++ b/crates/karva_logging/src/verbosity.rs
@@ -49,3 +49,39 @@ impl VerbosityLevel {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verbosity_levels_map_to_tracing_filters() {
+        assert_eq!(VerbosityLevel::Default.level_filter(), LevelFilter::WARN);
+        assert_eq!(VerbosityLevel::Verbose.level_filter(), LevelFilter::INFO);
+        assert_eq!(
+            VerbosityLevel::ExtraVerbose.level_filter(),
+            LevelFilter::DEBUG
+        );
+        assert_eq!(VerbosityLevel::Trace.level_filter(), LevelFilter::TRACE);
+    }
+
+    #[test]
+    fn verbosity_levels_map_to_worker_cli_args() {
+        assert_eq!(VerbosityLevel::Default.cli_arg(), None);
+        assert_eq!(VerbosityLevel::Verbose.cli_arg(), Some("-v"));
+        assert_eq!(VerbosityLevel::ExtraVerbose.cli_arg(), Some("-vv"));
+        assert_eq!(VerbosityLevel::Trace.cli_arg(), Some("-vvv"));
+    }
+
+    #[test]
+    fn predicate_methods_match_exact_levels() {
+        assert!(VerbosityLevel::Default.is_default());
+        assert!(!VerbosityLevel::Verbose.is_default());
+
+        assert!(VerbosityLevel::ExtraVerbose.is_extra_verbose());
+        assert!(!VerbosityLevel::Trace.is_extra_verbose());
+
+        assert!(VerbosityLevel::Trace.is_trace());
+        assert!(!VerbosityLevel::ExtraVerbose.is_trace());
+    }
+}


### PR DESCRIPTION
## Summary

Verbosity unit tests now cover CLI count-to-level mapping, tracing filter mapping, worker CLI forwarding arguments, and the exact-level predicates used by tracing setup. This locks down the shared verbosity behavior without changing runtime code.

## Test Plan

`just test -p karva_cli -p karva_logging`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `uvx prek run -a`.
