### PR TITLE
Enable Seal pull request creation

### DIFF
--- a/seal.toml
+++ b/seal.toml
@@ -16,6 +16,8 @@ branch-name = "release/v{version}"
 push = true
 confirm = true
 
+[release.pull-request]
+
 [changelog.section-labels]
 "Bug Fixes" = ["bug"]
 "Test Running" = ["test-running"]

--- a/seal.toml
+++ b/seal.toml
@@ -17,6 +17,10 @@ push = true
 confirm = true
 
 [release.pull-request]
+title = "Release v{version}"
+body = "Prepare release v{version}."
+base = "main"
+draft = false
 
 [changelog.section-labels]
 "Bug Fixes" = ["bug"]


### PR DESCRIPTION
## Summary

Enable Seal’s merged pull-request workflow so version bumps automatically open or update a GitHub pull request after pushing the release branch.

## Test Plan

`uvx prek run -a`