### PR TITLE
Report fixture dependency cycles

### DIFF
--- a/crates/karva/tests/it/extensions/fixtures/cycles.rs
+++ b/crates/karva/tests/it/extensions/fixtures/cycles.rs
@@ -1,0 +1,262 @@
+use insta_cmd::assert_cmd_snapshot;
+
+use crate::common::TestContext;
+
+#[test]
+fn test_direct_fixture_cycle() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+from pathlib import Path
+
+@karva.fixture
+def value(value):
+    Path("fixture-ran").touch()
+
+def test_cycle(value):
+    Path("test-ran").touch()
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_cycle
+
+    diagnostics:
+
+    error[fixture-cycle]: Fixture dependency cycle detected
+     --> test.py:6:5
+      |
+    6 | def value(value):
+      |     ^^^^^
+      |
+    info: value -> value
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+    assert!(!context.root().join("fixture-ran").exists());
+    assert!(!context.root().join("test-ran").exists());
+}
+
+#[test]
+fn test_async_generator_fixture_cycle() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+from pathlib import Path
+
+@karva.fixture
+async def database(client):
+    Path("database-ran").touch()
+    return client
+
+@karva.fixture
+def client(database):
+    Path("client-ran").touch()
+    yield database
+
+def test_cycle(database):
+    Path("test-ran").touch()
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_cycle
+
+    diagnostics:
+
+    error[fixture-cycle]: Fixture dependency cycle detected
+     --> test.py:6:11
+      |
+    6 | async def database(client):
+      |           ^^^^^^^^
+      |
+    info: Fixture `client` requires `database`
+      --> test.py:11:5
+       |
+    11 | def client(database):
+       |     ^^^^^^
+       |
+    info: database -> client -> database
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+    assert!(!context.root().join("database-ran").exists());
+    assert!(!context.root().join("client-ran").exists());
+    assert!(!context.root().join("test-ran").exists());
+}
+
+#[test]
+fn test_fixture_cycle_across_module_and_conftest() {
+    let context = TestContext::with_files([
+        (
+            "conftest.py",
+            r#"
+import karva
+from pathlib import Path
+
+@karva.fixture
+def database(client):
+    Path("database-ran").touch()
+    return client
+"#,
+        ),
+        (
+            "test.py",
+            r#"
+import karva
+from pathlib import Path
+
+@karva.fixture
+def client(database):
+    Path("client-ran").touch()
+    return database
+
+def test_cycle(database):
+    Path("test-ran").touch()
+"#,
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_cycle
+
+    diagnostics:
+
+    error[fixture-cycle]: Fixture dependency cycle detected
+     --> conftest.py:6:5
+      |
+    6 | def database(client):
+      |     ^^^^^^^^
+      |
+    info: Fixture `client` requires `database`
+     --> test.py:6:5
+      |
+    6 | def client(database):
+      |     ^^^^^^
+      |
+    info: database -> client -> database
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+    assert!(!context.root().join("database-ran").exists());
+    assert!(!context.root().join("client-ran").exists());
+    assert!(!context.root().join("test-ran").exists());
+}
+
+#[test]
+fn test_autouse_fixture_cycle() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+from pathlib import Path
+
+@karva.fixture(scope="module", auto_use=True)
+def first(second):
+    Path("first-ran").touch()
+
+@karva.fixture(scope="module")
+def second(first):
+    Path("second-ran").touch()
+
+def test_cycle():
+    Path("test-ran").touch()
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_cycle
+
+    diagnostics:
+
+    error[fixture-cycle]: Fixture dependency cycle detected
+     --> test.py:6:5
+      |
+    6 | def first(second):
+      |     ^^^^^
+      |
+    info: Fixture `second` requires `first`
+      --> test.py:10:5
+       |
+    10 | def second(first):
+       |     ^^^^^^
+       |
+    info: first -> second -> first
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+    assert!(!context.root().join("first-ran").exists());
+    assert!(!context.root().join("second-ran").exists());
+    assert!(!context.root().join("test-ran").exists());
+}
+
+#[test]
+fn test_diamond_fixture_graph() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+calls = 0
+
+@karva.fixture
+def shared():
+    global calls
+    calls += 1
+    return calls
+
+@karva.fixture
+def left(shared):
+    return shared
+
+@karva.fixture
+def right(shared):
+    return shared
+
+def test_diamond(left, right):
+    assert left == right == 1
+",
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_diamond(left=1, right=1)
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}

--- a/crates/karva/tests/it/extensions/fixtures/cycles.rs
+++ b/crates/karva/tests/it/extensions/fixtures/cycles.rs
@@ -167,20 +167,87 @@ def test_cycle(database):
 }
 
 #[test]
-fn test_autouse_fixture_cycle() {
+fn test_cycle_excludes_noncyclic_prefix() {
     let context = TestContext::with_file(
         "test.py",
         r#"
 import karva
 from pathlib import Path
 
-@karva.fixture(scope="module", auto_use=True)
-def first(second):
-    Path("first-ran").touch()
+@karva.fixture
+def requested(first):
+    Path("fixture-ran").touch()
 
-@karva.fixture(scope="module")
+@karva.fixture
+def first(second):
+    Path("fixture-ran").touch()
+
+@karva.fixture
+def second(third):
+    Path("fixture-ran").touch()
+
+@karva.fixture
+def third(first):
+    Path("fixture-ran").touch()
+
+def test_cycle(requested):
+    Path("test-ran").touch()
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_cycle
+
+    diagnostics:
+
+    error[fixture-cycle]: Fixture dependency cycle detected
+      --> test.py:10:5
+       |
+    10 | def first(second):
+       |     ^^^^^
+       |
+    info: Fixture `second` requires `third`
+      --> test.py:14:5
+       |
+    14 | def second(third):
+       |     ^^^^^^
+       |
+    info: Fixture `third` requires `first`
+      --> test.py:18:5
+       |
+    18 | def third(first):
+       |     ^^^^^
+       |
+    info: first -> second -> third -> first
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+    assert!(!context.root().join("fixture-ran").exists());
+    assert!(!context.root().join("test-ran").exists());
+}
+
+#[test]
+fn test_function_autouse_fixture_cycle() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+from pathlib import Path
+
+@karva.fixture(auto_use=True)
+def first(second):
+    Path("fixture-ran").touch()
+
+@karva.fixture
 def second(first):
-    Path("second-ran").touch()
+    Path("fixture-ran").touch()
 
 def test_cycle():
     Path("test-ran").touch()
@@ -215,8 +282,253 @@ def test_cycle():
 
     ----- stderr -----
     ");
+    assert!(!context.root().join("fixture-ran").exists());
+    assert!(!context.root().join("test-ran").exists());
+}
+
+#[test]
+fn test_module_autouse_fixture_cycle() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+from pathlib import Path
+
+@karva.fixture(scope="module", auto_use=True)
+def first(second):
+    Path("first-ran").touch()
+
+@karva.fixture(scope="module")
+def second(first):
+    Path("second-ran").touch()
+
+def test_cycle_one():
+    Path("test-one-ran").touch()
+
+def test_cycle_two():
+    Path("test-two-ran").touch()
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            FAIL [TIME] test::test_cycle_one
+            FAIL [TIME] test::test_cycle_two
+
+    diagnostics:
+
+    error[fixture-cycle]: Fixture dependency cycle detected
+     --> test.py:6:5
+      |
+    6 | def first(second):
+      |     ^^^^^
+      |
+    info: Fixture `second` requires `first`
+      --> test.py:10:5
+       |
+    10 | def second(first):
+       |     ^^^^^^
+       |
+    info: first -> second -> first
+
+    ────────────
+         Summary [TIME] 2 tests run: 0 passed, 2 failed, 0 skipped
+
+    ----- stderr -----
+    ");
     assert!(!context.root().join("first-ran").exists());
     assert!(!context.root().join("second-ran").exists());
+    assert!(!context.root().join("test-one-ran").exists());
+    assert!(!context.root().join("test-two-ran").exists());
+}
+
+#[test]
+fn test_package_autouse_fixture_cycle() {
+    let context = TestContext::with_files([
+        (
+            "conftest.py",
+            r#"
+import karva
+from pathlib import Path
+
+@karva.fixture(scope="package", auto_use=True)
+def first(second):
+    Path("fixture-ran").touch()
+
+@karva.fixture(scope="package")
+def second(first):
+    Path("fixture-ran").touch()
+"#,
+        ),
+        (
+            "test.py",
+            r#"
+from pathlib import Path
+
+def test_cycle():
+    Path("test-ran").touch()
+"#,
+        ),
+        (
+            "nested/test_nested.py",
+            r#"
+from pathlib import Path
+
+def test_nested_cycle():
+    Path("nested-test-ran").touch()
+"#,
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            FAIL [TIME] test::test_cycle
+            FAIL [TIME] nested.test_nested::test_nested_cycle
+
+    diagnostics:
+
+    error[fixture-cycle]: Fixture dependency cycle detected
+     --> conftest.py:6:5
+      |
+    6 | def first(second):
+      |     ^^^^^
+      |
+    info: Fixture `second` requires `first`
+      --> conftest.py:10:5
+       |
+    10 | def second(first):
+       |     ^^^^^^
+       |
+    info: first -> second -> first
+
+    ────────────
+         Summary [TIME] 2 tests run: 0 passed, 2 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+    assert!(!context.root().join("fixture-ran").exists());
+    assert!(!context.root().join("test-ran").exists());
+    assert!(!context.root().join("nested-test-ran").exists());
+}
+
+#[test]
+fn test_session_autouse_fixture_cycle() {
+    let context = TestContext::with_files([
+        (
+            "conftest.py",
+            r#"
+import karva
+from pathlib import Path
+
+@karva.fixture(scope="session", auto_use=True)
+def first(second):
+    Path("fixture-ran").touch()
+
+@karva.fixture(scope="session")
+def second(first):
+    Path("fixture-ran").touch()
+"#,
+        ),
+        (
+            "test.py",
+            r#"
+from pathlib import Path
+
+def test_cycle():
+    Path("test-ran").touch()
+"#,
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_cycle
+
+    diagnostics:
+
+    error[fixture-cycle]: Fixture dependency cycle detected
+     --> conftest.py:6:5
+      |
+    6 | def first(second):
+      |     ^^^^^
+      |
+    info: Fixture `second` requires `first`
+      --> conftest.py:10:5
+       |
+    10 | def second(first):
+       |     ^^^^^^
+       |
+    info: first -> second -> first
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+    assert!(!context.root().join("fixture-ran").exists());
+    assert!(!context.root().join("test-ran").exists());
+}
+
+#[test]
+fn test_use_fixtures_cycle() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+from pathlib import Path
+
+@karva.fixture
+def first(second):
+    Path("fixture-ran").touch()
+
+@karva.fixture
+def second(first):
+    Path("fixture-ran").touch()
+
+@karva.tags.use_fixtures("first")
+def test_cycle():
+    Path("test-ran").touch()
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_cycle
+
+    diagnostics:
+
+    error[fixture-cycle]: Fixture dependency cycle detected
+     --> test.py:6:5
+      |
+    6 | def first(second):
+      |     ^^^^^
+      |
+    info: Fixture `second` requires `first`
+      --> test.py:10:5
+       |
+    10 | def second(first):
+       |     ^^^^^^
+       |
+    info: first -> second -> first
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+    assert!(!context.root().join("fixture-ran").exists());
     assert!(!context.root().join("test-ran").exists());
 }
 

--- a/crates/karva/tests/it/extensions/fixtures/mod.rs
+++ b/crates/karva/tests/it/extensions/fixtures/mod.rs
@@ -1,6 +1,7 @@
 pub mod autouse;
 pub mod basic;
 pub mod builtins;
+pub mod cycles;
 pub mod decorators;
 pub mod generators;
 pub mod invalid;

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -19,7 +19,7 @@ mod metadata;
 
 pub use metadata::{DiagnosticGuardBuilder, DiagnosticType};
 
-use crate::runner::{FixtureArguments, FixtureCallError, FixtureChainEntry};
+use crate::runner::{FixtureArguments, FixtureCallError, FixtureChainEntry, FixtureCycleError};
 use crate::utils::truncate_string;
 use crate::{Context, declare_diagnostic_type};
 
@@ -79,6 +79,16 @@ declare_diagnostic_type! {
     /// If a finalizer tries to yield another value, we will raise this error.
     pub static INVALID_FIXTURE_FINALIZER = {
         summary: "Tried to run an invalid fixture finalizer",
+        severity: Severity::Error,
+    }
+}
+
+declare_diagnostic_type! {
+    /// ## Fixture dependency cycle
+    ///
+    /// Raised when fixture dependencies form a cycle and cannot be resolved.
+    pub static FIXTURE_CYCLE = {
+        summary: "Fixture dependency cycle detected",
         severity: Severity::Error,
     }
 }
@@ -277,6 +287,44 @@ pub fn report_fixture_failure(context: &Context, py: Python, error: FixtureCallE
         &arguments,
         FunctionKind::Fixture,
         &error,
+    );
+}
+
+pub fn report_fixture_cycle(context: &Context, error: FixtureCycleError) {
+    let FixtureCycleError { cycle } = error;
+    let Some(first_fixture) = cycle.first() else {
+        return;
+    };
+
+    let builder = context.report_diagnostic(&FIXTURE_CYCLE);
+    let mut diagnostic = builder.into_diagnostic("Fixture dependency cycle detected");
+
+    annotate_function_name(
+        &mut diagnostic,
+        first_fixture.source_file.clone(),
+        &first_fixture.stmt_function_def,
+    );
+
+    for dependency_edge in cycle.windows(2).skip(1) {
+        let [fixture, dependency] = dependency_edge else {
+            continue;
+        };
+        let mut sub = SubDiagnostic::new(
+            SubDiagnosticSeverity::Info,
+            format!("Fixture `{}` requires `{}`", fixture.name, dependency.name),
+        );
+        let span = Span::from(fixture.source_file.clone())
+            .with_range(fixture.stmt_function_def.name.range);
+        sub.annotate(Annotation::primary(span));
+        diagnostic.sub(sub);
+    }
+
+    diagnostic.info(
+        cycle
+            .iter()
+            .map(|fixture| fixture.name.as_str())
+            .collect::<Vec<_>>()
+            .join(" -> "),
     );
 }
 

--- a/crates/karva_test_semantic/src/runner/fixture_resolver.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_resolver.rs
@@ -53,6 +53,35 @@ impl FixtureCycleError {
     }
 }
 
+#[derive(Default)]
+struct FixturePath<'a> {
+    fixtures: Vec<&'a DiscoveredFixture>,
+}
+
+impl<'a> FixturePath<'a> {
+    fn enter<T>(
+        &mut self,
+        fixture: &'a DiscoveredFixture,
+        resolve: impl FnOnce(&mut Self) -> Result<T, FixtureCycleError>,
+    ) -> Result<T, FixtureCycleError> {
+        if let Some(cycle_start) = self
+            .fixtures
+            .iter()
+            .position(|active_fixture| std::ptr::eq(*active_fixture, fixture))
+        {
+            return Err(FixtureCycleError::new(
+                &self.fixtures[cycle_start..],
+                fixture,
+            ));
+        }
+
+        self.fixtures.push(fixture);
+        let result = resolve(self);
+        let _ = self.fixtures.pop();
+        result
+    }
+}
+
 impl<'a> RuntimeFixtureResolver<'a> {
     pub(super) fn new(
         parents: &'a [&'a DiscoveredPackage],
@@ -75,7 +104,7 @@ impl<'a> RuntimeFixtureResolver<'a> {
         &mut self,
         py: Python,
         fixture: &'a DiscoveredFixture,
-        path: &mut Vec<&'a DiscoveredFixture>,
+        path: &mut FixturePath<'a>,
     ) -> Result<Rc<NormalizedFixture>, FixtureCycleError> {
         let cache_key = fixture.name().to_string();
 
@@ -85,19 +114,10 @@ impl<'a> RuntimeFixtureResolver<'a> {
             }
         }
 
-        if let Some(cycle_start) = path
-            .iter()
-            .position(|active_fixture| std::ptr::eq(*active_fixture, fixture))
-        {
-            return Err(FixtureCycleError::new(&path[cycle_start..], fixture));
-        }
-
-        path.push(fixture);
-        let required_fixtures: Vec<String> = fixture.required_fixtures(py);
-        let dependent_fixtures =
-            self.get_dependent_fixtures(py, Some(fixture), &required_fixtures, path);
-        let _ = path.pop();
-        let dependent_fixtures = dependent_fixtures?;
+        let dependent_fixtures = path.enter(fixture, |path| {
+            let required_fixtures: Vec<String> = fixture.required_fixtures(py);
+            self.get_dependent_fixtures(py, Some(fixture), &required_fixtures, path)
+        })?;
 
         let result = Rc::new(NormalizedFixture {
             name: fixture.name().clone(),
@@ -123,7 +143,7 @@ impl<'a> RuntimeFixtureResolver<'a> {
         scope: FixtureScope,
     ) -> Result<Vec<Rc<NormalizedFixture>>, FixtureCycleError> {
         let auto_use_fixtures = get_auto_use_fixtures(self.parents, self.current, scope);
-        let mut path = Vec::new();
+        let mut path = FixturePath::default();
 
         auto_use_fixtures
             .into_iter()
@@ -144,7 +164,8 @@ impl<'a> RuntimeFixtureResolver<'a> {
             .cloned()
             .collect();
 
-        self.get_dependent_fixtures(py, None, &regular_fixture_names, &mut Vec::new())
+        let mut path = FixturePath::default();
+        self.get_dependent_fixtures(py, None, &regular_fixture_names, &mut path)
     }
 
     /// Resolve `use_fixtures` dependencies.
@@ -153,7 +174,8 @@ impl<'a> RuntimeFixtureResolver<'a> {
         py: Python,
         fixture_names: &[String],
     ) -> Result<Vec<Rc<NormalizedFixture>>, FixtureCycleError> {
-        self.get_dependent_fixtures(py, None, fixture_names, &mut Vec::new())
+        let mut path = FixturePath::default();
+        self.get_dependent_fixtures(py, None, fixture_names, &mut path)
     }
 
     /// Get dependent fixtures for a list of fixture names.
@@ -162,7 +184,7 @@ impl<'a> RuntimeFixtureResolver<'a> {
         py: Python,
         current_fixture: Option<&'a DiscoveredFixture>,
         fixture_names: &[String],
-        path: &mut Vec<&'a DiscoveredFixture>,
+        path: &mut FixturePath<'a>,
     ) -> Result<Vec<Rc<NormalizedFixture>>, FixtureCycleError> {
         let mut normalized_fixtures = Vec::with_capacity(fixture_names.len());
 

--- a/crates/karva_test_semantic/src/runner/fixture_resolver.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_resolver.rs
@@ -2,6 +2,8 @@ use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use pyo3::prelude::*;
+use ruff_python_ast::StmtFunctionDef;
+use ruff_source_file::SourceFile;
 
 use crate::discovery::DiscoveredPackage;
 use crate::extensions::fixtures::{
@@ -22,6 +24,33 @@ pub(super) struct RuntimeFixtureResolver<'a> {
     parents: &'a [&'a DiscoveredPackage],
     current: &'a (dyn HasFixtures<'a> + 'a),
     fixture_cache: HashMap<String, Rc<NormalizedFixture>>,
+}
+
+pub struct FixtureCycleEntry {
+    pub(crate) name: String,
+    pub(crate) stmt_function_def: Rc<StmtFunctionDef>,
+    pub(crate) source_file: SourceFile,
+}
+
+pub struct FixtureCycleError {
+    pub(crate) cycle: Vec<FixtureCycleEntry>,
+}
+
+impl FixtureCycleError {
+    fn new(cycle: &[&DiscoveredFixture], repeated: &DiscoveredFixture) -> Self {
+        let cycle = cycle
+            .iter()
+            .copied()
+            .chain(std::iter::once(repeated))
+            .map(|fixture| FixtureCycleEntry {
+                name: fixture.name().function_name().to_string(),
+                stmt_function_def: Rc::clone(fixture.stmt_function_def()),
+                source_file: fixture.source_file().clone(),
+            })
+            .collect();
+
+        Self { cycle }
+    }
 }
 
 impl<'a> RuntimeFixtureResolver<'a> {
@@ -45,18 +74,30 @@ impl<'a> RuntimeFixtureResolver<'a> {
     fn normalize_fixture(
         &mut self,
         py: Python,
-        fixture: &DiscoveredFixture,
-    ) -> Rc<NormalizedFixture> {
+        fixture: &'a DiscoveredFixture,
+        path: &mut Vec<&'a DiscoveredFixture>,
+    ) -> Result<Rc<NormalizedFixture>, FixtureCycleError> {
         let cache_key = fixture.name().to_string();
 
         if fixture.scope() != FixtureScope::Function {
             if let Some(cached) = self.fixture_cache.get(&cache_key) {
-                return Rc::clone(cached);
+                return Ok(Rc::clone(cached));
             }
         }
 
+        if let Some(cycle_start) = path
+            .iter()
+            .position(|active_fixture| std::ptr::eq(*active_fixture, fixture))
+        {
+            return Err(FixtureCycleError::new(&path[cycle_start..], fixture));
+        }
+
+        path.push(fixture);
         let required_fixtures: Vec<String> = fixture.required_fixtures(py);
-        let dependent_fixtures = self.get_dependent_fixtures(py, Some(fixture), &required_fixtures);
+        let dependent_fixtures =
+            self.get_dependent_fixtures(py, Some(fixture), &required_fixtures, path);
+        let _ = path.pop();
+        let dependent_fixtures = dependent_fixtures?;
 
         let result = Rc::new(NormalizedFixture {
             name: fixture.name().clone(),
@@ -72,7 +113,7 @@ impl<'a> RuntimeFixtureResolver<'a> {
             self.fixture_cache.insert(cache_key, Rc::clone(&result));
         }
 
-        result
+        Ok(result)
     }
 
     /// Get normalized auto-use fixtures for a given scope.
@@ -80,12 +121,13 @@ impl<'a> RuntimeFixtureResolver<'a> {
         &mut self,
         py: Python,
         scope: FixtureScope,
-    ) -> Vec<Rc<NormalizedFixture>> {
+    ) -> Result<Vec<Rc<NormalizedFixture>>, FixtureCycleError> {
         let auto_use_fixtures = get_auto_use_fixtures(self.parents, self.current, scope);
+        let mut path = Vec::new();
 
         auto_use_fixtures
             .into_iter()
-            .map(|fixture| self.normalize_fixture(py, fixture))
+            .map(|fixture| self.normalize_fixture(py, fixture, &mut path))
             .collect()
     }
 
@@ -95,14 +137,14 @@ impl<'a> RuntimeFixtureResolver<'a> {
         py: Python,
         fixture_names: &[String],
         parametrize_param_names: &HashSet<&str>,
-    ) -> Vec<Rc<NormalizedFixture>> {
+    ) -> Result<Vec<Rc<NormalizedFixture>>, FixtureCycleError> {
         let regular_fixture_names: Vec<String> = fixture_names
             .iter()
             .filter(|name| !parametrize_param_names.contains(name.as_str()))
             .cloned()
             .collect();
 
-        self.get_dependent_fixtures(py, None, &regular_fixture_names)
+        self.get_dependent_fixtures(py, None, &regular_fixture_names, &mut Vec::new())
     }
 
     /// Resolve `use_fixtures` dependencies.
@@ -110,34 +152,42 @@ impl<'a> RuntimeFixtureResolver<'a> {
         &mut self,
         py: Python,
         fixture_names: &[String],
-    ) -> Vec<Rc<NormalizedFixture>> {
-        self.get_dependent_fixtures(py, None, fixture_names)
+    ) -> Result<Vec<Rc<NormalizedFixture>>, FixtureCycleError> {
+        self.get_dependent_fixtures(py, None, fixture_names, &mut Vec::new())
     }
 
     /// Get dependent fixtures for a list of fixture names.
     fn get_dependent_fixtures(
         &mut self,
         py: Python,
-        current_fixture: Option<&DiscoveredFixture>,
+        current_fixture: Option<&'a DiscoveredFixture>,
         fixture_names: &[String],
-    ) -> Vec<Rc<NormalizedFixture>> {
+        path: &mut Vec<&'a DiscoveredFixture>,
+    ) -> Result<Vec<Rc<NormalizedFixture>>, FixtureCycleError> {
         let mut normalized_fixtures = Vec::with_capacity(fixture_names.len());
 
         for dep_name in fixture_names {
             if let Some(fixture) =
                 find_fixture(current_fixture, dep_name, self.parents, self.current)
             {
-                let normalized = self.normalize_fixture(py, fixture);
+                let normalized = self.normalize_fixture(py, fixture, path)?;
+                normalized_fixtures.push(normalized);
+            } else if let Some(fixture) = current_fixture
+                && fixture.name().function_name() == dep_name
+            {
+                let normalized = self.normalize_fixture(py, fixture, path)?;
                 normalized_fixtures.push(normalized);
             }
         }
 
-        normalized_fixtures
+        Ok(normalized_fixtures)
     }
 }
 
 /// Finds a fixture by name, searching in the current node and parent packages.
-/// We pass in the current fixture to avoid returning it (which would cause infinite recursion).
+/// The current definition is skipped so a fixture can override and depend on a
+/// same-name fixture from a parent scope. If no override exists, the resolver
+/// handles the dependency as a direct cycle.
 fn find_fixture<'a>(
     current_fixture: Option<&DiscoveredFixture>,
     name: &str,

--- a/crates/karva_test_semantic/src/runner/mod.rs
+++ b/crates/karva_test_semantic/src/runner/mod.rs
@@ -9,4 +9,5 @@ mod test_iterator;
 use finalizer_cache::FinalizerCache;
 pub use fixture_arguments::FixtureArguments;
 use fixture_cache::FixtureCache;
+pub use fixture_resolver::FixtureCycleError;
 pub use package_runner::{FixtureCallError, FixtureChainEntry, PackageRunner};

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -18,7 +18,7 @@ use crate::diagnostic::{
     report_fixture_cycle, report_fixture_failure, report_missing_fixtures, report_test_failure,
     report_test_pass_on_expect_failure, report_test_returned_value,
 };
-use crate::discovery::{DiscoveredModule, DiscoveredPackage};
+use crate::discovery::{DiscoveredModule, DiscoveredPackage, DiscoveredTestFunction};
 use crate::extensions::fixtures::{
     Finalizer, FixtureScope, HasFixtures, NormalizedFixture, missing_arguments_from_error,
 };
@@ -102,6 +102,15 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             self.failed_count
                 .set(self.failed_count.get().saturating_add(1));
         }
+    }
+
+    fn register_failed_test(&self, test: &DiscoveredTestFunction) {
+        self.context.register_test_case_result(
+            &QualifiedTestName::new(test.name.clone(), None),
+            IndividualTestResultKind::Failed,
+            std::time::Duration::ZERO,
+        );
+        self.record_outcome(false);
     }
 
     fn start_output_capture(&self, py: Python<'_>) -> Option<PythonOutputCapture> {
@@ -194,13 +203,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         if let Err(error) = self.run_auto_use_fixtures(py, parents, module, FixtureScope::Module) {
             report_fixture_cycle(self.context, error);
             for test_function in module.test_functions() {
-                let test_name = QualifiedTestName::new(test_function.name.clone(), None);
-                let test_passed = self.context.register_test_case_result(
-                    &test_name,
-                    IndividualTestResultKind::Failed,
-                    std::time::Duration::ZERO,
-                );
-                self.record_outcome(test_passed);
+                self.register_failed_test(test_function);
                 if self.max_fail_reached() {
                     break;
                 }
@@ -218,13 +221,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                 Ok(variants) => variants,
                 Err(error) => {
                     report_fixture_cycle(self.context, error);
-                    let test_name = QualifiedTestName::new(test_function.name.clone(), None);
-                    let test_passed = self.context.register_test_case_result(
-                        &test_name,
-                        IndividualTestResultKind::Failed,
-                        std::time::Duration::ZERO,
-                    );
-                    self.record_outcome(test_passed);
+                    self.register_failed_test(test_function);
                     passed = false;
                     if self.max_fail_reached() {
                         break;

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -15,7 +15,7 @@ use ruff_source_file::SourceFile;
 
 use crate::Context;
 use crate::diagnostic::{
-    report_fixture_failure, report_missing_fixtures, report_test_failure,
+    report_fixture_cycle, report_fixture_failure, report_missing_fixtures, report_test_failure,
     report_test_pass_on_expect_failure, report_test_returned_value,
 };
 use crate::discovery::{DiscoveredModule, DiscoveredPackage};
@@ -28,7 +28,7 @@ use crate::extensions::tags::timeout::TimeoutTag;
 use crate::output_capture::PythonOutputCapture;
 use crate::runner::fixture_resolver::RuntimeFixtureResolver;
 use crate::runner::test_iterator::{TestVariant, TestVariantIterator};
-use crate::runner::{FinalizerCache, FixtureArguments, FixtureCache};
+use crate::runner::{FinalizerCache, FixtureArguments, FixtureCache, FixtureCycleError};
 use crate::utils::{
     full_test_name, run_coroutine, run_test_with_timeout, set_attempt_env, set_test_name_env,
     truncate_string,
@@ -149,30 +149,35 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         // the user conftest at the session root and the framework module. No
         // `if let Some(...)` gate: the session always exists, and if neither
         // slot contributes any autouse fixtures the walk returns an empty vec.
-        self.run_auto_use_fixtures(py, &[], session, FixtureScope::Session);
+        if let Err(error) = self.run_auto_use_fixtures(py, &[], session, FixtureScope::Session) {
+            report_fixture_cycle(self.context, error);
+            return;
+        }
 
         self.execute_package(py, session, &[]);
 
         self.clean_up_scope(py, FixtureScope::Session);
     }
 
-    /// Resolve and run auto-use fixtures for `scope`, reporting any failures
-    /// through the standard fixture-failure diagnostic. The `current` source
-    /// is whichever `HasFixtures` provider applies for this scope (the
-    /// session package, a module, or a package configuration module).
+    /// Resolve and run auto-use fixtures for `scope`. Resolution cycles are
+    /// returned to the caller; execution failures are reported here. The
+    /// `current` source is whichever `HasFixtures` provider applies for this
+    /// scope (the session package, a module, or a package configuration module).
     fn run_auto_use_fixtures<'b>(
         &self,
         py: Python<'_>,
         parents: &'b [&'b DiscoveredPackage],
         current: &'b (dyn HasFixtures<'b> + 'b),
         scope: FixtureScope,
-    ) {
+    ) -> Result<(), FixtureCycleError> {
         let mut resolver = RuntimeFixtureResolver::new(parents, current);
-        let auto_use_fixtures = resolver.get_normalized_auto_use_fixtures(py, scope);
+        let auto_use_fixtures = resolver.get_normalized_auto_use_fixtures(py, scope)?;
         let auto_use_errors = self.run_fixtures(py, &auto_use_fixtures);
         for error in auto_use_errors {
             report_fixture_failure(self.context, py, error);
         }
+
+        Ok(())
     }
 
     /// Execute a module.
@@ -186,7 +191,22 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         module: &DiscoveredModule,
         parents: &[&DiscoveredPackage],
     ) -> bool {
-        self.run_auto_use_fixtures(py, parents, module, FixtureScope::Module);
+        if let Err(error) = self.run_auto_use_fixtures(py, parents, module, FixtureScope::Module) {
+            report_fixture_cycle(self.context, error);
+            for test_function in module.test_functions() {
+                let test_name = QualifiedTestName::new(test_function.name.clone(), None);
+                let test_passed = self.context.register_test_case_result(
+                    &test_name,
+                    IndividualTestResultKind::Failed,
+                    std::time::Duration::ZERO,
+                );
+                self.record_outcome(test_passed);
+                if self.max_fail_reached() {
+                    break;
+                }
+            }
+            return false;
+        }
 
         let mut passed = true;
 
@@ -194,8 +214,27 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             // Create a new resolver for each test to handle fixture resolution
             let mut test_resolver = RuntimeFixtureResolver::new(parents, module);
 
+            let variants = match TestVariantIterator::new(py, test_function, &mut test_resolver) {
+                Ok(variants) => variants,
+                Err(error) => {
+                    report_fixture_cycle(self.context, error);
+                    let test_name = QualifiedTestName::new(test_function.name.clone(), None);
+                    let test_passed = self.context.register_test_case_result(
+                        &test_name,
+                        IndividualTestResultKind::Failed,
+                        std::time::Duration::ZERO,
+                    );
+                    self.record_outcome(test_passed);
+                    passed = false;
+                    if self.max_fail_reached() {
+                        break;
+                    }
+                    continue;
+                }
+            };
+
             // Iterate over all test variants (parametrize combinations × fixture combinations).
-            for variant in TestVariantIterator::new(py, test_function, &mut test_resolver) {
+            for variant in variants {
                 let variant_passed = self.execute_test_variant(py, variant);
                 self.record_outcome(variant_passed);
                 passed &= variant_passed;
@@ -230,7 +269,12 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         new_parents.push(package);
 
         if let Some(config_module) = package.configuration_module_impl() {
-            self.run_auto_use_fixtures(py, parents, config_module, FixtureScope::Package);
+            if let Err(error) =
+                self.run_auto_use_fixtures(py, parents, config_module, FixtureScope::Package)
+            {
+                report_fixture_cycle(self.context, error);
+                return false;
+            }
         }
 
         let mut passed = true;

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -113,6 +113,31 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         self.record_outcome(false);
     }
 
+    fn register_failed_module_tests(&self, module: &DiscoveredModule) {
+        for test in module.test_functions() {
+            self.register_failed_test(test);
+            if self.max_fail_reached() {
+                return;
+            }
+        }
+    }
+
+    fn register_failed_package_tests(&self, package: &DiscoveredPackage) {
+        for module in package.modules().values() {
+            self.register_failed_module_tests(module);
+            if self.max_fail_reached() {
+                return;
+            }
+        }
+
+        for child_package in package.packages().values() {
+            self.register_failed_package_tests(child_package);
+            if self.max_fail_reached() {
+                return;
+            }
+        }
+    }
+
     fn start_output_capture(&self, py: Python<'_>) -> Option<PythonOutputCapture> {
         if self.context.settings().terminal().show_python_output {
             return None;
@@ -160,6 +185,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         // slot contributes any autouse fixtures the walk returns an empty vec.
         if let Err(error) = self.run_auto_use_fixtures(py, &[], session, FixtureScope::Session) {
             report_fixture_cycle(self.context, error);
+            self.register_failed_package_tests(session);
             return;
         }
 
@@ -202,12 +228,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
     ) -> bool {
         if let Err(error) = self.run_auto_use_fixtures(py, parents, module, FixtureScope::Module) {
             report_fixture_cycle(self.context, error);
-            for test_function in module.test_functions() {
-                self.register_failed_test(test_function);
-                if self.max_fail_reached() {
-                    break;
-                }
-            }
+            self.register_failed_module_tests(module);
             return false;
         }
 
@@ -270,6 +291,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                 self.run_auto_use_fixtures(py, parents, config_module, FixtureScope::Package)
             {
                 report_fixture_cycle(self.context, error);
+                self.register_failed_package_tests(package);
                 return false;
             }
         }

--- a/crates/karva_test_semantic/src/runner/test_iterator.rs
+++ b/crates/karva_test_semantic/src/runner/test_iterator.rs
@@ -8,7 +8,7 @@ use crate::discovery::DiscoveredTestFunction;
 use crate::extensions::fixtures::{NormalizedFixture, RequiresFixtures};
 use crate::extensions::tags::Tags;
 use crate::extensions::tags::parametrize::ParametrizationArgs;
-use crate::runner::fixture_resolver::RuntimeFixtureResolver;
+use crate::runner::fixture_resolver::{FixtureCycleError, RuntimeFixtureResolver};
 
 /// A single variant of a test to be executed.
 ///
@@ -93,7 +93,7 @@ impl<'a> TestVariantIterator<'a> {
         py: Python,
         test: &'a DiscoveredTestFunction,
         resolver: &mut RuntimeFixtureResolver,
-    ) -> Self {
+    ) -> Result<Self, FixtureCycleError> {
         let test_params = test.tags.parametrize_args();
 
         let parametrize_param_names: HashSet<&str> = test_params
@@ -108,13 +108,13 @@ impl<'a> TestVariantIterator<'a> {
         let auto_use_fixtures = resolver.get_normalized_auto_use_fixtures(
             py,
             crate::extensions::fixtures::FixtureScope::Function,
-        );
+        )?;
 
         let fixture_dependencies =
-            resolver.resolve_test_fixtures(py, &function_param_names, &parametrize_param_names);
+            resolver.resolve_test_fixtures(py, &function_param_names, &parametrize_param_names)?;
 
         let use_fixture_names = test.tags.required_fixtures_names();
-        let use_fixture_dependencies = resolver.resolve_use_fixtures(py, &use_fixture_names);
+        let use_fixture_dependencies = resolver.resolve_use_fixtures(py, &use_fixture_names)?;
 
         let param_args = if test_params.is_empty() {
             vec![ParametrizationArgs::default()]
@@ -122,13 +122,13 @@ impl<'a> TestVariantIterator<'a> {
             test_params
         };
 
-        Self {
+        Ok(Self {
             test,
             param_args: param_args.into_iter(),
             fixture_dependencies: Rc::from(fixture_dependencies),
             use_fixture_dependencies: Rc::from(use_fixture_dependencies),
             auto_use_fixtures: Rc::from(auto_use_fixtures),
-        }
+        })
     }
 }
 


### PR DESCRIPTION
## Summary

Detect fixture dependency cycles during runtime resolution and report the complete annotated chain instead of recursing or producing a missing-fixture error. Cyclic fixtures and affected test bodies are not executed. Fixes #960.

## Test Plan

Ran the fixture integration suite, strict workspace Clippy, and `uvx prek run -a`.