### PR TITLE
Prune empty package shells

### DIFF
--- a/crates/karva_collector/src/models.rs
+++ b/crates/karva_collector/src/models.rs
@@ -209,13 +209,12 @@ impl CollectedPackage {
 
     /// Remove empty modules and packages recursively.
     pub fn shrink(&mut self) {
-        self.modules.retain(|_, module| !module.is_empty());
-
-        self.packages.retain(|_, package| !package.is_empty());
-
         for package in self.packages.values_mut() {
             package.shrink();
         }
+
+        self.modules.retain(|_, module| !module.is_empty());
+        self.packages.retain(|_, package| !package.is_empty());
     }
 }
 
@@ -263,5 +262,28 @@ impl From<&Utf8PathBuf> for ModuleType {
         } else {
             Self::Test
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use camino::Utf8PathBuf;
+
+    use super::CollectedPackage;
+
+    #[test]
+    fn shrink_removes_packages_that_become_empty_after_child_shrink() {
+        let mut root = CollectedPackage::new(Utf8PathBuf::from("/project"));
+        let mut child = CollectedPackage::new(Utf8PathBuf::from("/project/pkg"));
+        let empty_path = Utf8PathBuf::from("/project/pkg/empty");
+        child
+            .packages
+            .insert(empty_path.clone(), CollectedPackage::new(empty_path));
+        root.packages
+            .insert(Utf8PathBuf::from("/project/pkg"), child);
+
+        root.shrink();
+
+        assert!(root.packages.is_empty());
     }
 }

--- a/crates/karva_test_semantic/src/discovery/models/package.rs
+++ b/crates/karva_test_semantic/src/discovery/models/package.rs
@@ -78,20 +78,39 @@ impl DiscoveredPackage {
 
     /// Remove empty modules and packages.
     pub(crate) fn shrink(&mut self) {
-        self.modules.retain(|_, module| !module.is_empty());
-
         for module in self.modules.values_mut() {
             module.shrink();
         }
 
-        self.packages.retain(|_, package| !package.is_empty());
-
         for package in self.packages.values_mut() {
             package.shrink();
         }
+
+        self.modules.retain(|_, module| !module.is_empty());
+        self.packages.retain(|_, package| !package.is_empty());
     }
 
     pub(crate) fn is_empty(&self) -> bool {
         self.modules.is_empty() && self.packages.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use camino::Utf8PathBuf;
+
+    use super::DiscoveredPackage;
+
+    #[test]
+    fn shrink_removes_packages_that_become_empty_after_child_shrink() {
+        let mut root = DiscoveredPackage::new(Utf8PathBuf::from("/project"));
+        let mut child = DiscoveredPackage::new(Utf8PathBuf::from("/project/pkg"));
+        let empty_path = Utf8PathBuf::from("/project/pkg/empty");
+        child.add_direct_subpackage(DiscoveredPackage::new(empty_path));
+        root.add_direct_subpackage(child);
+
+        root.shrink();
+
+        assert!(root.packages().is_empty());
     }
 }


### PR DESCRIPTION
## Summary

This changes collected and discovered package shrinking to recurse into child packages before deciding whether each child is empty. Empty package shells that only become empty after their own shrink pass are now removed consistently.

## Test Plan

Verified with `just test shrink_removes_packages_that_become_empty_after_child_shrink`, `cargo clippy -p karva_collector -p karva_test_semantic --all-targets --all-features -- -D warnings`, and `uvx prek run -a`.