### PR TITLE
Parse test paths without intermediate vectors

### DIFF
--- a/crates/karva_project/src/lib.rs
+++ b/crates/karva_project/src/lib.rs
@@ -86,24 +86,19 @@ impl Project {
     }
 
     pub fn test_paths(&self) -> Vec<Result<TestPath, TestPathError>> {
-        let mut discovered_paths: Vec<Utf8PathBuf> = self
-            .settings
+        if self.settings.src().include_paths.is_empty() {
+            return vec![TestPath::new(self.cwd().as_str())];
+        }
+
+        self.settings
             .src()
             .include_paths
             .iter()
-            .map(|p| absolute(p, self.cwd()))
-            .collect();
-
-        if discovered_paths.is_empty() {
-            discovered_paths.push(self.cwd().clone());
-        }
-
-        let test_paths: Vec<Result<TestPath, TestPathError>> = discovered_paths
-            .iter()
-            .map(|p| TestPath::new(p.as_str()))
-            .collect();
-
-        test_paths
+            .map(|path| {
+                let path = absolute(path, self.cwd());
+                TestPath::new(path.as_str())
+            })
+            .collect()
     }
 
     pub fn metadata(&self) -> &ProjectMetadata {

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -115,16 +115,14 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
 
     let python_version = current_python_version();
 
-    let test_paths: Vec<Utf8PathBuf> = args
+    let test_paths: Vec<Result<TestPath, TestPathError>> = args
         .sub_command
         .paths
         .iter()
-        .map(|p| absolute(p, cwd.clone()))
-        .collect();
-
-    let test_paths: Vec<Result<TestPath, TestPathError>> = test_paths
-        .iter()
-        .map(|p| TestPath::new(p.as_str()))
+        .map(|path| {
+            let path = absolute(path, &cwd);
+            TestPath::new(path.as_str())
+        })
         .collect();
 
     let filter = FiltersetSet::new(&args.sub_command.filter_expressions)


### PR DESCRIPTION
## Summary

This removes the temporary path vectors used while converting configured or worker-received paths into `TestPath` values. Main discovery and worker execution now normalize each path and parse it in the same pass.

## Test Plan

Verified with focused `karva_project` and `karva_worker` tests, clippy for both touched crates, and `uvx prek run -a`.
