### PR TITLE
Avoid cloning test results for stats

### DIFF
--- a/crates/karva_diagnostic/src/result/kind.rs
+++ b/crates/karva_diagnostic/src/result/kind.rs
@@ -54,7 +54,13 @@ impl TestResultKind {
 
 impl From<IndividualTestResultKind> for TestResultKind {
     fn from(val: IndividualTestResultKind) -> Self {
-        match val {
+        Self::from(&val)
+    }
+}
+
+impl From<&IndividualTestResultKind> for TestResultKind {
+    fn from(val: &IndividualTestResultKind) -> Self {
+        match *val {
             IndividualTestResultKind::Passed => Self::Passed,
             IndividualTestResultKind::Failed => Self::Failed,
             IndividualTestResultKind::Skipped { .. } => Self::Skipped,

--- a/crates/karva_diagnostic/src/result/mod.rs
+++ b/crates/karva_diagnostic/src/result/mod.rs
@@ -83,7 +83,7 @@ impl TestRunResult {
         duration: std::time::Duration,
         reporter: Option<&dyn Reporter>,
     ) {
-        self.stats.add(result.clone().into());
+        self.stats.add(TestResultKind::from(&result));
 
         let function_name = test_case_name.function_name().clone();
         self.test_cases.push(TestCaseResult::new(
@@ -125,7 +125,7 @@ impl TestRunResult {
         total_attempts: u32,
         _reporter: Option<&dyn Reporter>,
     ) {
-        self.stats.add(result.clone().into());
+        self.stats.add(TestResultKind::from(result));
 
         let function_name = test_case_name.function_name().clone();
         self.test_cases.push(TestCaseResult::retried(


### PR DESCRIPTION
## Summary

This adds a borrowed conversion from individual test outcomes to aggregate result kinds. Stats registration can now preserve the owned outcome for reporting without cloning skip context that the stats layer discards anyway.

## Test Plan

Verified with `just test -p karva_diagnostic -p karva_test_semantic`, clippy for both crates, and `uvx prek run -a`.
