### PR TITLE
Stabilize snapshot file names

### DIFF
--- a/crates/karva/tests/it/extensions/snapshot/json.rs
+++ b/crates/karva/tests/it/extensions/snapshot/json.rs
@@ -39,7 +39,7 @@ def test_data():
 }
 
 #[test]
-fn test_json_snapshot_uses_params_and_ignores_fixture_values() {
+fn test_json_snapshot_uses_param_values_and_fixture_names() {
     let context = TestContext::with_file(
         "test.py",
         r#"
@@ -47,8 +47,12 @@ from pathlib import Path
 
 import karva
 
+@karva.fixture
+def machine_path():
+    return Path("/machine-specific/path")
+
 @karva.tags.parametrize("ok", [True])
-def test_response(tmp_path: Path, monkeypatch: karva.MockEnv, ok):
+def test_response(machine_path, tmp_path: Path, monkeypatch: karva.MockEnv, ok):
     karva.assert_json_snapshot({"ok": ok})
         "#,
     );
@@ -68,10 +72,12 @@ def test_response(tmp_path: Path, monkeypatch: karva.MockEnv, ok):
     "
     );
 
-    let content = context.read_file("snapshots/test__test_response(ok=True).snap");
+    let content = context.read_file(
+        "snapshots/test__test_response(machine_path, monkeypatch, ok=True, tmp_path).snap",
+    );
     insta::assert_snapshot!(content, @r#"
     ---
-    source: test.py:8::test_response(ok=True)
+    source: test.py:12::test_response(machine_path, monkeypatch, ok=True, tmp_path)
     ---
     {
       "ok": true

--- a/crates/karva/tests/it/extensions/snapshot/json.rs
+++ b/crates/karva/tests/it/extensions/snapshot/json.rs
@@ -39,7 +39,7 @@ def test_data():
 }
 
 #[test]
-fn test_json_snapshot_ignores_fixture_values() {
+fn test_json_snapshot_uses_params_and_ignores_fixture_values() {
     let context = TestContext::with_file(
         "test.py",
         r#"
@@ -47,8 +47,9 @@ from pathlib import Path
 
 import karva
 
-def test_response(tmp_path: Path, monkeypatch: karva.MockEnv):
-    karva.assert_json_snapshot({"ok": True})
+@karva.tags.parametrize("ok", [True])
+def test_response(tmp_path: Path, monkeypatch: karva.MockEnv, ok):
+    karva.assert_json_snapshot({"ok": ok})
         "#,
     );
 
@@ -67,10 +68,10 @@ def test_response(tmp_path: Path, monkeypatch: karva.MockEnv):
     "
     );
 
-    let content = context.read_file("snapshots/test__test_response.snap");
+    let content = context.read_file("snapshots/test__test_response(ok=True).snap");
     insta::assert_snapshot!(content, @r#"
     ---
-    source: test.py:7::test_response
+    source: test.py:8::test_response(ok=True)
     ---
     {
       "ok": true

--- a/crates/karva/tests/it/extensions/snapshot/json.rs
+++ b/crates/karva/tests/it/extensions/snapshot/json.rs
@@ -39,7 +39,7 @@ def test_data():
 }
 
 #[test]
-fn test_json_snapshot_uses_framework_fixture_names() {
+fn test_json_snapshot_ignores_fixture_values() {
     let context = TestContext::with_file(
         "test.py",
         r#"
@@ -67,10 +67,10 @@ def test_response(tmp_path: Path, monkeypatch: karva.MockEnv):
     "
     );
 
-    let content = context.read_file("snapshots/test__test_response(monkeypatch, tmp_path).snap");
+    let content = context.read_file("snapshots/test__test_response.snap");
     insta::assert_snapshot!(content, @r#"
     ---
-    source: test.py:7::test_response(monkeypatch, tmp_path)
+    source: test.py:7::test_response
     ---
     {
       "ok": true
@@ -297,14 +297,14 @@ def test_inline_json():
 }
 
 #[test]
-fn test_json_snapshot_named() {
+fn test_json_snapshot_named_with_path_separators() {
     let context = TestContext::with_file(
         "test.py",
         r"
 import karva
 
 def test_fn():
-    karva.assert_json_snapshot({'b': 2, 'a': 1}, name='config')
+    karva.assert_json_snapshot({'b': 2, 'a': 1}, name='nested/config\\value')
         ",
     );
 
@@ -320,7 +320,7 @@ def test_fn():
     ----- stderr -----
     ");
 
-    let content = context.read_file("snapshots/test__test_fn--config.snap");
+    let content = context.read_file("snapshots/test__test_fn--nested%2Fconfig%5Cvalue.snap");
     insta::assert_snapshot!(content, @r#"
     ---
     source: test.py:5::test_fn

--- a/crates/karva_snapshot/src/storage.rs
+++ b/crates/karva_snapshot/src/storage.rs
@@ -21,8 +21,14 @@ pub fn snapshot_dir(test_file: &Utf8Path) -> Utf8PathBuf {
 /// Return the path to a snapshot file.
 ///
 /// Format: `{test_dir}/snapshots/{module_name}__{snapshot_name}.snap`
+/// Path separators in the snapshot name are percent-escaped.
 pub fn snapshot_path(test_file: &Utf8Path, module_name: &str, snapshot_name: &str) -> Utf8PathBuf {
     let dir = snapshot_dir(test_file);
+    let snapshot_name = snapshot_name
+        .replace('%', "%25")
+        .replace('/', "%2F")
+        .replace('\\', "%5C")
+        .replace("::", "__");
     dir.join(format!("{module_name}__{snapshot_name}.snap"))
 }
 
@@ -538,6 +544,34 @@ mod tests {
             normalize_path(&snapshot_path(Utf8Path::new("tests/test_example.py"), "test_example", "test_foo")),
             @"tests/snapshots/test_example__test_foo.snap"
         );
+    }
+
+    #[test]
+    fn snapshot_path_escapes_separators() {
+        insta::assert_snapshot!(
+            normalize_path(&snapshot_path(
+                Utf8Path::new("tests/test_example.py"),
+                "test_example",
+                "TestClass::test_foo(left/right\\value%2F)",
+            )),
+            @"tests/snapshots/test_example__TestClass__test_foo(left%2Fright%5Cvalue%252F).snap"
+        );
+    }
+
+    #[test]
+    fn snapshot_path_escaping_preserves_identity() {
+        let test_file = Utf8Path::new("tests/test_example.py");
+        let slash = snapshot_path(test_file, "test_example", "test_foo(a/b)");
+        let backslash = snapshot_path(test_file, "test_example", "test_foo(a\\b)");
+        let underscore = snapshot_path(test_file, "test_example", "test_foo(a_b)");
+        let escaped = snapshot_path(test_file, "test_example", "test_foo(a%2Fb)");
+
+        assert_ne!(slash, backslash);
+        assert_ne!(slash, underscore);
+        assert_ne!(slash, escaped);
+        assert_ne!(backslash, underscore);
+        assert_ne!(backslash, escaped);
+        assert_ne!(underscore, escaped);
     }
 
     #[test]

--- a/crates/karva_snapshot/src/storage.rs
+++ b/crates/karva_snapshot/src/storage.rs
@@ -21,7 +21,8 @@ pub fn snapshot_dir(test_file: &Utf8Path) -> Utf8PathBuf {
 /// Return the path to a snapshot file.
 ///
 /// Format: `{test_dir}/snapshots/{module_name}__{snapshot_name}.snap`
-/// Path separators in the snapshot name are percent-escaped.
+/// Percent signs and path separators in the snapshot name are percent-escaped.
+/// Qualified-name separators (`::`) are replaced with `__`.
 pub fn snapshot_path(test_file: &Utf8Path, module_name: &str, snapshot_name: &str) -> Utf8PathBuf {
     let dir = snapshot_dir(test_file);
     let snapshot_name = snapshot_name

--- a/crates/karva_test_semantic/src/extensions/functions/snapshot.rs
+++ b/crates/karva_test_semantic/src/extensions/functions/snapshot.rs
@@ -374,9 +374,7 @@ fn assert_snapshot_impl(
     let test_file_path = Utf8Path::new(&test_file);
     let module_name = test_file_path.file_stem().unwrap_or("unknown");
 
-    // Sanitize `::` to `__` for filesystem compatibility (`:` is reserved on Windows)
-    let fs_snapshot_name = snapshot_name.replace("::", "__");
-    let snap_path = snapshot_path(test_file_path, module_name, &fs_snapshot_name);
+    let snap_path = snapshot_path(test_file_path, module_name, &snapshot_name);
 
     let relative_test_file = test_file_path
         .file_name()

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -541,12 +541,23 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         let start_time = std::time::Instant::now();
         let expect_fail_tag = tags.expect_fail_tag();
 
+        // Snapshot identity uses the unqualified function name and every `@parametrize` value.
+        // Fixture values are runtime dependencies and can be machine-specific (for example,
+        // `tmp_path`), so they must not affect snapshot file names. `snapshot_path()` prepends
+        // the test file stem. Build the identity here because `setup_test_fixtures()` consumes
+        // `params`.
         let snapshot_test_name = {
-            let mut arguments = FixtureArguments::default();
-            for (name, value) in &params {
-                arguments.insert(name.clone(), value.as_ref().clone_ref(py));
+            let mut parametrize_arguments = FixtureArguments::default();
+            for (param_name, param_value) in &params {
+                parametrize_arguments
+                    .insert(param_name.clone(), param_value.as_ref().clone_ref(py));
             }
-            full_test_name(py, name.function_name().to_string(), &arguments, &[])
+            full_test_name(
+                py,
+                name.function_name().to_string(),
+                &parametrize_arguments,
+                &[],
+            )
         };
 
         let (function_arguments, fixture_call_errors, test_finalizers) = self.setup_test_fixtures(
@@ -576,9 +587,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
 
         let test_name_env_result = set_test_name_env(py, &qualified_test_name.to_string());
 
-        // Set snapshot context so `karva.assert_snapshot()` can determine the current test.
-        // Use `function_name()` (not `qualified_test_name`) to avoid doubling the module prefix,
-        // since `snapshot_path()` already prepends the module name from the file stem.
+        // Make the identity available before snapshot assertions run.
         crate::extensions::functions::snapshot::set_snapshot_context(
             test_module_path.to_string(),
             snapshot_test_name,

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -541,25 +541,6 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         let start_time = std::time::Instant::now();
         let expect_fail_tag = tags.expect_fail_tag();
 
-        // Snapshot identity uses the unqualified function name and every `@parametrize` value.
-        // Fixture values are runtime dependencies and can be machine-specific (for example,
-        // `tmp_path`), so they must not affect snapshot file names. `snapshot_path()` prepends
-        // the test file stem. Build the identity here because `setup_test_fixtures()` consumes
-        // `params`.
-        let snapshot_test_name = {
-            let mut parametrize_arguments = FixtureArguments::default();
-            for (param_name, param_value) in &params {
-                parametrize_arguments
-                    .insert(param_name.clone(), param_value.as_ref().clone_ref(py));
-            }
-            full_test_name(
-                py,
-                name.function_name().to_string(),
-                &parametrize_arguments,
-                &[],
-            )
-        };
-
         let (function_arguments, fixture_call_errors, test_finalizers) = self.setup_test_fixtures(
             py,
             &fixture_dependencies,
@@ -568,7 +549,11 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             params,
         );
 
-        let name_only_arguments = fixture_dependencies
+        let fixture_names = fixture_dependencies
+            .iter()
+            .map(|fixture| fixture.function_name())
+            .collect::<Vec<_>>();
+        let framework_fixture_names = fixture_dependencies
             .iter()
             .filter(|fixture| fixture.name.module_path().module_name() == "karva._builtins")
             .map(|fixture| fixture.function_name())
@@ -577,7 +562,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             py,
             name.to_string(),
             &function_arguments,
-            &name_only_arguments,
+            &framework_fixture_names,
         );
 
         let qualified_test_name =
@@ -587,7 +572,15 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
 
         let test_name_env_result = set_test_name_env(py, &qualified_test_name.to_string());
 
-        // Make the identity available before snapshot assertions run.
+        // Parameter values distinguish snapshot variants, but fixture values can be
+        // machine-specific, so snapshot identity includes fixture names only. Use the
+        // unqualified function name because `snapshot_path()` prepends the test file stem.
+        let snapshot_test_name = full_test_name(
+            py,
+            name.function_name().to_string(),
+            &function_arguments,
+            &fixture_names,
+        );
         crate::extensions::functions::snapshot::set_snapshot_context(
             test_module_path.to_string(),
             snapshot_test_name,

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -541,6 +541,14 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         let start_time = std::time::Instant::now();
         let expect_fail_tag = tags.expect_fail_tag();
 
+        let snapshot_test_name = {
+            let mut arguments = FixtureArguments::default();
+            for (name, value) in &params {
+                arguments.insert(name.clone(), value.as_ref().clone_ref(py));
+            }
+            full_test_name(py, name.function_name().to_string(), &arguments, &[])
+        };
+
         let (function_arguments, fixture_call_errors, test_finalizers) = self.setup_test_fixtures(
             py,
             &fixture_dependencies,
@@ -571,12 +579,6 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         // Set snapshot context so `karva.assert_snapshot()` can determine the current test.
         // Use `function_name()` (not `qualified_test_name`) to avoid doubling the module prefix,
         // since `snapshot_path()` already prepends the module name from the file stem.
-        let snapshot_test_name = full_test_name(
-            py,
-            name.function_name().to_string(),
-            &function_arguments,
-            &name_only_arguments,
-        );
         crate::extensions::functions::snapshot::set_snapshot_context(
             test_module_path.to_string(),
             snapshot_test_name,


### PR DESCRIPTION
## Summary

Keep parameter values and fixture names in snapshot identity without embedding runtime fixture values, and percent-escape path separators centrally so snapshots remain stable across machines. Fixes #989.

## Test Plan

Verified with the snapshot integration suite, strict workspace Clippy, and uvx prek run -a.