### PR TITLE
Expand timeout interaction coverage

### DIFF
--- a/crates/karva/tests/it/coverage.rs
+++ b/crates/karva/tests/it/coverage.rs
@@ -400,6 +400,44 @@ def test_add():
 }
 
 #[test]
+fn test_cov_tracks_timed_test_thread() {
+    let context = TestContext::with_file(
+        "test_timed.py",
+        r"
+def covered():
+    return 1
+
+def test_covered():
+    assert covered() == 1
+",
+    );
+
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .arg("--cov")
+            .arg("--timeout=60")
+            .arg("--status-level=none")
+            .arg("test_timed.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    Name            Stmts   Miss   Cover
+    [LONG-LINE]
+    test_timed.py       4      0    100%
+    [LONG-LINE]
+    TOTAL               4      0    100%
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
 fn test_cov_partial() {
     let context = TestContext::with_file(
         "test_partial.py",

--- a/crates/karva/tests/it/extensions/snapshot/basic.rs
+++ b/crates/karva/tests/it/extensions/snapshot/basic.rs
@@ -273,6 +273,78 @@ async def test_hello():
 }
 
 #[test]
+fn test_multiple_snapshots_with_timeout() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+@karva.tags.timeout(60)
+def test_multiple():
+    with karva.snapshot_settings(allow_duplicates=True):
+        karva.assert_snapshot('first')
+        karva.assert_snapshot('second')
+        ",
+    );
+
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .args(["--snapshot-update", "--status-level=none"]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+
+    assert_eq!(
+        context
+            .read_file("snapshots/test__test_multiple-0.snap")
+            .trim_end(),
+        "---\nsource: test.py:7::test_multiple\n---\nfirst"
+    );
+    assert_eq!(
+        context
+            .read_file("snapshots/test__test_multiple-1.snap")
+            .trim_end(),
+        "---\nsource: test.py:8::test_multiple\n---\nsecond"
+    );
+}
+
+#[test]
+fn test_parametrized_snapshots_with_timeout() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+@karva.tags.timeout(60)
+@karva.tags.parametrize('value', [1, 2])
+def test_value(value):
+    karva.assert_snapshot(value, inline=str(value))
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_value(value=1)
+            PASS [TIME] test::test_value(value=2)
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_snapshot_malformed_existing_file_fails_without_pending_snapshot() {
     let context = TestContext::with_files([
         (

--- a/crates/karva/tests/it/extensions/snapshot/cmd.rs
+++ b/crates/karva/tests/it/extensions/snapshot/cmd.rs
@@ -42,6 +42,38 @@ def test_echo():
 }
 
 #[test]
+fn test_cmd_snapshot_with_timeout() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import sys
+
+import karva
+
+@karva.tags.timeout(60)
+def test_echo():
+    command = karva.Command(sys.executable).args(["-c", "print('hello')"])
+    karva.assert_cmd_snapshot(
+        command,
+        inline="success: true\nexit_code: 0\n----- stdout -----\nhello\n----- stderr -----",
+    )
+        "#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_echo
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_cmd_snapshot_creates_snap_new() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva/tests/it/extensions/snapshot/filters.rs
+++ b/crates/karva/tests/it/extensions/snapshot/filters.rs
@@ -39,6 +39,37 @@ def test_filtered():
 }
 
 #[test]
+fn test_fixture_snapshot_settings_with_timeout() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+
+@karva.fixture
+def snapshot_filter():
+    with karva.snapshot_settings(filters=[(r"\d+", "[id]")]):
+        yield
+
+@karva.tags.timeout(60)
+def test_filtered(snapshot_filter):
+    karva.assert_snapshot("request=123", inline="request=[id]")
+        "#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_filtered(snapshot_filter=None)
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_snapshot_filter_multiple() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva/tests/it/extensions/snapshot/json.rs
+++ b/crates/karva/tests/it/extensions/snapshot/json.rs
@@ -39,6 +39,32 @@ def test_data():
 }
 
 #[test]
+fn test_json_snapshot_with_timeout() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+
+@karva.tags.timeout(60)
+def test_data():
+    karva.assert_json_snapshot({"b": 2, "a": 1}, inline='{\n  "a": 1,\n  "b": 2\n}')
+        "#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_data
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_json_snapshot_uses_param_values_and_fixture_names() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva/tests/it/extensions/tags/timeout.rs
+++ b/crates/karva/tests/it/extensions/tags/timeout.rs
@@ -488,3 +488,190 @@ def test_slow():
     ----- stderr -----
     ");
 }
+
+#[test]
+fn test_timeout_preserves_fixture_context_variables() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+from contextvars import ContextVar
+
+import karva
+
+request_id = ContextVar("request_id")
+
+@karva.fixture
+def request_context():
+    token = request_id.set("abc123")
+    yield
+    request_id.reset(token)
+
+@karva.tags.timeout(60)
+def test_context(request_context):
+    assert request_id.get() == "abc123"
+        "#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_context(request_context=None)
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_timeout_with_runtime_skip() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+@karva.tags.timeout(60)
+def test_skip():
+    karva.skip('not today')
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_timeout_with_expected_failure() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+@karva.tags.timeout(60)
+@karva.tags.expect_fail
+def test_expected_failure():
+    assert False
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_expected_failure
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_timeout_runs_fixture_teardown_before_next_test() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+events = []
+
+@karva.fixture
+def resource():
+    events.append('setup')
+    yield 'resource'
+    events.append('teardown')
+
+@karva.tags.timeout(60)
+def test_resource(resource):
+    assert events == ['setup']
+
+@karva.tags.timeout(60)
+def test_after_resource():
+    assert events == ['setup', 'teardown']
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            PASS [TIME] test::test_resource(resource=resource)
+            PASS [TIME] test::test_after_resource
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_timeout_exposes_retry_environment() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import os
+import karva
+
+@karva.tags.timeout(60)
+def test_retry():
+    attempt = int(os.environ['KARVA_ATTEMPT'])
+    assert os.environ['KARVA_TOTAL_ATTEMPTS'] == '2'
+    assert attempt == 2
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--retry=1"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+      TRY 1 FAIL [TIME] test::test_retry
+      TRY 2 PASS [TIME] test::test_retry
+    ────────────
+         Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test::test_retry
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_timeout_exposes_parametrized_test_name() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import os
+import karva
+
+@karva.tags.timeout(60)
+@karva.tags.parametrize('value', [1, 2])
+def test_name(value):
+    assert os.environ['KARVA_TEST_NAME'] == f'test::test_name(value={value})'
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_name(value=1)
+            PASS [TIME] test::test_name(value=2)
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}

--- a/crates/karva_coverage/src/tracer.rs
+++ b/crates/karva_coverage/src/tracer.rs
@@ -98,6 +98,8 @@ impl CoverageSession {
             mon.call_method1("free_tool_id", (tool_id,))?;
         } else {
             py.import("sys")?.call_method1("settrace", (py.None(),))?;
+            py.import("threading")?
+                .call_method1("settrace", (py.None(),))?;
         }
 
         let borrowed = bound.borrow();
@@ -663,7 +665,8 @@ fn release_monitoring_tool(
 
 fn install_settrace(py: Python<'_>, tracer: &Py<CoverageTracer>) -> PyResult<()> {
     let trace = tracer.bind(py).getattr("trace")?;
-    py.import("sys")?.call_method1("settrace", (trace,))?;
+    py.import("sys")?.call_method1("settrace", (&trace,))?;
+    py.import("threading")?.call_method1("settrace", (trace,))?;
     Ok(())
 }
 

--- a/crates/karva_test_semantic/src/extensions/functions/snapshot.rs
+++ b/crates/karva_test_semantic/src/extensions/functions/snapshot.rs
@@ -38,9 +38,16 @@ impl SnapshotContext {
     }
 }
 
+#[derive(Clone)]
 struct ActiveSettings {
     filters: Vec<(String, String)>,
     allow_duplicates: bool,
+}
+
+#[derive(Clone)]
+pub struct SnapshotThreadState {
+    context: SnapshotContext,
+    settings: Vec<ActiveSettings>,
 }
 
 thread_local! {
@@ -264,6 +271,20 @@ fn display_relative(path: &Utf8Path) -> String {
 pub fn set_snapshot_context(context: SnapshotContext) {
     SNAPSHOT_CONTEXT.with(|ctx| {
         *ctx.borrow_mut() = Some(context);
+    });
+}
+
+pub fn capture_snapshot_thread_state(context: SnapshotContext) -> SnapshotThreadState {
+    SnapshotThreadState {
+        context,
+        settings: SNAPSHOT_SETTINGS.with(|stack| stack.borrow().clone()),
+    }
+}
+
+pub fn set_snapshot_thread_state(state: SnapshotThreadState) {
+    set_snapshot_context(state.context);
+    SNAPSHOT_SETTINGS.with(|stack| {
+        *stack.borrow_mut() = state.settings;
     });
 }
 

--- a/crates/karva_test_semantic/src/utils.rs
+++ b/crates/karva_test_semantic/src/utils.rs
@@ -8,7 +8,9 @@ use pyo3::types::{PyAnyMethods, PyCFunction, PyDict, PyTuple};
 use pyo3::{PyResult, Python};
 use ruff_python_ast::Parameters;
 
-use crate::extensions::functions::snapshot::{SnapshotContext, set_snapshot_context};
+use crate::extensions::functions::snapshot::{
+    SnapshotContext, capture_snapshot_thread_state, set_snapshot_thread_state,
+};
 use crate::runner::FixtureArguments;
 
 const MAKE_SYNC_CODE: &std::ffi::CStr = c"
@@ -59,14 +61,13 @@ fn run_sync_with_timeout(
 ) -> PyResult<Py<PyAny>> {
     let concurrent_futures = py.import("concurrent.futures")?;
     let timeout_class = concurrent_futures.getattr("TimeoutError")?;
-    // Snapshot context is thread-local, so the executor thread needs its own copy.
-    let snapshot_context = snapshot_context.clone();
+    let snapshot_state = capture_snapshot_thread_state(snapshot_context.clone());
     let initializer = PyCFunction::new_closure(
         py,
         None,
         None,
         move |_args: &Bound<'_, PyTuple>, _kwargs: Option<&Bound<'_, PyDict>>| -> PyResult<()> {
-            set_snapshot_context(snapshot_context.clone());
+            set_snapshot_thread_state(snapshot_state.clone());
             Ok(())
         },
     )?;
@@ -76,7 +77,12 @@ fn run_sync_with_timeout(
         .getattr("ThreadPoolExecutor")?
         .call((1u32,), Some(&executor_kwargs))?;
 
-    let future = executor.call_method("submit", (function,), Some(kwargs_dict))?;
+    let copied_context = py.import("contextvars")?.call_method0("copy_context")?;
+    let future = executor.call_method(
+        "submit",
+        (copied_context.getattr("run")?, function),
+        Some(kwargs_dict),
+    )?;
     let result = future.call_method1("result", (seconds,));
 
     let shutdown_kwargs = PyDict::new(py);


### PR DESCRIPTION
## Summary

Adds cross-feature integration coverage around timeout execution, including snapshots, fixture state, retries, parametrization, skips, expected failures, teardown, and coverage. The new tests exposed three related thread-boundary bugs: synchronous timeout workers dropped Python `ContextVar` state and fixture-scoped snapshot settings, while the pre-3.12 coverage backend did not trace timeout worker threads. The runner now propagates those states and installs thread coverage tracing.

Follow-up to #1018.

## Test Plan

`just test --no-fail-fast`, strict Clippy, `uvx prek run -a`, and targeted Python 3.10 timeout regressions.