### PR TITLE
Clarify cov-report path errors

### DIFF
--- a/crates/karva_cli/src/enums.rs
+++ b/crates/karva_cli/src/enums.rs
@@ -52,8 +52,11 @@ impl FromStr for CovReport {
             Some(("xml", _)) => Err("`xml` report path cannot be empty".to_string()),
             Some(("json", _)) => Err("`json` report path cannot be empty".to_string()),
             Some(("html", _)) => Err("`html` report path cannot be empty".to_string()),
-            Some((kind, _)) => Err(format!(
+            Some((kind @ ("term" | "term-missing"), _)) => Err(format!(
                 "report `{kind}` does not accept a path; expected `term`, `term-missing`, `xml[:PATH]`, `json[:PATH]`, or `html[:PATH]`"
+            )),
+            Some((_, _)) => Err(format!(
+                "invalid value `{raw}`; expected one of `term`, `term-missing`, `xml[:PATH]`, `json[:PATH]`, or `html[:PATH]`"
             )),
         }
     }

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -562,4 +562,20 @@ mod tests {
             })
         );
     }
+
+    #[test]
+    fn parse_term_cov_report_rejects_path() {
+        assert_eq!(
+            parse_cov_report("term:build/coverage.txt"),
+            Err("report `term` does not accept a path; expected `term`, `term-missing`, `xml[:PATH]`, `json[:PATH]`, or `html[:PATH]`".to_string()),
+        );
+    }
+
+    #[test]
+    fn parse_unknown_cov_report_with_path_reports_invalid_value() {
+        assert_eq!(
+            parse_cov_report("bogus:build/coverage.txt"),
+            Err("invalid value `bogus:build/coverage.txt`; expected one of `term`, `term-missing`, `xml[:PATH]`, `json[:PATH]`, or `html[:PATH]`".to_string()),
+        );
+    }
 }


### PR DESCRIPTION
## Summary

This makes `--cov-report=<unknown>:<path>` report an invalid coverage report value instead of saying the unknown report does not accept a path. Known terminal reports with paths still get the specific unsupported-path message.

## Test Plan

Verified with `just test -p karva_cli cov_report`, `cargo clippy -p karva_cli --all-targets --all-features -- -D warnings`, and `uvx prek run -a`.