### PR TITLE
Return slices from model accessors

### DIFF
--- a/crates/karva_test_semantic/src/discovery/models/module.rs
+++ b/crates/karva_test_semantic/src/discovery/models/module.rs
@@ -47,7 +47,7 @@ impl DiscoveredModule {
         self.path.module_name()
     }
 
-    pub(crate) fn test_functions(&self) -> &Vec<DiscoveredTestFunction> {
+    pub(crate) fn test_functions(&self) -> &[DiscoveredTestFunction] {
         &self.test_functions
     }
 
@@ -55,7 +55,7 @@ impl DiscoveredModule {
         self.test_functions.push(test_function);
     }
 
-    pub(crate) fn fixtures(&self) -> &Vec<DiscoveredFixture> {
+    pub(crate) fn fixtures(&self) -> &[DiscoveredFixture] {
         &self.fixtures
     }
 

--- a/crates/karva_test_semantic/src/extensions/fixtures/normalized_fixture.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/normalized_fixture.rs
@@ -49,7 +49,7 @@ impl NormalizedFixture {
     }
 
     /// Returns the fixture dependencies.
-    pub(crate) fn dependencies(&self) -> &Vec<Rc<Self>> {
+    pub(crate) fn dependencies(&self) -> &[Rc<Self>] {
         &self.dependencies
     }
 


### PR DESCRIPTION
## Summary

Returns slices from internal discovery and fixture model accessors instead of exposing `Vec` references. This keeps callers tied to the collection view they need without depending on the backing storage type.

## Test Plan

`cargo test -p karva_test_semantic`, `cargo clippy -p karva_test_semantic --all-targets --all-features -- -D warnings`, and `uvx prek run -a`.