### PR TITLE
Prefer pytest fixture validation errors

### DIFF
--- a/crates/karva/tests/it/extensions/fixtures/invalid.rs
+++ b/crates/karva/tests/it/extensions/fixtures/invalid.rs
@@ -35,7 +35,7 @@ fn test_invalid_pytest_fixture_scope() {
     5 | def some_fixture() -> int:
       |     ^^^^^^^^^^^^
       |
-    info: 'FixtureFunctionDefinition' object is not an instance of 'FixtureFunctionDefinition'
+    info: Invalid fixture scope: sessionss
 
     error[missing-fixtures]: Test `test_all_scopes` has missing fixtures
      --> test.py:8:5

--- a/crates/karva_test_semantic/src/extensions/fixtures/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/mod.rs
@@ -115,39 +115,25 @@ impl DiscoveredFixture {
 
         let function = py_module.getattr(stmt_function_def.name.to_string())?;
 
-        let try_karva = Self::try_from_karva_function(
-            py,
-            stmt_function_def.clone(),
-            &function,
-            module_path.clone(),
-            source_file.clone(),
-            is_generator_function,
-        );
+        if get_fixture_function_marker(&function).is_ok() {
+            return Self::try_from_pytest_function(
+                py,
+                stmt_function_def,
+                &function,
+                module_path.clone(),
+                source_file,
+                is_generator_function,
+            );
+        }
 
-        let try_karva_err = match try_karva {
-            Ok(fixture) => return Ok(fixture),
-            Err(e) => {
-                tracing::debug!("Failed to create fixture from Karva function: {}", e);
-                Some(e)
-            }
-        };
-
-        let try_pytest = Self::try_from_pytest_function(
+        Self::try_from_karva_function(
             py,
             stmt_function_def,
             &function,
             module_path.clone(),
             source_file,
             is_generator_function,
-        );
-
-        match try_pytest {
-            Ok(fixture) => Ok(fixture),
-            Err(e) => {
-                tracing::debug!("Failed to create fixture from Pytest function: {}", e);
-                Err(try_karva_err.unwrap_or(e))
-            }
-        }
+        )
     }
 
     pub(crate) fn try_from_pytest_function(


### PR DESCRIPTION
## Summary

Prefer pytest fixture parsing when a function has pytest fixture metadata, so invalid pytest fixture configuration reports the real validation error instead of a misleading Karva type-cast failure. This also simplifies the fixture parsing path by avoiding the previous try-both fallback for pytest fixtures.

## Test Plan

Ran focused invalid fixture integration tests, `cargo test -p karva_test_semantic`, `cargo clippy -p karva_test_semantic --all-targets --all-features -- -D warnings`, and `uvx prek run -a`.