### PR TITLE
Use bumped version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,15 +2,10 @@ name: Release
 
 on:
   workflow_dispatch:
-    inputs:
-      tag:
-        description: "Tag to release (e.g., 1.0.0)"
-        required: true
-        default: dry-run
-        type: string
 
 env:
   PYTHON_VERSION: "3.14"
+  VERSION: "0.0.1-alpha.8"
 
 permissions: {}
 
@@ -22,7 +17,7 @@ jobs:
       contents: read
     outputs:
       release-metadata: ${{ steps.seal-generate.outputs.metadata }}
-      tag: ${{ github.event.inputs.tag }}
+      tag: ${{ env.VERSION }}
 
     steps:
       - name: Checkout repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,7 +179,8 @@ seal bump <version>
 ```
 
 Seal creates the release branch, commits and pushes the changes, and opens a pull request. The
-release workflow handles the remaining publication steps after merge.
+release workflow handles the remaining publication steps after merge. Its release version is
+updated by `seal bump`, so running the workflow requires no version input.
 
 ## GitHub Actions
 

--- a/seal.toml
+++ b/seal.toml
@@ -2,6 +2,7 @@
 current-version = "0.0.1-alpha.8"
 
 version-files = [
+    { path = ".github/workflows/release.yml", search = "VERSION: \"{version}\"" },
     "README.md",
     "crates/karva/Cargo.toml",
     "crates/karva_version/Cargo.toml",


### PR DESCRIPTION
## Summary

Remove the manual release tag input and use the version stored in the workflow. Add a targeted Seal replacement so each release bump updates that tag automatically.

## Test Plan

`seal validate config`, `seal bump alpha --dry-run`, `pinact run`, and `uvx prek run -a`