### PR TITLE
Ignore commented defs when pruning snapshots

### DIFF
--- a/crates/karva/tests/it/extensions/snapshot/prune.rs
+++ b/crates/karva/tests/it/extensions/snapshot/prune.rs
@@ -51,6 +51,48 @@ def test_other():
 }
 
 #[test]
+fn test_snapshot_prune_ignores_commented_function_name() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+def test_hello():
+    karva.assert_snapshot('hello world')
+        ",
+    );
+
+    let _ = context
+        .command_no_parallel()
+        .arg("--snapshot-update")
+        .output();
+
+    context.write_file(
+        "test.py",
+        r"
+# def test_hello():
+#     pass
+REMOVED_TEST = 'def test_hello():'
+
+def test_other():
+    pass
+        ",
+    );
+
+    assert_cmd_snapshot!(context.snapshot("prune"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Removed: <temp_dir>/snapshots/test__test_hello.snap (function `test_hello` not found in test.py)
+
+    1 snapshot(s) pruned.
+
+    ----- stderr -----
+    warning: Prune uses static analysis and may not detect all unreferenced snapshots.
+    ");
+}
+
+#[test]
 fn test_snapshot_prune_dry_run() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva_snapshot/src/storage.rs
+++ b/crates/karva_snapshot/src/storage.rs
@@ -380,8 +380,22 @@ pub fn function_exists_in_file(path: &Utf8Path, name: &str) -> io::Result<bool> 
             format!("failed to read source file `{path}`: {err}"),
         )
     })?;
-    let pattern = format!("def {name}(");
-    Ok(content.contains(&pattern))
+    Ok(content
+        .lines()
+        .any(|line| line_declares_function(line, name)))
+}
+
+fn line_declares_function(line: &str, name: &str) -> bool {
+    let trimmed = line.trim_start();
+    let Some(rest) = trimmed
+        .strip_prefix("def ")
+        .or_else(|| trimmed.strip_prefix("async def "))
+    else {
+        return false;
+    };
+
+    rest.strip_prefix(name)
+        .is_some_and(|after_name| after_name.starts_with('('))
 }
 
 /// Recursively find all committed snapshot files (`.snap`, not `.snap.new`).


### PR DESCRIPTION
## Summary

Snapshot prune now checks source files line by line for real `def` or `async def` declarations instead of treating any `def name(` substring as a live test. This lets prune remove stale snapshots when the old test name only remains in comments or string data, and the behavior is covered by a CLI integration test.

## Test Plan

just test -p karva --test it test_snapshot_prune_ignores_commented_function_name; just test -p karva_snapshot; cargo clippy -p karva_snapshot -p karva --test it --all-features -- -D warnings; uvx prek run -a