### PR TITLE
Avoid retrying skipped and expected-fail tests

### DIFF
--- a/crates/karva/tests/it/extensions/functions.rs
+++ b/crates/karva/tests/it/extensions/functions.rs
@@ -208,6 +208,35 @@ def test_conditional_skip():
     }
 }
 
+#[rstest]
+fn test_runtime_skip_does_not_retry(#[values("pytest", "karva")] framework: &str) {
+    let context = TestContext::with_file(
+        "test.py",
+        &format!(
+            r"
+import {framework}
+
+def test_skip():
+    {framework}.skip('This test is skipped at runtime')
+    assert False, 'This should not be reached'
+        "
+        ),
+    );
+
+    allow_duplicates! {
+        assert_cmd_snapshot!(context.command_no_parallel().arg("--retry=2"), @"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+            Starting 1 test across 1 worker
+        ────────────
+             Summary [TIME] 1 test run: 0 passed, 1 skipped
+
+        ----- stderr -----
+        ");
+    }
+}
+
 #[test]
 fn test_mixed_skip_and_pass() {
     let context = TestContext::with_file(

--- a/crates/karva/tests/it/extensions/tags/expect_fail.rs
+++ b/crates/karva/tests/it/extensions/tags/expect_fail.rs
@@ -512,6 +512,32 @@ def test_1():
 }
 
 #[test]
+fn test_expect_fail_does_not_retry_expected_failure() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+@karva.tags.expect_fail(reason='Expected to fail')
+def test_1():
+    assert False
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--retry=2"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_1
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_expect_fail_with_assertion_error() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -441,6 +441,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         py: Python<'_>,
         qualified_test_name: &QualifiedTestName,
         configured_retries: u32,
+        should_retry_error: impl Fn(&PyErr) -> bool,
         mut run_test: impl FnMut() -> PyResult<Py<PyAny>>,
     ) -> RetryOutcome {
         let max_attempts = configured_retries.saturating_add(1);
@@ -456,7 +457,10 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         let mut final_attempt_duration = attempt_start.elapsed();
 
         while retry_count > 0 {
-            if test_result.is_ok() {
+            let Err(err) = &test_result else {
+                break;
+            };
+            if !should_retry_error(err) {
                 break;
             }
             let attempt_duration = attempt_start.elapsed();
@@ -483,10 +487,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             //   TRY 2 PASS ...   (or TRY 2 FAIL for an exhausted retry)
             // The diagnostic for the final attempt (if any) is collected by
             // `classify_test_result` and shown in the end-of-run block.
-            let final_kind = match &test_result {
-                Ok(_) => IndividualTestResultKind::Passed,
-                Err(_) => IndividualTestResultKind::Failed,
-            };
+            let final_kind = attempt_result_kind(py, &test_result);
             self.context.report_test_attempt(
                 qualified_test_name,
                 attempt,
@@ -606,6 +607,9 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         };
 
         let configured_retries = self.context.settings().retry_for(&eval_ctx);
+        let expect_fail = expect_fail_tag
+            .as_ref()
+            .is_some_and(ExpectFailTag::should_expect_fail);
         self.context.report_test_started(&qualified_test_name);
         if let Some(coverage) = self.coverage {
             coverage.set_current_context(py, Some(&qualified_name_str));
@@ -615,7 +619,13 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             attempt,
             max_attempts,
             was_retried,
-        } = self.run_with_retries(py, &qualified_test_name, configured_retries, run_test);
+        } = self.run_with_retries(
+            py,
+            &qualified_test_name,
+            configured_retries,
+            |err| !expect_fail && !is_skip_exception(py, err),
+            run_test,
+        );
         self.context.report_test_finished(&qualified_test_name);
 
         let report_ctx = VariantReportCtx {
@@ -842,6 +852,19 @@ fn get_value_and_finalizer(
         }
     } else {
         Ok((fixture_call_result, None))
+    }
+}
+
+fn attempt_result_kind(
+    py: Python<'_>,
+    test_result: &PyResult<Py<PyAny>>,
+) -> IndividualTestResultKind {
+    match test_result {
+        Ok(_) => IndividualTestResultKind::Passed,
+        Err(err) if is_skip_exception(py, err) => IndividualTestResultKind::Skipped {
+            reason: extract_skip_reason(py, err),
+        },
+        Err(_) => IndividualTestResultKind::Failed,
     }
 }
 


### PR DESCRIPTION
## Summary

Retries now stop before outcomes that are not real failures: runtime skips and expected failures are classified once instead of burning the retry budget and showing misleading `TRY N FAIL` lines. This keeps retry reporting focused on failures that can actually become flaky passes.

## Test Plan

`just test -p karva test_runtime_skip_does_not_retry test_expect_fail_does_not_retry_expected_failure`, `just test -p karva retry`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `uvx prek run -a`.