### PR TITLE
Share captured output indexing

### DIFF
--- a/crates/karva/src/commands/test/junit.rs
+++ b/crates/karva/src/commands/test/junit.rs
@@ -4,7 +4,9 @@ use std::fmt::Write as _;
 use anyhow::{Context as _, Result};
 use camino::Utf8Path;
 use karva_cache::AggregatedResults;
-use karva_diagnostic::{CapturedTestOutput, TestCaseOutcome, TestCaseResult};
+use karva_diagnostic::{
+    CapturedTestOutput, TestCaseOutcome, TestCaseResult, captured_outputs_by_test,
+};
 use karva_metadata::JunitSettings;
 use karva_project::path::absolute;
 
@@ -31,7 +33,7 @@ pub(super) fn write_junit_report(
 }
 
 fn build_junit_xml(settings: &JunitSettings, results: &AggregatedResults) -> Result<String> {
-    let captured_outputs = captured_outputs_by_test(results);
+    let captured_outputs = captured_outputs_by_test(&results.captured_outputs);
     let suites = test_cases_by_module(&results.test_cases);
     let total_time = results
         .test_cases
@@ -164,14 +166,6 @@ fn test_cases_by_module(cases: &[TestCaseResult]) -> BTreeMap<&str, Vec<&TestCas
             .push(case);
     }
     by_module
-}
-
-fn captured_outputs_by_test(results: &AggregatedResults) -> HashMap<&str, &CapturedTestOutput> {
-    results
-        .captured_outputs
-        .iter()
-        .map(|output| (output.test_name(), output))
-        .collect()
 }
 
 fn escape_xml(value: &str) -> String {

--- a/crates/karva/src/commands/test/result_report.rs
+++ b/crates/karva/src/commands/test/result_report.rs
@@ -1,11 +1,12 @@
-use std::collections::HashMap;
 use std::time::Duration;
 
 use anyhow::{Context as _, Result};
 use camino::Utf8Path;
 use karva_cache::AggregatedResults;
 use karva_cli::ResultFormat;
-use karva_diagnostic::{CapturedTestOutput, TestCaseOutcome, TestCaseResult, TestCaseRetry};
+use karva_diagnostic::{
+    CapturedTestOutput, TestCaseOutcome, TestCaseResult, TestCaseRetry, captured_outputs_by_test,
+};
 use karva_project::path::absolute;
 use serde::Serialize;
 
@@ -104,7 +105,7 @@ struct RunReport<'a> {
 
 impl<'a> RunReport<'a> {
     fn new(results: &'a AggregatedResults, elapsed: Duration, status: RunStatus) -> Self {
-        let captured_outputs = captured_outputs_by_test(results);
+        let captured_outputs = captured_outputs_by_test(&results.captured_outputs);
         let tests = results
             .test_cases
             .iter()
@@ -263,12 +264,4 @@ struct RunFinishedEvent {
 )]
 fn is_false(value: &bool) -> bool {
     !*value
-}
-
-fn captured_outputs_by_test(results: &AggregatedResults) -> HashMap<&str, &CapturedTestOutput> {
-    results
-        .captured_outputs
-        .iter()
-        .map(|output| (output.test_name(), output))
-        .collect()
 }

--- a/crates/karva_diagnostic/src/lib.rs
+++ b/crates/karva_diagnostic/src/lib.rs
@@ -7,7 +7,7 @@ pub use reporter::{DummyReporter, Reporter, TestCaseReporter};
 pub use result::{
     CapturedTestOutcome, CapturedTestOutput, DisplayFlakyTest, DisplayFlakyTests, FlakyTest,
     IndividualTestResultKind, TestCaseOutcome, TestCaseResult, TestCaseRetry, TestResultKind,
-    TestResultStats, TestRunResult,
+    TestResultStats, TestRunResult, captured_outputs_by_test,
 };
 
 #[cfg(feature = "traceback")]

--- a/crates/karva_diagnostic/src/result/mod.rs
+++ b/crates/karva_diagnostic/src/result/mod.rs
@@ -14,7 +14,7 @@ use crate::reporter::Reporter;
 pub use case::{TestCaseOutcome, TestCaseResult, TestCaseRetry};
 pub use flaky::{DisplayFlakyTest, DisplayFlakyTests, FlakyTest};
 pub use kind::{IndividualTestResultKind, TestResultKind};
-pub use output::{CapturedTestOutcome, CapturedTestOutput};
+pub use output::{CapturedTestOutcome, CapturedTestOutput, captured_outputs_by_test};
 pub use stats::TestResultStats;
 
 /// Represents the result of a test run.

--- a/crates/karva_diagnostic/src/result/output.rs
+++ b/crates/karva_diagnostic/src/result/output.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use super::kind::IndividualTestResultKind;
@@ -8,6 +10,15 @@ pub struct CapturedTestOutput {
     outcome: CapturedTestOutcome,
     stdout: String,
     stderr: String,
+}
+
+pub fn captured_outputs_by_test(
+    outputs: &[CapturedTestOutput],
+) -> HashMap<&str, &CapturedTestOutput> {
+    outputs
+        .iter()
+        .map(|output| (output.test_name(), output))
+        .collect()
 }
 
 impl CapturedTestOutput {


### PR DESCRIPTION
## Summary

Moves the captured-output lookup used by JUnit and machine-readable result reports into `karva_diagnostic`. Both report writers now use the same helper instead of carrying duplicate indexing code.

## Test Plan

`cargo test -p karva_diagnostic`, `cargo clippy -p karva -p karva_diagnostic --all-targets --all-features -- -D warnings`, `just test -p karva --test it result_report`, `just test -p karva --test it junit`, and `uvx prek run -a`.