### PR TITLE
Speed up Windows CI test partitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,6 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           command: build
-          args: --profile test
 
       - name: Run tests
         env:
@@ -237,22 +236,25 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           command: build
-          args: --profile test
 
       - name: "Archive tests"
         run: cargo nextest archive --workspace --archive-file nextest-archive.tar.zst
 
-      - name: "Upload test archive"
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: windows-nextest-archive
-          path: nextest-archive.tar.zst
+      - name: "Prepare test artifacts"
+        run: |
+          Copy-Item (Get-Command cargo-nextest).Source cargo-nextest.exe
+          Copy-Item .config/nextest.toml nextest.toml
 
-      - name: "Upload wheel"
+      - name: "Upload test artifacts"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: windows-karva-wheel
-          path: target/wheels/*.whl
+          name: windows-test-artifacts
+          path: |
+            nextest-archive.tar.zst
+            cargo-nextest.exe
+            nextest.toml
+            target/wheels/*.whl
+            crates/karva/tests/it/requirements.txt
 
   cargo-test-windows:
     name: "cargo test (windows ${{ matrix.partition }}/5)"
@@ -268,15 +270,6 @@ jobs:
         partition: [1, 2, 3, 4, 5]
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: "Install cargo nextest"
-        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2.83.2
-        with:
-          tool: cargo-nextest
-
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           python-version: "3.10"
@@ -287,23 +280,17 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: "Download test archive"
+      - name: "Download test artifacts"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: windows-nextest-archive
-
-      - name: "Download wheel"
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: windows-karva-wheel
-          path: target/wheels
+          name: windows-test-artifacts
 
       - name: Run tests
         env:
           PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
           KARVA_MAX_PARALLELISM: 2
         run: |
-          cargo nextest run --profile ci --archive-file nextest-archive.tar.zst --partition hash:${{ matrix.partition }}/5
+          .\cargo-nextest.exe nextest run --config-file nextest.toml --profile ci --archive-file nextest-archive.tar.zst --partition hash:${{ matrix.partition }}/5
 
   build-docs:
     name: "Build docs"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,12 +285,15 @@ jobs:
         with:
           name: windows-test-artifacts
 
+      - name: "Restore cargo nextest"
+        run: Move-Item cargo-nextest.exe "$env:USERPROFILE\.cargo\bin\cargo-nextest.exe"
+
       - name: Run tests
         env:
           PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
           KARVA_MAX_PARALLELISM: 2
         run: |
-          .\cargo-nextest.exe nextest run --profile ci --archive-file nextest-archive.tar.zst --partition hash:${{ matrix.partition }}/5
+          cargo nextest run --profile ci --archive-file nextest-archive.tar.zst --partition hash:${{ matrix.partition }}/5
 
   build-docs:
     name: "Build docs"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,9 +241,7 @@ jobs:
         run: cargo nextest archive --workspace --archive-file nextest-archive.tar.zst
 
       - name: "Prepare test artifacts"
-        run: |
-          Copy-Item (Get-Command cargo-nextest).Source cargo-nextest.exe
-          Copy-Item .config/nextest.toml nextest.toml
+        run: Copy-Item (Get-Command cargo-nextest).Source cargo-nextest.exe
 
       - name: "Upload test artifacts"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -252,9 +250,7 @@ jobs:
           path: |
             nextest-archive.tar.zst
             cargo-nextest.exe
-            nextest.toml
             target/wheels/*.whl
-            crates/karva/tests/it/requirements.txt
 
   cargo-test-windows:
     name: "cargo test (windows ${{ matrix.partition }}/5)"
@@ -270,6 +266,10 @@ jobs:
         partition: [1, 2, 3, 4, 5]
 
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           python-version: "3.10"
@@ -290,7 +290,7 @@ jobs:
           PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
           KARVA_MAX_PARALLELISM: 2
         run: |
-          .\cargo-nextest.exe nextest run --config-file nextest.toml --profile ci --archive-file nextest-archive.tar.zst --partition hash:${{ matrix.partition }}/5
+          .\cargo-nextest.exe nextest run --profile ci --archive-file nextest-archive.tar.zst --partition hash:${{ matrix.partition }}/5
 
   build-docs:
     name: "Build docs"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,7 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           command: build
+          args: --profile test
 
       - name: Run tests
         env:
@@ -236,6 +237,7 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           command: build
+          args: --profile test
 
       - name: "Archive tests"
         run: cargo nextest archive --workspace --archive-file nextest-archive.tar.zst


### PR DESCRIPTION
## Summary

Package cargo-nextest and the wheel with the Windows nextest archive. Partition jobs reuse the exact cargo-nextest binary from the build job, avoiding five redundant installs and replacing two artifact downloads with one.

Against the latest main push, the Windows test path fell from 4m55s to 4m30s. A same-window rerun showed substantial hosted-runner variance, while the directly affected partition setup had a stable median improvement from 35s to 19s.

## Test Plan

ci