### PR TITLE
Forward configured retries to workers

### DIFF
--- a/crates/karva/tests/it/configuration/mod.rs
+++ b/crates/karva/tests/it/configuration/mod.rs
@@ -504,6 +504,44 @@ def test_c():
 }
 
 #[test]
+fn test_retry_from_config() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r"
+[profile.default.test]
+retry = 2
+",
+        ),
+        (
+            "test.py",
+            r"
+attempts = 0
+
+def test_config_retry():
+    global attempts
+    attempts += 1
+    assert attempts == 2
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+      TRY 1 FAIL [TIME] test::test_config_retry
+      TRY 2 PASS [TIME] test::test_config_retry
+    ────────────
+         Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
+       FLAKY 2/3 [TIME] test::test_config_retry
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_fail_fast_true() {
     let context = TestContext::with_files([
         (

--- a/crates/karva_runner/src/worker_args.rs
+++ b/crates/karva_runner/src/worker_args.rs
@@ -109,9 +109,9 @@ fn inner_cli_args(settings: &ProjectSettings, args: &SubTestCommand) -> Vec<Stri
         cli_args.push("--snapshot-update".to_string());
     }
 
-    if let Some(retry) = args.retry {
+    if settings.test().retry > 0 {
         cli_args.push("--retry".to_string());
-        cli_args.push(retry.to_string());
+        cli_args.push(settings.test().retry.to_string());
     }
 
     if let Some(threshold) = settings.test().slow_timeout {


### PR DESCRIPTION
## Summary

This fixes worker argument construction so resolved `retry` settings from `karva.toml` are forwarded to worker processes instead of only forwarding raw CLI retry flags. The integration test covers config-driven retry behavior through the CLI.

## Test Plan

Verified with `just test -p karva test_retry_from_config`, targeted clippy, and `uvx prek run -a`.