### PR TITLE
Reject duplicate test and fixture definitions

### DIFF
--- a/crates/karva/tests/it/discovery/edge_cases.rs
+++ b/crates/karva/tests/it/discovery/edge_cases.rs
@@ -296,6 +296,90 @@ def test_consumes_generator_internally():
     }
 }
 
+#[test]
+fn test_duplicate_test_definitions_are_rejected_without_running_body() {
+    let context = TestContext::with_file(
+        "test_duplicates.py",
+        r#"
+from pathlib import Path
+
+def mark(name):
+    Path(name).write_text("ran")
+
+def test_duplicate():
+    mark("first.txt")
+
+async def test_duplicate():
+    mark("second.txt")
+
+def test_ok():
+    assert True
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 3 tests across 1 worker
+            PASS [TIME] test_duplicates::test_ok
+
+    diagnostics:
+
+    error[duplicate-test]: Test `test_duplicate` is defined more than once
+      --> test_duplicates.py:10:11
+       |
+    10 | async def test_duplicate():
+       |           ^^^^^^^^^^^^^^
+       |
+    info: First definition of `test_duplicate` is here
+     --> test_duplicates.py:7:5
+      |
+    7 | def test_duplicate():
+      |     ^^^^^^^^^^^^^^
+      |
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+
+    for marker in ["first.txt", "second.txt"] {
+        assert!(!context.root().join(marker).exists());
+    }
+}
+
+#[test]
+fn test_duplicate_test_names_in_different_modules_are_allowed() {
+    let context = TestContext::with_files([
+        (
+            "test_a.py",
+            r"
+def test_same():
+    assert True
+",
+        ),
+        (
+            "test_b.py",
+            r"
+def test_same():
+    assert True
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--status-level=none"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
 /// An empty subdirectory (no Python files at all) is discovered without error.
 #[test]
 fn test_empty_subdirectory_is_ignored() {

--- a/crates/karva/tests/it/extensions/fixtures/invalid.rs
+++ b/crates/karva/tests/it/extensions/fixtures/invalid.rs
@@ -121,11 +121,13 @@ from pathlib import Path
 def mark(name):
     Path(name).write_text("ran")
 
-@karva.fixture(name="shared", auto_use=True)
+fixture_name = "shared"
+
+@karva.fixture(name=fixture_name, auto_use=True)
 def first_fixture():
     mark("first.txt")
 
-@pytest.fixture(name="shared", autouse=True)
+@pytest.fixture(name=fixture_name, autouse=True)
 def second_fixture():
     mark("second.txt")
 
@@ -144,15 +146,15 @@ def test_ok():
     diagnostics:
 
     error[duplicate-fixture]: Fixture `shared` is defined more than once
-      --> test.py:14:5
+      --> test.py:16:5
        |
-    14 | def second_fixture():
+    16 | def second_fixture():
        |     ^^^^^^^^^^^^^^
        |
     info: First definition of `shared` is here
-      --> test.py:10:5
+      --> test.py:12:5
        |
-    10 | def first_fixture():
+    12 | def first_fixture():
        |     ^^^^^^^^^^^^^
        |
 

--- a/crates/karva/tests/it/extensions/fixtures/invalid.rs
+++ b/crates/karva/tests/it/extensions/fixtures/invalid.rs
@@ -110,6 +110,64 @@ def test_all_scopes(some_fixture: int) -> None:
 }
 
 #[test]
+fn test_duplicate_fixture_names_are_rejected_without_running_body() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+import pytest
+from pathlib import Path
+
+def mark(name):
+    Path(name).write_text("ran")
+
+@karva.fixture(name="shared", auto_use=True)
+def first_fixture():
+    mark("first.txt")
+
+@pytest.fixture(name="shared", autouse=True)
+def second_fixture():
+    mark("second.txt")
+
+def test_ok():
+    assert True
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_ok
+
+    diagnostics:
+
+    error[duplicate-fixture]: Fixture `shared` is defined more than once
+      --> test.py:14:5
+       |
+    14 | def second_fixture():
+       |     ^^^^^^^^^^^^^^
+       |
+    info: First definition of `shared` is here
+      --> test.py:10:5
+       |
+    10 | def first_fixture():
+       |     ^^^^^^^^^^^^^
+       |
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+
+    for marker in ["first.txt", "second.txt"] {
+        assert!(!context.root().join(marker).exists());
+    }
+}
+
+#[test]
 fn test_missing_fixture() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva_collector/src/models.rs
+++ b/crates/karva_collector/src/models.rs
@@ -223,8 +223,8 @@ impl CollectedModule {
     /// Merges function definitions from the other module into this one.
     pub(crate) fn update(&mut self, module: Self) {
         if self.path == module.path {
-            add_unique_definitions(&mut self.test_function_defs, module.test_function_defs);
-            add_unique_definitions(
+            add_new_definitions(&mut self.test_function_defs, module.test_function_defs);
+            add_new_definitions(
                 &mut self.fixture_function_defs,
                 module.fixture_function_defs,
             );
@@ -232,11 +232,9 @@ impl CollectedModule {
     }
 }
 
-/// Adds function definitions from `new_defs` into `existing`, skipping any
-/// whose name already appears.
-fn add_unique_definitions(existing: &mut Vec<StmtFunctionDef>, new_defs: Vec<StmtFunctionDef>) {
+fn add_new_definitions(existing: &mut Vec<StmtFunctionDef>, new_defs: Vec<StmtFunctionDef>) {
     for def in new_defs {
-        if !existing.iter().any(|e| e.name == def.name) {
+        if !existing.iter().any(|existing| existing.range == def.range) {
             existing.push(def);
         }
     }

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -75,6 +75,16 @@ declare_diagnostic_type! {
 }
 
 declare_diagnostic_type! {
+    /// ## Duplicate fixture
+    ///
+    /// Raised when a module defines the same fixture more than once.
+    pub static DUPLICATE_FIXTURE = {
+        summary: "Discovered duplicate fixture definitions",
+        severity: Severity::Error,
+    }
+}
+
+declare_diagnostic_type! {
     /// ## Invalid fixture
     ///
     /// There are several reasons a fixture may be invalid,
@@ -158,6 +168,16 @@ declare_diagnostic_type! {
 }
 
 declare_diagnostic_type! {
+    /// ## Duplicate test
+    ///
+    /// Raised when a module defines the same test function more than once.
+    pub static DUPLICATE_TEST = {
+        summary: "Discovered duplicate test definitions",
+        severity: Severity::Error,
+    }
+}
+
+declare_diagnostic_type! {
     /// ## Invalid Test
     ///
     /// If a test definition cannot be run by Karva, we will raise this error.
@@ -198,6 +218,21 @@ fn annotate_function_name(
 ) {
     let span = Span::from(source_file).with_range(stmt_function_def.name.range);
     diagnostic.annotate(Annotation::primary(span));
+}
+
+fn annotate_first_definition(
+    diagnostic: &mut Diagnostic,
+    source_file: SourceFile,
+    name: &str,
+    stmt_function_def: &StmtFunctionDef,
+) {
+    let mut sub = SubDiagnostic::new(
+        SubDiagnosticSeverity::Info,
+        format!("First definition of `{name}` is here"),
+    );
+    let span = Span::from(source_file).with_range(stmt_function_def.name.range);
+    sub.annotate(Annotation::primary(span));
+    diagnostic.sub(sub);
 }
 
 /// Emits sub-diagnostics for each intermediate fixture in the dependency chain,
@@ -251,6 +286,39 @@ pub fn report_failed_to_discover_imported_fixture(
     ));
 
     context.add_run_diagnostic(diagnostic);
+}
+
+pub fn report_duplicate_fixture(
+    context: &Context,
+    source_file: SourceFile,
+    fixture_name: &str,
+    first_definition: &StmtFunctionDef,
+    duplicate_definition: &StmtFunctionDef,
+) {
+    let builder = context.report_diagnostic(&DUPLICATE_FIXTURE);
+
+    let mut diagnostic = builder.into_diagnostic(format!(
+        "Fixture `{fixture_name}` is defined more than once"
+    ));
+
+    annotate_function_name(&mut diagnostic, source_file.clone(), duplicate_definition);
+    annotate_first_definition(&mut diagnostic, source_file, fixture_name, first_definition);
+}
+
+pub fn report_duplicate_test(
+    context: &Context,
+    source_file: SourceFile,
+    test_name: &str,
+    first_definition: &StmtFunctionDef,
+    duplicate_definition: &StmtFunctionDef,
+) {
+    let builder = context.report_diagnostic(&DUPLICATE_TEST);
+
+    let mut diagnostic =
+        builder.into_diagnostic(format!("Test `{test_name}` is defined more than once"));
+
+    annotate_function_name(&mut diagnostic, source_file.clone(), duplicate_definition);
+    annotate_first_definition(&mut diagnostic, source_file, test_name, first_definition);
 }
 
 pub fn report_invalid_fixture(

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -295,14 +295,13 @@ pub fn report_duplicate_fixture(
     first_definition: &StmtFunctionDef,
     duplicate_definition: &StmtFunctionDef,
 ) {
-    let builder = context.report_diagnostic(&DUPLICATE_FIXTURE);
-
-    let mut diagnostic = builder.into_diagnostic(format!(
+    let mut diagnostic = DUPLICATE_FIXTURE.diagnostic(format!(
         "Fixture `{fixture_name}` is defined more than once"
     ));
 
     annotate_function_name(&mut diagnostic, source_file.clone(), duplicate_definition);
     annotate_first_definition(&mut diagnostic, source_file, fixture_name, first_definition);
+    context.add_run_diagnostic(diagnostic);
 }
 
 pub fn report_duplicate_test(
@@ -312,13 +311,12 @@ pub fn report_duplicate_test(
     first_definition: &StmtFunctionDef,
     duplicate_definition: &StmtFunctionDef,
 ) {
-    let builder = context.report_diagnostic(&DUPLICATE_TEST);
-
     let mut diagnostic =
-        builder.into_diagnostic(format!("Test `{test_name}` is defined more than once"));
+        DUPLICATE_TEST.diagnostic(format!("Test `{test_name}` is defined more than once"));
 
     annotate_function_name(&mut diagnostic, source_file.clone(), duplicate_definition);
     annotate_first_definition(&mut diagnostic, source_file, test_name, first_definition);
+    context.add_run_diagnostic(diagnostic);
 }
 
 pub fn report_invalid_fixture(

--- a/crates/karva_test_semantic/src/discovery/visitor.rs
+++ b/crates/karva_test_semantic/src/discovery/visitor.rs
@@ -1,9 +1,10 @@
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::rc::Rc;
 
 use camino::Utf8Path;
 use fs_err as fs;
-use karva_python_semantic::ModulePath;
+use karva_python_semantic::{ModulePath, is_fixture};
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
 use ruff_python_ast::visitor::source_order::{self, SourceOrderVisitor};
@@ -13,8 +14,8 @@ use ruff_source_file::SourceFileBuilder;
 
 use crate::Context;
 use crate::diagnostic::{
-    report_failed_to_discover_imported_fixture, report_failed_to_import_module,
-    report_generator_test, report_invalid_fixture,
+    report_duplicate_fixture, report_duplicate_test, report_failed_to_discover_imported_fixture,
+    report_failed_to_import_module, report_generator_test, report_invalid_fixture,
 };
 use crate::discovery::{DiscoveredModule, DiscoveredTestFunction};
 use crate::extensions::fixtures::DiscoveredFixture;
@@ -277,7 +278,25 @@ pub fn discover(
 
     let mut visitor = FunctionDefinitionVisitor::new(py, context, module);
 
-    for test_function_def in test_function_defs {
+    let duplicate_test_indices = duplicate_definition_indices(
+        &test_function_defs,
+        |test_function_def| test_function_def.name.to_string(),
+        |name, first_definition, duplicate_definition| {
+            report_duplicate_test(
+                context,
+                visitor.module.source_file(),
+                name,
+                first_definition,
+                duplicate_definition,
+            );
+        },
+    );
+
+    for (index, test_function_def) in test_function_defs.into_iter().enumerate() {
+        if duplicate_test_indices.contains(&index) {
+            continue;
+        }
+
         if is_generator(&test_function_def) {
             report_generator_test(context, visitor.module.source_file(), &test_function_def);
             continue;
@@ -286,12 +305,99 @@ pub fn discover(
         visitor.process_test_function(test_function_def);
     }
 
-    for fixture_function_def in fixture_function_defs {
+    let duplicate_fixture_indices = duplicate_definition_indices(
+        &fixture_function_defs,
+        fixture_definition_name,
+        |name, first_definition, duplicate_definition| {
+            report_duplicate_fixture(
+                context,
+                visitor.module.source_file(),
+                name,
+                first_definition,
+                duplicate_definition,
+            );
+        },
+    );
+
+    for (index, fixture_function_def) in fixture_function_defs.into_iter().enumerate() {
+        if duplicate_fixture_indices.contains(&index) {
+            continue;
+        }
+
         visitor.process_fixture_function(fixture_function_def);
     }
 
     if is_conftest || context.settings().test().try_import_fixtures {
         visitor.find_extra_fixtures();
+    }
+}
+
+fn duplicate_definition_indices(
+    definitions: &[StmtFunctionDef],
+    mut name: impl FnMut(&StmtFunctionDef) -> String,
+    mut report: impl FnMut(&str, &StmtFunctionDef, &StmtFunctionDef),
+) -> HashSet<usize> {
+    let mut seen: HashMap<String, usize> = HashMap::new();
+    let mut duplicates: HashSet<usize> = HashSet::new();
+
+    for (index, definition) in definitions.iter().enumerate() {
+        let definition_name = name(definition);
+
+        if let Some(first_index) = seen.get(&definition_name) {
+            let first_definition = &definitions[*first_index];
+            if first_definition.range == definition.range {
+                duplicates.insert(index);
+                continue;
+            }
+
+            report(&definition_name, first_definition, definition);
+            duplicates.insert(*first_index);
+            duplicates.insert(index);
+        } else {
+            seen.insert(definition_name, index);
+        }
+    }
+
+    duplicates
+}
+
+fn fixture_definition_name(stmt_function_def: &StmtFunctionDef) -> String {
+    stmt_function_def
+        .decorator_list
+        .iter()
+        .find_map(|decorator| {
+            fixture_name_from_decorator(&decorator.expression, stmt_function_def.name.as_str())
+        })
+        .unwrap_or_else(|| stmt_function_def.name.to_string())
+}
+
+fn fixture_name_from_decorator(expr: &Expr, default_name: &str) -> Option<String> {
+    match expr {
+        Expr::Call(call) if is_fixture(call.func.as_ref()) => Some(
+            explicit_fixture_name(call)
+                .map(ToOwned::to_owned)
+                .unwrap_or_else(|| default_name.to_string()),
+        ),
+        _ if is_fixture(expr) => Some(default_name.to_string()),
+        _ => None,
+    }
+}
+
+fn explicit_fixture_name(call: &ruff_python_ast::ExprCall) -> Option<&str> {
+    call.arguments.keywords.iter().find_map(|keyword| {
+        if keyword.arg.as_ref().is_some_and(|arg| arg == "name") {
+            string_literal_value(&keyword.value)
+        } else {
+            None
+        }
+    })
+}
+
+fn string_literal_value(expr: &Expr) -> Option<&str> {
+    if let Expr::StringLiteral(string_literal) = expr {
+        Some(string_literal.value.to_str())
+    } else {
+        None
     }
 }
 

--- a/crates/karva_test_semantic/src/discovery/visitor.rs
+++ b/crates/karva_test_semantic/src/discovery/visitor.rs
@@ -4,13 +4,14 @@ use std::rc::Rc;
 
 use camino::Utf8Path;
 use fs_err as fs;
-use karva_python_semantic::{ModulePath, is_fixture};
+use karva_python_semantic::ModulePath;
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
 use ruff_python_ast::visitor::source_order::{self, SourceOrderVisitor};
 use ruff_python_ast::{Expr, PythonVersion, Stmt, StmtFunctionDef};
 use ruff_python_parser::{Mode, ParseOptions, parse_unchecked};
 use ruff_source_file::SourceFileBuilder;
+use ruff_text_size::TextRange;
 
 use crate::Context;
 use crate::diagnostic::{
@@ -80,12 +81,13 @@ impl<'ctx, 'py, 'a, 'b> FunctionDefinitionVisitor<'ctx, 'py, 'a, 'b> {
 }
 
 impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
-    fn process_fixture_function(&mut self, stmt_function_def: StmtFunctionDef) {
+    fn process_fixture_function(
+        &mut self,
+        stmt_function_def: StmtFunctionDef,
+    ) -> Option<DiscoveredFixture> {
         self.try_import_module();
 
-        let Some(py_module) = self.py_module.as_ref() else {
-            return;
-        };
+        let py_module = self.py_module.as_ref()?;
 
         let is_generator_function = is_generator(&stmt_function_def);
 
@@ -99,7 +101,7 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
             self.module.source_file(),
             is_generator_function,
         ) {
-            Ok(fixture_def) => self.module.add_fixture(fixture_def),
+            Ok(fixture_def) => Some(fixture_def),
             Err(e) => {
                 report_invalid_fixture(
                     self.context,
@@ -108,6 +110,7 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
                     &stmt_function_def,
                     &e,
                 );
+                None
             }
         }
     }
@@ -281,6 +284,7 @@ pub fn discover(
     let duplicate_test_indices = duplicate_definition_indices(
         &test_function_defs,
         |test_function_def| test_function_def.name.to_string(),
+        |test_function_def| test_function_def.range,
         |name, first_definition, duplicate_definition| {
             report_duplicate_test(
                 context,
@@ -305,26 +309,34 @@ pub fn discover(
         visitor.process_test_function(test_function_def);
     }
 
+    let mut fixtures = Vec::with_capacity(fixture_function_defs.len());
+    for fixture_function_def in fixture_function_defs {
+        if let Some(fixture) = visitor.process_fixture_function(fixture_function_def) {
+            fixtures.push(fixture);
+        }
+    }
+
     let duplicate_fixture_indices = duplicate_definition_indices(
-        &fixture_function_defs,
-        fixture_definition_name,
+        &fixtures,
+        |fixture| fixture.name().function_name().to_string(),
+        |fixture| fixture.stmt_function_def().range,
         |name, first_definition, duplicate_definition| {
             report_duplicate_fixture(
                 context,
                 visitor.module.source_file(),
                 name,
-                first_definition,
-                duplicate_definition,
+                first_definition.stmt_function_def(),
+                duplicate_definition.stmt_function_def(),
             );
         },
     );
 
-    for (index, fixture_function_def) in fixture_function_defs.into_iter().enumerate() {
+    for (index, fixture) in fixtures.into_iter().enumerate() {
         if duplicate_fixture_indices.contains(&index) {
             continue;
         }
 
-        visitor.process_fixture_function(fixture_function_def);
+        visitor.module.add_fixture(fixture);
     }
 
     if is_conftest || context.settings().test().try_import_fixtures {
@@ -332,10 +344,11 @@ pub fn discover(
     }
 }
 
-fn duplicate_definition_indices(
-    definitions: &[StmtFunctionDef],
-    mut name: impl FnMut(&StmtFunctionDef) -> String,
-    mut report: impl FnMut(&str, &StmtFunctionDef, &StmtFunctionDef),
+fn duplicate_definition_indices<T>(
+    definitions: &[T],
+    mut name: impl FnMut(&T) -> String,
+    mut range: impl FnMut(&T) -> TextRange,
+    mut report: impl FnMut(&str, &T, &T),
 ) -> HashSet<usize> {
     let mut seen: HashMap<String, usize> = HashMap::new();
     let mut duplicates: HashSet<usize> = HashSet::new();
@@ -345,7 +358,7 @@ fn duplicate_definition_indices(
 
         if let Some(first_index) = seen.get(&definition_name) {
             let first_definition = &definitions[*first_index];
-            if first_definition.range == definition.range {
+            if range(first_definition) == range(definition) {
                 duplicates.insert(index);
                 continue;
             }
@@ -359,46 +372,6 @@ fn duplicate_definition_indices(
     }
 
     duplicates
-}
-
-fn fixture_definition_name(stmt_function_def: &StmtFunctionDef) -> String {
-    stmt_function_def
-        .decorator_list
-        .iter()
-        .find_map(|decorator| {
-            fixture_name_from_decorator(&decorator.expression, stmt_function_def.name.as_str())
-        })
-        .unwrap_or_else(|| stmt_function_def.name.to_string())
-}
-
-fn fixture_name_from_decorator(expr: &Expr, default_name: &str) -> Option<String> {
-    match expr {
-        Expr::Call(call) if is_fixture(call.func.as_ref()) => Some(
-            explicit_fixture_name(call)
-                .map(ToOwned::to_owned)
-                .unwrap_or_else(|| default_name.to_string()),
-        ),
-        _ if is_fixture(expr) => Some(default_name.to_string()),
-        _ => None,
-    }
-}
-
-fn explicit_fixture_name(call: &ruff_python_ast::ExprCall) -> Option<&str> {
-    call.arguments.keywords.iter().find_map(|keyword| {
-        if keyword.arg.as_ref().is_some_and(|arg| arg == "name") {
-            string_literal_value(&keyword.value)
-        } else {
-            None
-        }
-    })
-}
-
-fn string_literal_value(expr: &Expr) -> Option<&str> {
-    if let Expr::StringLiteral(string_literal) = expr {
-        Some(string_literal.value.to_str())
-    } else {
-        None
-    }
 }
 
 /// Returns `true` if the function body contains a yield or yield-from expression.


### PR DESCRIPTION
## Summary

Reject duplicate test functions and same-module fixture definitions during discovery, reporting both the first definition and the conflicting definition before duplicate bodies can run. Fixture duplicate checks honor explicit fixture names from Karva and pytest decorators, while collection still deduplicates repeated collection entries by exact source range.

Fixes #959.

## Test Plan

Ran `just test -p karva --test it test_duplicate test_generator_tests_are_rejected_without_running_body test_fixture_override_in_test_modules`, `just test -p karva_collector -p karva_test_semantic`, `cargo clippy -p karva_collector -p karva_test_semantic -p karva --all-targets --all-features -- -D warnings`, and `uvx prek run -a`.
