### PR TITLE
Clarify required-version diagnostics

### DIFF
--- a/crates/karva/tests/it/configuration/required_version.rs
+++ b/crates/karva/tests/it/configuration/required_version.rs
@@ -46,7 +46,7 @@ required-version = ">=999.0.0"
 
     ----- stderr -----
     Karva failed
-      Cause: <temp_dir>/karva.toml: the installed karva [VERSION] does not satisfy `required-version = ">=999.0.0"`
+      Cause: <temp_dir>/karva.toml has an incompatible `required-version`
       Cause: the installed karva [VERSION] does not satisfy `required-version = ">=999.0.0"`
     "#);
 }
@@ -74,7 +74,7 @@ required-version = ">=999.0.0"
 
     ----- stderr -----
     Karva failed
-      Cause: <temp_dir>/pyproject.toml: the installed karva [VERSION] does not satisfy `required-version = ">=999.0.0"`
+      Cause: <temp_dir>/pyproject.toml has an incompatible `required-version`
       Cause: the installed karva [VERSION] does not satisfy `required-version = ">=999.0.0"`
     "#);
 }

--- a/crates/karva_metadata/src/lib.rs
+++ b/crates/karva_metadata/src/lib.rs
@@ -347,7 +347,7 @@ pub enum ProjectMetadataError {
         path: Utf8PathBuf,
     },
 
-    #[error("{path}: {source}")]
+    #[error("{path} has an incompatible `required-version`")]
     IncompatibleVersion {
         path: Utf8PathBuf,
         #[source]


### PR DESCRIPTION
## Summary

This makes required-version metadata errors report the config file as path/context and leaves the concrete version mismatch to the source error. The CLI error chain no longer repeats the same version mismatch text.

## Test Plan

Verified with `just test -p karva required_version`, `cargo clippy -p karva -p karva_metadata --all-targets --all-features -- -D warnings`, and `uvx prek run -a`.