### PR TITLE
Fail tests that return values

### DIFF
--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -216,6 +216,163 @@ fn test_one_test_fail() {
 }
 
 #[test]
+fn test_non_none_returns_fail() {
+    let context = TestContext::with_file(
+        "test_return.py",
+        r#"
+import functools
+import karva
+
+class LargeRepr:
+    def __repr__(self):
+        return "value-" + ("x" * 80)
+
+def passthrough(func):
+    @functools.wraps(func)
+    def wrapper():
+        return func()
+    return wrapper
+
+def test_explicit_none():
+    return None
+
+def test_returned_true():
+    return True
+
+def test_returned_false():
+    return False
+
+def test_returned_object():
+    return LargeRepr()
+
+async def test_returned_async_value():
+    return True
+
+@karva.tags.parametrize("value", [1, 2])
+def test_returned_parametrized(value):
+    return value
+
+@passthrough
+def test_returned_decorated():
+    return "decorated"
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 7 tests across 1 worker
+            PASS [TIME] test_return::test_explicit_none
+            FAIL [TIME] test_return::test_returned_true
+            FAIL [TIME] test_return::test_returned_false
+            FAIL [TIME] test_return::test_returned_object
+            FAIL [TIME] test_return::test_returned_async_value
+            FAIL [TIME] test_return::test_returned_parametrized(value=1)
+            FAIL [TIME] test_return::test_returned_parametrized(value=2)
+            FAIL [TIME] test_return::test_returned_decorated
+
+    diagnostics:
+
+    error[test-returned-value]: Test `test_returned_true` returned `True`
+      --> test_return.py:18:5
+       |
+    18 | def test_returned_true():
+       |     ^^^^^^^^^^^^^^^^^^
+       |
+    info: Test functions must return None. Did you mean to use `assert`?
+
+    error[test-returned-value]: Test `test_returned_false` returned `False`
+      --> test_return.py:21:5
+       |
+    21 | def test_returned_false():
+       |     ^^^^^^^^^^^^^^^^^^^
+       |
+    info: Test functions must return None. Did you mean to use `assert`?
+
+    error[test-returned-value]: Test `test_returned_object` returned `value-xxxxxxxxxxxxxxxxxxxxx...`
+      --> test_return.py:24:5
+       |
+    24 | def test_returned_object():
+       |     ^^^^^^^^^^^^^^^^^^^^
+       |
+    info: Test functions must return None. Did you mean to use `assert`?
+
+    error[test-returned-value]: Test `test_returned_async_value` returned `True`
+      --> test_return.py:27:11
+       |
+    27 | async def test_returned_async_value():
+       |           ^^^^^^^^^^^^^^^^^^^^^^^^^
+       |
+    info: Test functions must return None. Did you mean to use `assert`?
+
+    error[test-returned-value]: Test `test_returned_parametrized` returned `1`
+      --> test_return.py:31:5
+       |
+    31 | def test_returned_parametrized(value):
+       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+       |
+    info: Test functions must return None. Did you mean to use `assert`?
+
+    error[test-returned-value]: Test `test_returned_parametrized` returned `2`
+      --> test_return.py:31:5
+       |
+    31 | def test_returned_parametrized(value):
+       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+       |
+    info: Test functions must return None. Did you mean to use `assert`?
+
+    error[test-returned-value]: Test `test_returned_decorated` returned `'decorated'`
+      --> test_return.py:35:5
+       |
+    35 | def test_returned_decorated():
+       |     ^^^^^^^^^^^^^^^^^^^^^^^
+       |
+    info: Test functions must return None. Did you mean to use `assert`?
+
+    ────────────
+         Summary [TIME] 8 tests run: 1 passed, 7 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_returned_value_retries() {
+    let context = TestContext::with_file(
+        "test_return.py",
+        r"
+def test_returned_value():
+    return True
+",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--retry=1"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+      TRY 1 FAIL [TIME] test_return::test_returned_value
+      TRY 2 FAIL [TIME] test_return::test_returned_value
+
+    diagnostics:
+
+    error[test-returned-value]: Test `test_returned_value` returned `True`
+     --> test_return.py:2:5
+      |
+    2 | def test_returned_value():
+      |     ^^^^^^^^^^^^^^^^^^^
+      |
+    info: Test functions must return None. Did you mean to use `assert`?
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_failure_diagnostic_uses_discovered_source_after_file_is_deleted() {
     let context = TestContext::with_file(
         "test_deleted_source.py",

--- a/crates/karva/tests/it/extensions/tags/expect_fail.rs
+++ b/crates/karva/tests/it/extensions/tags/expect_fail.rs
@@ -538,6 +538,32 @@ def test_1():
 }
 
 #[test]
+fn test_expect_fail_with_returned_value() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+@karva.tags.expect_fail(reason='Expected returned value')
+def test_1():
+    return False
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--retry=2"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_1
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_expect_fail_with_assertion_error() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -124,6 +124,16 @@ declare_diagnostic_type! {
     }
 }
 
+declare_diagnostic_type! {
+    /// ## Test Returned Value
+    ///
+    /// If a test returns anything other than `None`, we will raise this error.
+    pub static TEST_RETURNED_VALUE = {
+        summary: "Test returned a non-None value",
+        severity: Severity::Error,
+    }
+}
+
 /// Annotate a diagnostic with a primary span pointing at a function's name.
 fn annotate_function_name(
     diagnostic: &mut Diagnostic,
@@ -371,6 +381,23 @@ pub fn report_test_failure(
         FunctionKind::Test,
         error,
     );
+}
+
+pub fn report_test_returned_value(
+    context: &Context,
+    source_file: SourceFile,
+    stmt_function_def: &StmtFunctionDef,
+    returned_value: &str,
+) {
+    let builder = context.report_diagnostic(&TEST_RETURNED_VALUE);
+
+    let mut diagnostic = builder.into_diagnostic(format!(
+        "Test `{}` returned `{returned_value}`",
+        stmt_function_def.name
+    ));
+
+    annotate_function_name(&mut diagnostic, source_file, stmt_function_def);
+    diagnostic.info("Test functions must return None. Did you mean to use `assert`?");
 }
 
 fn handle_failed_function_call(

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -16,7 +16,7 @@ use ruff_source_file::SourceFile;
 use crate::Context;
 use crate::diagnostic::{
     report_fixture_failure, report_missing_fixtures, report_test_failure,
-    report_test_pass_on_expect_failure,
+    report_test_pass_on_expect_failure, report_test_returned_value,
 };
 use crate::discovery::{DiscoveredModule, DiscoveredPackage};
 use crate::extensions::fixtures::{
@@ -31,6 +31,7 @@ use crate::runner::test_iterator::{TestVariant, TestVariantIterator};
 use crate::runner::{FinalizerCache, FixtureArguments, FixtureCache};
 use crate::utils::{
     full_test_name, run_coroutine, run_test_with_timeout, set_attempt_env, set_test_name_env,
+    truncate_string,
 };
 
 /// Executes discovered tests within a package hierarchy.
@@ -370,7 +371,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
     fn classify_test_result(
         &self,
         py: Python<'_>,
-        test_result: PyResult<Py<PyAny>>,
+        test_result: PyResult<TestCallOutcome>,
         fixture_call_errors: Vec<FixtureCallError>,
         ctx: &VariantReportCtx<'_>,
         register: impl FnOnce(IndividualTestResultKind) -> bool,
@@ -381,7 +382,19 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             .is_some_and(ExpectFailTag::should_expect_fail);
 
         let err = match test_result {
-            Ok(_) if expect_fail => {
+            Ok(TestCallOutcome::ReturnedValue(_)) if expect_fail => {
+                return register(IndividualTestResultKind::Passed);
+            }
+            Ok(TestCallOutcome::ReturnedValue(value)) => {
+                report_test_returned_value(
+                    self.context,
+                    ctx.source_file.clone(),
+                    ctx.stmt_function_def,
+                    &value,
+                );
+                return register(IndividualTestResultKind::Failed);
+            }
+            Ok(TestCallOutcome::ReturnedNone) if expect_fail => {
                 let reason = ctx.expect_fail_tag.as_ref().and_then(ExpectFailTag::reason);
                 report_test_pass_on_expect_failure(
                     self.context,
@@ -391,7 +404,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                 );
                 return register(IndividualTestResultKind::Failed);
             }
-            Ok(_) => return register(IndividualTestResultKind::Passed),
+            Ok(TestCallOutcome::ReturnedNone) => return register(IndividualTestResultKind::Passed),
             Err(err) => err,
         };
 
@@ -441,8 +454,8 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         py: Python<'_>,
         qualified_test_name: &QualifiedTestName,
         configured_retries: u32,
-        should_retry_error: impl Fn(&PyErr) -> bool,
-        mut run_test: impl FnMut() -> PyResult<Py<PyAny>>,
+        expect_fail: bool,
+        mut run_test: impl FnMut() -> PyResult<TestCallOutcome>,
     ) -> RetryOutcome {
         let max_attempts = configured_retries.saturating_add(1);
         let mut run_attempt =
@@ -457,10 +470,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         let mut final_attempt_duration = attempt_start.elapsed();
 
         while retry_count > 0 {
-            let Err(err) = &test_result else {
-                break;
-            };
-            if !should_retry_error(err) {
+            if !should_retry_result(py, &test_result, expect_fail) {
                 break;
             }
             let attempt_duration = attempt_start.elapsed();
@@ -584,26 +594,23 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             if let Err(err) = &async_patch_result {
                 return Err(err.clone_ref(py));
             }
-            if let Some(seconds) = timeout_seconds {
-                return run_test_with_timeout(
-                    py,
-                    &function,
-                    &function_arguments,
-                    is_async,
-                    seconds,
-                );
-            }
-            let result = if function_arguments.is_empty() {
-                function.call0(py)
+            let result = if let Some(seconds) = timeout_seconds {
+                run_test_with_timeout(py, &function, &function_arguments, is_async, seconds)
             } else {
-                let py_dict = function_arguments.to_kwargs(py)?;
-                function.call(py, (), Some(&py_dict))
+                let result = if function_arguments.is_empty() {
+                    function.call0(py)
+                } else {
+                    let py_dict = function_arguments.to_kwargs(py)?;
+                    function.call(py, (), Some(&py_dict))
+                };
+                if is_async {
+                    result.and_then(|coroutine| run_coroutine(py, coroutine))
+                } else {
+                    result
+                }
             };
-            if is_async {
-                result.and_then(|coroutine| run_coroutine(py, coroutine))
-            } else {
-                result
-            }
+
+            result.map(|value| reject_non_none_return(py, &value))
         };
 
         let configured_retries = self.context.settings().retry_for(&eval_ctx);
@@ -623,7 +630,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             py,
             &qualified_test_name,
             configured_retries,
-            |err| !expect_fail && !is_skip_exception(py, err),
+            expect_fail,
             run_test,
         );
         self.context.report_test_finished(&qualified_test_name);
@@ -855,12 +862,21 @@ fn get_value_and_finalizer(
     }
 }
 
+fn reject_non_none_return(py: Python<'_>, value: &Py<PyAny>) -> TestCallOutcome {
+    if value.bind(py).is_none() {
+        TestCallOutcome::ReturnedNone
+    } else {
+        TestCallOutcome::ReturnedValue(returned_value_repr(py, value))
+    }
+}
+
 fn attempt_result_kind(
     py: Python<'_>,
-    test_result: &PyResult<Py<PyAny>>,
+    test_result: &PyResult<TestCallOutcome>,
 ) -> IndividualTestResultKind {
     match test_result {
-        Ok(_) => IndividualTestResultKind::Passed,
+        Ok(TestCallOutcome::ReturnedNone) => IndividualTestResultKind::Passed,
+        Ok(TestCallOutcome::ReturnedValue(_)) => IndividualTestResultKind::Failed,
         Err(err) if is_skip_exception(py, err) => IndividualTestResultKind::Skipped {
             reason: extract_skip_reason(py, err),
         },
@@ -868,9 +884,40 @@ fn attempt_result_kind(
     }
 }
 
+fn should_retry_result(
+    py: Python<'_>,
+    test_result: &PyResult<TestCallOutcome>,
+    expect_fail: bool,
+) -> bool {
+    if expect_fail {
+        return false;
+    }
+
+    match test_result {
+        Ok(TestCallOutcome::ReturnedNone) => false,
+        Ok(TestCallOutcome::ReturnedValue(_)) => true,
+        Err(err) => !is_skip_exception(py, err),
+    }
+}
+
+fn returned_value_repr(py: Python<'_>, value: &Py<PyAny>) -> String {
+    match value.bind(py).repr() {
+        Ok(repr) => truncate_string(&repr.to_string()),
+        Err(err) => {
+            let error = truncate_string(&err.value(py).to_string());
+            format!("<repr failed: {error}>")
+        }
+    }
+}
+
+enum TestCallOutcome {
+    ReturnedNone,
+    ReturnedValue(String),
+}
+
 /// Outcome of driving a test through the configured retry budget.
 struct RetryOutcome {
-    test_result: PyResult<Py<PyAny>>,
+    test_result: PyResult<TestCallOutcome>,
     /// The attempt number on which the test produced its final result.
     attempt: u32,
     /// The maximum number of attempts the test was allowed (`retries + 1`).


### PR DESCRIPTION
## Summary

Tests that return anything other than `None` now fail with a dedicated `test-returned-value` diagnostic that points at the test definition and includes a truncated returned-value representation. The runner treats returned values as failed outcomes for retry accounting while preserving expected-failure behavior, and the integration coverage exercises normal returns, explicit `None`, async tests, parametrized cases, decorated tests, retries, and expected failures.

Closes #965.

## Test Plan

just test -p karva --test it test_non_none_returns_fail test_returned_value_retries test_expect_fail_with_returned_value; just test -p karva_test_semantic; cargo clippy --workspace --all-targets --all-features -- -D warnings; uvx prek run -a
