### PR TITLE
Simplify snapshot batch accept

### DIFF
--- a/crates/karva/src/commands/snapshot/accept.rs
+++ b/crates/karva/src/commands/snapshot/accept.rs
@@ -9,8 +9,7 @@ pub fn accept(filter_paths: &[String]) -> Result<ExitStatus> {
     let Some((mut stdout, filtered)) = pending_setup(filter_paths)? else {
         return Ok(ExitStatus::Success);
     };
-    let refs: Vec<_> = filtered.iter().collect();
-    karva_snapshot::storage::accept_pending_batch(&refs)?;
+    karva_snapshot::storage::accept_pending_batch(&filtered)?;
     for info in &filtered {
         writeln!(stdout, "Accepted: {}", info.pending_path)?;
     }

--- a/crates/karva_snapshot/src/review.rs
+++ b/crates/karva_snapshot/src/review.rs
@@ -182,8 +182,7 @@ pub fn run_review(root: &Utf8Path, resolved_filters: &[Utf8PathBuf]) -> io::Resu
                     break;
                 }
                 ReviewAction::AcceptAll => {
-                    let to_accept: Vec<&PendingSnapshotInfo> = filtered[i..].iter().collect();
-                    accept_pending_batch(&to_accept)?;
+                    accept_pending_batch(&filtered[i..])?;
                     for item in &filtered[i..] {
                         summary.accepted.push(item.pending_path.to_string());
                     }

--- a/crates/karva_snapshot/src/storage.rs
+++ b/crates/karva_snapshot/src/storage.rs
@@ -172,9 +172,9 @@ struct InlineInfo<'a> {
 type ClassifiedPendingSnapshots<'a> = (HashMap<String, Vec<InlineInfo<'a>>>, Vec<&'a Utf8Path>);
 
 /// Classify pending snapshots into inline (grouped by source file) and file-based.
-fn classify_pending_snapshots<'a>(
-    pending: &'a [&PendingSnapshotInfo],
-) -> io::Result<ClassifiedPendingSnapshots<'a>> {
+fn classify_pending_snapshots(
+    pending: &[PendingSnapshotInfo],
+) -> io::Result<ClassifiedPendingSnapshots<'_>> {
     let mut inline_by_source: HashMap<String, Vec<InlineInfo<'_>>> = HashMap::new();
     let mut file_based: Vec<&Utf8Path> = Vec::new();
 
@@ -240,7 +240,7 @@ fn process_file_based_snapshots(file_based: &[&Utf8Path]) -> io::Result<()> {
 /// expansion shifts line numbers for subsequent snapshots. By processing in
 /// descending line order (bottom-to-top), edits at higher lines don't affect
 /// line numbers above.
-pub fn accept_pending_batch(pending: &[&PendingSnapshotInfo]) -> io::Result<()> {
+pub fn accept_pending_batch(pending: &[PendingSnapshotInfo]) -> io::Result<()> {
     let (mut inline_by_source, file_based) = classify_pending_snapshots(pending)?;
     process_inline_snapshots(&mut inline_by_source)?;
     process_file_based_snapshots(&file_based)


### PR DESCRIPTION
## Summary

Simplify snapshot batch acceptance by passing pending snapshot slices directly into `accept_pending_batch`. This removes the temporary reference vectors from both `snapshot accept` and review Accept All without changing behavior.

## Test Plan

Ran `cargo test -p karva_snapshot`, focused snapshot accept/review integration tests, `cargo clippy -p karva_snapshot -p karva --all-targets --all-features -- -D warnings`, and `uvx prek run -a`.