### PR TITLE
Simplify no-tests exit handling

### DIFF
--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -222,33 +222,23 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
 
     if no_tests_collected(&result) {
         let has_filters = !sub_command.filter_expressions.is_empty();
-        match project.settings().test().no_tests {
-            NoTestsMode::Pass => {
-                let exit_status = ExitStatus::Success;
-                write_result_report(exit_status)?;
-                return Ok(exit_status);
-            }
-            NoTestsMode::Auto if has_filters => {
-                let exit_status = ExitStatus::Success;
-                write_result_report(exit_status)?;
-                return Ok(exit_status);
-            }
+        let exit_status = match project.settings().test().no_tests {
+            NoTestsMode::Pass => ExitStatus::Success,
+            NoTestsMode::Auto if has_filters => ExitStatus::Success,
             NoTestsMode::Warn => {
                 let mut stdout = printer.stream_for_message().lock();
                 writeln!(stdout, "warning: no tests to run")?;
-                let exit_status = ExitStatus::Success;
-                write_result_report(exit_status)?;
-                return Ok(exit_status);
+                ExitStatus::Success
             }
             NoTestsMode::Auto | NoTestsMode::Fail => {
                 let mut stdout = printer.stream_for_message().lock();
                 writeln!(stdout, "error: no tests to run")?;
                 writeln!(stdout, "(hint: use `--no-tests` to customize)")?;
-                let exit_status = ExitStatus::Failure;
-                write_result_report(exit_status)?;
-                return Ok(exit_status);
+                ExitStatus::Failure
             }
-        }
+        };
+        write_result_report(exit_status)?;
+        return Ok(exit_status);
     }
 
     let exit_status = if result.stats.is_success()


### PR DESCRIPTION
## Summary

This simplifies the no-tests branch in the test command by computing the exit status once and sharing the result-report write path. The behavior stays the same, but the command no longer repeats the same report-and-return code in every match arm.

## Test Plan

Verified with the focused no-tests integration cases, the matching result-report case, clippy for `karva`, and `uvx prek run -a`.
