### PR TITLE
Update Cargo.lock during releases

### DIFF
--- a/seal.toml
+++ b/seal.toml
@@ -15,6 +15,7 @@ commit-message = "Release v{version}"
 branch-name = "release/v{version}"
 push = true
 confirm = true
+pre-commit-commands = ["cargo update --workspace"]
 
 [release.pull-request]
 title = "Release v{version}"


### PR DESCRIPTION
## Summary

Run `cargo update --workspace` before Seal creates a release commit so workspace package versions are refreshed in `Cargo.lock` without upgrading already locked dependencies.

## Test Plan

Validated `seal.toml`, ran Cargo’s workspace update dry run, and ran `uvx prek run -a`.