### PR TITLE
Preserve argument order in test names

### DIFF
--- a/crates/karva/tests/it/extensions/fixtures/autouse.rs
+++ b/crates/karva/tests/it/extensions/fixtures/autouse.rs
@@ -137,8 +137,8 @@ fn test_auto_use_fixture(#[values("pytest", "karva")] framework: &str) {
         exit_code: 0
         ----- stdout -----
             Starting 2 tests across 1 worker
-                PASS [TIME] test::test_string_only(first_entry=a, order=['a'])
-                PASS [TIME] test::test_string_and_int(first_entry=a, order=['a'])
+                PASS [TIME] test::test_string_only(order=['a'], first_entry=a)
+                PASS [TIME] test::test_string_and_int(order=['a'], first_entry=a)
         ────────────
              Summary [TIME] 2 tests run: 2 passed, 0 skipped
 

--- a/crates/karva/tests/it/extensions/fixtures/basic.rs
+++ b/crates/karva/tests/it/extensions/fixtures/basic.rs
@@ -511,7 +511,7 @@ fn test_fixture_initialization_order(#[values("pytest", "karva")] framework: &st
         exit_code: 0
         ----- stdout -----
             Starting 1 test across 1 worker
-                PASS [TIME] test::test_all_scopes(function_fixture=4, module_fixture=2, package_fixture=3, session_fixture=1)
+                PASS [TIME] test::test_all_scopes(session_fixture=1, module_fixture=2, package_fixture=3, function_fixture=4)
         ────────────
              Summary [TIME] 1 test run: 1 passed, 0 skipped
 

--- a/crates/karva/tests/it/extensions/fixtures/more_builtins.rs
+++ b/crates/karva/tests/it/extensions/fixtures/more_builtins.rs
@@ -111,7 +111,7 @@ def test_tmp_path_still_works(tmp_path, monkeypatch):
     exit_code: 0
     ----- stdout -----
         Starting 1 test across 1 worker
-            PASS [TIME] test_framework::test_tmp_path_still_works(monkeypatch, tmp_path)
+            PASS [TIME] test_framework::test_tmp_path_still_works(tmp_path, monkeypatch)
     ────────────
          Summary [TIME] 1 test run: 1 passed, 0 skipped
 

--- a/crates/karva/tests/it/extensions/fixtures/parametrized.rs
+++ b/crates/karva/tests/it/extensions/fixtures/parametrized.rs
@@ -260,7 +260,7 @@ fn test_fixture_with_multiple_fixtures(#[values("pytest", "karva")] framework: &
         exit_code: 0
         ----- stdout -----
             Starting 1 test across 1 worker
-                PASS [TIME] test::test_combination(letter=X, number=100)
+                PASS [TIME] test::test_combination(number=100, letter=X)
         ────────────
              Summary [TIME] 1 test run: 1 passed, 0 skipped
 

--- a/crates/karva/tests/it/extensions/snapshot/json.rs
+++ b/crates/karva/tests/it/extensions/snapshot/json.rs
@@ -73,11 +73,11 @@ def test_response(machine_path, tmp_path: Path, monkeypatch: karva.MockEnv, ok):
     );
 
     let content = context.read_file(
-        "snapshots/test__test_response(machine_path, monkeypatch, ok=True, tmp_path).snap",
+        "snapshots/test__test_response(machine_path, tmp_path, monkeypatch, ok=True).snap",
     );
     insta::assert_snapshot!(content, @r#"
     ---
-    source: test.py:12::test_response(machine_path, monkeypatch, ok=True, tmp_path)
+    source: test.py:12::test_response(machine_path, tmp_path, monkeypatch, ok=True)
     ---
     {
       "ok": true

--- a/crates/karva/tests/it/extensions/tags/parametrize.rs
+++ b/crates/karva/tests/it/extensions/tags/parametrize.rs
@@ -45,6 +45,62 @@ def test_parametrize_with_fixture(a, fixture_value):
 }
 
 #[test]
+fn test_argument_order_matches_function_signature() {
+    let test_context = TestContext::with_file(
+        "test.py",
+        r#"
+import os
+import karva
+
+@karva.fixture
+def first():
+    return 1
+
+@karva.fixture
+def third():
+    return 3
+
+@karva.tags.parametrize("second", [2])
+def test_order(third, second, first):
+    assert os.environ["KARVA_TEST_NAME"] == "test::test_order(third=3, second=2, first=1)"
+    assert False
+        "#,
+    );
+
+    assert_cmd_snapshot!(test_context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_order(third=3, second=2, first=1)
+
+    diagnostics:
+
+    error[test-failure]: Test `test_order` failed
+      --> test.py:14:5
+       |
+    14 | def test_order(third, second, first):
+       |     ^^^^^^^^^^
+       |
+    info: Test ran with arguments:
+    info: `third`: `3`
+    info: `second`: `2`
+    info: `first`: `1`
+    info: Test failed here
+      --> test.py:16:5
+       |
+    16 |     assert False
+       |     ^^^^^^^^^^^^
+       |
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_parametrize_with_fixture_parametrize_priority() {
     let test_context = TestContext::with_file(
         "test.py",
@@ -164,8 +220,8 @@ fn test_parametrize_multiple_args_single_string(#[values("pytest", "karva")] fra
         exit_code: 0
         ----- stdout -----
             Starting 1 test across 1 worker
-                PASS [TIME] test::test_square(expected=4, input=2)
-                PASS [TIME] test::test_square(expected=9, input=3)
+                PASS [TIME] test::test_square(input=2, expected=4)
+                PASS [TIME] test::test_square(input=3, expected=9)
         ────────────
              Summary [TIME] 2 tests run: 2 passed, 0 skipped
 
@@ -228,9 +284,9 @@ def test_square(input, expected):
     exit_code: 0
     ----- stdout -----
         Starting 1 test across 1 worker
-            PASS [TIME] test::test_square(expected=4, input=2)
-            PASS [TIME] test::test_square(expected=9, input=3)
-            PASS [TIME] test::test_square(expected=16, input=4)
+            PASS [TIME] test::test_square(input=2, expected=4)
+            PASS [TIME] test::test_square(input=3, expected=9)
+            PASS [TIME] test::test_square(input=4, expected=16)
     ────────────
          Summary [TIME] 3 tests run: 3 passed, 0 skipped
 
@@ -260,9 +316,9 @@ def test_square(input, expected):
     exit_code: 0
     ----- stdout -----
         Starting 1 test across 1 worker
-            PASS [TIME] test::test_square(expected=4, input=2)
-            PASS [TIME] test::test_square(expected=9, input=3)
-            PASS [TIME] test::test_square(expected=16, input=4)
+            PASS [TIME] test::test_square(input=2, expected=4)
+            PASS [TIME] test::test_square(input=3, expected=9)
+            PASS [TIME] test::test_square(input=4, expected=16)
     ────────────
          Summary [TIME] 3 tests run: 3 passed, 0 skipped
 
@@ -292,9 +348,9 @@ def test_square(input, expected):
     exit_code: 0
     ----- stdout -----
         Starting 1 test across 1 worker
-            PASS [TIME] test::test_square(expected=4, input=2)
-            PASS [TIME] test::test_square(expected=9, input=3)
-            PASS [TIME] test::test_square(expected=16, input=4)
+            PASS [TIME] test::test_square(input=2, expected=4)
+            PASS [TIME] test::test_square(input=3, expected=9)
+            PASS [TIME] test::test_square(input=4, expected=16)
     ────────────
          Summary [TIME] 3 tests run: 3 passed, 0 skipped
 
@@ -362,8 +418,8 @@ def test_square(input, expected):
     exit_code: 0
     ----- stdout -----
         Starting 1 test across 1 worker
-            PASS [TIME] test::test_square(expected=4, input=2)
-            PASS [TIME] test::test_square(expected=26, input=5)
+            PASS [TIME] test::test_square(input=2, expected=4)
+            PASS [TIME] test::test_square(input=5, expected=26)
     ────────────
          Summary [TIME] 3 tests run: 2 passed, 1 skipped
 
@@ -425,9 +481,9 @@ def test_square(input, expected):
     exit_code: 0
     ----- stdout -----
         Starting 1 test across 1 worker
-            PASS [TIME] test::test_square(expected=4, input=2)
-            PASS [TIME] test::test_square(expected=9, input=3)
-            PASS [TIME] test::test_square(expected=16, input=4)
+            PASS [TIME] test::test_square(input=2, expected=4)
+            PASS [TIME] test::test_square(input=3, expected=9)
+            PASS [TIME] test::test_square(input=4, expected=16)
     ────────────
          Summary [TIME] 3 tests run: 3 passed, 0 skipped
 
@@ -457,9 +513,9 @@ def test_square(input, expected):
     exit_code: 0
     ----- stdout -----
         Starting 1 test across 1 worker
-            PASS [TIME] test::test_square(expected=4, input=2)
-            PASS [TIME] test::test_square(expected=9, input=3)
-            PASS [TIME] test::test_square(expected=16, input=4)
+            PASS [TIME] test::test_square(input=2, expected=4)
+            PASS [TIME] test::test_square(input=3, expected=9)
+            PASS [TIME] test::test_square(input=4, expected=16)
     ────────────
          Summary [TIME] 3 tests run: 3 passed, 0 skipped
 
@@ -489,9 +545,9 @@ def test_square(input, expected):
     exit_code: 0
     ----- stdout -----
         Starting 1 test across 1 worker
-            PASS [TIME] test::test_square(expected=4, input=2)
-            PASS [TIME] test::test_square(expected=9, input=3)
-            PASS [TIME] test::test_square(expected=16, input=4)
+            PASS [TIME] test::test_square(input=2, expected=4)
+            PASS [TIME] test::test_square(input=3, expected=9)
+            PASS [TIME] test::test_square(input=4, expected=16)
     ────────────
          Summary [TIME] 3 tests run: 3 passed, 0 skipped
 
@@ -561,9 +617,9 @@ def test_square(input, expected):
     exit_code: 0
     ----- stdout -----
         Starting 1 test across 1 worker
-            PASS [TIME] test::test_square(expected=4, input=2)
-            PASS [TIME] test::test_square(expected=26, input=5)
-            PASS [TIME] test::test_square(expected=50, input=7)
+            PASS [TIME] test::test_square(input=2, expected=4)
+            PASS [TIME] test::test_square(input=5, expected=26)
+            PASS [TIME] test::test_square(input=7, expected=50)
     ────────────
          Summary [TIME] 5 tests run: 3 passed, 2 skipped
 
@@ -722,10 +778,10 @@ def test2(input, expected):
     exit_code: 0
     ----- stdout -----
         Starting 2 tests across 1 worker
-            PASS [TIME] test::test1(expected=4, input=2)
-            PASS [TIME] test::test1(expected=16, input=4)
-            PASS [TIME] test::test2(expected=4, input=2)
-            PASS [TIME] test::test2(expected=16, input=4)
+            PASS [TIME] test::test1(input=2, expected=4)
+            PASS [TIME] test::test1(input=4, expected=16)
+            PASS [TIME] test::test2(input=2, expected=4)
+            PASS [TIME] test::test2(input=4, expected=16)
     ────────────
          Summary [TIME] 4 tests run: 4 passed, 0 skipped
 

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -444,10 +444,7 @@ fn handle_failed_function_call(
         ));
     }
 
-    let mut sorted_arguments = arguments.iter().collect::<Vec<_>>();
-    sorted_arguments.sort_by_key(|&(name, _)| name);
-
-    for (name, value) in sorted_arguments {
+    for (name, value) in arguments.iter_in_signature_order(&stmt_function_def.parameters) {
         let value_str = value.bind(py).to_string();
         let truncated_value = truncate_string(&value_str);
         let truncated_name = truncate_string(name);

--- a/crates/karva_test_semantic/src/runner/fixture_arguments.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_arguments.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
+use ruff_python_ast::Parameters;
 
 /// Keyword arguments resolved for a test or fixture call.
 #[derive(Default)]
@@ -20,6 +21,21 @@ impl FixtureArguments {
 
     pub fn iter(&self) -> std::collections::hash_map::Iter<'_, String, Py<PyAny>> {
         self.inner.iter()
+    }
+
+    pub fn iter_in_signature_order<'a>(
+        &'a self,
+        parameters: &Parameters,
+    ) -> impl Iterator<Item = (&'a String, &'a Py<PyAny>)> {
+        let mut arguments = self.iter().collect::<Vec<_>>();
+        arguments.sort_by(|(left, _), (right, _)| {
+            let left_position = parameters.index(left).unwrap_or(usize::MAX);
+            let right_position = parameters.index(right).unwrap_or(usize::MAX);
+            left_position
+                .cmp(&right_position)
+                .then_with(|| left.cmp(right))
+        });
+        arguments.into_iter()
     }
 
     pub fn to_kwargs<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -562,6 +562,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             py,
             name.to_string(),
             &function_arguments,
+            &stmt_function_def.parameters,
             &framework_fixture_names,
         );
 
@@ -579,6 +580,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             py,
             name.function_name().to_string(),
             &function_arguments,
+            &stmt_function_def.parameters,
             &fixture_names,
         );
         crate::extensions::functions::snapshot::set_snapshot_context(

--- a/crates/karva_test_semantic/src/utils.rs
+++ b/crates/karva_test_semantic/src/utils.rs
@@ -6,6 +6,7 @@ use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3::types::{PyAnyMethods, PyDict};
 use pyo3::{PyResult, Python};
+use ruff_python_ast::Parameters;
 
 use crate::runner::FixtureArguments;
 
@@ -210,16 +211,14 @@ pub(crate) fn full_test_name(
     py: Python,
     function: String,
     kwargs: &FixtureArguments,
+    parameters: &Parameters,
     name_only_arguments: &[&str],
 ) -> String {
     if kwargs.is_empty() {
         function
     } else {
         let mut args_str = String::new();
-        let mut sorted_kwargs: Vec<_> = kwargs.iter().collect();
-        sorted_kwargs.sort_by_key(|(key, _)| &**key);
-
-        for (i, (key, value)) in sorted_kwargs.iter().enumerate() {
+        for (i, (key, value)) in kwargs.iter_in_signature_order(parameters).enumerate() {
             if i > 0 {
                 args_str.push_str(", ");
             }


### PR DESCRIPTION
## Summary

Preserve Python function signature order in generated test names, snapshot identities, environment names, and failure diagnostics while keeping unknown arguments deterministic. Fixes #993.

## Test Plan

Verified with the integration suite, strict workspace Clippy, and `uvx prek run -a`.