### PR TITLE
Capture subprocess output during tests

### DIFF
--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -659,10 +659,60 @@ fn test_stdout() {
 }
 
 #[test]
+fn test_subprocess_output_capture() {
+    let context = TestContext::with_file(
+        "test_subprocess_output.py",
+        r#"
+        import subprocess
+        import sys
+
+        def test_subprocess_output():
+            print("python output")
+            subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    "import sys; print('child stdout'); print('child stderr', file=sys.stderr)",
+                ],
+                check=True,
+            )
+        "#,
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test_subprocess_output::test_subprocess_output
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+
+    assert_cmd_snapshot!(context.command().arg("--show-output"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+    python output
+    child stdout
+            PASS [TIME] test_subprocess_output::test_subprocess_output
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    child stderr
+    ");
+}
+
+#[test]
 fn test_failed_output_is_captured() {
     let context = TestContext::with_file(
         "test_failed_output.py",
-        r"
+        r#"
+        import subprocess
         import sys
 
         def test_pass_with_output():
@@ -671,8 +721,16 @@ fn test_failed_output_is_captured() {
         def test_fail_with_output():
             print('stdout from failure')
             print('stderr from failure', file=sys.stderr)
+            subprocess.run(
+                [
+                    sys.executable,
+                    '-c',
+                    "import sys; print('child stdout'); print('child stderr', file=sys.stderr)",
+                ],
+                check=True,
+            )
             assert False
-        ",
+        "#,
     );
 
     assert_cmd_snapshot!(context.command_no_parallel(), @"
@@ -688,22 +746,24 @@ fn test_failed_output_is_captured() {
     test_failed_output::test_fail_with_output:
 
     error[test-failure]: Test `test_fail_with_output` failed
-     --> test_failed_output.py:7:5
+     --> test_failed_output.py:8:5
       |
-    7 | def test_fail_with_output():
+    8 | def test_fail_with_output():
       |     ^^^^^^^^^^^^^^^^^^^^^
       |
     info: Test failed here
-      --> test_failed_output.py:10:5
+      --> test_failed_output.py:19:5
        |
-    10 |     assert False
+    19 |     assert False
        |     ^^^^^^^^^^^^
        |
 
     captured stdout:
     stdout from failure
+    child stdout
     captured stderr:
     stderr from failure
+    child stderr
 
     ────────────
          Summary [TIME] 2 tests run: 1 passed, 1 failed, 0 skipped

--- a/crates/karva_logging/src/lib.rs
+++ b/crates/karva_logging/src/lib.rs
@@ -17,7 +17,7 @@ mod status_level;
 pub mod time;
 mod verbosity;
 
-pub use printer::{Printer, Stdout};
+pub use printer::{Printer, SavedStdout, Stdout, save_stdout};
 pub use status_level::{FinalStatusLevel, StatusLevel};
 pub use verbosity::VerbosityLevel;
 

--- a/crates/karva_logging/src/printer.rs
+++ b/crates/karva_logging/src/printer.rs
@@ -1,6 +1,40 @@
+use std::cell::RefCell;
+use std::fs::File;
 use std::io::{self, StdoutLock, Write};
+use std::sync::{Arc, Mutex};
+
+#[cfg(unix)]
+use std::os::fd::AsFd;
+#[cfg(windows)]
+use std::os::windows::io::AsHandle;
 
 use crate::status_level::{FinalStatusLevel, StatusLevel};
+
+thread_local! {
+    static SAVED_STDOUT: RefCell<Option<Arc<Mutex<File>>>> = const { RefCell::new(None) };
+}
+
+/// Restores the previous [`Printer`] stdout destination when dropped.
+pub struct SavedStdout {
+    previous: Option<Arc<Mutex<File>>>,
+}
+
+/// Directs [`Printer`] output to the current stdout destination until the returned guard is dropped.
+pub fn save_stdout() -> io::Result<SavedStdout> {
+    let stdout = std::io::stdout();
+    #[cfg(unix)]
+    let file = File::from(stdout.as_fd().try_clone_to_owned()?);
+    #[cfg(windows)]
+    let file = File::from(stdout.as_handle().try_clone_to_owned()?);
+    let previous = SAVED_STDOUT.replace(Some(Arc::new(Mutex::new(file))));
+    Ok(SavedStdout { previous })
+}
+
+impl Drop for SavedStdout {
+    fn drop(&mut self) {
+        SAVED_STDOUT.set(self.previous.take());
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Printer {
@@ -64,6 +98,7 @@ impl Printer {
 pub struct Stdout {
     enabled: bool,
     lock: Option<StdoutLock<'static>>,
+    saved: Option<Arc<Mutex<File>>>,
 }
 
 impl Stdout {
@@ -71,12 +106,13 @@ impl Stdout {
         Self {
             enabled,
             lock: None,
+            saved: SAVED_STDOUT.with_borrow(Clone::clone),
         }
     }
 
     #[must_use]
     pub fn lock(mut self) -> Self {
-        if self.enabled {
+        if self.enabled && self.saved.is_none() {
             self.lock = Some(std::io::stdout().lock());
         }
         self
@@ -97,19 +133,29 @@ impl Stdout {
 
 impl Write for Stdout {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        if self.enabled {
-            self.handle().write(buf)
-        } else {
-            Ok(buf.len())
+        if !self.enabled {
+            return Ok(buf.len());
         }
+        if let Some(saved) = self.saved.as_ref() {
+            return saved
+                .lock()
+                .map_err(|_| io::Error::other("saved stdout lock poisoned"))?
+                .write(buf);
+        }
+        self.handle().write(buf)
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        if self.enabled {
-            self.handle().flush()
-        } else {
-            Ok(())
+        if !self.enabled {
+            return Ok(());
         }
+        if let Some(saved) = self.saved.as_ref() {
+            return saved
+                .lock()
+                .map_err(|_| io::Error::other("saved stdout lock poisoned"))?
+                .flush();
+        }
+        self.handle().flush()
     }
 }
 

--- a/crates/karva_test_semantic/src/lib.rs
+++ b/crates/karva_test_semantic/src/lib.rs
@@ -49,7 +49,7 @@ pub fn run_tests(
 
         let session = StandardDiscoverer::new(&context).discover_with_py(py, test_paths);
 
-        PackageRunner::new(&context, cov_session.as_ref()).execute(py, &session);
+        PackageRunner::new(&context, cov_session.as_ref(), py).execute(py, &session);
 
         if let Some(cov_session) = cov_session
             && let Err(err) = cov_session.stop_and_save(py)

--- a/crates/karva_test_semantic/src/lib.rs
+++ b/crates/karva_test_semantic/src/lib.rs
@@ -49,7 +49,9 @@ pub fn run_tests(
 
         let session = StandardDiscoverer::new(&context).discover_with_py(py, test_paths);
 
-        PackageRunner::new(&context, cov_session.as_ref(), py).execute(py, &session);
+        let runner = PackageRunner::new(&context, cov_session.as_ref(), py);
+        runner.execute(py, &session);
+        runner.stop_output_capture(py);
 
         if let Some(cov_session) = cov_session
             && let Err(err) = cov_session.stop_and_save(py)

--- a/crates/karva_test_semantic/src/output_capture.rs
+++ b/crates/karva_test_semantic/src/output_capture.rs
@@ -5,6 +5,7 @@ pub struct PythonOutputCapture {
     old_stderr: Py<PyAny>,
     stdout: Py<PyAny>,
     stderr: Py<PyAny>,
+    file_descriptors: FileDescriptorCapture,
 }
 
 impl PythonOutputCapture {
@@ -27,11 +28,24 @@ impl PythonOutputCapture {
             return Err(err);
         }
 
+        let file_descriptors = match FileDescriptorCapture::start(py) {
+            Ok(capture) => capture,
+            Err(err) => {
+                if let Err(restore_err) = restore_stdio(&sys, &old_stdout, &old_stderr, py) {
+                    tracing::warn!(
+                        "failed to restore Python output after file descriptor capture setup error: {restore_err}"
+                    );
+                }
+                return Err(err);
+            }
+        };
+
         Ok(Self {
             old_stdout,
             old_stderr,
             stdout,
             stderr,
+            file_descriptors,
         })
     }
 
@@ -40,17 +54,146 @@ impl PythonOutputCapture {
         flush_current_streams(&sys);
 
         let restore_result = restore_stdio(&sys, &self.old_stdout, &self.old_stderr, py);
-        let stdout = self.stdout.bind(py).call_method0("getvalue")?.extract()?;
-        let stderr = self.stderr.bind(py).call_method0("getvalue")?.extract()?;
+        let stdout_result = self.stdout.bind(py).call_method0("getvalue")?.extract();
+        let stderr_result = self.stderr.bind(py).call_method0("getvalue")?.extract();
+        let file_descriptor_result = self.file_descriptors.finish(py);
         restore_result?;
+        let mut stdout: String = stdout_result?;
+        let mut stderr: String = stderr_result?;
+        let file_descriptor_output = file_descriptor_result?;
+        stdout.push_str(&file_descriptor_output.stdout);
+        stderr.push_str(&file_descriptor_output.stderr);
 
         Ok(CapturedPythonOutput { stdout, stderr })
+    }
+
+    pub fn with_file_descriptors_restored<R>(&self, py: Python<'_>, f: impl FnOnce() -> R) -> R {
+        if let Err(err) = self.file_descriptors.suspend(py) {
+            tracing::warn!("failed to suspend file descriptor output capture: {err}");
+        }
+        let result = f();
+        if let Err(err) = self.file_descriptors.resume(py) {
+            tracing::warn!("failed to resume file descriptor output capture: {err}");
+        }
+        result
     }
 }
 
 pub struct CapturedPythonOutput {
     pub stdout: String,
     pub stderr: String,
+}
+
+struct FileDescriptorCapture {
+    stdout: Py<PyAny>,
+    stderr: Py<PyAny>,
+    old_stdout: i32,
+    old_stderr: i32,
+}
+
+impl FileDescriptorCapture {
+    fn start(py: Python<'_>) -> PyResult<Self> {
+        let temporary_file = py.import("tempfile")?.getattr("TemporaryFile")?;
+        let stdout = temporary_file.call1(("w+b",))?.unbind();
+        let stderr = temporary_file.call1(("w+b",))?.unbind();
+        let os = py.import("os")?;
+        let old_stdout = os.call_method1("dup", (1,))?.extract()?;
+        let old_stderr = match os.call_method1("dup", (2,)).and_then(|fd| fd.extract()) {
+            Ok(fd) => fd,
+            Err(err) => {
+                if let Err(close_err) = os.call_method1("close", (old_stdout,)) {
+                    tracing::warn!(
+                        "failed to close saved stdout after capture setup error: {close_err}"
+                    );
+                }
+                return Err(err);
+            }
+        };
+        let capture = Self {
+            stdout,
+            stderr,
+            old_stdout,
+            old_stderr,
+        };
+        if let Err(err) = capture.resume(py) {
+            if let Err(close_err) = capture.close_resources(py) {
+                tracing::warn!(
+                    "failed to close file descriptor capture after setup error: {close_err}"
+                );
+            }
+            return Err(err);
+        }
+        Ok(capture)
+    }
+
+    fn finish(self, py: Python<'_>) -> PyResult<CapturedPythonOutput> {
+        let suspend_result = self.suspend(py);
+        let stdout_result = read_file(py, &self.stdout);
+        let stderr_result = read_file(py, &self.stderr);
+        let close_result = self.close_resources(py);
+        suspend_result?;
+        let stdout = stdout_result?;
+        let stderr = stderr_result?;
+        close_result?;
+        Ok(CapturedPythonOutput { stdout, stderr })
+    }
+
+    fn suspend(&self, py: Python<'_>) -> PyResult<()> {
+        let os = py.import("os")?;
+        os.call_method1("dup2", (self.old_stdout, 1))?;
+        if let Err(err) = os.call_method1("dup2", (self.old_stderr, 2)) {
+            if let Err(restore_err) = redirect_descriptor(&os, py, &self.stdout, 1) {
+                tracing::warn!("failed to restore stdout capture after setup error: {restore_err}");
+            }
+            return Err(err);
+        }
+        Ok(())
+    }
+
+    fn resume(&self, py: Python<'_>) -> PyResult<()> {
+        let os = py.import("os")?;
+        redirect_descriptor(&os, py, &self.stdout, 1)?;
+        if let Err(err) = redirect_descriptor(&os, py, &self.stderr, 2) {
+            if let Err(restore_err) = os.call_method1("dup2", (self.old_stdout, 1)) {
+                tracing::warn!("failed to restore stdout after capture setup error: {restore_err}");
+            }
+            return Err(err);
+        }
+        Ok(())
+    }
+
+    fn close_resources(&self, py: Python<'_>) -> PyResult<()> {
+        let os = py.import("os")?;
+        let results = [
+            self.stdout.bind(py).call_method0("close").map(|_| ()),
+            self.stderr.bind(py).call_method0("close").map(|_| ()),
+            os.call_method1("close", (self.old_stdout,)).map(|_| ()),
+            os.call_method1("close", (self.old_stderr,)).map(|_| ()),
+        ];
+        for result in results {
+            result?;
+        }
+        Ok(())
+    }
+}
+
+fn redirect_descriptor(
+    os: &Bound<'_, PyModule>,
+    py: Python<'_>,
+    file: &Py<PyAny>,
+    target: i32,
+) -> PyResult<()> {
+    let source: i32 = file.bind(py).call_method0("fileno")?.extract()?;
+    os.call_method1("dup2", (source, target))?;
+    Ok(())
+}
+
+fn read_file(py: Python<'_>, file: &Py<PyAny>) -> PyResult<String> {
+    let file = file.bind(py);
+    file.call_method1("seek", (0,))?;
+    file.call_method0("read")?
+        .call_method1("decode", ("utf-8", "replace"))?
+        .extract()
 }
 
 fn flush_current_streams(sys: &Bound<'_, PyModule>) {

--- a/crates/karva_test_semantic/src/output_capture.rs
+++ b/crates/karva_test_semantic/src/output_capture.rs
@@ -66,17 +66,24 @@ impl PythonOutputCapture {
 
         Ok(CapturedPythonOutput { stdout, stderr })
     }
+}
 
-    pub fn with_file_descriptors_restored<R>(&self, py: Python<'_>, f: impl FnOnce() -> R) -> R {
-        if let Err(err) = self.file_descriptors.suspend(py) {
-            tracing::warn!("failed to suspend file descriptor output capture: {err}");
-        }
-        let result = f();
-        if let Err(err) = self.file_descriptors.resume(py) {
-            tracing::warn!("failed to resume file descriptor output capture: {err}");
-        }
-        result
+pub fn with_restored_file_descriptors<R>(
+    capture: Option<&PythonOutputCapture>,
+    py: Python<'_>,
+    f: impl FnOnce() -> R,
+) -> R {
+    let Some(capture) = capture else {
+        return f();
+    };
+    if let Err(err) = capture.file_descriptors.suspend(py) {
+        tracing::warn!("failed to suspend file descriptor output capture: {err}");
     }
+    let result = f();
+    if let Err(err) = capture.file_descriptors.resume(py) {
+        tracing::warn!("failed to resume file descriptor output capture: {err}");
+    }
+    result
 }
 
 pub struct CapturedPythonOutput {

--- a/crates/karva_test_semantic/src/output_capture.rs
+++ b/crates/karva_test_semantic/src/output_capture.rs
@@ -1,15 +1,31 @@
 use pyo3::prelude::*;
 
-pub struct PythonOutputCapture {
+pub struct OutputCapture {
+    file_descriptors: FileDescriptorCapture,
+}
+
+impl OutputCapture {
+    pub fn new(py: Python<'_>) -> PyResult<Self> {
+        Ok(Self {
+            file_descriptors: FileDescriptorCapture::new(py)?,
+        })
+    }
+
+    pub fn start(&self, py: Python<'_>) -> PyResult<PythonOutputCapture<'_>> {
+        PythonOutputCapture::start(py, &self.file_descriptors)
+    }
+}
+
+pub struct PythonOutputCapture<'capture> {
     old_stdout: Py<PyAny>,
     old_stderr: Py<PyAny>,
     stdout: Py<PyAny>,
     stderr: Py<PyAny>,
-    file_descriptors: FileDescriptorCapture,
+    file_descriptors: &'capture FileDescriptorCapture,
 }
 
-impl PythonOutputCapture {
-    pub fn start(py: Python<'_>) -> PyResult<Self> {
+impl<'capture> PythonOutputCapture<'capture> {
+    fn start(py: Python<'_>, file_descriptors: &'capture FileDescriptorCapture) -> PyResult<Self> {
         let sys = py.import("sys")?;
         let string_io = py.import("io")?.getattr("StringIO")?;
 
@@ -28,17 +44,14 @@ impl PythonOutputCapture {
             return Err(err);
         }
 
-        let file_descriptors = match FileDescriptorCapture::start(py) {
-            Ok(capture) => capture,
-            Err(err) => {
-                if let Err(restore_err) = restore_stdio(&sys, &old_stdout, &old_stderr, py) {
-                    tracing::warn!(
-                        "failed to restore Python output after file descriptor capture setup error: {restore_err}"
-                    );
-                }
-                return Err(err);
+        if let Err(err) = file_descriptors.start(py) {
+            if let Err(restore_err) = restore_stdio(&sys, &old_stdout, &old_stderr, py) {
+                tracing::warn!(
+                    "failed to restore Python output after file descriptor capture setup error: {restore_err}"
+                );
             }
-        };
+            return Err(err);
+        }
 
         Ok(Self {
             old_stdout,
@@ -69,19 +82,30 @@ impl PythonOutputCapture {
 }
 
 pub fn with_restored_file_descriptors<R>(
-    capture: Option<&PythonOutputCapture>,
+    capture: Option<&PythonOutputCapture<'_>>,
     py: Python<'_>,
     f: impl FnOnce() -> R,
 ) -> R {
     let Some(capture) = capture else {
         return f();
     };
+    let current_file_descriptors = match SavedFileDescriptors::new(py) {
+        Ok(file_descriptors) => file_descriptors,
+        Err(err) => {
+            tracing::warn!("failed to save active file descriptors: {err}");
+            return f();
+        }
+    };
     if let Err(err) = capture.file_descriptors.suspend(py) {
         tracing::warn!("failed to suspend file descriptor output capture: {err}");
+        if let Err(restore_err) = current_file_descriptors.restore(py) {
+            tracing::warn!("failed to restore active file descriptors: {restore_err}");
+        }
+        return f();
     }
     let result = f();
-    if let Err(err) = capture.file_descriptors.resume(py) {
-        tracing::warn!("failed to resume file descriptor output capture: {err}");
+    if let Err(err) = current_file_descriptors.restore(py) {
+        tracing::warn!("failed to restore active file descriptors: {err}");
     }
     result
 }
@@ -94,61 +118,41 @@ pub struct CapturedPythonOutput {
 struct FileDescriptorCapture {
     stdout: Py<PyAny>,
     stderr: Py<PyAny>,
-    old_stdout: i32,
-    old_stderr: i32,
+    old: SavedFileDescriptors,
 }
 
 impl FileDescriptorCapture {
-    fn start(py: Python<'_>) -> PyResult<Self> {
+    fn new(py: Python<'_>) -> PyResult<Self> {
         let temporary_file = py.import("tempfile")?.getattr("TemporaryFile")?;
         let stdout = temporary_file.call1(("w+b",))?.unbind();
         let stderr = temporary_file.call1(("w+b",))?.unbind();
-        let os = py.import("os")?;
-        let old_stdout = os.call_method1("dup", (1,))?.extract()?;
-        let old_stderr = match os.call_method1("dup", (2,)).and_then(|fd| fd.extract()) {
-            Ok(fd) => fd,
-            Err(err) => {
-                if let Err(close_err) = os.call_method1("close", (old_stdout,)) {
-                    tracing::warn!(
-                        "failed to close saved stdout after capture setup error: {close_err}"
-                    );
-                }
-                return Err(err);
-            }
-        };
-        let capture = Self {
+        let old = SavedFileDescriptors::new(py)?;
+        Ok(Self {
             stdout,
             stderr,
-            old_stdout,
-            old_stderr,
-        };
-        if let Err(err) = capture.resume(py) {
-            if let Err(close_err) = capture.close_resources(py) {
-                tracing::warn!(
-                    "failed to close file descriptor capture after setup error: {close_err}"
-                );
-            }
-            return Err(err);
-        }
-        Ok(capture)
+            old,
+        })
     }
 
-    fn finish(self, py: Python<'_>) -> PyResult<CapturedPythonOutput> {
+    fn start(&self, py: Python<'_>) -> PyResult<()> {
+        clear_file(py, &self.stdout)?;
+        clear_file(py, &self.stderr)?;
+        self.resume(py)
+    }
+
+    fn finish(&self, py: Python<'_>) -> PyResult<CapturedPythonOutput> {
         let suspend_result = self.suspend(py);
         let stdout_result = read_file(py, &self.stdout);
         let stderr_result = read_file(py, &self.stderr);
-        let close_result = self.close_resources(py);
         suspend_result?;
         let stdout = stdout_result?;
         let stderr = stderr_result?;
-        close_result?;
         Ok(CapturedPythonOutput { stdout, stderr })
     }
 
     fn suspend(&self, py: Python<'_>) -> PyResult<()> {
-        let os = py.import("os")?;
-        os.call_method1("dup2", (self.old_stdout, 1))?;
-        if let Err(err) = os.call_method1("dup2", (self.old_stderr, 2)) {
+        if let Err(err) = self.old.restore(py) {
+            let os = py.import("os")?;
             if let Err(restore_err) = redirect_descriptor(&os, py, &self.stdout, 1) {
                 tracing::warn!("failed to restore stdout capture after setup error: {restore_err}");
             }
@@ -161,26 +165,46 @@ impl FileDescriptorCapture {
         let os = py.import("os")?;
         redirect_descriptor(&os, py, &self.stdout, 1)?;
         if let Err(err) = redirect_descriptor(&os, py, &self.stderr, 2) {
-            if let Err(restore_err) = os.call_method1("dup2", (self.old_stdout, 1)) {
+            if let Err(restore_err) = redirect_descriptor(&os, py, &self.old.stdout, 1) {
                 tracing::warn!("failed to restore stdout after capture setup error: {restore_err}");
             }
             return Err(err);
         }
         Ok(())
     }
+}
 
-    fn close_resources(&self, py: Python<'_>) -> PyResult<()> {
+struct SavedFileDescriptors {
+    stdout: Py<PyAny>,
+    stderr: Py<PyAny>,
+}
+
+impl SavedFileDescriptors {
+    fn new(py: Python<'_>) -> PyResult<Self> {
         let os = py.import("os")?;
-        let results = [
-            self.stdout.bind(py).call_method0("close").map(|_| ()),
-            self.stderr.bind(py).call_method0("close").map(|_| ()),
-            os.call_method1("close", (self.old_stdout,)).map(|_| ()),
-            os.call_method1("close", (self.old_stderr,)).map(|_| ()),
-        ];
-        for result in results {
-            result?;
+        Ok(Self {
+            stdout: duplicate_descriptor(&os, 1)?,
+            stderr: duplicate_descriptor(&os, 2)?,
+        })
+    }
+
+    fn restore(&self, py: Python<'_>) -> PyResult<()> {
+        let os = py.import("os")?;
+        redirect_descriptor(&os, py, &self.stdout, 1)?;
+        redirect_descriptor(&os, py, &self.stderr, 2)
+    }
+}
+
+fn duplicate_descriptor(os: &Bound<'_, PyModule>, target: i32) -> PyResult<Py<PyAny>> {
+    let descriptor: i32 = os.call_method1("dup", (target,))?.extract()?;
+    match os.call_method1("fdopen", (descriptor, "wb")) {
+        Ok(file) => Ok(file.unbind()),
+        Err(err) => {
+            if let Err(close_err) = os.call_method1("close", (descriptor,)) {
+                tracing::warn!("failed to close duplicated file descriptor: {close_err}");
+            }
+            Err(err)
         }
-        Ok(())
     }
 }
 
@@ -201,6 +225,13 @@ fn read_file(py: Python<'_>, file: &Py<PyAny>) -> PyResult<String> {
     file.call_method0("read")?
         .call_method1("decode", ("utf-8", "replace"))?
         .extract()
+}
+
+fn clear_file(py: Python<'_>, file: &Py<PyAny>) -> PyResult<()> {
+    let file = file.bind(py);
+    file.call_method1("seek", (0,))?;
+    file.call_method1("truncate", (0,))?;
+    Ok(())
 }
 
 fn flush_current_streams(sys: &Bound<'_, PyModule>) {

--- a/crates/karva_test_semantic/src/output_capture.rs
+++ b/crates/karva_test_semantic/src/output_capture.rs
@@ -6,14 +6,37 @@ pub struct OutputCapture {
 
 impl OutputCapture {
     pub fn new(py: Python<'_>) -> PyResult<Self> {
-        Ok(Self {
-            file_descriptors: FileDescriptorCapture::new(py)?,
-        })
+        let file_descriptors = FileDescriptorCapture::new(py)?;
+        file_descriptors.resume(py)?;
+        Ok(Self { file_descriptors })
     }
 
     pub fn start(&self, py: Python<'_>) -> PyResult<PythonOutputCapture<'_>> {
         PythonOutputCapture::start(py, &self.file_descriptors)
     }
+
+    pub fn stop(&self, py: Python<'_>) -> PyResult<()> {
+        self.file_descriptors.suspend(py)
+    }
+}
+
+pub fn with_suspended_output_capture<R>(
+    capture: Option<&OutputCapture>,
+    py: Python<'_>,
+    f: impl FnOnce() -> R,
+) -> R {
+    let Some(capture) = capture else {
+        return f();
+    };
+    if let Err(err) = capture.file_descriptors.suspend(py) {
+        tracing::warn!("failed to suspend file descriptor output capture: {err}");
+        return f();
+    }
+    let result = f();
+    if let Err(err) = capture.file_descriptors.resume(py) {
+        tracing::warn!("failed to resume file descriptor output capture: {err}");
+    }
+    result
 }
 
 pub struct PythonOutputCapture<'capture> {
@@ -136,15 +159,12 @@ impl FileDescriptorCapture {
 
     fn start(&self, py: Python<'_>) -> PyResult<()> {
         clear_file(py, &self.stdout)?;
-        clear_file(py, &self.stderr)?;
-        self.resume(py)
+        clear_file(py, &self.stderr)
     }
 
     fn finish(&self, py: Python<'_>) -> PyResult<CapturedPythonOutput> {
-        let suspend_result = self.suspend(py);
         let stdout_result = read_file(py, &self.stdout);
         let stderr_result = read_file(py, &self.stderr);
-        suspend_result?;
         let stdout = stdout_result?;
         let stderr = stderr_result?;
         Ok(CapturedPythonOutput { stdout, stderr })

--- a/crates/karva_test_semantic/src/output_capture.rs
+++ b/crates/karva_test_semantic/src/output_capture.rs
@@ -1,14 +1,21 @@
 use pyo3::prelude::*;
 
+use karva_logging::{SavedStdout, save_stdout};
+
 pub struct OutputCapture {
     file_descriptors: FileDescriptorCapture,
+    _saved_stdout: SavedStdout,
 }
 
 impl OutputCapture {
     pub fn new(py: Python<'_>) -> PyResult<Self> {
+        let stdout = save_stdout()?;
         let file_descriptors = FileDescriptorCapture::new(py)?;
         file_descriptors.resume(py)?;
-        Ok(Self { file_descriptors })
+        Ok(Self {
+            file_descriptors,
+            _saved_stdout: stdout,
+        })
     }
 
     pub fn start(&self, py: Python<'_>) -> PyResult<PythonOutputCapture<'_>> {
@@ -18,25 +25,6 @@ impl OutputCapture {
     pub fn stop(&self, py: Python<'_>) -> PyResult<()> {
         self.file_descriptors.suspend(py)
     }
-}
-
-pub fn with_suspended_output_capture<R>(
-    capture: Option<&OutputCapture>,
-    py: Python<'_>,
-    f: impl FnOnce() -> R,
-) -> R {
-    let Some(capture) = capture else {
-        return f();
-    };
-    if let Err(err) = capture.file_descriptors.suspend(py) {
-        tracing::warn!("failed to suspend file descriptor output capture: {err}");
-        return f();
-    }
-    let result = f();
-    if let Err(err) = capture.file_descriptors.resume(py) {
-        tracing::warn!("failed to resume file descriptor output capture: {err}");
-    }
-    result
 }
 
 pub struct PythonOutputCapture<'capture> {
@@ -158,8 +146,8 @@ impl FileDescriptorCapture {
     }
 
     fn start(&self, py: Python<'_>) -> PyResult<()> {
-        clear_file(py, &self.stdout)?;
-        clear_file(py, &self.stderr)
+        clear_if_needed(py, &self.stdout)?;
+        clear_if_needed(py, &self.stderr)
     }
 
     fn finish(&self, py: Python<'_>) -> PyResult<CapturedPythonOutput> {
@@ -239,19 +227,35 @@ fn redirect_descriptor(
     Ok(())
 }
 
-fn read_file(py: Python<'_>, file: &Py<PyAny>) -> PyResult<String> {
-    let file = file.bind(py);
-    file.call_method1("seek", (0,))?;
-    file.call_method0("read")?
-        .call_method1("decode", ("utf-8", "replace"))?
-        .extract()
+fn file_position(py: Python<'_>, file: &Py<PyAny>) -> PyResult<u64> {
+    file.bind(py).call_method0("tell")?.extract()
 }
 
-fn clear_file(py: Python<'_>, file: &Py<PyAny>) -> PyResult<()> {
+fn clear_if_needed(py: Python<'_>, file: &Py<PyAny>) -> PyResult<()> {
+    let position = file_position(py, file)?;
+    if position == 0 {
+        return Ok(());
+    }
     let file = file.bind(py);
     file.call_method1("seek", (0,))?;
     file.call_method1("truncate", (0,))?;
     Ok(())
+}
+
+fn read_file(py: Python<'_>, file: &Py<PyAny>) -> PyResult<String> {
+    let file = file.bind(py);
+    let end = file.call_method0("tell")?.extract::<u64>()?;
+    if end == 0 {
+        return Ok(String::new());
+    }
+    file.call_method1("seek", (0,))?;
+    let output = file
+        .call_method1("read", (end,))?
+        .call_method1("decode", ("utf-8", "replace"))?
+        .extract();
+    file.call_method1("seek", (0,))?;
+    file.call_method1("truncate", (0,))?;
+    output
 }
 
 fn flush_current_streams(sys: &Bound<'_, PyModule>) {

--- a/crates/karva_test_semantic/src/output_capture.rs
+++ b/crates/karva_test_semantic/src/output_capture.rs
@@ -127,16 +127,70 @@ pub struct CapturedPythonOutput {
 }
 
 struct FileDescriptorCapture {
-    stdout: Py<PyAny>,
-    stderr: Py<PyAny>,
+    stdout: CaptureFile,
+    stderr: CaptureFile,
     old: SavedFileDescriptors,
+}
+
+struct CaptureFile {
+    file: Py<PyAny>,
+    tell: Py<PyAny>,
+    seek: Py<PyAny>,
+    truncate: Py<PyAny>,
+    read: Py<PyAny>,
+}
+
+impl CaptureFile {
+    fn new(file: Bound<'_, PyAny>) -> PyResult<Self> {
+        let tell = file.getattr("tell")?.unbind();
+        let seek = file.getattr("seek")?.unbind();
+        let truncate = file.getattr("truncate")?.unbind();
+        let read = file.getattr("read")?.unbind();
+        Ok(Self {
+            file: file.unbind(),
+            tell,
+            seek,
+            truncate,
+            read,
+        })
+    }
+
+    fn position(&self, py: Python<'_>) -> PyResult<u64> {
+        self.tell.bind(py).call0()?.extract()
+    }
+
+    fn clear_if_needed(&self, py: Python<'_>) -> PyResult<()> {
+        if self.position(py)? == 0 {
+            return Ok(());
+        }
+        self.seek.bind(py).call1((0,))?;
+        self.truncate.bind(py).call1((0,))?;
+        Ok(())
+    }
+
+    fn read(&self, py: Python<'_>) -> PyResult<String> {
+        let end = self.position(py)?;
+        if end == 0 {
+            return Ok(String::new());
+        }
+        self.seek.bind(py).call1((0,))?;
+        let output = self
+            .read
+            .bind(py)
+            .call1((end,))?
+            .call_method1("decode", ("utf-8", "replace"))?
+            .extract();
+        self.seek.bind(py).call1((0,))?;
+        self.truncate.bind(py).call1((0,))?;
+        output
+    }
 }
 
 impl FileDescriptorCapture {
     fn new(py: Python<'_>) -> PyResult<Self> {
         let temporary_file = py.import("tempfile")?.getattr("TemporaryFile")?;
-        let stdout = temporary_file.call1(("w+b",))?.unbind();
-        let stderr = temporary_file.call1(("w+b",))?.unbind();
+        let stdout = CaptureFile::new(temporary_file.call1(("w+b",))?)?;
+        let stderr = CaptureFile::new(temporary_file.call1(("w+b",))?)?;
         let old = SavedFileDescriptors::new(py)?;
         Ok(Self {
             stdout,
@@ -146,13 +200,13 @@ impl FileDescriptorCapture {
     }
 
     fn start(&self, py: Python<'_>) -> PyResult<()> {
-        clear_if_needed(py, &self.stdout)?;
-        clear_if_needed(py, &self.stderr)
+        self.stdout.clear_if_needed(py)?;
+        self.stderr.clear_if_needed(py)
     }
 
     fn finish(&self, py: Python<'_>) -> PyResult<CapturedPythonOutput> {
-        let stdout_result = read_file(py, &self.stdout);
-        let stderr_result = read_file(py, &self.stderr);
+        let stdout_result = self.stdout.read(py);
+        let stderr_result = self.stderr.read(py);
         let stdout = stdout_result?;
         let stderr = stderr_result?;
         Ok(CapturedPythonOutput { stdout, stderr })
@@ -161,7 +215,7 @@ impl FileDescriptorCapture {
     fn suspend(&self, py: Python<'_>) -> PyResult<()> {
         if let Err(err) = self.old.restore(py) {
             let os = py.import("os")?;
-            if let Err(restore_err) = redirect_descriptor(&os, py, &self.stdout, 1) {
+            if let Err(restore_err) = redirect_descriptor(&os, py, &self.stdout.file, 1) {
                 tracing::warn!("failed to restore stdout capture after setup error: {restore_err}");
             }
             return Err(err);
@@ -171,8 +225,8 @@ impl FileDescriptorCapture {
 
     fn resume(&self, py: Python<'_>) -> PyResult<()> {
         let os = py.import("os")?;
-        redirect_descriptor(&os, py, &self.stdout, 1)?;
-        if let Err(err) = redirect_descriptor(&os, py, &self.stderr, 2) {
+        redirect_descriptor(&os, py, &self.stdout.file, 1)?;
+        if let Err(err) = redirect_descriptor(&os, py, &self.stderr.file, 2) {
             if let Err(restore_err) = redirect_descriptor(&os, py, &self.old.stdout, 1) {
                 tracing::warn!("failed to restore stdout after capture setup error: {restore_err}");
             }
@@ -225,37 +279,6 @@ fn redirect_descriptor(
     let source: i32 = file.bind(py).call_method0("fileno")?.extract()?;
     os.call_method1("dup2", (source, target))?;
     Ok(())
-}
-
-fn file_position(py: Python<'_>, file: &Py<PyAny>) -> PyResult<u64> {
-    file.bind(py).call_method0("tell")?.extract()
-}
-
-fn clear_if_needed(py: Python<'_>, file: &Py<PyAny>) -> PyResult<()> {
-    let position = file_position(py, file)?;
-    if position == 0 {
-        return Ok(());
-    }
-    let file = file.bind(py);
-    file.call_method1("seek", (0,))?;
-    file.call_method1("truncate", (0,))?;
-    Ok(())
-}
-
-fn read_file(py: Python<'_>, file: &Py<PyAny>) -> PyResult<String> {
-    let file = file.bind(py);
-    let end = file.call_method0("tell")?.extract::<u64>()?;
-    if end == 0 {
-        return Ok(String::new());
-    }
-    file.call_method1("seek", (0,))?;
-    let output = file
-        .call_method1("read", (end,))?
-        .call_method1("decode", ("utf-8", "replace"))?
-        .extract();
-    file.call_method1("seek", (0,))?;
-    file.call_method1("truncate", (0,))?;
-    output
 }
 
 fn flush_current_streams(sys: &Bound<'_, PyModule>) {

--- a/crates/karva_test_semantic/src/runner/package_runner/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/mod.rs
@@ -12,7 +12,7 @@ use crate::Context;
 use crate::diagnostic::{fixture_resolution_diagnostic, invalid_parametrize_diagnostic};
 use crate::discovery::{DiscoveredModule, DiscoveredPackage, DiscoveredTestFunction};
 use crate::extensions::fixtures::FixtureScope;
-use crate::output_capture::{OutputCapture, with_suspended_output_capture};
+use crate::output_capture::OutputCapture;
 use crate::runner::fixture_resolver::RuntimeFixtureResolver;
 use crate::runner::test_iterator::TestVariantIterator;
 use crate::runner::{FinalizerCache, FixtureCache};
@@ -192,9 +192,7 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
             self.run_auto_use_fixtures(py, &[], session, FixtureScope::Session)
         {
             let diagnostic = diagnostics.remove(0);
-            with_suspended_output_capture(self.output_capture.as_ref(), py, || {
-                self.register_error_package_tests(session, &diagnostic, &diagnostics);
-            });
+            self.register_error_package_tests(session, &diagnostic, &diagnostics);
             return;
         }
 
@@ -213,9 +211,7 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
             self.run_auto_use_fixtures(py, parents, module, FixtureScope::Module)
         {
             let diagnostic = diagnostics.remove(0);
-            with_suspended_output_capture(self.output_capture.as_ref(), py, || {
-                self.register_error_module_tests(module, &diagnostic, &diagnostics);
-            });
+            self.register_error_module_tests(module, &diagnostic, &diagnostics);
             return false;
         }
 
@@ -226,9 +222,7 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
                 Ok(variants) => variants,
                 Err(error) => {
                     let diagnostic = fixture_resolution_diagnostic(error);
-                    with_suspended_output_capture(self.output_capture.as_ref(), py, || {
-                        self.register_error_test(test, diagnostic, Vec::new());
-                    });
+                    self.register_error_test(test, diagnostic, Vec::new());
                     passed = false;
                     if self.max_fail_reached() {
                         break;
@@ -271,9 +265,7 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
                 self.run_auto_use_fixtures(py, parents, configuration_module, FixtureScope::Package)
         {
             let diagnostic = diagnostics.remove(0);
-            with_suspended_output_capture(self.output_capture.as_ref(), py, || {
-                self.register_error_package_tests(package, &diagnostic, &diagnostics);
-            });
+            self.register_error_package_tests(package, &diagnostic, &diagnostics);
             return false;
         }
 

--- a/crates/karva_test_semantic/src/runner/package_runner/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/mod.rs
@@ -12,7 +12,7 @@ use crate::Context;
 use crate::diagnostic::{fixture_resolution_diagnostic, invalid_parametrize_diagnostic};
 use crate::discovery::{DiscoveredModule, DiscoveredPackage, DiscoveredTestFunction};
 use crate::extensions::fixtures::FixtureScope;
-use crate::output_capture::OutputCapture;
+use crate::output_capture::{OutputCapture, with_suspended_output_capture};
 use crate::runner::fixture_resolver::RuntimeFixtureResolver;
 use crate::runner::test_iterator::TestVariantIterator;
 use crate::runner::{FinalizerCache, FixtureCache};
@@ -85,6 +85,14 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
         if !passed {
             self.failed_count
                 .set(self.failed_count.get().saturating_add(1));
+        }
+    }
+
+    pub(crate) fn stop_output_capture(&self, py: Python<'_>) {
+        if let Some(capture) = &self.output_capture
+            && let Err(error) = capture.stop(py)
+        {
+            tracing::warn!("failed to stop Python output capture: {error}");
         }
     }
 
@@ -184,7 +192,9 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
             self.run_auto_use_fixtures(py, &[], session, FixtureScope::Session)
         {
             let diagnostic = diagnostics.remove(0);
-            self.register_error_package_tests(session, &diagnostic, &diagnostics);
+            with_suspended_output_capture(self.output_capture.as_ref(), py, || {
+                self.register_error_package_tests(session, &diagnostic, &diagnostics);
+            });
             return;
         }
 
@@ -203,7 +213,9 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
             self.run_auto_use_fixtures(py, parents, module, FixtureScope::Module)
         {
             let diagnostic = diagnostics.remove(0);
-            self.register_error_module_tests(module, &diagnostic, &diagnostics);
+            with_suspended_output_capture(self.output_capture.as_ref(), py, || {
+                self.register_error_module_tests(module, &diagnostic, &diagnostics);
+            });
             return false;
         }
 
@@ -213,11 +225,10 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
             let variants = match TestVariantIterator::new(py, test, &mut resolver) {
                 Ok(variants) => variants,
                 Err(error) => {
-                    self.register_error_test(
-                        test,
-                        fixture_resolution_diagnostic(error),
-                        Vec::new(),
-                    );
+                    let diagnostic = fixture_resolution_diagnostic(error);
+                    with_suspended_output_capture(self.output_capture.as_ref(), py, || {
+                        self.register_error_test(test, diagnostic, Vec::new());
+                    });
                     passed = false;
                     if self.max_fail_reached() {
                         break;
@@ -260,7 +271,9 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
                 self.run_auto_use_fixtures(py, parents, configuration_module, FixtureScope::Package)
         {
             let diagnostic = diagnostics.remove(0);
-            self.register_error_package_tests(package, &diagnostic, &diagnostics);
+            with_suspended_output_capture(self.output_capture.as_ref(), py, || {
+                self.register_error_package_tests(package, &diagnostic, &diagnostics);
+            });
             return false;
         }
 

--- a/crates/karva_test_semantic/src/runner/package_runner/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/mod.rs
@@ -12,6 +12,7 @@ use crate::Context;
 use crate::diagnostic::{fixture_resolution_diagnostic, invalid_parametrize_diagnostic};
 use crate::discovery::{DiscoveredModule, DiscoveredPackage, DiscoveredTestFunction};
 use crate::extensions::fixtures::FixtureScope;
+use crate::output_capture::OutputCapture;
 use crate::runner::fixture_resolver::RuntimeFixtureResolver;
 use crate::runner::test_iterator::TestVariantIterator;
 use crate::runner::{FinalizerCache, FixtureCache};
@@ -38,6 +39,8 @@ pub struct PackageRunner<'context, 'settings> {
     coverage: Option<&'context CoverageSession>,
     /// Failed variants observed so far, used to enforce `max-fail`.
     failed_count: Cell<u32>,
+    /// Reusable files backing subprocess output capture.
+    output_capture: Option<OutputCapture>,
 }
 
 impl<'context, 'settings> PackageRunner<'context, 'settings> {
@@ -45,13 +48,26 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
     pub(crate) fn new(
         context: &'context Context<'settings>,
         coverage: Option<&'context CoverageSession>,
+        py: Python<'_>,
     ) -> Self {
+        let output_capture = if context.settings().terminal().show_python_output {
+            None
+        } else {
+            match OutputCapture::new(py) {
+                Ok(capture) => Some(capture),
+                Err(error) => {
+                    tracing::warn!("failed to initialize Python output capture: {error}");
+                    None
+                }
+            }
+        };
         Self {
             context,
             fixture_cache: FixtureCache::default(),
             finalizer_cache: FinalizerCache::default(),
             coverage,
             failed_count: Cell::new(0),
+            output_capture,
         }
     }
 

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
@@ -109,7 +109,12 @@ impl<'runner, 'context, 'settings, 'test, 'py>
         let test_name_env_result =
             set_test_name_env(self.py, &settings.qualified_test_name.to_string());
 
-        tracing::debug!("Running test `{}`", settings.qualified_test_name);
+        let trace_test = || tracing::debug!("Running test `{}`", settings.qualified_test_name);
+        if let Some(capture) = &output_capture {
+            capture.with_file_descriptors_restored(self.py, trace_test);
+        } else {
+            trace_test();
+        }
         self.package_runner
             .context
             .report_test_started(&settings.qualified_test_name);
@@ -135,14 +140,21 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             );
 
             if attempt.retryable && attempt_number < settings.max_attempts {
-                self.package_runner.context.report_test_attempt(
-                    &settings.qualified_test_name,
-                    attempt_number,
-                    attempt.lifecycle.outcome.result_kind(),
-                    attempt.lifecycle.duration,
-                );
+                let report_attempt = || {
+                    self.package_runner.context.report_test_attempt(
+                        &settings.qualified_test_name,
+                        attempt_number,
+                        attempt.lifecycle.outcome.result_kind(),
+                        attempt.lifecycle.duration,
+                    );
+                    tracing::debug!("Retrying test `{}`", settings.qualified_test_name);
+                };
+                if let Some(capture) = &output_capture {
+                    capture.with_file_descriptors_restored(self.py, report_attempt);
+                } else {
+                    report_attempt();
+                }
                 prior_attempts.push(attempt.lifecycle);
-                tracing::debug!("Retrying test `{}`", settings.qualified_test_name);
                 attempt_number += 1;
             } else {
                 break attempt.lifecycle;

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
@@ -100,9 +100,9 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             return result;
         }
 
-        let output_capture = self.start_output_capture();
         let retry_params = self.params.clone();
         let first_params = std::mem::take(&mut self.params);
+        let output_capture = self.start_output_capture();
         let first_attempt = self.prepare_attempt(first_params);
         let settings = self.settings(&first_attempt.fixtures.function_arguments);
         let function = self.test.py_function.clone_ref(self.py);

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
@@ -17,7 +17,7 @@ use crate::extensions::tags::Tags;
 use crate::extensions::tags::expect_fail::ExpectFailTag;
 use crate::extensions::tags::fail_slow::FailSlowTag;
 use crate::extensions::tags::timeout::TimeoutTag;
-use crate::output_capture::PythonOutputCapture;
+use crate::output_capture::{PythonOutputCapture, with_restored_file_descriptors};
 use crate::runner::fixture_arguments::FixtureArguments;
 use crate::runner::test_iterator::TestVariant;
 use crate::utils::{full_test_name, set_attempt_env, set_test_name_env};
@@ -109,12 +109,9 @@ impl<'runner, 'context, 'settings, 'test, 'py>
         let test_name_env_result =
             set_test_name_env(self.py, &settings.qualified_test_name.to_string());
 
-        let trace_test = || tracing::debug!("Running test `{}`", settings.qualified_test_name);
-        if let Some(capture) = &output_capture {
-            capture.with_file_descriptors_restored(self.py, trace_test);
-        } else {
-            trace_test();
-        }
+        with_restored_file_descriptors(output_capture.as_ref(), self.py, || {
+            tracing::debug!("Running test `{}`", settings.qualified_test_name);
+        });
         self.package_runner
             .context
             .report_test_started(&settings.qualified_test_name);
@@ -140,7 +137,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             );
 
             if attempt.retryable && attempt_number < settings.max_attempts {
-                let report_attempt = || {
+                with_restored_file_descriptors(output_capture.as_ref(), self.py, || {
                     self.package_runner.context.report_test_attempt(
                         &settings.qualified_test_name,
                         attempt_number,
@@ -148,12 +145,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
                         attempt.lifecycle.duration,
                     );
                     tracing::debug!("Retrying test `{}`", settings.qualified_test_name);
-                };
-                if let Some(capture) = &output_capture {
-                    capture.with_file_descriptors_restored(self.py, report_attempt);
-                } else {
-                    report_attempt();
-                }
+                });
                 prior_attempts.push(attempt.lifecycle);
                 attempt_number += 1;
             } else {

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
@@ -109,9 +109,11 @@ impl<'runner, 'context, 'settings, 'test, 'py>
         let test_name_env_result =
             set_test_name_env(self.py, &settings.qualified_test_name.to_string());
 
-        with_restored_file_descriptors(output_capture.as_ref(), self.py, || {
-            tracing::debug!("Running test `{}`", settings.qualified_test_name);
-        });
+        if tracing::enabled!(tracing::Level::DEBUG) {
+            with_restored_file_descriptors(output_capture.as_ref(), self.py, || {
+                tracing::debug!("Running test `{}`", settings.qualified_test_name);
+            });
+        }
         self.package_runner
             .context
             .report_test_started(&settings.qualified_test_name);
@@ -286,7 +288,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
     fn finish(
         &self,
         settings: &VariantSettings,
-        output_capture: Option<PythonOutputCapture>,
+        output_capture: Option<PythonOutputCapture<'_>>,
         prior_attempts: Vec<TestLifecycleAttempt>,
         final_attempt: TestLifecycleAttempt,
     ) -> bool {
@@ -388,18 +390,8 @@ impl<'runner, 'context, 'settings, 'test, 'py>
     }
 
     /// Starts best-effort Python output capture when terminal output is hidden.
-    fn start_output_capture(&self) -> Option<PythonOutputCapture> {
-        if self
-            .package_runner
-            .context
-            .settings()
-            .terminal()
-            .show_python_output
-        {
-            return None;
-        }
-
-        match PythonOutputCapture::start(self.py) {
+    fn start_output_capture(&self) -> Option<PythonOutputCapture<'_>> {
+        match self.package_runner.output_capture.as_ref()?.start(self.py) {
             Ok(capture) => Some(capture),
             Err(error) => {
                 tracing::warn!("failed to start Python output capture: {error}");
@@ -445,7 +437,7 @@ struct VariantSettings {
 /// Finishes best-effort Python output capture.
 fn finish_output_capture(
     py: Python<'_>,
-    capture: Option<PythonOutputCapture>,
+    capture: Option<PythonOutputCapture<'_>>,
 ) -> Option<CapturedTestOutput> {
     let capture = capture?;
 

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
@@ -139,15 +139,17 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             );
 
             if attempt.retryable && attempt_number < settings.max_attempts {
-                with_restored_file_descriptors(output_capture.as_ref(), self.py, || {
-                    self.package_runner.context.report_test_attempt(
-                        &settings.qualified_test_name,
-                        attempt_number,
-                        attempt.lifecycle.outcome.result_kind(),
-                        attempt.lifecycle.duration,
-                    );
-                    tracing::debug!("Retrying test `{}`", settings.qualified_test_name);
-                });
+                self.package_runner.context.report_test_attempt(
+                    &settings.qualified_test_name,
+                    attempt_number,
+                    attempt.lifecycle.outcome.result_kind(),
+                    attempt.lifecycle.duration,
+                );
+                if tracing::enabled!(tracing::Level::DEBUG) {
+                    with_restored_file_descriptors(output_capture.as_ref(), self.py, || {
+                        tracing::debug!("Retrying test `{}`", settings.qualified_test_name);
+                    });
+                }
                 prior_attempts.push(attempt.lifecycle);
                 attempt_number += 1;
             } else {


### PR DESCRIPTION
## Summary

Capture file descriptors 1 and 2 alongside Python streams so subprocess output stays hidden for passing tests and remains available in failed-test reports. Preserve framework progress and verbose tracing outside the capture boundary. Closes #1001.

## Test Plan

Full karva integration suite, strict workspace Clippy, and the full prek hook suite.