### PR TITLE
Share CLI exit status type

### DIFF
--- a/crates/karva/src/lib.rs
+++ b/crates/karva/src/lib.rs
@@ -1,9 +1,10 @@
 use std::ffi::OsString;
-use std::process::{ExitCode, Termination};
 
 use anyhow::Context;
 use clap::Parser;
 use karva_cli::{Args, Command};
+
+pub use karva_cli::ExitStatus;
 
 mod commands;
 mod utils;
@@ -42,29 +43,5 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
             commands::show_config::show_config(show_config_args)
         }
         Command::Version => commands::version::version().map(|()| ExitStatus::Success),
-    }
-}
-
-#[derive(Copy, Clone)]
-pub enum ExitStatus {
-    /// Checking was successful and there were no errors.
-    Success = 0,
-
-    /// Checking was successful but there were errors.
-    Failure = 1,
-
-    /// Checking failed.
-    Error = 2,
-}
-
-impl Termination for ExitStatus {
-    fn report(self) -> ExitCode {
-        ExitCode::from(self as u8)
-    }
-}
-
-impl ExitStatus {
-    pub fn to_i32(self) -> i32 {
-        self as i32
     }
 }

--- a/crates/karva_cli/src/exit_status.rs
+++ b/crates/karva_cli/src/exit_status.rs
@@ -1,0 +1,25 @@
+use std::process::{ExitCode, Termination};
+
+#[derive(Copy, Clone)]
+pub enum ExitStatus {
+    /// Checking was successful and there were no errors.
+    Success = 0,
+
+    /// Checking was successful but there were errors.
+    Failure = 1,
+
+    /// Checking failed.
+    Error = 2,
+}
+
+impl Termination for ExitStatus {
+    fn report(self) -> ExitCode {
+        ExitCode::from(self as u8)
+    }
+}
+
+impl ExitStatus {
+    pub fn to_i32(self) -> i32 {
+        self as i32
+    }
+}

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -4,6 +4,7 @@ use clap::builder::styling::{AnsiColor, Effects};
 
 mod cache;
 mod enums;
+mod exit_status;
 mod partition;
 mod show_config;
 mod snapshot;
@@ -12,6 +13,7 @@ mod verbosity;
 
 pub use cache::{CacheAction, CacheCommand};
 pub use enums::{CovContext, CovReport, NoTests, OutputFormat, ResultFormat, RunIgnored};
+pub use exit_status::ExitStatus;
 pub use partition::PartitionSelection;
 pub use show_config::ShowConfigCommand;
 pub use snapshot::{

--- a/crates/karva_worker/src/bin/main.rs
+++ b/crates/karva_worker/src/bin/main.rs
@@ -1,4 +1,5 @@
-use karva_worker::cli::{ExitStatus, karva_worker_main};
+use karva_cli::ExitStatus;
+use karva_worker::cli::karva_worker_main;
 
 fn main() -> ExitStatus {
     karva_worker_main(|args| args)

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -1,12 +1,11 @@
 use std::ffi::OsString;
-use std::process::{ExitCode, Termination};
 
 use anyhow::Context as _;
 use camino::Utf8PathBuf;
 use clap::Parser;
 use fs_err as fs;
 use karva_cache::{RunCache, RunHash};
-use karva_cli::{SubTestCommand, Verbosity};
+use karva_cli::{ExitStatus, SubTestCommand, Verbosity};
 use karva_diagnostic::{DummyReporter, Reporter, TestCaseReporter};
 use karva_logging::{Printer, StatusLevel, set_colored_override, setup_tracing};
 use karva_metadata::RunIgnoredMode;
@@ -47,29 +46,6 @@ impl Args {
     }
 }
 
-#[derive(Copy, Clone)]
-pub enum ExitStatus {
-    /// Checking was successful and there were no errors.
-    Success = 0,
-
-    /// Checking was successful but there were errors.
-    Failure = 1,
-
-    /// Checking failed.
-    Error = 2,
-}
-
-impl Termination for ExitStatus {
-    fn report(self) -> ExitCode {
-        ExitCode::from(self as u8)
-    }
-}
-
-impl ExitStatus {
-    pub fn to_i32(self) -> i32 {
-        self as i32
-    }
-}
 pub fn karva_worker_main(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> ExitStatus {
     run(f).unwrap_or_else(|error| {
         if karva_logging::error_chain_contains_broken_pipe(error.chain()) {


### PR DESCRIPTION
## Summary

Moves the shared `ExitStatus` enum into `karva_cli` so the main CLI and worker binary use the same exit-code contract instead of maintaining duplicate definitions. The `karva` crate re-exports the type for its existing command modules.

## Test Plan

`cargo test -p karva_cli -p karva -p karva_worker --lib --bins`, `cargo clippy -p karva_cli -p karva -p karva_worker --all-targets --all-features -- -D warnings`, and `uvx prek run -a`.