### PR TITLE
Reject zero test workers

### DIFF
--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -56,7 +56,7 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
     let num_workers = if args.no_parallel.unwrap_or(false) || args.no_capture {
         1
     } else if let Some(num_workers) = args.num_workers {
-        num_workers
+        num_workers.get()
     } else {
         karva_static::max_parallelism()
             .context("Failed to determine default worker count")?

--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -2509,6 +2509,23 @@ fn test_num_workers_invalid_value() {
     ");
 }
 
+/// `--num-workers` must reject zero before the runner starts.
+#[test]
+fn test_num_workers_zero_is_rejected() {
+    let context = TestContext::with_file("test.py", "def test_1(): pass");
+
+    assert_cmd_snapshot!(context.command().args(["--num-workers", "0"]), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: invalid value '0' for '--num-workers <NUM_WORKERS>': number would be zero for non-zero type
+
+    For more information, try '--help'.
+    ");
+}
+
 #[test]
 fn test_max_parallelism_env_invalid_value() {
     let context = TestContext::with_file("test.py", "def test_1(): pass");

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroUsize};
 
 use camino::Utf8PathBuf;
 use clap::Parser;
@@ -303,7 +303,7 @@ pub struct TestCommand {
 
     /// Number of parallel workers (default: number of CPU cores)
     #[clap(short = 'n', long, help_heading = "Runner options")]
-    pub num_workers: Option<usize>,
+    pub num_workers: Option<NonZeroUsize>,
 
     /// Wall-clock limit for the whole run, in seconds.
     ///


### PR DESCRIPTION
## Summary

`--num-workers=0` now fails during CLI parsing instead of reaching the runner and panicking during partitioning. The worker count is encoded as a non-zero value at the argument boundary, with integration coverage for the rejected zero case.

## Test Plan

`cargo test -p karva_cli`; `cargo clippy -p karva_cli -p karva --all-targets --all-features -- -D warnings`; `cargo run -p karva_dev generate-all`; `just test -p karva --test it test_num_workers_zero_is_rejected`; `uvx prek run -a`