### PR TITLE
Expand integration test coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,8 @@ pinact run
 - Follow existing code style. Check neighboring files for patterns.
 - Prefer integration tests under `crates/karva/tests/it/` when behavior crosses
   crate, Python, worker, or CLI boundaries. Command integration tests should
-  use snapshots.
+  use snapshots. Do not call `.output()` only to assert the exit status;
+  snapshot the exit code, stdout, and stderr together.
 - Keep changes focused. Do not expand the task to unrelated issues.
 - Before writing significant new code, look for existing utilities or
   mechanisms that solve the problem. Prefer fixing the underlying

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ karva test tests/test_example.py
 
 Contributions are welcome! See [CONTRIBUTING.md](https://github.com/MatthewMckee4/karva/blob/main/CONTRIBUTING.md) for more information.
 
+When snapshot output differs by platform, such as paths or operating system
+errors, use separate `#[cfg(unix)]` and `#[cfg(not(unix))]` snapshots.
+
 ## Support
 
 Use [GitHub issues](https://github.com/MatthewMckee4/karva/issues) for bug reports and feature requests, or join the [Discord](https://discord.gg/XG95vNz4Zu) for discussion.

--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -3178,3 +3178,40 @@ def test_fast(): pass
     "
     );
 }
+
+#[test]
+fn test_slow_timeout_counts_all_retry_attempts() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import os
+import time
+
+def test_slow_flaky():
+    time.sleep(0.1)
+    assert os.environ["KARVA_ATTEMPT"] == "2"
+"#,
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
+            "--retry=1",
+            "--slow-timeout=0.15",
+            "--status-level=slow",
+        ]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+      TRY 1 FAIL [TIME] test::test_slow_flaky
+      TRY 2 PASS [TIME] test::test_slow_flaky
+            SLOW [TIME] test::test_slow_flaky
+    ────────────
+         Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped, 1 slow
+       FLAKY 2/2 [TIME] test::test_slow_flaky
+
+    ----- stderr -----
+    "
+    );
+}

--- a/crates/karva/tests/it/coverage.rs
+++ b/crates/karva/tests/it/coverage.rs
@@ -908,6 +908,94 @@ def test_two():
 }
 
 #[test]
+fn test_cov_context_keeps_failed_retry_lines() {
+    let context = TestContext::with_files([
+        (
+            "src/app.py",
+            "def first_path():\n    return 1\n\ndef second_path():\n    return 2\n",
+        ),
+        (
+            "test_retry.py",
+            r#"
+import os
+from src.app import first_path, second_path
+
+def test_flaky():
+    if os.environ["KARVA_ATTEMPT"] == "1":
+        assert first_path() == 0
+    assert second_path() == 2
+"#,
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .args([
+                "--cov=src",
+                "--cov-context=test",
+                "--cov-report=json",
+                "--retry=1",
+                "--status-level=none",
+                "test_retry.py",
+            ]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test_retry::test_flaky
+
+    ----- stderr -----
+    "
+    );
+
+    let json = context.read_file("coverage.json");
+    insta::assert_snapshot!(json, @r#"
+    {
+      "meta": {
+        "format": 2,
+        "version": "karva",
+        "show_contexts": true
+      },
+      "files": {
+        "src/app.py": {
+          "executed_lines": [
+            1,
+            2,
+            4,
+            5
+          ],
+          "summary": {
+            "covered_lines": 4,
+            "num_statements": 4,
+            "percent_covered": 100.0,
+            "missing_lines": [],
+            "excluded_lines": []
+          },
+          "missing_lines": [],
+          "excluded_lines": [],
+          "contexts": {
+            "2": [
+              "test_retry::test_flaky"
+            ],
+            "5": [
+              "test_retry::test_flaky"
+            ]
+          }
+        }
+      },
+      "totals": {
+        "covered_lines": 4,
+        "num_statements": 4,
+        "percent_covered": 100.0
+      }
+    }
+    "#);
+}
+
+#[test]
 fn test_cov_report_cli_override_uses_default_path_when_config_path_is_stale() {
     let context = TestContext::with_files([
         (

--- a/crates/karva/tests/it/extensions/snapshot/basic.rs
+++ b/crates/karva/tests/it/extensions/snapshot/basic.rs
@@ -404,19 +404,34 @@ def test_hello():
         ("snapshots/test__test_hello.snap", "not a snapshot"),
     ]);
 
-    let output = context
-        .command_no_parallel()
-        .arg("--no-cache")
-        .output()
-        .expect("run karva");
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--no-cache"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_hello
 
-    assert!(!output.status.success());
-    assert!(
-        stdout.contains("Failed to read snapshot: malformed snapshot file")
-            && stdout.contains("missing opening frontmatter separator"),
-        "{stdout}"
-    );
+    diagnostics:
+
+    error[test-failure]: Test `test_hello` failed
+     --> test.py:4:5
+      |
+    4 | def test_hello():
+      |     ^^^^^^^^^^
+      |
+    info: Test failed here
+     --> test.py:5:5
+      |
+    5 |     karva.assert_snapshot('hello world')
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: Failed to read snapshot: malformed snapshot file `<temp_dir>/snapshots/test__test_hello.snap`: missing opening frontmatter separator `---`
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
     assert!(
         !context
             .root()

--- a/crates/karva/tests/it/extensions/snapshot/inline.rs
+++ b/crates/karva/tests/it/extensions/snapshot/inline.rs
@@ -565,8 +565,16 @@ def test_second():
 
     let _ = context.command_no_parallel().output();
 
-    let output = context.snapshot("accept").output().expect("accept failed");
-    assert!(output.status.success(), "Expected accept to succeed");
+    assert_cmd_snapshot!(context.snapshot("accept"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Accepted: <temp_dir>/snapshots/test__test_second_inline_8.snap.new
+
+    1 snapshot(s) accepted.
+
+    ----- stderr -----
+    ");
 
     let source = context.read_file("test.py");
     assert!(
@@ -705,8 +713,17 @@ def test_second():
         "Expected old .snap.new at line 8 to still exist"
     );
 
-    let output = context.snapshot("accept").output().expect("accept failed");
-    assert!(output.status.success(), "Expected accept to succeed");
+    assert_cmd_snapshot!(context.snapshot("accept"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Accepted: <temp_dir>/snapshots/test__test_second_inline_12.snap.new
+    Accepted: <temp_dir>/snapshots/test__test_second_inline_8.snap.new
+
+    2 snapshot(s) accepted.
+
+    ----- stderr -----
+    ");
 
     let source = context.read_file("test.py");
     assert!(
@@ -740,8 +757,17 @@ def test_third():
 
     let _ = context.command_no_parallel().output();
 
-    let output = context.snapshot("accept").output().expect("accept failed");
-    assert!(output.status.success(), "Expected accept to succeed");
+    assert_cmd_snapshot!(context.snapshot("accept"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Accepted: <temp_dir>/snapshots/test__test_first_inline_5.snap.new
+    Accepted: <temp_dir>/snapshots/test__test_third_inline_11.snap.new
+
+    2 snapshot(s) accepted.
+
+    ----- stderr -----
+    ");
 
     let source = context.read_file("test.py");
     assert!(
@@ -848,8 +874,21 @@ def test_f():
 
     let _ = context.command_no_parallel().output();
 
-    let output = context.snapshot("accept").output().expect("accept failed");
-    assert!(output.status.success(), "Expected accept to succeed");
+    assert_cmd_snapshot!(context.snapshot("accept"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Accepted: <temp_dir>/snapshots/test__test_a_inline_5.snap.new
+    Accepted: <temp_dir>/snapshots/test__test_b_inline_8.snap.new
+    Accepted: <temp_dir>/snapshots/test__test_c_inline_11.snap.new
+    Accepted: <temp_dir>/snapshots/test__test_d_inline_14.snap.new
+    Accepted: <temp_dir>/snapshots/test__test_e_inline_17.snap.new
+    Accepted: <temp_dir>/snapshots/test__test_f_inline_20.snap.new
+
+    6 snapshot(s) accepted.
+
+    ----- stderr -----
+    ");
 
     let source = context.read_file("test.py");
     insta::assert_snapshot!(source, @r#"
@@ -931,8 +970,16 @@ def test_custom():
 
     let _ = context.command_no_parallel().output();
 
-    let output = context.snapshot("accept").output().expect("accept failed");
-    assert!(output.status.success(), "Expected accept to succeed");
+    assert_cmd_snapshot!(context.snapshot("accept"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Accepted: <temp_dir>/snapshots/test__test_custom_inline_9.snap.new
+
+    1 snapshot(s) accepted.
+
+    ----- stderr -----
+    ");
 
     let source = context.read_file("test.py");
     insta::assert_snapshot!(source, @r#"

--- a/crates/karva/tests/it/extensions/snapshot/prune.rs
+++ b/crates/karva/tests/it/extensions/snapshot/prune.rs
@@ -236,6 +236,7 @@ fn test_snapshot_prune_reports_source_read_errors() {
         "---\nsource: test.py:5::test_hello\n---\nhello\n",
     );
 
+    #[cfg(unix)]
     assert_cmd_snapshot!(context.snapshot("prune"), @"
     success: false
     exit_code: 2
@@ -245,6 +246,17 @@ fn test_snapshot_prune_reports_source_read_errors() {
     warning: Prune uses static analysis and may not detect all unreferenced snapshots.
     Karva failed
       Cause: failed to read source file `<temp_dir>/test.py`: failed to read from file `<temp_dir>/test.py`: Is a directory (os error 21)
+    ");
+    #[cfg(not(unix))]
+    assert_cmd_snapshot!(context.snapshot("prune"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: Prune uses static analysis and may not detect all unreferenced snapshots.
+    Karva failed
+      Cause: failed to read source file `<temp_dir>/test.py`: failed to open file `<temp_dir>/test.py`: Access is denied. (os error 5)
     ");
     assert!(
         context

--- a/crates/karva/tests/it/extensions/snapshot/prune.rs
+++ b/crates/karva/tests/it/extensions/snapshot/prune.rs
@@ -236,14 +236,16 @@ fn test_snapshot_prune_reports_source_read_errors() {
         "---\nsource: test.py:5::test_hello\n---\nhello\n",
     );
 
-    let output = context.snapshot("prune").output().expect("run prune");
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_cmd_snapshot!(context.snapshot("prune"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
 
-    assert!(!output.status.success());
-    assert!(
-        stderr.contains("failed to read source file") && stderr.contains("test.py"),
-        "{stderr}"
-    );
+    ----- stderr -----
+    warning: Prune uses static analysis and may not detect all unreferenced snapshots.
+    Karva failed
+      Cause: failed to read source file `<temp_dir>/test.py`: failed to read from file `<temp_dir>/test.py`: Is a directory (os error 21)
+    ");
     assert!(
         context
             .root()

--- a/crates/karva/tests/it/junit.rs
+++ b/crates/karva/tests/it/junit.rs
@@ -84,3 +84,54 @@ def test_skip():
     </testsuites>
     "#);
 }
+
+#[test]
+fn junit_reports_final_retry_outcomes() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.ci.junit]
+path = "reports/test-results.xml"
+store-success-output = true
+"#,
+        ),
+        (
+            "test_retry.py",
+            r#"
+import os
+
+def test_fail():
+    assert False
+
+def test_flaky():
+    print(f"attempt {os.environ['KARVA_ATTEMPT']}")
+    assert os.environ["KARVA_ATTEMPT"] == "2"
+"#,
+        ),
+    ]);
+
+    let output = context
+        .command_no_parallel()
+        .args(["--profile=ci", "--retry=1", "--status-level=none"])
+        .output()
+        .expect("run karva");
+    assert_eq!(output.status.code(), Some(1));
+
+    let xml = normalize_junit_xml(&context.read_file("reports/test-results.xml"));
+    assert_snapshot!(xml, @r#"
+    <?xml version="1.0" encoding="UTF-8"?>
+    <testsuites name="karva-tests" tests="2" failures="1" skipped="0" errors="0" time="[TIME]">
+      <testsuite name="test_retry" tests="2" failures="1" skipped="0" errors="0" time="[TIME]">
+        <testcase classname="test_retry" name="test_fail" time="[TIME]">
+          <failure message="test failed"/>
+        </testcase>
+        <testcase classname="test_retry" name="test_flaky" time="[TIME]">
+          <system-out>attempt 1
+    attempt 2
+    </system-out>
+        </testcase>
+      </testsuite>
+    </testsuites>
+    "#);
+}

--- a/crates/karva/tests/it/junit.rs
+++ b/crates/karva/tests/it/junit.rs
@@ -51,12 +51,41 @@ def test_skip():
         ),
     ]);
 
-    let output = context
-        .command_no_parallel()
-        .args(["--profile=ci", "--status-level=none"])
-        .output()
-        .expect("run karva");
-    assert_eq!(output.status.code(), Some(1));
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .args(["--profile=ci", "--status-level=none"]),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    diagnostics:
+
+    error[test-failure]: Test `test_fail` failed
+     --> test_alpha.py:8:5
+      |
+    8 | def test_fail():
+      |     ^^^^^^^^^
+      |
+    info: Test failed here
+      --> test_alpha.py:11:5
+       |
+    11 |     assert False
+       |     ^^^^^^^^^^^^
+       |
+
+    captured stdout for test_alpha::test_fail:
+    fail stdout
+    captured stderr for test_alpha::test_fail:
+    fail stderr
+
+    ────────────
+         Summary [TIME] 3 tests run: 1 passed, 1 failed, 1 skipped
+
+    ----- stderr -----
+    "
+    );
 
     let xml = normalize_junit_xml(&context.read_file("reports/test-results.xml"));
     assert_snapshot!(xml, @r#"

--- a/crates/karva/tests/it/junit.rs
+++ b/crates/karva/tests/it/junit.rs
@@ -1,4 +1,5 @@
 use insta::assert_snapshot;
+use insta_cmd::assert_cmd_snapshot;
 use regex::Regex;
 
 use crate::common::TestContext;
@@ -111,12 +112,37 @@ def test_flaky():
         ),
     ]);
 
-    let output = context
-        .command_no_parallel()
-        .args(["--profile=ci", "--retry=1", "--status-level=none"])
-        .output()
-        .expect("run karva");
-    assert_eq!(output.status.code(), Some(1));
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .args(["--profile=ci", "--retry=1", "--status-level=none"]),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    diagnostics:
+
+    error[test-failure]: Test `test_fail` failed
+     --> test_retry.py:4:5
+      |
+    4 | def test_fail():
+      |     ^^^^^^^^^
+      |
+    info: Test failed here
+     --> test_retry.py:5:5
+      |
+    5 |     assert False
+      |     ^^^^^^^^^^^^
+      |
+
+    ────────────
+         Summary [TIME] 2 tests run: 1 passed (1 flaky), 1 failed, 0 skipped
+       FLAKY 2/2 [TIME] test_retry::test_flaky
+
+    ----- stderr -----
+    "
+    );
 
     let xml = normalize_junit_xml(&context.read_file("reports/test-results.xml"));
     assert_snapshot!(xml, @r#"

--- a/crates/karva/tests/it/last_failed.rs
+++ b/crates/karva/tests/it/last_failed.rs
@@ -376,3 +376,54 @@ def test_fail(): assert True
     ----- stderr -----
     ");
 }
+
+#[test]
+fn last_failed_excludes_flaky_passes() {
+    let context = TestContext::with_file(
+        "test_a.py",
+        r#"
+import os
+
+def test_flaky():
+    assert os.environ["KARVA_ATTEMPT"] == "2"
+
+def test_failure():
+    assert False
+
+def test_clean():
+    pass
+"#,
+    );
+
+    let _ = context
+        .command_no_parallel()
+        .arg("--retry=1")
+        .output()
+        .expect("run initial tests");
+
+    context.write_file(
+        "test_a.py",
+        r"
+def test_flaky():
+    assert False
+
+def test_failure():
+    pass
+
+def test_clean():
+    assert False
+",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--last-failed"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test_a::test_failure
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}

--- a/crates/karva/tests/it/partition.rs
+++ b/crates/karva/tests/it/partition.rs
@@ -199,3 +199,44 @@ fn invalid_partition_strategy_errors() {
     "
     );
 }
+
+#[test]
+fn partitioned_parametrized_variants_retry_independently() {
+    let context = TestContext::with_file(
+        "test_mod.py",
+        r#"
+import os
+import karva
+
+@karva.tags.parametrize("value", [1, 2])
+def test_a(value):
+    assert os.environ["KARVA_ATTEMPT"] == "2"
+
+@karva.tags.parametrize("value", [3, 4])
+def test_b(value):
+    assert False
+"#,
+    );
+
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .args(["--partition=slice:1/2", "--retry=1"]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+      TRY 1 FAIL [TIME] test_mod::test_a(value=1)
+      TRY 2 PASS [TIME] test_mod::test_a(value=1)
+      TRY 1 FAIL [TIME] test_mod::test_a(value=2)
+      TRY 2 PASS [TIME] test_mod::test_a(value=2)
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed (2 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test_mod::test_a(value=1)
+       FLAKY 2/2 [TIME] test_mod::test_a(value=2)
+
+    ----- stderr -----
+    "
+    );
+}

--- a/crates/karva/tests/it/result_report.rs
+++ b/crates/karva/tests/it/result_report.rs
@@ -1,4 +1,5 @@
 use insta::assert_snapshot;
+use insta_cmd::assert_cmd_snapshot;
 use serde_json::Value;
 
 use crate::common::TestContext;
@@ -33,16 +34,43 @@ fn writes_json_result_report() {
         "#,
     );
 
-    let output = context
-        .command_no_parallel()
-        .args([
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
             "--retry=1",
             "--status-level=none",
             "--result-output=reports/results.json",
-        ])
-        .output()
-        .expect("run karva");
-    assert_eq!(output.status.code(), Some(1));
+        ]),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    diagnostics:
+
+    error[test-failure]: Test `test_fail` failed
+      --> test_report.py:10:5
+       |
+    10 | def test_fail():
+       |     ^^^^^^^^^
+       |
+    info: Test failed here
+      --> test_report.py:12:5
+       |
+    12 |     assert False
+       |     ^^^^^^^^^^^^
+       |
+
+    captured stderr for test_report::test_fail:
+    fail stderr
+    fail stderr
+
+    ────────────
+         Summary [TIME] 4 tests run: 2 passed (1 flaky), 1 failed, 1 skipped
+       FLAKY 2/2 [TIME] test_report::test_flaky
+
+    ----- stderr -----
+    "
+    );
 
     assert_snapshot!(normalize_result_json(&context.read_file("reports/results.json")), @r#"
     {
@@ -124,16 +152,38 @@ fn writes_jsonl_result_events() {
         ",
     );
 
-    let output = context
-        .command_no_parallel()
-        .args([
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
             "--status-level=none",
             "--result-output=reports/events.jsonl",
             "--result-format=jsonl",
-        ])
-        .output()
-        .expect("run karva");
-    assert_eq!(output.status.code(), Some(1));
+        ]),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    diagnostics:
+
+    error[test-failure]: Test `test_fail` failed
+     --> test_events.py:5:5
+      |
+    5 | def test_fail():
+      |     ^^^^^^^^^
+      |
+    info: Test failed here
+     --> test_events.py:6:5
+      |
+    6 |     assert False
+      |     ^^^^^^^^^^^^
+      |
+
+    ────────────
+         Summary [TIME] 2 tests run: 1 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
 
     assert_snapshot!(normalize_result_jsonl(&context.read_file("reports/events.jsonl")), @r#"
     {"duration_seconds":"[TIME]","full_name":"test_events::test_fail","module":"test_events","name":"test_fail","schema_version":1,"status":"failed","type":"test"}
@@ -147,15 +197,23 @@ fn writes_jsonl_result_events() {
 fn result_report_status_matches_no_tests_failure() {
     let context = TestContext::new();
 
-    let output = context
-        .command_no_parallel()
-        .args([
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
             "--status-level=none",
             "--result-output=reports/no-tests.json",
-        ])
-        .output()
-        .expect("run karva");
-    assert_eq!(output.status.code(), Some(1));
+        ]),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 0 tests run: 0 passed, 0 skipped
+    error: no tests to run
+    (hint: use `--no-tests` to customize)
+
+    ----- stderr -----
+    "
+    );
 
     assert_snapshot!(normalize_result_json(&context.read_file("reports/no-tests.json")), @r#"
     {

--- a/crates/karva/tests/it/run_ignored.rs
+++ b/crates/karva/tests/it/run_ignored.rs
@@ -160,3 +160,78 @@ def test_normal():
     ----- stderr -----
     ");
 }
+
+#[test]
+fn runignored_only_runs_skipped_parametrized_variants() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+
+@karva.tags.parametrize("value", [
+    karva.param(1, tags=(karva.tags.skip("ignored"),)),
+    karva.param(2),
+])
+def test_value(value):
+    assert value == 1
+"#,
+    );
+
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .args(["--run-ignored", "only"]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_value(value=1)
+    ────────────
+         Summary [TIME] 2 tests run: 1 passed, 1 skipped
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
+fn runignored_all_intersects_with_filter() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+@karva.tags.skip
+def test_selected():
+    pass
+
+@karva.tags.skip
+def test_filtered_ignored():
+    assert False
+
+def test_filtered_normal():
+    assert False
+",
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
+            "--run-ignored",
+            "all",
+            "-E",
+            "test(~selected)",
+        ]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 3 tests across 1 worker
+            PASS [TIME] test::test_selected
+    ────────────
+         Summary [TIME] 3 tests run: 1 passed, 2 skipped
+
+    ----- stderr -----
+    "
+    );
+}


### PR DESCRIPTION
## Summary

Add focused integration coverage for retry behavior combined with coverage contexts, slow-test accounting, JUnit reports, last-failed selection, partitioned parametrization, and ignored-test filtering. These tests lock down final outcomes, retained failed-attempt coverage, accumulated duration, and selection boundaries without changing production behavior.

## Test Plan

`just test` and `uvx prek run -a`