### PR TITLE
Document minimal PR and label policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,10 +136,14 @@ pinact run
 
 ## Pull Requests
 
-Use the pull request template and add relevant labels. Keep the summary and
-test plan concise. Write descriptions as prose, not bullet lists or
-checklists. Explain what changed and why; include implementation details only
-when reviewers need them.
+Keep pull requests minimal and focused. Use the pull request template and add
+labels based on user-facing impact. If a pull request has no user-facing
+change, add only the `internal` label. CI performance changes use only the `ci`
+label; reserve `performance` for user-facing performance improvements.
+
+Keep the summary and test plan concise. Write descriptions as prose, not bullet
+lists or checklists. Explain what changed and why; include implementation
+details only when reviewers need them.
 
 Use a descriptive one-line commit subject by default. Never add an AI tool as
 an author or co-author.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,9 +149,13 @@ obvious from existing CI coverage.
 
 ## Opening a Pull Request
 
-Use the pull request template, link relevant issues, and add labels that match
-the affected area. Keep the pull request in draft while substantial work
-remains.
+Keep pull requests minimal and focused. Use the pull request template and link
+relevant issues. Add labels based on user-facing impact; if a pull request has
+no user-facing change, add only the `internal` label. CI performance changes
+use only the `ci` label; reserve `performance` for user-facing performance
+improvements.
+
+Keep the pull request in draft while substantial work remains.
 
 ### Summary
 


### PR DESCRIPTION
## Summary

Document that pull requests should stay minimal and use labels based on user-facing impact. Internal-only and CI-performance changes now have clear label rules.

## Test Plan

`uvx prek run -a`