### PR TITLE
Fix snapshot source path filters

### DIFF
--- a/crates/karva/src/commands/snapshot/mod.rs
+++ b/crates/karva/src/commands/snapshot/mod.rs
@@ -12,7 +12,9 @@ use camino::{Utf8Path, Utf8PathBuf};
 use karva_cli::{SnapshotAction, SnapshotCommand};
 use karva_logging::{Printer, Stdout};
 use karva_project::path::absolute;
-use karva_snapshot::storage::{PendingSnapshotInfo, find_pending_snapshots};
+use karva_snapshot::storage::{
+    PendingSnapshotInfo, find_pending_snapshots, matches_snapshot_filter,
+};
 
 use crate::ExitStatus;
 use crate::utils::cwd;
@@ -94,49 +96,5 @@ fn matches_filter(snapshot_path: &Utf8Path, resolved_filters: &[Utf8PathBuf]) ->
     resolved_filters.is_empty()
         || resolved_filters
             .iter()
-            .any(|filter| matches_snapshot_path(snapshot_path, filter))
-}
-
-fn matches_snapshot_path(snapshot_path: &Utf8Path, filter: &Utf8Path) -> bool {
-    matches_path(snapshot_path, filter)
-        || source_path_for_snapshot(snapshot_path)
-            .is_some_and(|source| matches_path(&source, filter))
-}
-
-fn matches_path(path: &Utf8Path, filter: &Utf8Path) -> bool {
-    path.starts_with(filter) || matches_snapshot_file_stem(path, filter)
-}
-
-fn matches_snapshot_file_stem(path: &Utf8Path, filter: &Utf8Path) -> bool {
-    if path.parent() != filter.parent() {
-        return false;
-    }
-
-    let Some(file_name) = path.file_name() else {
-        return false;
-    };
-    let Some(filter_name) = filter.file_name() else {
-        return false;
-    };
-    let Some(rest) = file_name.strip_prefix(filter_name) else {
-        return false;
-    };
-
-    rest.starts_with("__") || rest.starts_with(".snap")
-}
-
-fn source_path_for_snapshot(snapshot_path: &Utf8Path) -> Option<Utf8PathBuf> {
-    let snapshots_dir = snapshot_path.parent()?;
-    if snapshots_dir.file_name()? != "snapshots" {
-        return None;
-    }
-
-    let file_name = snapshot_path.file_name()?;
-    let snapshot_stem = file_name
-        .strip_suffix(".snap.new")
-        .or_else(|| file_name.strip_suffix(".snap"))?;
-    let (module_name, _) = snapshot_stem.split_once("__")?;
-    let source_dir = snapshots_dir.parent()?;
-
-    Some(source_dir.join(format!("{module_name}.py")))
+            .any(|filter| matches_snapshot_filter(snapshot_path, filter))
 }

--- a/crates/karva/src/commands/snapshot/mod.rs
+++ b/crates/karva/src/commands/snapshot/mod.rs
@@ -86,11 +86,57 @@ fn resolve_filter_paths(filter_paths: &[String], cwd: &Utf8Path) -> Vec<Utf8Path
     filter_paths.iter().map(|f| absolute(f, cwd)).collect()
 }
 
-/// Check if a snapshot path matches any resolved filter (absolute path prefix match).
-/// Returns true if filters is empty (match all).
+/// Check if a snapshot path matches any resolved filter.
+///
+/// Filters can target either the generated snapshot file or the source file
+/// whose stem is encoded in that snapshot filename.
 fn matches_filter(snapshot_path: &Utf8Path, resolved_filters: &[Utf8PathBuf]) -> bool {
     resolved_filters.is_empty()
         || resolved_filters
             .iter()
-            .any(|f| snapshot_path.as_str().starts_with(f.as_str()))
+            .any(|filter| matches_snapshot_path(snapshot_path, filter))
+}
+
+fn matches_snapshot_path(snapshot_path: &Utf8Path, filter: &Utf8Path) -> bool {
+    matches_path(snapshot_path, filter)
+        || source_path_for_snapshot(snapshot_path)
+            .is_some_and(|source| matches_path(&source, filter))
+}
+
+fn matches_path(path: &Utf8Path, filter: &Utf8Path) -> bool {
+    path.starts_with(filter) || matches_snapshot_file_stem(path, filter)
+}
+
+fn matches_snapshot_file_stem(path: &Utf8Path, filter: &Utf8Path) -> bool {
+    if path.parent() != filter.parent() {
+        return false;
+    }
+
+    let Some(file_name) = path.file_name() else {
+        return false;
+    };
+    let Some(filter_name) = filter.file_name() else {
+        return false;
+    };
+    let Some(rest) = file_name.strip_prefix(filter_name) else {
+        return false;
+    };
+
+    rest.starts_with("__") || rest.starts_with(".snap")
+}
+
+fn source_path_for_snapshot(snapshot_path: &Utf8Path) -> Option<Utf8PathBuf> {
+    let snapshots_dir = snapshot_path.parent()?;
+    if snapshots_dir.file_name()? != "snapshots" {
+        return None;
+    }
+
+    let file_name = snapshot_path.file_name()?;
+    let snapshot_stem = file_name
+        .strip_suffix(".snap.new")
+        .or_else(|| file_name.strip_suffix(".snap"))?;
+    let (module_name, _) = snapshot_stem.split_once("__")?;
+    let source_dir = snapshots_dir.parent()?;
+
+    Some(source_dir.join(format!("{module_name}.py")))
 }

--- a/crates/karva/tests/it/extensions/snapshot/delete.rs
+++ b/crates/karva/tests/it/extensions/snapshot/delete.rs
@@ -182,6 +182,60 @@ def test_from_two():
 }
 
 #[test]
+fn test_snapshot_delete_with_source_file_filter() {
+    let context = TestContext::default();
+    context.write_file(
+        "test_one.py",
+        r"
+import karva
+
+def test_from_one():
+    karva.assert_snapshot('from file one')
+        ",
+    );
+    context.write_file(
+        "test_one_extra.py",
+        r"
+import karva
+
+def test_from_extra():
+    karva.assert_snapshot('from extra file')
+        ",
+    );
+
+    let _ = context
+        .command_no_parallel()
+        .arg("--snapshot-update")
+        .output();
+
+    assert_cmd_snapshot!(context.snapshot("delete").arg("test_one.py"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Deleted: <temp_dir>/snapshots/test_one__test_from_one.snap
+
+    1 snapshot file(s) deleted.
+
+    ----- stderr -----
+    ");
+
+    assert!(
+        !context
+            .root()
+            .join("snapshots/test_one__test_from_one.snap")
+            .exists(),
+        "Expected test_one snapshot to be deleted"
+    );
+    assert!(
+        context
+            .root()
+            .join("snapshots/test_one_extra__test_from_extra.snap")
+            .exists(),
+        "Expected test_one_extra snapshot to still exist"
+    );
+}
+
+#[test]
 fn test_snapshot_delete_only_pending() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva/tests/it/extensions/snapshot/review.rs
+++ b/crates/karva/tests/it/extensions/snapshot/review.rs
@@ -237,6 +237,74 @@ def test_hello():
 }
 
 #[test]
+fn test_snapshot_review_with_source_file_filter() {
+    let context = TestContext::default();
+    context.write_file(
+        "test_one.py",
+        r"
+import karva
+
+def test_from_one():
+    karva.assert_snapshot('from file one')
+        ",
+    );
+    context.write_file(
+        "test_one_extra.py",
+        r"
+import karva
+
+def test_from_extra():
+    karva.assert_snapshot('from extra file')
+        ",
+    );
+
+    let _ = context.command_no_parallel().output();
+
+    assert_cmd_snapshot!(context.snapshot("review").arg("test_one.py").pass_stdin("a\n"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    Snapshot 1/1
+    File: <temp_dir>/snapshots/test_one__test_from_one.snap.new
+    Source: test_one.py:5::test_from_one
+
+    ────────────┬[LONG-LINE]
+              1 │ +from file one
+    ────────────┴[LONG-LINE]
+
+      a accept     keep the new snapshot
+      r reject     retain the old snapshot
+      s skip       keep both for now
+      i hide info  toggles extended snapshot info
+      d hide diff  toggle snapshot diff
+
+      Tip: Use uppercase A/R/S to apply to all remaining snapshots
+    > 
+    review finished
+    accepted:
+      <temp_dir>/snapshots/test_one__test_from_one.snap.new
+
+    ----- stderr -----
+    ");
+
+    assert!(
+        context
+            .root()
+            .join("snapshots/test_one__test_from_one.snap")
+            .exists(),
+        "Expected test_one snapshot to be accepted"
+    );
+    assert!(
+        context
+            .root()
+            .join("snapshots/test_one_extra__test_from_extra.snap.new")
+            .exists(),
+        "Expected test_one_extra pending snapshot to still exist"
+    );
+}
+
+#[test]
 fn test_snapshot_review_accept_all() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva_snapshot/src/review.rs
+++ b/crates/karva_snapshot/src/review.rs
@@ -7,7 +7,7 @@ use console::{Key, Term};
 use crate::diff::print_changeset;
 use crate::storage::{
     PendingSnapshotInfo, accept_pending, accept_pending_batch, find_pending_snapshots,
-    read_snapshot, reject_pending,
+    matches_snapshot_filter, read_snapshot, reject_pending,
 };
 
 /// Result of reviewing all pending snapshots.
@@ -117,7 +117,7 @@ pub fn run_review(root: &Utf8Path, resolved_filters: &[Utf8PathBuf]) -> io::Resu
             .filter(|info| {
                 resolved_filters
                     .iter()
-                    .any(|f| info.pending_path.as_str().starts_with(f.as_str()))
+                    .any(|filter| matches_snapshot_filter(&info.pending_path, filter))
             })
             .collect()
     };

--- a/crates/karva_snapshot/src/storage.rs
+++ b/crates/karva_snapshot/src/storage.rs
@@ -128,6 +128,54 @@ pub fn find_pending_snapshots(root: &Utf8Path) -> io::Result<Vec<PendingSnapshot
     Ok(results)
 }
 
+/// Check whether a generated snapshot path matches a user filter.
+///
+/// Filters can target either the generated snapshot file or the source file
+/// whose stem is encoded in that snapshot filename.
+pub fn matches_snapshot_filter(snapshot_path: &Utf8Path, filter: &Utf8Path) -> bool {
+    matches_filter_path(snapshot_path, filter)
+        || source_path_for_snapshot(snapshot_path)
+            .is_some_and(|source| matches_filter_path(&source, filter))
+}
+
+fn matches_filter_path(path: &Utf8Path, filter: &Utf8Path) -> bool {
+    path.starts_with(filter) || matches_snapshot_file_stem(path, filter)
+}
+
+fn matches_snapshot_file_stem(path: &Utf8Path, filter: &Utf8Path) -> bool {
+    if path.parent() != filter.parent() {
+        return false;
+    }
+
+    let Some(file_name) = path.file_name() else {
+        return false;
+    };
+    let Some(filter_name) = filter.file_name() else {
+        return false;
+    };
+    let Some(rest) = file_name.strip_prefix(filter_name) else {
+        return false;
+    };
+
+    rest.starts_with("__") || rest.starts_with(".snap")
+}
+
+fn source_path_for_snapshot(snapshot_path: &Utf8Path) -> Option<Utf8PathBuf> {
+    let snapshots_dir = snapshot_path.parent()?;
+    if snapshots_dir.file_name()? != "snapshots" {
+        return None;
+    }
+
+    let file_name = snapshot_path.file_name()?;
+    let snapshot_stem = file_name
+        .strip_suffix(".snap.new")
+        .or_else(|| file_name.strip_suffix(".snap"))?;
+    let (module_name, _) = snapshot_stem.split_once("__")?;
+    let source_dir = snapshots_dir.parent()?;
+
+    Some(source_dir.join(format!("{module_name}.py")))
+}
+
 /// Extract the bare function name from a snapshot's `source` metadata.
 ///
 /// Given a source like `test_file.py:5::TestClass::test_foo(x=1)`,


### PR DESCRIPTION
## Summary

Snapshot command filters now match documented source file paths as well as generated snapshot files. The shared matcher is used by both interactive review and non-interactive snapshot commands, and it avoids raw string-prefix overmatching so a filter for `test_one.py` does not affect snapshots from `test_one_extra.py`.

## Test Plan

Ran focused snapshot review/delete tests, `cargo clippy -p karva -p karva_snapshot --all-targets --all-features -- -D warnings`, and `uvx prek run -a`.