### PR TITLE
Stabilize wheel discovery ties

### DIFF
--- a/crates/karva_project/src/lib.rs
+++ b/crates/karva_project/src/lib.rs
@@ -47,7 +47,10 @@ fn find_karva_wheel_in(wheels_dir: &Utf8Path) -> anyhow::Result<Utf8PathBuf> {
             .modified()
             .with_context(|| format!("Could not read wheel modification time: {path}"))?;
 
-        if newest.as_ref().is_none_or(|(t, _)| mtime > *t) {
+        if newest
+            .as_ref()
+            .is_none_or(|(t, p)| (mtime, path.as_str()) > (*t, p.as_str()))
+        {
             newest = Some((mtime, path));
         }
     }
@@ -140,6 +143,18 @@ mod tests {
         let wheel = find_karva_wheel_in(root).expect("find wheel");
 
         assert_eq!(wheel, newest);
+    }
+
+    #[test]
+    fn find_karva_wheel_uses_stable_tiebreak_for_equal_mtimes() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let root = temp_path(&temp_dir);
+        write_wheel(root, "karva-0.1.0-py3-none-any.whl", 10);
+        let selected = write_wheel(root, "karva-0.2.0-py3-none-any.whl", 10);
+
+        let wheel = find_karva_wheel_in(root).expect("find wheel");
+
+        assert_eq!(wheel, selected);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Wheel discovery now breaks equal modification-time ties by path, so selecting from `target/wheels` no longer depends on directory iteration order when multiple Karva wheels have the same timestamp. The existing newest-wheel behavior is unchanged.

## Test Plan

`cargo test -p karva_project`; `cargo clippy -p karva_project --all-targets --all-features -- -D warnings`; `uvx prek run -a`