### PR TITLE
Report scheduled test count in start banner

### DIFF
--- a/crates/karva/tests/it/last_failed.rs
+++ b/crates/karva/tests/it/last_failed.rs
@@ -18,7 +18,7 @@ fn last_failed_reruns_only_failures() {
     success: false
     exit_code: 1
     ----- stdout -----
-        Starting 2 tests across 1 worker
+        Starting 1 test across 1 worker
             FAIL [TIME] test_a::test_fail
 
     diagnostics:
@@ -59,7 +59,7 @@ fn last_failed_lf_alias() {
     success: false
     exit_code: 1
     ----- stdout -----
-        Starting 2 tests across 1 worker
+        Starting 1 test across 1 worker
             FAIL [TIME] test_a::test_fail
 
     diagnostics:
@@ -218,7 +218,7 @@ def test_fail_b(): assert False
     success: false
     exit_code: 1
     ----- stdout -----
-        Starting 3 tests across 1 worker
+        Starting 2 tests across 1 worker
             FAIL [TIME] test_a::test_fail_a
 
     diagnostics:
@@ -368,7 +368,7 @@ def test_fail(): assert True
     success: true
     exit_code: 0
     ----- stdout -----
-        Starting 2 tests across 1 worker
+        Starting 1 test across 1 worker
             PASS [TIME] test_a::test_fail
     ────────────
          Summary [TIME] 1 test run: 1 passed, 0 skipped

--- a/crates/karva/tests/it/partition.rs
+++ b/crates/karva/tests/it/partition.rs
@@ -21,7 +21,7 @@ fn slice_first_of_three() {
     success: true
     exit_code: 0
     ----- stdout -----
-        Starting 6 tests across 1 worker
+        Starting 2 tests across 1 worker
             PASS [TIME] test_mod::test_a
             PASS [TIME] test_mod::test_d
     ────────────
@@ -42,7 +42,7 @@ fn slice_second_of_three() {
     success: true
     exit_code: 0
     ----- stdout -----
-        Starting 6 tests across 1 worker
+        Starting 2 tests across 1 worker
             PASS [TIME] test_mod::test_b
             PASS [TIME] test_mod::test_e
     ────────────
@@ -63,7 +63,7 @@ fn slice_third_of_three() {
     success: true
     exit_code: 0
     ----- stdout -----
-        Starting 6 tests across 1 worker
+        Starting 2 tests across 1 worker
             PASS [TIME] test_mod::test_c
             PASS [TIME] test_mod::test_f
     ────────────
@@ -109,7 +109,7 @@ fn hash_first_of_three() {
     success: true
     exit_code: 0
     ----- stdout -----
-        Starting 6 tests across 1 worker
+        Starting 2 tests across 1 worker
             PASS [TIME] test_mod::test_c
             PASS [TIME] test_mod::test_e
     ────────────
@@ -130,7 +130,7 @@ fn hash_second_of_three() {
     success: true
     exit_code: 0
     ----- stdout -----
-        Starting 6 tests across 1 worker
+        Starting 2 tests across 1 worker
             PASS [TIME] test_mod::test_b
             PASS [TIME] test_mod::test_d
     ────────────
@@ -151,7 +151,7 @@ fn hash_third_of_three() {
     success: true
     exit_code: 0
     ----- stdout -----
-        Starting 6 tests across 1 worker
+        Starting 2 tests across 1 worker
             PASS [TIME] test_mod::test_a
             PASS [TIME] test_mod::test_f
     ────────────

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -590,25 +590,6 @@ pub fn run_parallel_tests(
         );
     }
 
-    if total_tests > 0 {
-        let mut stdout = printer.stream_for_test_result().lock();
-        let label = format!("{:>12}", "Starting").green().bold();
-        let test_label = if total_tests == 1 { "test" } else { "tests" };
-        let worker_label = if num_workers == 1 {
-            "worker"
-        } else {
-            "workers"
-        };
-        let total_tests_bold = total_tests.to_string().bold();
-        let num_workers_bold = num_workers.to_string().bold();
-        if let Err(err) = writeln!(
-            stdout,
-            "{label} {total_tests_bold} {test_label} across {num_workers_bold} {worker_label}"
-        ) {
-            tracing::warn!("failed to write test start line: {err}");
-        }
-    }
-
     tracing::debug!(num_workers, "Partitioning tests");
 
     let cache_dir = project.cwd().join(CACHE_DIR);
@@ -632,11 +613,42 @@ pub fn run_parallel_tests(
         config.partition,
         config.test_ordering,
     );
+    let scheduled_tests: usize = partitions
+        .iter()
+        .map(|partition| partition.tests().len())
+        .sum();
+    let scheduled_workers = partitions
+        .iter()
+        .filter(|partition| !partition.tests().is_empty())
+        .count();
+
+    if scheduled_tests > 0 {
+        let mut stdout = printer.stream_for_test_result().lock();
+        let label = format!("{:>12}", "Starting").green().bold();
+        let test_label = if scheduled_tests == 1 {
+            "test"
+        } else {
+            "tests"
+        };
+        let worker_label = if scheduled_workers == 1 {
+            "worker"
+        } else {
+            "workers"
+        };
+        let total_tests_bold = scheduled_tests.to_string().bold();
+        let num_workers_bold = scheduled_workers.to_string().bold();
+        if let Err(err) = writeln!(
+            stdout,
+            "{label} {total_tests_bold} {test_label} across {num_workers_bold} {worker_label}"
+        ) {
+            tracing::warn!("failed to write test start line: {err}");
+        }
+    }
 
     let run_hash = RunHash::current_time();
     let cache = RunCache::new(&cache_dir, &run_hash);
 
-    tracing::info!("Spawning {} workers", partitions.len());
+    tracing::info!("Spawning {} workers", scheduled_workers);
 
     let worker_binary = find_karva_worker_binary(project.cwd())?;
     let spawn = WorkerSpawn {


### PR DESCRIPTION
## Summary

The start banner now reports the tests actually scheduled after `--last-failed` and `--partition` are applied, and the worker spawn log uses the non-empty worker count. This keeps the banner aligned with the tests Karva is about to run instead of the broader collected set.

## Test Plan

Ran `just test -p karva --test it partition`, `just test -p karva --test it last_failed`, `just test -p karva_runner`, `just test -p karva --test it test_parallel_worker_capping`, and `uvx prek run -a`.
