### PR TITLE
Fix HTML coverage branch total

### DIFF
--- a/crates/karva/tests/it/coverage.rs
+++ b/crates/karva/tests/it/coverage.rs
@@ -1193,6 +1193,47 @@ def test_only_covered():
 }
 
 #[test]
+fn test_cov_report_html_total_includes_branches() {
+    let context = TestContext::with_file(
+        "test_branch.py",
+        r"
+def choose(flag):
+    if flag:
+        return 'yes'
+    return 'no'
+
+def test_yes():
+    assert choose(True) == 'yes'
+",
+    );
+
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .arg("--cov")
+            .arg("--cov-branch")
+            .arg("--cov-report=html:htmlcov")
+            .arg("--status-level=none")
+            .arg("test_branch.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+
+    let html = context.read_file("htmlcov/index.html");
+    assert!(
+        html.contains("<p>Total coverage: <strong>75%</strong> (6/8)</p>"),
+        "{html}"
+    );
+}
+
+#[test]
 fn test_cov_report_path_warns_for_term_report_from_config() {
     let context = TestContext::with_files([
         (

--- a/crates/karva_coverage/src/report/html.rs
+++ b/crates/karva_coverage/src/report/html.rs
@@ -31,12 +31,14 @@ impl fmt::Display for HtmlReport<'_> {
 
         let total = totals_row(self.rows);
         let show_branches = total.branches_enabled;
+        let total_covered = total.hit.saturating_add(total.branch_hit);
+        let total_valid = total.stmts.saturating_add(total.branches);
         writeln!(
             html,
             "  <p>Total coverage: <strong>{:.0}%</strong> ({}/{})</p>",
             row_percent(&total),
-            total.hit,
-            total.stmts
+            total_covered,
+            total_valid
         )?;
         writeln!(html, "  <table>")?;
         writeln!(html, "    <thead>")?;


### PR DESCRIPTION
## Summary

HTML coverage reports now show the same covered/valid unit total that their percentage uses when branch coverage is enabled. This avoids displaying a branch-aware percentage next to a line-only fraction.

## Test Plan

Ran focused HTML coverage tests, targeted clippy, and `uvx prek run -a`.