### PR TITLE
Treat snapshot filter replacements literally

### DIFF
--- a/crates/karva/tests/it/extensions/snapshot/filters.rs
+++ b/crates/karva/tests/it/extensions/snapshot/filters.rs
@@ -112,6 +112,42 @@ def test_no_match():
 }
 
 #[test]
+fn test_snapshot_filter_replacement_is_literal() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+
+def test_literal_replacement():
+    with karva.snapshot_settings(filters=[
+        (r"cost=\d+", "cost=$1"),
+    ]):
+        karva.assert_snapshot("cost=42")
+        "#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--snapshot-update"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_literal_replacement
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+
+    let content = context.read_file("snapshots/test__test_literal_replacement.snap");
+    insta::assert_snapshot!(content, @r"
+    ---
+    source: test.py:8::test_literal_replacement
+    ---
+    cost=$1
+    ");
+}
+
+#[test]
 fn test_snapshot_filter_invalid_regex() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva_snapshot/src/filters.rs
+++ b/crates/karva_snapshot/src/filters.rs
@@ -1,4 +1,4 @@
-use regex::Regex;
+use regex::{NoExpand, Regex};
 
 /// A compiled snapshot filter that replaces regex matches with a fixed string.
 #[derive(Debug)]
@@ -21,7 +21,7 @@ pub fn apply_filters(input: &str, filters: &[SnapshotFilter]) -> String {
     for filter in filters {
         result = filter
             .regex
-            .replace_all(&result, &*filter.replacement)
+            .replace_all(&result, NoExpand(&filter.replacement))
             .into_owned();
     }
     result
@@ -56,6 +56,13 @@ mod tests {
         let filters =
             vec![SnapshotFilter::new(r"ZZZZZ", "[never]".to_string()).expect("valid regex")];
         insta::assert_snapshot!(apply_filters("hello world", &filters), @"hello world");
+    }
+
+    #[test]
+    fn replacement_text_is_literal() {
+        let filters =
+            vec![SnapshotFilter::new(r"cost=\d+", "cost=$1".to_string()).expect("valid regex")];
+        insta::assert_snapshot!(apply_filters("cost=42", &filters), @"cost=$1");
     }
 
     #[test]

--- a/docs/usage/writing-tests/snapshots.md
+++ b/docs/usage/writing-tests/snapshots.md
@@ -372,7 +372,7 @@ def test_api_response():
         karva.assert_snapshot(get_response())
 ```
 
-Each filter is a `(regex_pattern, replacement)` tuple. Filters are applied sequentially to the serialized value before it is compared or stored in the snapshot file.
+Each filter is a `(regex_pattern, replacement)` tuple. Filters are applied sequentially to the serialized value before it is compared or stored in the snapshot file. Replacement text is literal, so `$1` and other capture references are not expanded.
 
 ### Multiple Filters
 


### PR DESCRIPTION
## Summary

Snapshot filters now treat replacement text as a literal string. This prevents replacements containing `$` from being interpreted as regex capture references and changing the stored snapshot content.

## Test Plan

Verified with `just test -p karva_snapshot replacement_text_is_literal`, `just test -p karva test_snapshot_filter_replacement_is_literal`, `cargo clippy -p karva_snapshot -p karva --all-targets --all-features -- -D warnings`, and `uvx prek run -a`.