### PR TITLE
Improve contributor guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,52 +1,62 @@
 # Karva Repository
 
-Karva is a Rust workspace that builds a Python test framework through PyO3.
-Read `CONTRIBUTING.md` before changing files.
+This repository contains Karva, a Python test framework implemented as a Rust
+workspace with PyO3. Rust crates use the `karva_*` naming convention and live
+under `crates/`.
 
 Karva runs tests through a main `karva` process and `karva-worker`
-subprocesses. The binaries do not link against each other; they communicate
-through CLI arguments and a shared cache directory. Only the worker embeds
+subprocesses. The binaries do not link against each other. They communicate
+through CLI arguments and a shared cache directory, and only the worker embeds
 Python.
 
 ## Code Review Rules
 
-Review branches and pull requests critically. Report bugs, regressions,
-maintenance risks, weak coverage, unclear code, unnecessary complexity, and
-meaningful consistency issues. Order findings by severity, cite files and
-lines, and distinguish blockers from optional improvements.
+When reviewing a branch or pull request, be deliberately nitpicky. Report not
+only bugs and regressions, but also architectural and maintenance risks, weak
+test coverage, unclear code, unnecessary complexity, and meaningful style or
+consistency issues. Order findings by severity, cite files and lines, and
+distinguish blockers from non-blocking improvements. Number each review point
+for easy reference in subsequent review discussion.
 
 ## Running Tests
 
-Run the full suite through the project recipe:
+Run all tests:
 
 ```sh
 just test
 ```
 
-Pass `cargo nextest` or `cargo test` arguments through `just test` for focused
-runs:
+Run tests for a specific crate:
 
 ```sh
 just test -p karva_cache
+```
+
+Run a specific test:
+
+```sh
 just test -p karva test_name
 ```
 
-`just test` builds the Python wheel with `uvx maturin build`, then uses
-`cargo nextest run` when `cargo-nextest` is installed and falls back to
-`cargo test`.
+`just test` builds the Python wheel with `uvx maturin build` before running
+the Rust test suite.
 
-Prefer integration tests under `crates/karva/tests/it/` when behavior crosses
-crate, Python, worker, or CLI boundaries. Command integration tests should use
-snapshots.
+### Fallback Without Nextest
+
+The `just test` recipe uses `cargo nextest run` when `cargo-nextest` is
+installed and falls back to `cargo test` automatically. Arguments shown above
+work with either runner.
 
 ### Snapshot Updates
 
-Review every added or updated snapshot before accepting it. Check for pending
-`.snap.new` files before finishing. Do not accept unrelated snapshot changes.
+After running tests, always review every snapshot that was added or updated.
+Check for pending `.snap.new` files if affected tests use Karva snapshots.
+
+Do not edit snapshot files or inline snapshot bodies manually. Regenerate them
+by running the relevant tests or Karva snapshot command, then review the
+generated diff. Do not accept unrelated snapshot changes.
 
 ## Running Clippy
-
-Run Clippy with the same strictness as CI:
 
 ```sh
 cargo clippy --workspace --all-targets --all-features -- -D warnings
@@ -54,53 +64,82 @@ cargo clippy --workspace --all-targets --all-features -- -D warnings
 
 ## Running Debug Builds
 
-Use debug builds while developing. Run the CLI against a test file with:
+Use debug builds, not `--release`, while developing. Release builds lack debug
+assertions and take longer to compile.
+
+Run Karva against a test file:
 
 ```sh
 cargo run test tests/test_add.py
 ```
 
-## Generated Files
+## Generated Documentation
 
-Run the generator after changing configuration options, CLI arguments,
-environment variable definitions, or their reference documentation:
+Reference files under `docs/reference/` and
+`docs/configuration/configuration.md` are generated. Their headers identify
+the source file to change.
+
+After changing configuration options, CLI arguments, environment variable
+definitions, or their reference documentation, regenerate all references:
 
 ```sh
 cargo run -p karva_dev generate-all
 ```
 
-Generated files under `docs/reference/` and
-`docs/configuration/configuration.md` identify their source files in a header.
-Change the source, then regenerate.
+Review the generated diff before committing it.
 
-Run `pinact run` after changing GitHub Actions workflows.
+## GitHub Actions
+
+Actions must be pinned to full commit SHAs. After changing a workflow, run:
+
+```sh
+pinact run
+```
 
 ## Development Guidelines
 
-- Test every behavior change. If the relevant tests were not run, the change
-  is not done.
-- Look for existing utilities and neighboring patterns before writing new
-  code.
-- Keep changes focused. Do not refactor unrelated code.
-- Keep visibility narrow by default, but use `pub` when another workspace
-  crate needs it and that is the cleaner design.
-- Keep Rust imports at the top of the file.
+- All significant changes must be tested. Add or update focused tests for
+  behavior changes when existing coverage does not establish the intended
+  behavior.
+- Look for an existing test file before creating a new one.
+- Get the relevant tests to pass. If the tests were not run, the change is not
+  done.
+- Follow existing code style. Check neighboring files for patterns.
+- Prefer integration tests under `crates/karva/tests/it/` when behavior crosses
+  crate, Python, worker, or CLI boundaries. Command integration tests should
+  use snapshots.
+- Keep changes focused. Do not expand the task to unrelated issues.
+- Before writing significant new code, look for existing utilities or
+  mechanisms that solve the problem. Prefer fixing the underlying
+  architectural problem over adding a localized workaround. Ask for guidance
+  when the larger change is unclear.
+- Prefer narrow visibility because this workspace is generally its own
+  consumer. Do not add workarounds solely to avoid `pub`; make an item public
+  when another workspace crate needs it and that produces the cleaner design.
+- Keep Rust imports at the top of the file, never locally inside functions.
 - Avoid `panic!`, `unreachable!`, `.unwrap()`, unsafe code, and Clippy ignores.
   Encode constraints in the type system.
-- Prefer `if let` for fallibility and let chains over nested `if let` when they
-  improve readability.
-- Prefer `#[expect()]` over `#[allow()]` when a lint must be suppressed.
+- Prefer `if let` for fallibility. Prefer let chains over nested `if let`
+  statements when they reduce indentation.
+- If a Clippy lint must be suppressed, prefer `#[expect()]` over `#[allow()]`.
+  Delete unused code instead of suppressing dead-code warnings.
 - Prefer short imports over fully qualified paths.
-- Use comments for invariants and unusual decisions, not narration.
+- Do not use comments to narrate code. Use them to explain invariants and why
+  unusual decisions were made. Prefer plain language that makes sense without
+  prior context.
 - Avoid redundant comments and section separators in tests. Prefer function
   comments over inline comments.
 - Consider whether public APIs, flags, defaults, configuration, environment
-  variables, or CLI changes require a docs update.
-- Run `uvx prek run --files <path1> <path2>` during iteration with every
-  changed file, then run `uvx prek run -a` before finishing.
+  variables, or CLI changes require documentation updates.
+- Run `uvx prek run --files <path1> <path2>` during iteration and pass every
+  changed file. Run `uvx prek run -a` before finishing.
 
 ## Pull Requests
 
 Use the pull request template and add relevant labels. Keep the summary and
-test plan concise. Explain what changed and why; include implementation detail
-only when reviewers need it.
+test plan concise. Write descriptions as prose, not bullet lists or
+checklists. Explain what changed and why; include implementation details only
+when reviewers need them.
+
+Use a descriptive one-line commit subject by default. Never add an AI tool as
+an author or co-author.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,19 @@
 # Karva Repository
 
-Karva is a Rust workspace that builds a Python test framework through PyO3. Read `CONTRIBUTING.md` before changing files; it has the current architecture map, setup commands, benchmark notes, docs build commands, and release process.
+Karva is a Rust workspace that builds a Python test framework through PyO3.
+Read `CONTRIBUTING.md` before changing files.
+
+Karva runs tests through a main `karva` process and `karva-worker`
+subprocesses. The binaries do not link against each other; they communicate
+through CLI arguments and a shared cache directory. Only the worker embeds
+Python.
+
+## Code Review Rules
+
+Review branches and pull requests critically. Report bugs, regressions,
+maintenance risks, weak coverage, unclear code, unnecessary complexity, and
+meaningful consistency issues. Order findings by severity, cite files and
+lines, and distinguish blockers from optional improvements.
 
 ## Running Tests
 
@@ -10,19 +23,28 @@ Run the full suite through the project recipe:
 just test
 ```
 
-Pass `cargo nextest` or `cargo test` arguments through `just test` when a narrower run is enough during iteration:
+Pass `cargo nextest` or `cargo test` arguments through `just test` for focused
+runs:
 
 ```sh
 just test -p karva_cache
+just test -p karva test_name
 ```
 
-`just test` builds the wheel with `uvx maturin build`, then uses `cargo nextest run` if `cargo-nextest` is installed and falls back to `cargo test`.
+`just test` builds the Python wheel with `uvx maturin build`, then uses
+`cargo nextest run` when `cargo-nextest` is installed and falls back to
+`cargo test`.
 
-Use debug builds while developing. To run the CLI against a test file:
+Prefer integration tests under `crates/karva/tests/it/` when behavior crosses
+crate, Python, worker, or CLI boundaries. Command integration tests should use
+snapshots.
 
-```sh
-cargo run test tests/test_add.py
-```
+### Snapshot Updates
+
+Review every added or updated snapshot before accepting it. Check for pending
+`.snap.new` files before finishing. Do not accept unrelated snapshot changes.
+
+## Running Clippy
 
 Run Clippy with the same strictness as CI:
 
@@ -30,31 +52,55 @@ Run Clippy with the same strictness as CI:
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 ```
 
-Run `uvx prek run -a` at the end of every task. During iteration, use `uvx prek run --files <path1> <path2>` with every changed file to keep hook runs independent of staged state.
+## Running Debug Builds
 
-## Snapshots And Generated Files
+Use debug builds while developing. Run the CLI against a test file with:
 
-Prefer integration tests, for example under `it/...`, over unit tests when the behavior crosses crate or CLI boundaries. Command integration tests should use snapshots.
+```sh
+cargo run test tests/test_add.py
+```
 
-After updating snapshots, always review what changed before accepting them. Check for pending `.snap.new` files before finishing.
+## Generated Files
 
-Run `cargo dev generate-all` after changing configuration options, CLI arguments, environment variable definitions, or anything else that feeds generated reference docs under `docs/`.
+Run the generator after changing configuration options, CLI arguments,
+environment variable definitions, or their reference documentation:
+
+```sh
+cargo run -p karva_dev generate-all
+```
+
+Generated files under `docs/reference/` and
+`docs/configuration/configuration.md` identify their source files in a header.
+Change the source, then regenerate.
+
+Run `pinact run` after changing GitHub Actions workflows.
 
 ## Development Guidelines
 
-- All behavior changes must be tested. If you did not run the relevant tests, the change is not done.
-- Look for existing utilities and local patterns before writing new code.
-- Keep visibility narrow by default, but make an item public when another workspace crate needs it and that is the cleaner implementation.
-- Keep Rust imports at the top of the file, not locally inside functions.
-- Avoid `panic!`, `unreachable!`, `.unwrap()`, unsafe code, and Clippy ignores. Encode constraints in the type system instead.
-- Prefer `if let` for fallibility, and prefer let chains over nested `if let` when it improves readability.
-- Prefer `#[expect()]` over `#[allow()]` when a Clippy lint must be suppressed.
-- Prefer short imports over fully qualified paths for readability.
-- Use comments to explain invariants or unusual decisions, not to narrate code.
-- Avoid redundant comments and section separators in tests.
-- Prefer function comments over inline comments.
-- Consider whether a change needs a docs update under `docs/`. New flags, public APIs, removed features, changed defaults, config changes, CLI changes, and environment variable changes usually need one.
+- Test every behavior change. If the relevant tests were not run, the change
+  is not done.
+- Look for existing utilities and neighboring patterns before writing new
+  code.
+- Keep changes focused. Do not refactor unrelated code.
+- Keep visibility narrow by default, but use `pub` when another workspace
+  crate needs it and that is the cleaner design.
+- Keep Rust imports at the top of the file.
+- Avoid `panic!`, `unreachable!`, `.unwrap()`, unsafe code, and Clippy ignores.
+  Encode constraints in the type system.
+- Prefer `if let` for fallibility and let chains over nested `if let` when they
+  improve readability.
+- Prefer `#[expect()]` over `#[allow()]` when a lint must be suppressed.
+- Prefer short imports over fully qualified paths.
+- Use comments for invariants and unusual decisions, not narration.
+- Avoid redundant comments and section separators in tests. Prefer function
+  comments over inline comments.
+- Consider whether public APIs, flags, defaults, configuration, environment
+  variables, or CLI changes require a docs update.
+- Run `uvx prek run --files <path1> <path2>` during iteration with every
+  changed file, then run `uvx prek run -a` before finishing.
 
 ## Pull Requests
 
-Always use the pull request template and add labels. Write the description in concise prose paragraphs, with code examples only when they help the reviewer.
+Use the pull request template and add relevant labels. Keep the summary and
+test plan concise. Explain what changed and why; include implementation detail
+only when reviewers need it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,175 +1,191 @@
 # Contributing to Karva
 
-Thanks for your interest in contributing to Karva. Contributions of all kinds
-are welcome, and we try to keep the development process as smooth as possible.
+Welcome, and thanks for contributing to Karva.
 
-If you hit a bug, have a feature idea, or want to suggest an improvement to
-the contributing docs themselves, please
-[open an issue](https://github.com/MatthewMckee4/karva/issues/new).
+## Finding Ways to Help
 
-For small changes like bug fixes, feel free to jump straight to a pull request.
-For anything larger, it's usually worth opening an issue first to discuss the
-approach.
+[`contributor-friendly`](https://github.com/MatthewMckee4/karva/issues?q=is%3Aissue%20state%3Aopen%20label%3Acontributor-friendly)
+issues are ready for community contributions.
+[`bug`](https://github.com/MatthewMckee4/karva/issues?q=is%3Aissue%20state%3Aopen%20label%3Abug)
+issues are also good candidates when the expected behavior is clear.
 
-If you are wanting to attempt to tackle an issue that is already open, please
-leave a comment letting me know you would like to work on it. There's only one
-person working on this project right now, so issues may be out of date and I
-don't want you to work on something that doesn't align with the goals for the
-project, so let's have a chat about the issue first. Thank you in advance.
+Comment before starting work so another contributor does not duplicate it and
+the maintainer can confirm the issue is current. Discuss larger changes and
+new features before opening a pull request; they can affect Karva's deliberately
+small scope and long-term maintenance burden.
 
-## Architecture
+Use [GitHub issues](https://github.com/MatthewMckee4/karva/issues/new) for bug
+reports, feature proposals, and documentation problems.
 
-Karva runs tests using a **main process plus worker subprocesses**. When you
-run `karva test`, the main `karva` process discovers the test files, partitions
-them across workers, and spawns one or more `karva-worker` subprocesses to
-actually execute the tests. Each worker writes its results into a shared cache
-directory, and the main process aggregates everything once the workers finish.
-
-The two binaries never link against each other. They communicate only through
-CLI arguments and the cache directory on disk. Shared types live in
-`karva_cli`, which both binaries depend on. Only the worker embeds a Python
-interpreter via PyO3 — the main process only touches Python for wheel
-packaging.
-
-### Crate Map
-
-The two binaries:
-
-- `karva` — main CLI. Parses arguments, discovers test files, partitions work, spawns workers, and aggregates results.
-- `karva_worker` — worker subprocess. Receives a subset of test files, runs them, and writes results to the cache.
-
-Libraries shared between both binaries:
-
-- `karva_cli` — shared CLI types (`SubTestCommand`, `Verbosity`, etc.), the bridge between main and worker.
-- `karva_cache` — cache directory layout, result serialization, and duration tracking.
-- `karva_static` — environment variable constants and `max_parallelism()`.
-- `karva_metadata` — project configuration (`ProjectSettings`) and config file parsing.
-- `karva_diagnostic` — test result types (`TestRunResult`) and diagnostic reporting.
-- `karva_logging` — tracing setup, `Printer`, colored output control, and duration formatting.
-- `karva_python_semantic` — Python version detection and AST-level semantic types.
-
-Used only by the main process:
-
-- `karva_runner` — orchestration: worker spawning, partitioning, and parallel collection.
-- `karva_project` — project metadata, test path resolution, and path utilities.
-- `karva_collector` — file-level test collection (parsing Python files for test functions).
-- `karva_combine` — result combination and summary output.
-
-Used only by the worker process:
-
-- `karva_test_semantic` — the core test execution library: discovery, context, extensions, and the PyO3 runner.
-
-Infrastructure and tooling:
-
-- `karva_python` — the PyO3 `cdylib` that produces the Python wheel and wraps both `karva` and `karva_worker`.
-- `karva_macros` — procedural macros.
-- `karva_dev` — dev tools such as CLI reference generation.
-- `karva_benchmark` — wall-time benchmarks that run `karva test` against pinned synthetic and open-source benchmark projects.
+## The Basics
 
 ### Prerequisites
 
-Karva is written in Rust. You can install the [Rust Toolchain](https://www.rust-lang.org/tools/install) to get started.
+Karva development requires:
 
-You will also need to install [maturin](https://github.com/PyO3/maturin) to build the Python wheel:
+- The [Rust toolchain](https://www.rust-lang.org/tools/install).
+- [uv](https://docs.astral.sh/uv/getting-started/installation/) for Python
+  environments and tools.
+- [just](https://just.systems/) for project recipes.
 
-```bash
-uv tool install maturin
-```
+We recommend [nextest](https://nexte.st/) for faster Rust test runs:
 
-You can optionally install prek hooks to automatically run the validation checks when making a commit:
-
-```bash
-uv tool install prek
-prek install
-```
-
-We recommend [nextest](https://nexte.st/) for running the Rust test suite:
-
-```bash
+```sh
 cargo install cargo-nextest --locked
+```
+
+Install the optional repository hooks with:
+
+```sh
+uvx prek install
 ```
 
 ### Development
 
-Note, you can use [just](https://github.com/casey/just) to run some useful commands.
+Run Karva from the repository root with a debug build:
 
-To run the cli on a test file, run:
-
-```bash
+```sh
 cargo run test tests/test_add.py
 ```
 
-You need a Python installation with pytest available for integration tests that compare Karva behavior against pytest. Avoid relying on a project-local `uv` virtual environment for this; local development has been more reliable with pytest installed in the Python environment used by the test runner.
+The full test recipe builds a development wheel automatically. Some
+integration tests compare Karva with pytest and require pytest in the Python
+environment used by the test runner. Avoid relying on a project-local uv
+environment for these tests.
 
-If you want to run the tests, you need to build a wheel every time, so you need to run the following:
+### Project Structure
 
-```bash
-maturin build
-cargo nextest run
-```
+Karva uses a main process plus worker subprocesses. The `karva` binary
+discovers and partitions tests, starts `karva-worker` processes, then combines
+their cached results. Workers embed Python and execute tests. The binaries
+communicate only through CLI arguments and the shared cache directory.
 
-Or simply, with just, run:
+All Rust crates live under `crates/`:
 
-```bash
+- `karva` contains the main CLI and orchestration entry point.
+- `karva_worker` embeds Python and runs assigned tests.
+- `karva_cli` contains command types shared by both binaries.
+- `karva_runner`, `karva_project`, `karva_collector`, and `karva_combine`
+  implement discovery, partitioning, process management, and result
+  aggregation.
+- `karva_test_semantic` implements Python test execution and extensions.
+- `karva_cache`, `karva_diagnostic`, `karva_logging`, `karva_metadata`, and
+  `karva_static` provide shared infrastructure.
+- `karva_python` builds the Python wheel and exposes the binaries.
+- `karva_dev` contains documentation generators.
+- `karva_benchmark` contains wall-time benchmarks and benchmark projects.
+
+Python packaging files live under `python/`, documentation under `docs/`, and
+CLI integration tests under `crates/karva/tests/it/`.
+
+## Testing
+
+Run the full suite:
+
+```sh
 just test
 ```
 
-Pass test arguments through `just test` for focused iteration:
+Pass standard `cargo nextest` or `cargo test` arguments for focused runs:
 
-```bash
+```sh
 just test -p karva_cache
+just test -p karva test_name
 ```
 
-Before opening a pull request, run the relevant tests plus the full validation sweep:
+`just test` builds the wheel with `uvx maturin build`, then runs nextest when
+available and falls back to `cargo test`.
 
-```bash
+Before opening a pull request, run relevant focused tests and the validation
+sweep:
+
+```sh
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 uvx prek run -a
 ```
 
-### Benchmarks
+GitHub Actions runs tests on Linux, macOS, and Windows. Platform-specific
+behavior should have focused coverage where practical.
 
-Karva has a pinned benchmark suite for CI. It includes the synthetic
-`karva-benchmark-1` project plus selected open-source projects that the
-installed Karva CLI can run cleanly today. Pull requests build both the base
-commit and the PR commit as wheels, then run each CLI-compatible open-source
-benchmark project as a separate matrix job. Each matrix job compares base and PR
-wheels on the same GitHub Actions runner using a project-specific iteration
-count, and the benchmark workflow posts sticky PR comments with the merged
-median CLI wall-time and peak-memory results. Peak memory is measured on the
-Ubuntu benchmark runners with GNU `/usr/bin/time` maximum resident set size.
+### Snapshot Tests
 
-### Documentation
+Prefer integration tests when behavior crosses crate, Python, worker, or CLI
+boundaries. Command integration tests should use snapshots so diagnostics and
+exit behavior remain visible.
 
-We use zensical to build the documentation.
+Review every snapshot change before accepting it. Check for unexpected
+`.snap.new` files before finishing, and never include unrelated snapshot
+updates in a pull request.
 
-```bash
-uv run -s scripts/prepare_docs.py
+## Documentation
+
+Karva uses [Zensical](https://zensical.org/) for its documentation site. Build
+the site with:
+
+```sh
+uv run --script scripts/prepare_docs.py
 uv run --isolated --only-group docs zensical build
 ```
 
-Run `cargo run -p karva_dev generate-all` after changing configuration options, CLI arguments, or environment variable definitions. These changes regenerate the reference docs under `docs/`.
+Run the documentation generator after changing configuration options, CLI
+arguments, or environment variable definitions:
+
+```sh
+cargo run -p karva_dev generate-all
+```
+
+Files under `docs/reference/` and
+`docs/configuration/configuration.md` are generated. Their headers identify
+the source to edit.
+
+## Benchmarks
+
+The pull request benchmark workflow compares base and PR wheels against pinned
+projects. It reports median wall time and peak memory in a PR comment. Keep
+benchmark projects deterministic and pin external inputs.
+
+Performance changes should include benchmark evidence when the impact is not
+obvious from existing CI coverage.
+
+## Opening a Pull Request
+
+Use the pull request template, link relevant issues, and add labels that match
+the affected area. Keep the pull request in draft while substantial work
+remains.
+
+### Summary
+
+Explain what changed and why in concise prose. Include implementation details
+only when reviewers need them to understand the design or trade-offs.
+
+### Test Plan
+
+State what you verified in one short sentence. If CI is the only remaining
+validation, write `ci`.
+
+Keep commits focused and use descriptive one-line subjects. Do not mix
+formatter churn or unrelated cleanup with the change.
 
 ## Release Process
 
-Currently, everything is automated for releasing a new version of Karva.
+Releases are automated. Maintainers use
+[`seal`](https://github.com/MatthewMckee4/seal) to update the version and
+create a release branch:
 
-First, install [seal](https://github.com/MatthewMckee4/seal), then bump the version with the following:
-
-```bash
-# Bump the alpha version
+```sh
 seal bump alpha
-
-# Bump to a version
 seal bump <version>
 ```
 
-This will create a new branch and make a commit, so you just need to make a pull request.
+Open a pull request from the generated branch. The release workflow handles
+the remaining publication steps after merge.
 
 ## GitHub Actions
 
-If you are updating github actions, ensure to run `pinact` to pin action versions.
+Actions must be pinned to full commit SHAs. After editing a workflow, run:
 
-```bash
+```sh
 pinact run
 ```
+
+Review generated workflow changes before committing them.


### PR DESCRIPTION
## Summary

Restructure `AGENTS.md` and `CONTRIBUTING.md` around the clearer workflow used by Ruff while keeping Karva-specific commands and a compact project map. Contributor guidance now separates agent rules from human onboarding, testing, documentation, pull request, benchmark, release, and workflow instructions.

## Test Plan

`uvx prek run -a`