### PR TITLE
Avoid files for inline snapshot mismatches

### DIFF
--- a/crates/karva/tests/it/extensions/snapshot/cmd.rs
+++ b/crates/karva/tests/it/extensions/snapshot/cmd.rs
@@ -522,6 +522,8 @@ def test_inline_wrong():
 
     ----- stderr -----
     "#);
+
+    assert!(!context.root().join("snapshots").exists());
 }
 
 #[test]

--- a/crates/karva_test_semantic/src/extensions/functions/snapshot.rs
+++ b/crates/karva_test_semantic/src/extensions/functions/snapshot.rs
@@ -478,7 +478,14 @@ fn handle_inline_snapshot(
         return Ok(());
     }
 
-    // Write a .snap.new with inline metadata so `karva snapshot accept` can rewrite the source
+    if !is_empty {
+        let diff = format_diff(&expected, actual);
+        return Err(SnapshotMismatchError::new_err(format!(
+            "Inline snapshot mismatch for '{test_name}'.\n{diff}"
+        )));
+    }
+
+    // New inline snapshots need metadata so `karva snapshot accept` can rewrite the source.
     let test_file_path = Utf8Path::new(test_file);
     let module_name = test_file_path.file_stem().unwrap_or("unknown");
     let snapshot_name = format!("{test_name}_inline_{lineno}");
@@ -502,17 +509,10 @@ fn handle_inline_snapshot(
         SnapshotMismatchError::new_err(format!("Failed to write pending inline snapshot: {e}"))
     })?;
 
-    if is_empty {
-        let pending = Utf8PathBuf::from(format!("{snap_path}.new"));
-        let display_path = display_relative(&pending);
-        return Err(SnapshotMismatchError::new_err(format!(
-            "New inline snapshot for '{test_name}'.\nRun `karva snapshot accept` to accept, or re-run with `--snapshot-update`.\nPending file: {display_path}"
-        )));
-    }
-
-    let diff = format_diff(&expected, actual);
+    let pending = Utf8PathBuf::from(format!("{snap_path}.new"));
+    let display_path = display_relative(&pending);
     Err(SnapshotMismatchError::new_err(format!(
-        "Inline snapshot mismatch for '{test_name}'.\n{diff}"
+        "New inline snapshot for '{test_name}'.\nRun `karva snapshot accept` to accept, or re-run with `--snapshot-update`.\nPending file: {display_path}"
     )))
 }
 

--- a/docs/usage/writing-tests/snapshots.md
+++ b/docs/usage/writing-tests/snapshots.md
@@ -174,7 +174,7 @@ hello world
 
 The `source` field records the file, line number, and test name that produced the snapshot.
 
-When a test produces a new or changed snapshot, a `.snap.new` file is created alongside the existing `.snap` file. This pending file must be explicitly accepted or rejected before the test will pass.
+When a test produces a new or changed file-based snapshot, a `.snap.new` file is created alongside the existing `.snap` file. This pending file must be explicitly accepted or rejected before the test will pass.
 
 ## Inline Snapshots
 
@@ -201,6 +201,8 @@ karva test --snapshot-update
 ```
 
 Karva rewrites your source file, replacing `inline=""` with the actual value.
+
+A mismatch with an existing inline snapshot reports the diff without creating a snapshot file. Run with `--snapshot-update` to replace the inline value.
 
 ### Multiline Values
 


### PR DESCRIPTION
## Summary

Inline snapshot mismatches now report their diff without writing a `.snap.new` file or creating a `snapshots` directory. Empty inline snapshots keep the existing pending/accept workflow, and `--snapshot-update` still rewrites stale inline values.

Closes #1012.

## Test Plan

`just test`, strict workspace Clippy, and `uvx prek run -a`.