### PR TITLE
Add release preparation workflow

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,43 @@
+name: Prepare release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version bump to perform (e.g., alpha or 1.2.3)"
+        required: true
+        default: alpha
+        type: string
+
+permissions: {}
+
+jobs:
+  prepare-release:
+    name: Prepare release
+    if: github.repository == 'MatthewMckee4/karva'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: true
+
+      - name: Install seal
+        run: |
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/MatthewMckee4/seal/releases/download/0.0.1-alpha.6/seal-installer.sh | sh
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version and create pull request
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: printf 'y\n' | seal bump "$VERSION"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,17 +168,18 @@ formatter churn or unrelated cleanup with the change.
 
 ## Release Process
 
-Releases are automated. Maintainers use
-[`seal`](https://github.com/MatthewMckee4/seal) to update the version and
-create a release branch:
+Run the `Prepare release` workflow with the version bump to perform, such as `alpha` or an
+explicit version. The workflow runs `seal bump <version>` and opens the release pull request.
+
+To prepare a release locally, install [`seal`](https://github.com/MatthewMckee4/seal), then run:
 
 ```sh
 seal bump alpha
 seal bump <version>
 ```
 
-Open a pull request from the generated branch. The release workflow handles
-the remaining publication steps after merge.
+Seal creates the release branch, commits and pushes the changes, and opens a pull request. The
+release workflow handles the remaining publication steps after merge.
 
 ## GitHub Actions
 


### PR DESCRIPTION
## Summary

Adds a manual release preparation workflow that passes the requested version to `seal bump` and provides scoped credentials for Seal to push its release branch and open the pull request. Updates the contributing guide with the automated path.

## Test Plan

`pinact run` and `uvx prek run -a`