### PR TITLE
Use Seal alpha.6 in release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install seal
         run: |
-          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/MatthewMckee4/seal/releases/download/0.0.1-alpha.5/seal-installer.sh | sh
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/MatthewMckee4/seal/releases/download/0.0.1-alpha.6/seal-installer.sh | sh
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Generate release metadata


### PR DESCRIPTION
## Summary

Update the release workflow to install Seal 0.0.1-alpha.6. That Seal release must be published before the workflow is dispatched.

## Test Plan

Ran `pinact run` and `uvx prek run -a`.