### PR TITLE
Reset snapshot state between retry attempts

### DIFF
--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -1437,6 +1437,99 @@ def test_1():
 }
 
 #[test]
+fn test_async_retry() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import asyncio
+import os
+
+async def test_flaky():
+    await asyncio.sleep(0)
+    assert os.environ["KARVA_ATTEMPT"] == "2"
+        "#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--retry=1"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+      TRY 1 FAIL [TIME] test::test_flaky
+      TRY 2 PASS [TIME] test::test_flaky
+    ────────────
+         Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test::test_flaky
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_returned_value_then_none_is_flaky() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import os
+
+def test_flaky_return():
+    if os.environ["KARVA_ATTEMPT"] == "1":
+        return "not none"
+        "#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--retry=1"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+      TRY 1 FAIL [TIME] test::test_flaky_return
+      TRY 2 PASS [TIME] test::test_flaky_return
+    ────────────
+         Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test::test_flaky_return
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_max_fail_counts_final_retry_outcome() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import os
+
+def test_flaky():
+    assert os.environ["KARVA_ATTEMPT"] == "2"
+
+def test_after():
+    pass
+        "#,
+    );
+
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .args(["--retry=1", "--max-fail=1"]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+      TRY 1 FAIL [TIME] test::test_flaky
+      TRY 2 PASS [TIME] test::test_flaky
+            PASS [TIME] test::test_after
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed (1 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test::test_flaky
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
 fn test_parallel_worker_capping() {
     let context = TestContext::with_file(
         "test_a.py",

--- a/crates/karva/tests/it/extensions/functions.rs
+++ b/crates/karva/tests/it/extensions/functions.rs
@@ -238,6 +238,35 @@ def test_skip():
 }
 
 #[test]
+fn test_runtime_skip_after_failed_attempt() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import os
+import karva
+
+def test_skip_on_retry():
+    if os.environ["KARVA_ATTEMPT"] == "1":
+        assert False
+    karva.skip("skip after retry")
+        "#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--retry=2"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+      TRY 1 FAIL [TIME] test::test_skip_on_retry
+      TRY 2 SKIP [TIME] test::test_skip_on_retry
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_mixed_skip_and_pass() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva/tests/it/extensions/snapshot/basic.rs
+++ b/crates/karva/tests/it/extensions/snapshot/basic.rs
@@ -89,6 +89,48 @@ def test_hello():
 }
 
 #[test]
+fn test_snapshot_retry_resets_unnamed_counter() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import os
+import karva
+
+def test_flaky():
+    karva.assert_snapshot("stable")
+    assert os.environ["KARVA_ATTEMPT"] == "2"
+        "#,
+    );
+
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .args(["--snapshot-update", "--retry=1"]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+      TRY 1 FAIL [TIME] test::test_flaky
+      TRY 2 PASS [TIME] test::test_flaky
+    ────────────
+         Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test::test_flaky
+
+    ----- stderr -----
+    "
+    );
+
+    let content = context.read_file("snapshots/test__test_flaky.snap");
+    insta::assert_snapshot!(content, @r"
+    ---
+    source: test.py:6::test_flaky
+    ---
+    stable
+    ");
+}
+
+#[test]
 fn test_snapshot_update_env_creates_snap_file() {
     let context = TestContext::with_file(
         "test.py",
@@ -302,18 +344,21 @@ def test_multiple():
     "
     );
 
-    assert_eq!(
-        context
-            .read_file("snapshots/test__test_multiple-0.snap")
-            .trim_end(),
-        "---\nsource: test.py:7::test_multiple\n---\nfirst"
-    );
-    assert_eq!(
-        context
-            .read_file("snapshots/test__test_multiple-1.snap")
-            .trim_end(),
-        "---\nsource: test.py:8::test_multiple\n---\nsecond"
-    );
+    let first_snapshot = context.read_file("snapshots/test__test_multiple-0.snap");
+    insta::assert_snapshot!(first_snapshot, @r"
+    ---
+    source: test.py:7::test_multiple
+    ---
+    first
+    ");
+
+    let second_snapshot = context.read_file("snapshots/test__test_multiple-1.snap");
+    insta::assert_snapshot!(second_snapshot, @r"
+    ---
+    source: test.py:8::test_multiple
+    ---
+    second
+    ");
 }
 
 #[test]

--- a/crates/karva/tests/it/extensions/tags/parametrize.rs
+++ b/crates/karva/tests/it/extensions/tags/parametrize.rs
@@ -45,6 +45,38 @@ def test_parametrize_with_fixture(a, fixture_value):
 }
 
 #[test]
+fn test_parametrized_variants_retry_independently() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import os
+import karva
+
+@karva.tags.parametrize("value", [1, 2])
+def test_flaky(value):
+    assert os.environ["KARVA_ATTEMPT"] == "2"
+        "#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--retry=1"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+      TRY 1 FAIL [TIME] test::test_flaky(value=1)
+      TRY 2 PASS [TIME] test::test_flaky(value=1)
+      TRY 1 FAIL [TIME] test::test_flaky(value=2)
+      TRY 2 PASS [TIME] test::test_flaky(value=2)
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed (2 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test::test_flaky(value=1)
+       FLAKY 2/2 [TIME] test::test_flaky(value=2)
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_argument_order_matches_function_signature() {
     let test_context = TestContext::with_file(
         "test.py",

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -650,7 +650,6 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                 &fixture_names,
             ),
         );
-        set_snapshot_context(snapshot_context.clone());
 
         let custom_tag_names = tags.custom_tag_names();
         let qualified_name_str = qualified_test_name.to_string();
@@ -672,6 +671,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                 .map(|d| d.as_secs_f64())
         });
         let run_test = || {
+            set_snapshot_context(snapshot_context.clone());
             if let Err(err) = &test_name_env_result {
                 return Err(err.clone_ref(py));
             }


### PR DESCRIPTION
## Summary

Reset snapshot context before every retry attempt so a failed attempt cannot leave the unnamed snapshot counter dirty for the next attempt. This fixes retries failing with a misleading multiple-unnamed-snapshots error and adds focused coverage for snapshot, async, returned-value, parametrized, runtime-skip, and max-fail retry interactions. Generated snapshot file assertions now use inline snapshots.

## Test Plan

`just test` and `uvx prek run -a`