### PR TITLE
Add current test parse context

### DIFF
--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use fs_err as fs;
 use karva_diagnostic::{
@@ -115,7 +115,7 @@ impl RunCache {
     /// has cleared its progress file after finishing a test.
     pub fn read_current_test(&self, worker_id: usize) -> Result<Option<CurrentTest>> {
         let path = self.current_test_file(worker_id);
-        let content = match fs::read_to_string(path) {
+        let content = match fs::read_to_string(&path) {
             Ok(content) => content,
             Err(err) if err.kind() == ErrorKind::NotFound => return Ok(None),
             Err(err) => return Err(err.into()),
@@ -125,7 +125,9 @@ impl RunCache {
             return Ok(None);
         }
 
-        Ok(Some(serde_json::from_str(&content)?))
+        serde_json::from_str(&content)
+            .with_context(|| format!("failed to parse current test state `{path}`"))
+            .map(Some)
     }
 
     /// Returns paths to every per-worker coverage file that exists for this
@@ -789,6 +791,26 @@ mod tests {
         let error = cache
             .read_current_test(0)
             .expect_err("directory progress file should fail");
+
+        assert!(
+            error.to_string().contains(progress_file.as_str()),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn read_current_test_reports_path_on_parse_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let run_hash = RunHash::from_existing("run-770");
+        let cache = RunCache::new(&cache_dir, &run_hash);
+        let progress_file = cache.current_test_file(0);
+        fs::create_dir_all(progress_file.parent().expect("progress file parent")).unwrap();
+        fs::write(&progress_file, "not-json").unwrap();
+
+        let error = cache
+            .read_current_test(0)
+            .expect_err("malformed progress file should fail");
 
         assert!(
             error.to_string().contains(progress_file.as_str()),


### PR DESCRIPTION
## Summary

This adds the progress file path to malformed `current_test.json` errors. Read failures already included the path, and parse failures now get the same diagnostic context instead of returning a bare JSON error.

## Test Plan

Verified with `just test -p karva_cache read_current_test`, `cargo clippy -p karva_cache --all-targets --all-features -- -D warnings`, and `uvx prek run -a`.