### PR TITLE
Preserve snapshot context for timed tests

### DIFF
--- a/crates/karva/tests/it/extensions/snapshot/basic.rs
+++ b/crates/karva/tests/it/extensions/snapshot/basic.rs
@@ -246,6 +246,33 @@ def test_hello():
 }
 
 #[test]
+fn test_async_snapshot_matches_with_timeout() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import asyncio
+import karva
+
+async def test_hello():
+    await asyncio.sleep(0)
+    karva.assert_snapshot('hello world', inline='hello world')
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--timeout=60"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_hello
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_snapshot_malformed_existing_file_fails_without_pending_snapshot() {
     let context = TestContext::with_files([
         (

--- a/crates/karva/tests/it/extensions/snapshot/basic.rs
+++ b/crates/karva/tests/it/extensions/snapshot/basic.rs
@@ -221,6 +221,31 @@ def test_hello():
 }
 
 #[test]
+fn test_snapshot_matches_with_timeout() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+def test_hello():
+    karva.assert_snapshot('hello world', inline='hello world')
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--timeout=60"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_hello
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_snapshot_malformed_existing_file_fails_without_pending_snapshot() {
     let context = TestContext::with_files([
         (

--- a/crates/karva_test_semantic/src/extensions/functions/snapshot.rs
+++ b/crates/karva_test_semantic/src/extensions/functions/snapshot.rs
@@ -21,10 +21,21 @@ pyo3::create_exception!(
     pyo3::exceptions::PyAssertionError
 );
 
-struct SnapshotContext {
+#[derive(Clone)]
+pub struct SnapshotContext {
     test_file: String,
     test_name: String,
     counter: u32,
+}
+
+impl SnapshotContext {
+    pub fn new(test_file: String, test_name: String) -> Self {
+        Self {
+            test_file,
+            test_name,
+            counter: 0,
+        }
+    }
 }
 
 struct ActiveSettings {
@@ -250,13 +261,9 @@ fn display_relative(path: &Utf8Path) -> String {
 }
 
 /// Called by the test runner before each test to set snapshot context.
-pub fn set_snapshot_context(test_file: String, test_name: String) {
+pub fn set_snapshot_context(context: SnapshotContext) {
     SNAPSHOT_CONTEXT.with(|ctx| {
-        *ctx.borrow_mut() = Some(SnapshotContext {
-            test_file,
-            test_name,
-            counter: 0,
-        });
+        *ctx.borrow_mut() = Some(context);
     });
 }
 

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -22,6 +22,7 @@ use crate::discovery::{DiscoveredModule, DiscoveredPackage, DiscoveredTestFuncti
 use crate::extensions::fixtures::{
     Finalizer, FixtureScope, HasFixtures, NormalizedFixture, missing_arguments_from_error,
 };
+use crate::extensions::functions::snapshot::{SnapshotContext, set_snapshot_context};
 use crate::extensions::tags::expect_fail::ExpectFailTag;
 use crate::extensions::tags::skip::{extract_skip_reason, is_skip_exception};
 use crate::extensions::tags::timeout::TimeoutTag;
@@ -639,18 +640,17 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         // Parameter values distinguish snapshot variants, but fixture values can be
         // machine-specific, so snapshot identity includes fixture names only. Use the
         // unqualified function name because `snapshot_path()` prepends the test file stem.
-        let snapshot_test_name = full_test_name(
-            py,
-            name.function_name().to_string(),
-            &function_arguments,
-            &stmt_function_def.parameters,
-            &fixture_names,
+        let snapshot_context = SnapshotContext::new(
+            test_module_path.to_string(),
+            full_test_name(
+                py,
+                name.function_name().to_string(),
+                &function_arguments,
+                &stmt_function_def.parameters,
+                &fixture_names,
+            ),
         );
-        let snapshot_test_file = test_module_path.to_string();
-        crate::extensions::functions::snapshot::set_snapshot_context(
-            snapshot_test_file.clone(),
-            snapshot_test_name.clone(),
-        );
+        set_snapshot_context(snapshot_context.clone());
 
         let custom_tag_names = tags.custom_tag_names();
         let qualified_name_str = qualified_test_name.to_string();
@@ -685,8 +685,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                     &function_arguments,
                     is_async,
                     seconds,
-                    &snapshot_test_file,
-                    &snapshot_test_name,
+                    &snapshot_context,
                 )
             } else {
                 let result = if function_arguments.is_empty() {

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -646,9 +646,10 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             &stmt_function_def.parameters,
             &fixture_names,
         );
+        let snapshot_test_file = test_module_path.to_string();
         crate::extensions::functions::snapshot::set_snapshot_context(
-            test_module_path.to_string(),
-            snapshot_test_name,
+            snapshot_test_file.clone(),
+            snapshot_test_name.clone(),
         );
 
         let custom_tag_names = tags.custom_tag_names();
@@ -678,7 +679,15 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                 return Err(err.clone_ref(py));
             }
             let result = if let Some(seconds) = timeout_seconds {
-                run_test_with_timeout(py, &function, &function_arguments, is_async, seconds)
+                run_test_with_timeout(
+                    py,
+                    &function,
+                    &function_arguments,
+                    is_async,
+                    seconds,
+                    &snapshot_test_file,
+                    &snapshot_test_name,
+                )
             } else {
                 let result = if function_arguments.is_empty() {
                     function.call0(py)

--- a/crates/karva_test_semantic/src/utils.rs
+++ b/crates/karva_test_semantic/src/utils.rs
@@ -4,7 +4,7 @@ use camino::Utf8Path;
 use karva_static::WorkerEnvVars;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
-use pyo3::types::{PyAnyMethods, PyDict};
+use pyo3::types::{PyAnyMethods, PyCFunction, PyDict, PyTuple};
 use pyo3::{PyResult, Python};
 use ruff_python_ast::Parameters;
 
@@ -39,12 +39,21 @@ pub(crate) fn run_test_with_timeout(
     kwargs: &FixtureArguments,
     is_async: bool,
     seconds: f64,
+    snapshot_test_file: &str,
+    snapshot_test_name: &str,
 ) -> PyResult<Py<PyAny>> {
     let kwargs_dict = kwargs.to_kwargs(py)?;
     if is_async {
         run_async_with_timeout(py, function, &kwargs_dict, seconds)
     } else {
-        run_sync_with_timeout(py, function, &kwargs_dict, seconds)
+        run_sync_with_timeout(
+            py,
+            function,
+            &kwargs_dict,
+            seconds,
+            snapshot_test_file,
+            snapshot_test_name,
+        )
     }
 }
 
@@ -53,12 +62,31 @@ fn run_sync_with_timeout(
     function: &Py<PyAny>,
     kwargs_dict: &Bound<'_, PyDict>,
     seconds: f64,
+    snapshot_test_file: &str,
+    snapshot_test_name: &str,
 ) -> PyResult<Py<PyAny>> {
     let concurrent_futures = py.import("concurrent.futures")?;
     let timeout_class = concurrent_futures.getattr("TimeoutError")?;
+    // Snapshot context is thread-local, so the executor thread needs its own copy.
+    let snapshot_test_file = snapshot_test_file.to_owned();
+    let snapshot_test_name = snapshot_test_name.to_owned();
+    let initializer = PyCFunction::new_closure(
+        py,
+        None,
+        None,
+        move |_args: &Bound<'_, PyTuple>, _kwargs: Option<&Bound<'_, PyDict>>| -> PyResult<()> {
+            crate::extensions::functions::snapshot::set_snapshot_context(
+                snapshot_test_file.clone(),
+                snapshot_test_name.clone(),
+            );
+            Ok(())
+        },
+    )?;
+    let executor_kwargs = PyDict::new(py);
+    executor_kwargs.set_item("initializer", initializer)?;
     let executor = concurrent_futures
         .getattr("ThreadPoolExecutor")?
-        .call1((1u32,))?;
+        .call((1u32,), Some(&executor_kwargs))?;
 
     let future = executor.call_method("submit", (function,), Some(kwargs_dict))?;
     let result = future.call_method1("result", (seconds,));

--- a/crates/karva_test_semantic/src/utils.rs
+++ b/crates/karva_test_semantic/src/utils.rs
@@ -8,6 +8,7 @@ use pyo3::types::{PyAnyMethods, PyCFunction, PyDict, PyTuple};
 use pyo3::{PyResult, Python};
 use ruff_python_ast::Parameters;
 
+use crate::extensions::functions::snapshot::{SnapshotContext, set_snapshot_context};
 use crate::runner::FixtureArguments;
 
 const MAKE_SYNC_CODE: &std::ffi::CStr = c"
@@ -39,21 +40,13 @@ pub(crate) fn run_test_with_timeout(
     kwargs: &FixtureArguments,
     is_async: bool,
     seconds: f64,
-    snapshot_test_file: &str,
-    snapshot_test_name: &str,
+    snapshot_context: &SnapshotContext,
 ) -> PyResult<Py<PyAny>> {
     let kwargs_dict = kwargs.to_kwargs(py)?;
     if is_async {
         run_async_with_timeout(py, function, &kwargs_dict, seconds)
     } else {
-        run_sync_with_timeout(
-            py,
-            function,
-            &kwargs_dict,
-            seconds,
-            snapshot_test_file,
-            snapshot_test_name,
-        )
+        run_sync_with_timeout(py, function, &kwargs_dict, seconds, snapshot_context)
     }
 }
 
@@ -62,23 +55,18 @@ fn run_sync_with_timeout(
     function: &Py<PyAny>,
     kwargs_dict: &Bound<'_, PyDict>,
     seconds: f64,
-    snapshot_test_file: &str,
-    snapshot_test_name: &str,
+    snapshot_context: &SnapshotContext,
 ) -> PyResult<Py<PyAny>> {
     let concurrent_futures = py.import("concurrent.futures")?;
     let timeout_class = concurrent_futures.getattr("TimeoutError")?;
     // Snapshot context is thread-local, so the executor thread needs its own copy.
-    let snapshot_test_file = snapshot_test_file.to_owned();
-    let snapshot_test_name = snapshot_test_name.to_owned();
+    let snapshot_context = snapshot_context.clone();
     let initializer = PyCFunction::new_closure(
         py,
         None,
         None,
         move |_args: &Bound<'_, PyTuple>, _kwargs: Option<&Bound<'_, PyDict>>| -> PyResult<()> {
-            crate::extensions::functions::snapshot::set_snapshot_context(
-                snapshot_test_file.clone(),
-                snapshot_test_name.clone(),
-            );
+            set_snapshot_context(snapshot_context.clone());
             Ok(())
         },
     )?;


### PR DESCRIPTION
## Summary

Preserve snapshot context when synchronous tests run in timeout executor threads, so snapshot assertions work with `--timeout`.

Fixes #1018

## Test Plan

Snapshot and timeout integration suites, strict Clippy, and all prek hooks pass.