### PR TITLE
Reject generator test functions

### DIFF
--- a/crates/karva/tests/it/discovery/edge_cases.rs
+++ b/crates/karva/tests/it/discovery/edge_cases.rs
@@ -158,6 +158,144 @@ def test_one(): pass
     ");
 }
 
+#[test]
+fn test_generator_tests_are_rejected_without_running_body() {
+    let context = TestContext::with_file(
+        "test_generators.py",
+        r#"
+from pathlib import Path
+import functools
+import karva
+
+def mark(name):
+    Path(name).write_text("ran")
+
+def decorator(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+    return wrapper
+
+def values():
+    yield 1
+
+def test_plain_generator():
+    mark("plain.txt")
+    yield 1
+
+async def test_async_generator():
+    mark("async.txt")
+    yield 1
+
+@decorator
+def test_decorated_generator():
+    mark("decorated.txt")
+    yield 1
+
+@karva.tags.parametrize("value", [1])
+def test_parametrized_generator(value):
+    mark("parametrized.txt")
+    yield value
+
+@karva.tags.skip(reason="still invalid")
+def test_skipped_generator():
+    mark("skipped.txt")
+    yield 1
+
+@karva.tags.expect_fail(reason="still invalid")
+def test_expected_failure_generator():
+    mark("expected_failure.txt")
+    yield 1
+
+def test_consumes_generator_internally():
+    def nested():
+        yield 1
+
+    class Iterable:
+        def __iter__(self):
+            yield 2
+
+    assert list(values()) == [1]
+    assert list(nested()) == [1]
+    assert list(Iterable()) == [2]
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 7 tests across 1 worker
+            PASS [TIME] test_generators::test_consumes_generator_internally
+
+    diagnostics:
+
+    error[invalid-test]: Generator test `test_plain_generator` is not supported
+      --> test_generators.py:18:5
+       |
+    18 | def test_plain_generator():
+       |     ^^^^^^^^^^^^^^^^^^^^
+       |
+    info: Use `@karva.tags.parametrize` to define multiple test cases.
+
+    error[invalid-test]: Generator test `test_async_generator` is not supported
+      --> test_generators.py:22:11
+       |
+    22 | async def test_async_generator():
+       |           ^^^^^^^^^^^^^^^^^^^^
+       |
+    info: Use `@karva.tags.parametrize` to define multiple test cases.
+
+    error[invalid-test]: Generator test `test_decorated_generator` is not supported
+      --> test_generators.py:27:5
+       |
+    27 | def test_decorated_generator():
+       |     ^^^^^^^^^^^^^^^^^^^^^^^^
+       |
+    info: Use `@karva.tags.parametrize` to define multiple test cases.
+
+    error[invalid-test]: Generator test `test_parametrized_generator` is not supported
+      --> test_generators.py:32:5
+       |
+    32 | def test_parametrized_generator(value):
+       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       |
+    info: Use `@karva.tags.parametrize` to define multiple test cases.
+
+    error[invalid-test]: Generator test `test_skipped_generator` is not supported
+      --> test_generators.py:37:5
+       |
+    37 | def test_skipped_generator():
+       |     ^^^^^^^^^^^^^^^^^^^^^^
+       |
+    info: Use `@karva.tags.parametrize` to define multiple test cases.
+
+    error[invalid-test]: Generator test `test_expected_failure_generator` is not supported
+      --> test_generators.py:42:5
+       |
+    42 | def test_expected_failure_generator():
+       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       |
+    info: Use `@karva.tags.parametrize` to define multiple test cases.
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+
+    for marker in [
+        "plain.txt",
+        "async.txt",
+        "decorated.txt",
+        "parametrized.txt",
+        "skipped.txt",
+        "expected_failure.txt",
+    ] {
+        assert!(!context.root().join(marker).exists());
+    }
+}
+
 /// An empty subdirectory (no Python files at all) is discovered without error.
 #[test]
 fn test_empty_subdirectory_is_ignored() {

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -125,6 +125,16 @@ declare_diagnostic_type! {
 }
 
 declare_diagnostic_type! {
+    /// ## Invalid Test
+    ///
+    /// If a test definition cannot be run by Karva, we will raise this error.
+    pub static INVALID_TEST = {
+        summary: "Discovered an invalid test",
+        severity: Severity::Error,
+    }
+}
+
+declare_diagnostic_type! {
     /// ## Test Returned Value
     ///
     /// If a test returns anything other than `None`, we will raise this error.
@@ -381,6 +391,22 @@ pub fn report_test_failure(
         FunctionKind::Test,
         error,
     );
+}
+
+pub fn report_generator_test(
+    context: &Context,
+    source_file: SourceFile,
+    stmt_function_def: &StmtFunctionDef,
+) {
+    let builder = context.report_diagnostic(&INVALID_TEST);
+
+    let mut diagnostic = builder.into_diagnostic(format!(
+        "Generator test `{}` is not supported",
+        stmt_function_def.name
+    ));
+
+    annotate_function_name(&mut diagnostic, source_file, stmt_function_def);
+    diagnostic.info("Use `@karva.tags.parametrize` to define multiple test cases.");
 }
 
 pub fn report_test_returned_value(

--- a/crates/karva_test_semantic/src/discovery/visitor.rs
+++ b/crates/karva_test_semantic/src/discovery/visitor.rs
@@ -14,7 +14,7 @@ use ruff_source_file::SourceFileBuilder;
 use crate::Context;
 use crate::diagnostic::{
     report_failed_to_discover_imported_fixture, report_failed_to_import_module,
-    report_invalid_fixture,
+    report_generator_test, report_invalid_fixture,
 };
 use crate::discovery::{DiscoveredModule, DiscoveredTestFunction};
 use crate::extensions::fixtures::DiscoveredFixture;
@@ -279,6 +279,11 @@ pub fn discover(
     let mut visitor = FunctionDefinitionVisitor::new(py, context, module);
 
     for test_function_def in test_function_defs {
+        if is_generator(&test_function_def) {
+            report_generator_test(context, visitor.module.source_file(), &test_function_def);
+            continue;
+        }
+
         visitor.process_test_function(test_function_def);
     }
 
@@ -309,9 +314,18 @@ struct GeneratorFunctionVisitor {
 }
 
 impl SourceOrderVisitor<'_> for GeneratorFunctionVisitor {
+    fn visit_stmt(&mut self, stmt: &'_ Stmt) {
+        match stmt {
+            Stmt::FunctionDef(_) | Stmt::ClassDef(_) => {}
+            _ => source_order::walk_stmt(self, stmt),
+        }
+    }
+
     fn visit_expr(&mut self, expr: &'_ Expr) {
         if let Expr::Yield(_) | Expr::YieldFrom(_) = *expr {
             self.is_generator = true;
+        } else {
+            source_order::walk_expr(self, expr);
         }
     }
 }


### PR DESCRIPTION
## Summary

Generator and async-generator test definitions now produce an `invalid-test` diagnostic during discovery instead of being imported and treated as runnable tests. The generator detector ignores `yield` inside nested functions and classes, so ordinary tests that define or consume generators still run.

Closes #966.

## Test Plan

just test -p karva --test it test_generator_tests_are_rejected_without_running_body; just test -p karva --test it test_fixture_generator; just test -p karva_test_semantic; cargo test -p karva_benchmark --bin karva-benchmark; cargo run -p karva_benchmark --bin karva-benchmark -- list-projects; cargo run -p karva_benchmark --bin karva-benchmark -- compare --iterations 1 --project outcome --project pluggy --project werkzeug; cargo clippy -p karva_test_semantic -p karva_benchmark -p karva --all-targets --all-features -- -D warnings; uvx prek run -a