### PR TITLE
Validate parametrization before test execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,9 +1375,11 @@ dependencies = [
  "ruff_macros",
  "ruff_python_ast",
  "ruff_python_parser",
+ "ruff_python_stdlib",
  "ruff_source_file",
+ "ruff_text_size",
+ "thiserror",
  "tracing",
- "unicode-ident",
 ]
 
 [[package]]
@@ -2205,6 +2207,15 @@ dependencies = [
  "unicode-ident",
  "unicode-normalization",
  "unicode_names2",
+]
+
+[[package]]
+name = "ruff_python_stdlib"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff/?branch=main#fb2b844c0a72b9ee4578f836f407938cc2ab1b79"
+dependencies = [
+ "bitflags 2.11.0",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,6 +1377,7 @@ dependencies = [
  "ruff_python_parser",
  "ruff_source_file",
  "tracing",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2549,7 +2550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2987,7 +2988,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ tracing-subscriber = { version = "0.3.23", default-features = false, features = 
     "fmt",
 ] }
 tracing-tree = { version = "0.4.1" }
+unicode-ident = "1.0.24"
 uuid = { version = "1.23", features = ["v4"] }
 which = { version = "8.0" }
 wild = { version = "2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ ruff_notebook = { git = "https://github.com/astral-sh/ruff/", branch = "main" }
 ruff_options_metadata = { git = "https://github.com/astral-sh/ruff/", branch = "main" }
 ruff_python_ast = { git = "https://github.com/astral-sh/ruff/", branch = "main" }
 ruff_python_parser = { git = "https://github.com/astral-sh/ruff/", branch = "main" }
+ruff_python_stdlib = { git = "https://github.com/astral-sh/ruff/", branch = "main" }
 ruff_python_trivia = { git = "https://github.com/astral-sh/ruff/", branch = "main" }
 ruff_source_file = { git = "https://github.com/astral-sh/ruff/", branch = "main" }
 ruff_text_size = { git = "https://github.com/astral-sh/ruff/", branch = "main" }
@@ -84,7 +85,6 @@ tracing-subscriber = { version = "0.3.23", default-features = false, features = 
     "fmt",
 ] }
 tracing-tree = { version = "0.4.1" }
-unicode-ident = "1.0.24"
 uuid = { version = "1.23", features = ["v4"] }
 which = { version = "8.0" }
 wild = { version = "2" }

--- a/crates/karva/tests/it/extensions/tags/parametrize.rs
+++ b/crates/karva/tests/it/extensions/tags/parametrize.rs
@@ -19,12 +19,13 @@ fn test_parametrize_rejects_wrong_row_arity(#[values("pytest", "karva")] framewo
         &format!(
             r#"
 import {framework}
+parametrize = {parametrize}
 
-@{parametrize}("left,right", [(1, 2), (3,)])
+@parametrize("left,right", [(1, 2), (3,)])
 def test_too_few(left, right, fixture):
     assert fixture
 
-@{parametrize}("left,right", [(1, 2), (3, 4, 5)])
+@parametrize("left,right", [(1, 2), (3, 4, 5)])
 def test_too_many(left, right):
     pass
 
@@ -46,7 +47,7 @@ def fixture():
     );
 
     allow_duplicates! {
-        assert_cmd_snapshot!(context.command(), @"
+        assert_cmd_snapshot!(context.command(), @r#"
         success: false
         exit_code: 1
         ----- stdout -----
@@ -57,45 +58,54 @@ def fixture():
         diagnostics:
 
         error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 1
-         --> test.py:5:5
+         --> test.py:5:37
           |
-        5 | def test_too_few(left, right, fixture):
-          |     ^^^^^^^^^^^^
+        5 | @parametrize("left,right", [(1, 2), (3,)])
+          |                                     ^^^^ contains 1 values
+          |
+        info: expects 2 values
+         --> test.py:5:14
+          |
+        5 | @parametrize("left,right", [(1, 2), (3,)])
+          |              ^^^^^^^^^^^^
           |
 
         error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 3
-         --> test.py:9:5
+         --> test.py:9:37
           |
-        9 | def test_too_many(left, right):
-          |     ^^^^^^^^^^^^^
+        9 | @parametrize("left,right", [(1, 2), (3, 4, 5)])
+          |                                     ^^^^^^^^^ contains 3 values
+          |
+        info: expects 2 values
+         --> test.py:9:14
+          |
+        9 | @parametrize("left,right", [(1, 2), (3, 4, 5)])
+          |              ^^^^^^^^^^^^
           |
 
         ────────────
              Summary [TIME] 2 tests run: 0 passed, 2 failed, 0 skipped
 
         ----- stderr -----
-        ");
+        "#);
     }
 }
 
-#[rstest]
-fn test_parametrize_rejects_duplicate_name(#[values("pytest", "karva")] framework: &str) {
+#[test]
+fn test_parametrize_rejects_duplicate_name_string() {
     let context = TestContext::with_file(
         "test.py",
-        &format!(
-            r#"
-import {framework}
+        r#"
+import karva
 
-@{parametrize}("value,value", [(1, 2)])
+@karva.tags.parametrize("value,value", [(1, 2)])
 def test_value(value):
     pass
 "#,
-            parametrize = get_parametrize_function(framework),
-        ),
     );
 
     allow_duplicates! {
-        assert_cmd_snapshot!(context.command(), @"
+        assert_cmd_snapshot!(context.command(), @r#"
         success: false
         exit_code: 1
         ----- stdout -----
@@ -105,17 +115,65 @@ def test_value(value):
         diagnostics:
 
         error[invalid-parametrize]: Parameter `value` is parametrized more than once
-         --> test.py:5:5
+         --> test.py:4:25
           |
-        5 | def test_value(value):
-          |     ^^^^^^^^^^
+        4 | @karva.tags.parametrize("value,value", [(1, 2)])
+          |                         ^^^^^^^^^^^^^ duplicate parameter
           |
 
         ────────────
              Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
 
         ----- stderr -----
-        ");
+        "#);
+    }
+}
+
+#[rstest]
+fn test_parametrize_rejects_duplicate_name_list(#[values("pytest", "karva")] framework: &str) {
+    let context = TestContext::with_file(
+        "test.py",
+        &format!(
+            r#"
+import {framework}
+parametrize = {parametrize}
+
+@parametrize(["value", "value"], [(1, 2)])
+def test_value(value):
+    pass
+"#,
+            parametrize = get_parametrize_function(framework),
+        ),
+    );
+
+    allow_duplicates! {
+        assert_cmd_snapshot!(context.command(), @r#"
+        success: false
+        exit_code: 1
+        ----- stdout -----
+            Starting 1 test across 1 worker
+                FAIL [TIME] test::test_value
+
+        diagnostics:
+
+        error[invalid-parametrize]: Parameter `value` is parametrized more than once
+         --> test.py:5:24
+          |
+        5 | @parametrize(["value", "value"], [(1, 2)])
+          |                        ^^^^^^^ duplicate parameter
+          |
+        info: first parametrized here
+         --> test.py:5:15
+          |
+        5 | @parametrize(["value", "value"], [(1, 2)])
+          |               ^^^^^^^
+          |
+
+        ────────────
+             Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+        ----- stderr -----
+        "#);
     }
 }
 
@@ -128,9 +186,10 @@ fn test_parametrize_rejects_duplicate_name_across_decorators(
         &format!(
             r#"
 import {framework}
+parametrize = {parametrize}
 
-@{parametrize}("value", [1])
-@{parametrize}("value", [2])
+@parametrize("value", [1])
+@parametrize("value", [2])
 def test_value(value):
     pass
 "#,
@@ -139,7 +198,7 @@ def test_value(value):
     );
 
     allow_duplicates! {
-        assert_cmd_snapshot!(context.command(), @"
+        assert_cmd_snapshot!(context.command(), @r#"
         success: false
         exit_code: 1
         ----- stdout -----
@@ -149,17 +208,23 @@ def test_value(value):
         diagnostics:
 
         error[invalid-parametrize]: Parameter `value` is parametrized more than once
-         --> test.py:6:5
+         --> test.py:6:14
           |
-        6 | def test_value(value):
-          |     ^^^^^^^^^^
+        6 | @parametrize("value", [2])
+          |              ^^^^^^^ duplicate parameter
+          |
+        info: first parametrized here
+         --> test.py:5:14
+          |
+        5 | @parametrize("value", [1])
+          |              ^^^^^^^
           |
 
         ────────────
              Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
 
         ----- stderr -----
-        ");
+        "#);
     }
 }
 
@@ -170,8 +235,9 @@ fn test_parametrize_rejects_unknown_name(#[values("pytest", "karva")] framework:
         &format!(
             r#"
 import {framework}
+parametrize = {parametrize}
 
-@{parametrize}("missing", [1])
+@parametrize("missing", [1])
 def test_value(value):
     pass
 "#,
@@ -180,7 +246,7 @@ def test_value(value):
     );
 
     allow_duplicates! {
-        assert_cmd_snapshot!(context.command(), @"
+        assert_cmd_snapshot!(context.command(), @r#"
         success: false
         exit_code: 1
         ----- stdout -----
@@ -190,17 +256,23 @@ def test_value(value):
         diagnostics:
 
         error[invalid-parametrize]: Parameter `missing` does not exist in the test function signature
-         --> test.py:5:5
+         --> test.py:5:14
           |
-        5 | def test_value(value):
-          |     ^^^^^^^^^^
+        5 | @parametrize("missing", [1])
+          |              ^^^^^^^^^ unknown parameter
+          |
+        info: test parameters declared here
+         --> test.py:6:15
+          |
+        6 | def test_value(value):
+          |               ^^^^^^^
           |
 
         ────────────
              Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
 
         ----- stderr -----
-        ");
+        "#);
     }
 }
 
@@ -211,8 +283,9 @@ fn test_parametrize_rejects_empty_cases(#[values("pytest", "karva")] framework: 
         &format!(
             r#"
 import {framework}
+parametrize = {parametrize}
 
-@{parametrize}("value", [])
+@parametrize("value", [])
 def test_value(value):
     pass
 "#,
@@ -221,7 +294,7 @@ def test_value(value):
     );
 
     allow_duplicates! {
-        assert_cmd_snapshot!(context.command(), @"
+        assert_cmd_snapshot!(context.command(), @r#"
         success: false
         exit_code: 1
         ----- stdout -----
@@ -231,17 +304,23 @@ def test_value(value):
         diagnostics:
 
         error[invalid-parametrize]: Parametrization has no cases
-         --> test.py:5:5
+         --> test.py:5:23
           |
-        5 | def test_value(value):
-          |     ^^^^^^^^^^
+        5 | @parametrize("value", [])
+          |                       ^^ no cases provided
+          |
+        info: parameters declared here
+         --> test.py:5:14
+          |
+        5 | @parametrize("value", [])
+          |              ^^^^^^^
           |
 
         ────────────
              Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
 
         ----- stderr -----
-        ");
+        "#);
     }
 }
 
@@ -252,8 +331,9 @@ fn test_parametrize_rejects_empty_name(#[values("pytest", "karva")] framework: &
         &format!(
             r#"
 import {framework}
+parametrize = {parametrize}
 
-@{parametrize}("", [1])
+@parametrize("", [1])
 def test_value(value):
     pass
 "#,
@@ -262,7 +342,7 @@ def test_value(value):
     );
 
     allow_duplicates! {
-        assert_cmd_snapshot!(context.command(), @"
+        assert_cmd_snapshot!(context.command(), @r#"
         success: false
         exit_code: 1
         ----- stdout -----
@@ -272,17 +352,23 @@ def test_value(value):
         diagnostics:
 
         error[invalid-parametrize]: Parameter name cannot be empty
-         --> test.py:5:5
+         --> test.py:5:14
           |
-        5 | def test_value(value):
-          |     ^^^^^^^^^^
+        5 | @parametrize("", [1])
+          |              ^^ empty parameter name
+          |
+        info: test parameters declared here
+         --> test.py:6:15
+          |
+        6 | def test_value(value):
+          |               ^^^^^^^
           |
 
         ────────────
              Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
 
         ----- stderr -----
-        ");
+        "#);
     }
 }
 
@@ -293,8 +379,9 @@ fn test_parametrize_rejects_invalid_name(#[values("pytest", "karva")] framework:
         &format!(
             r#"
 import {framework}
+parametrize = {parametrize}
 
-@{parametrize}("not valid", [1])
+@parametrize("not valid", [1])
 def test_value(value):
     pass
 "#,
@@ -303,7 +390,7 @@ def test_value(value):
     );
 
     allow_duplicates! {
-        assert_cmd_snapshot!(context.command(), @"
+        assert_cmd_snapshot!(context.command(), @r#"
         success: false
         exit_code: 1
         ----- stdout -----
@@ -313,17 +400,23 @@ def test_value(value):
         diagnostics:
 
         error[invalid-parametrize]: `not valid` is not a valid Python identifier
-         --> test.py:5:5
+         --> test.py:5:14
           |
-        5 | def test_value(value):
-          |     ^^^^^^^^^^
+        5 | @parametrize("not valid", [1])
+          |              ^^^^^^^^^^^ invalid parameter name
+          |
+        info: test parameters declared here
+         --> test.py:6:15
+          |
+        6 | def test_value(value):
+          |               ^^^^^^^
           |
 
         ────────────
              Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
 
         ----- stderr -----
-        ");
+        "#);
     }
 }
 

--- a/crates/karva/tests/it/extensions/tags/parametrize.rs
+++ b/crates/karva/tests/it/extensions/tags/parametrize.rs
@@ -84,6 +84,315 @@ def fixture():
 }
 
 #[test]
+fn test_parametrize_rejects_wrong_arity_with_karva_keyword_arguments() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+
+@karva.tags.parametrize(
+    arg_values=[(1, 2), (3,)],
+    arg_names=("left", "right"),
+)
+def test_value(left, right):
+    pass
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command(), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_value
+
+    diagnostics:
+
+    error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 1
+     --> test.py:5:25
+      |
+    5 |     arg_values=[(1, 2), (3,)],
+      |                         ^^^^ contains 1 value
+    6 |     arg_names=("left", "right"),
+      |               ----------------- expects 2 values
+      |
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    "#);
+}
+
+#[test]
+fn test_parametrize_rejects_wrong_arity_with_pytest_keyword_arguments() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import pytest
+
+@pytest.mark.parametrize(
+    argvalues=[(1, 2), (3,)],
+    argnames=("left," "right"),
+)
+def test_value(left, right):
+    pass
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command(), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_value
+
+    diagnostics:
+
+    error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 1
+     --> test.py:5:24
+      |
+    5 |     argvalues=[(1, 2), (3,)],
+      |                        ^^^^ contains 1 value
+    6 |     argnames=("left," "right"),
+      |               --------------- expects 2 values
+      |
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    "#);
+}
+
+#[test]
+fn test_parametrize_rejects_wrong_arity_with_aliased_decorator_and_named_values() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+
+CASES = [(1, 2), (3,)]
+cases = karva.tags.parametrize
+
+@cases(("left", "right"), CASES)
+def test_value(left, right):
+    pass
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command(), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_value
+
+    diagnostics:
+
+    error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 1
+     --> test.py:7:8
+      |
+    7 | @cases(("left", "right"), CASES)
+      |        -----------------  ^^^^^ contains 1 value
+      |        |
+      |        expects 2 values
+      |
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    "#);
+}
+
+#[test]
+fn test_parametrize_rejects_wrong_arity_with_unpacked_arguments() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+
+ARGS = ("left,right", [(1,)])
+KWARGS = {
+    "arg_names": "left,right",
+    "arg_values": [(1,)],
+}
+
+@karva.tags.parametrize(*ARGS)
+def test_args(left, right):
+    pass
+
+@karva.tags.parametrize(**KWARGS)
+def test_kwargs(left, right):
+    pass
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            FAIL [TIME] test::test_args
+            FAIL [TIME] test::test_kwargs
+
+    diagnostics:
+
+    error[invalid-parametrize]: Expected 2 values for `left,right`, but case 1 contains 1
+      --> test.py:11:5
+       |
+    11 | def test_args(left, right):
+       |     ^^^^^^^^^
+       |
+
+    error[invalid-parametrize]: Expected 2 values for `left,right`, but case 1 contains 1
+      --> test.py:15:5
+       |
+    15 | def test_kwargs(left, right):
+       |     ^^^^^^^^^^^
+       |
+
+    ────────────
+         Summary [TIME] 2 tests run: 0 passed, 2 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_parametrize_rejects_wrong_arity_with_multiline_list_names() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+
+cases = karva.tags.parametrize
+
+@cases(
+    [
+        "left",
+        "right",
+    ],
+    [
+        (1, 2),
+        (3,),
+    ],
+)
+def test_value(left, right):
+    pass
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command(), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_value
+
+    diagnostics:
+
+    error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 1
+      --> test.py:13:9
+       |
+    13 |           (3,),
+       |           ^^^^ contains 1 value
+       |
+      ::: test.py:7:5
+       |
+     7 | /     [
+     8 | |         "left",
+     9 | |         "right",
+    10 | |     ],
+       | |_____- expects 2 values
+       |
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    "#);
+}
+
+#[test]
+fn test_parametrize_rejects_wrong_arity_on_matching_stacked_decorator() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+
+@karva.tags.parametrize("left,right", [(1, 2)])
+@karva.tags.parametrize("left,right", [(3,)])
+def test_value(left, right):
+    pass
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command(), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_value
+
+    diagnostics:
+
+    error[invalid-parametrize]: Expected 2 values for `left,right`, but case 1 contains 1
+     --> test.py:5:25
+      |
+    5 | @karva.tags.parametrize("left,right", [(3,)])
+      |                         ------------   ^^^^ contains 1 value
+      |                         |
+      |                         expects 2 values
+      |
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    "#);
+}
+
+#[test]
+fn test_parametrize_rejects_wrong_arity_for_one_name() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+
+@karva.tags.parametrize("value", [karva.param(1, 2)])
+def test_value(value):
+    pass
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command(), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_value
+
+    diagnostics:
+
+    error[invalid-parametrize]: Expected 1 value for `value`, but case 1 contains 2
+     --> test.py:4:25
+      |
+    4 | @karva.tags.parametrize("value", [karva.param(1, 2)])
+      |                         -------   ^^^^^^^^^^^^^^^^^ contains 2 values
+      |                         |
+      |                         expects 1 value
+      |
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    "#);
+}
+
+#[test]
 fn test_parametrize_rejects_duplicate_name_string() {
     let context = TestContext::with_file(
         "test.py",
@@ -121,6 +430,94 @@ def test_value(value):
     }
 }
 
+#[test]
+fn test_parametrize_rejects_duplicate_name_in_multiline_tuple() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+
+@karva.tags.parametrize(
+    (
+        "value",
+        "value",
+    ),
+    [(1, 2)],
+)
+def test_value(value):
+    pass
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command(), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_value
+
+    diagnostics:
+
+    error[invalid-parametrize]: Parameter `value` is parametrized more than once
+     --> test.py:6:9
+      |
+    6 |         "value",
+      |         ------- first parametrized here
+    7 |         "value",
+      |         ^^^^^^^ duplicate parameter
+      |
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    "#);
+}
+
+#[test]
+fn test_parametrize_duplicate_diagnostic_ignores_unrelated_decorator_arguments() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+
+def metadata(*args):
+    def decorate(function):
+        return function
+    return decorate
+
+@metadata(["value"], [1])
+@karva.tags.parametrize(["value", "value"], [(1, 2)])
+def test_value(value):
+    pass
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command(), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_value
+
+    diagnostics:
+
+    error[invalid-parametrize]: Parameter `value` is parametrized more than once
+      --> test.py:10:26
+       |
+    10 | @karva.tags.parametrize(["value", "value"], [(1, 2)])
+       |                          -------  ^^^^^^^ duplicate parameter
+       |                          |
+       |                          first parametrized here
+       |
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    "#);
+}
+
 #[rstest]
 fn test_parametrize_rejects_duplicate_name_list(#[values("pytest", "karva")] framework: &str) {
     let context = TestContext::with_file(
@@ -149,16 +546,12 @@ def test_value(value):
         diagnostics:
 
         error[invalid-parametrize]: Parameter `value` is parametrized more than once
-         --> test.py:5:24
-          |
-        5 | @parametrize(["value", "value"], [(1, 2)])
-          |                        ^^^^^^^ duplicate parameter
-          |
-        info: first parametrized here
          --> test.py:5:15
           |
         5 | @parametrize(["value", "value"], [(1, 2)])
-          |               ^^^^^^^
+          |               -------  ^^^^^^^ duplicate parameter
+          |               |
+          |               first parametrized here
           |
 
         ────────────
@@ -200,16 +593,12 @@ def test_value(value):
         diagnostics:
 
         error[invalid-parametrize]: Parameter `value` is parametrized more than once
-         --> test.py:6:14
-          |
-        6 | @parametrize("value", [2])
-          |              ^^^^^^^ duplicate parameter
-          |
-        info: first parametrized here
          --> test.py:5:14
           |
         5 | @parametrize("value", [1])
-          |              ^^^^^^^
+          |              ------- first parametrized here
+        6 | @parametrize("value", [2])
+          |              ^^^^^^^ duplicate parameter
           |
 
         ────────────
@@ -252,12 +641,8 @@ def test_value(value):
           |
         5 | @parametrize("missing", [1])
           |              ^^^^^^^^^ unknown parameter
-          |
-        info: test parameters declared here
-         --> test.py:6:15
-          |
         6 | def test_value(value):
-          |               ^^^^^^^
+          |               ------- test parameters declared here
           |
 
         ────────────
@@ -266,6 +651,46 @@ def test_value(value):
         ----- stderr -----
         "#);
     }
+}
+
+#[test]
+fn test_parametrize_rejects_unknown_name_with_aliased_decorator() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+
+cases = karva.tags.parametrize
+
+@cases(("value", "missing"), [(1, 2)])
+def test_value(value):
+    pass
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command(), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_value
+
+    diagnostics:
+
+    error[invalid-parametrize]: Parameter `missing` does not exist in the test function signature
+     --> test.py:6:18
+      |
+    6 | @cases(("value", "missing"), [(1, 2)])
+      |                  ^^^^^^^^^ unknown parameter
+    7 | def test_value(value):
+      |               ------- test parameters declared here
+      |
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    "#);
 }
 
 #[rstest]
@@ -296,16 +721,12 @@ def test_value(value):
         diagnostics:
 
         error[invalid-parametrize]: Parametrization has no cases
-         --> test.py:5:23
-          |
-        5 | @parametrize("value", [])
-          |                       ^^ no cases provided
-          |
-        info: parameters declared here
          --> test.py:5:14
           |
         5 | @parametrize("value", [])
-          |              ^^^^^^^
+          |              -------  ^^ no cases provided
+          |              |
+          |              parameters declared here
           |
 
         ────────────
@@ -314,6 +735,46 @@ def test_value(value):
         ----- stderr -----
         "#);
     }
+}
+
+#[test]
+fn test_parametrize_rejects_empty_cases_with_aliased_keyword_arguments() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+
+cases = karva.tags.parametrize
+
+@cases(arg_values=(), arg_names=("value",))
+def test_value(value):
+    pass
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command(), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_value
+
+    diagnostics:
+
+    error[invalid-parametrize]: Parametrization has no cases
+     --> test.py:6:19
+      |
+    6 | @cases(arg_values=(), arg_names=("value",))
+      |                   ^^            ---------- parameters declared here
+      |                   |
+      |                   no cases provided
+      |
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    "#);
 }
 
 #[rstest]
@@ -348,12 +809,8 @@ def test_value(value):
           |
         5 | @parametrize("", [1])
           |              ^^ empty parameter name
-          |
-        info: test parameters declared here
-         --> test.py:6:15
-          |
         6 | def test_value(value):
-          |               ^^^^^^^
+          |               ------- test parameters declared here
           |
 
         ────────────
@@ -396,12 +853,8 @@ def test_value(value):
           |
         5 | @parametrize("not valid", [1])
           |              ^^^^^^^^^^^ invalid parameter name
-          |
-        info: test parameters declared here
-         --> test.py:6:15
-          |
         6 | def test_value(value):
-          |               ^^^^^^^
+          |               ------- test parameters declared here
           |
 
         ────────────

--- a/crates/karva/tests/it/extensions/tags/parametrize.rs
+++ b/crates/karva/tests/it/extensions/tags/parametrize.rs
@@ -57,7 +57,7 @@ def fixture():
 
         diagnostics:
 
-        error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 1
+        error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 1 value
          --> test.py:5:14
           |
         5 | @parametrize("left,right", [(1, 2), (3,)])
@@ -66,7 +66,7 @@ def fixture():
           |              expects 2 values
           |
 
-        error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 3
+        error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 3 values
          --> test.py:9:14
           |
         9 | @parametrize("left,right", [(1, 2), (3, 4, 5)])
@@ -108,7 +108,7 @@ def test_value(left, right):
 
     diagnostics:
 
-    error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 1
+    error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 1 value
      --> test.py:5:25
       |
     5 |     arg_values=[(1, 2), (3,)],
@@ -149,7 +149,7 @@ def test_value(left, right):
 
     diagnostics:
 
-    error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 1
+    error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 1 value
      --> test.py:5:24
       |
     5 |     argvalues=[(1, 2), (3,)],
@@ -190,7 +190,7 @@ def test_value(left, right):
 
     diagnostics:
 
-    error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 1
+    error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 1 value
      --> test.py:7:8
       |
     7 | @cases(("left", "right"), CASES)
@@ -239,14 +239,14 @@ def test_kwargs(left, right):
 
     diagnostics:
 
-    error[invalid-parametrize]: Expected 2 values for `left,right`, but case 1 contains 1
+    error[invalid-parametrize]: Expected 2 values for `left,right`, but case 1 contains 1 value
       --> test.py:11:5
        |
     11 | def test_args(left, right):
        |     ^^^^^^^^^
        |
 
-    error[invalid-parametrize]: Expected 2 values for `left,right`, but case 1 contains 1
+    error[invalid-parametrize]: Expected 2 values for `left,right`, but case 1 contains 1 value
       --> test.py:15:5
        |
     15 | def test_kwargs(left, right):
@@ -293,7 +293,7 @@ def test_value(left, right):
 
     diagnostics:
 
-    error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 1
+    error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 1 value
       --> test.py:13:9
        |
     13 |           (3,),
@@ -338,7 +338,7 @@ def test_value(left, right):
 
     diagnostics:
 
-    error[invalid-parametrize]: Expected 2 values for `left,right`, but case 1 contains 1
+    error[invalid-parametrize]: Expected 2 values for `left,right`, but case 1 contains 1 value
      --> test.py:5:25
       |
     5 | @karva.tags.parametrize("left,right", [(3,)])
@@ -376,7 +376,7 @@ def test_value(value):
 
     diagnostics:
 
-    error[invalid-parametrize]: Expected 1 value for `value`, but case 1 contains 2
+    error[invalid-parametrize]: Expected 1 value for `value`, but case 1 contains 2 values
      --> test.py:4:25
       |
     4 | @karva.tags.parametrize("value", [karva.param(1, 2)])
@@ -640,9 +640,9 @@ def test_value(value):
          --> test.py:5:14
           |
         5 | @parametrize("missing", [1])
-          |              ^^^^^^^^^ unknown parameter
+          |              ^^^^^^^^^ not accepted by test
         6 | def test_value(value):
-          |               ------- test parameters declared here
+          |               ------- available parameter
           |
 
         ────────────
@@ -681,9 +681,9 @@ def test_value(value):
      --> test.py:6:18
       |
     6 | @cases(("value", "missing"), [(1, 2)])
-      |                  ^^^^^^^^^ unknown parameter
+      |                  ^^^^^^^^^ not accepted by test
     7 | def test_value(value):
-      |               ------- test parameters declared here
+      |               ------- available parameter
       |
 
     ────────────
@@ -810,7 +810,7 @@ def test_value(value):
         5 | @parametrize("", [1])
           |              ^^ empty parameter name
         6 | def test_value(value):
-          |               ------- test parameters declared here
+          |               ------- available parameter
           |
 
         ────────────
@@ -854,7 +854,7 @@ def test_value(value):
         5 | @parametrize("not valid", [1])
           |              ^^^^^^^^^^^ invalid parameter name
         6 | def test_value(value):
-          |               ------- test parameters declared here
+          |               ------- available parameter
           |
 
         ────────────
@@ -863,6 +863,91 @@ def test_value(value):
         ----- stderr -----
         "#);
     }
+}
+
+#[test]
+fn test_parametrize_name_diagnostics_with_multiline_function_parameters() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+
+@karva.tags.parametrize("missing", [1])
+def test_unknown(
+    value,
+    *,
+    other,
+):
+    pass
+
+@karva.tags.parametrize("", [1])
+def test_empty(
+    value,
+):
+    pass
+
+@karva.tags.parametrize("not valid", [1])
+def test_invalid(
+    value: int = 1,
+):
+    pass
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command(), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 3 tests across 1 worker
+            FAIL [TIME] test::test_unknown
+            FAIL [TIME] test::test_empty
+            FAIL [TIME] test::test_invalid
+
+    diagnostics:
+
+    error[invalid-parametrize]: Parameter `missing` does not exist in the test function signature
+     --> test.py:4:25
+      |
+    4 |   @karva.tags.parametrize("missing", [1])
+      |                           ^^^^^^^^^ not accepted by test
+    5 |   def test_unknown(
+      |  _________________-
+    6 | |     value,
+    7 | |     *,
+    8 | |     other,
+    9 | | ):
+      | |_- available parameters
+      |
+
+    error[invalid-parametrize]: Parameter name cannot be empty
+      --> test.py:12:25
+       |
+    12 |   @karva.tags.parametrize("", [1])
+       |                           ^^ empty parameter name
+    13 |   def test_empty(
+       |  _______________-
+    14 | |     value,
+    15 | | ):
+       | |_- available parameter
+       |
+
+    error[invalid-parametrize]: `not valid` is not a valid Python identifier
+      --> test.py:18:25
+       |
+    18 |   @karva.tags.parametrize("not valid", [1])
+       |                           ^^^^^^^^^^^ invalid parameter name
+    19 |   def test_invalid(
+       |  _________________-
+    20 | |     value: int = 1,
+    21 | | ):
+       | |_- available parameter
+       |
+
+    ────────────
+         Summary [TIME] 3 tests run: 0 passed, 3 failed, 0 skipped
+
+    ----- stderr -----
+    "#);
 }
 
 #[test]

--- a/crates/karva/tests/it/extensions/tags/parametrize.rs
+++ b/crates/karva/tests/it/extensions/tags/parametrize.rs
@@ -58,20 +58,22 @@ def fixture():
         diagnostics:
 
         error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 1
-         --> test.py:5:37
+         --> test.py:5:14
           |
         5 | @parametrize("left,right", [(1, 2), (3,)])
-          |                                     ^^^^ contains 1 value
+          |              ------------           ^^^^ contains 1 value
+          |              |
+          |              expects 2 values
           |
-        info: expects 2 values
 
         error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 3
-         --> test.py:9:37
+         --> test.py:9:14
           |
         9 | @parametrize("left,right", [(1, 2), (3, 4, 5)])
-          |                                     ^^^^^^^^^ contains 3 values
+          |              ------------           ^^^^^^^^^ contains 3 values
+          |              |
+          |              expects 2 values
           |
-        info: expects 2 values
 
         ────────────
              Summary [TIME] 2 tests run: 0 passed, 2 failed, 0 skipped

--- a/crates/karva/tests/it/extensions/tags/parametrize.rs
+++ b/crates/karva/tests/it/extensions/tags/parametrize.rs
@@ -61,14 +61,9 @@ def fixture():
          --> test.py:5:37
           |
         5 | @parametrize("left,right", [(1, 2), (3,)])
-          |                                     ^^^^ contains 1 values
+          |                                     ^^^^ contains 1 value
           |
         info: expects 2 values
-         --> test.py:5:14
-          |
-        5 | @parametrize("left,right", [(1, 2), (3,)])
-          |              ^^^^^^^^^^^^
-          |
 
         error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 3
          --> test.py:9:37
@@ -77,11 +72,6 @@ def fixture():
           |                                     ^^^^^^^^^ contains 3 values
           |
         info: expects 2 values
-         --> test.py:9:14
-          |
-        9 | @parametrize("left,right", [(1, 2), (3, 4, 5)])
-          |              ^^^^^^^^^^^^
-          |
 
         ────────────
              Summary [TIME] 2 tests run: 0 passed, 2 failed, 0 skipped

--- a/crates/karva/tests/it/extensions/tags/parametrize.rs
+++ b/crates/karva/tests/it/extensions/tags/parametrize.rs
@@ -12,6 +12,321 @@ fn get_parametrize_function(framework: &str) -> &str {
     }
 }
 
+#[rstest]
+fn test_parametrize_rejects_wrong_row_arity(#[values("pytest", "karva")] framework: &str) {
+    let context = TestContext::with_file(
+        "test.py",
+        &format!(
+            r#"
+import {framework}
+
+@{parametrize}("left,right", [(1, 2), (3,)])
+def test_too_few(left, right, fixture):
+    assert fixture
+
+@{parametrize}("left,right", [(1, 2), (3, 4, 5)])
+def test_too_many(left, right):
+    pass
+
+def test_never_runs():
+    raise AssertionError("test ran")
+"#,
+            parametrize = get_parametrize_function(framework),
+        ),
+    );
+    context.write_file(
+        "conftest.py",
+        r#"
+import karva
+
+@karva.fixture
+def fixture():
+    raise AssertionError("fixture ran")
+"#,
+    );
+
+    allow_duplicates! {
+        assert_cmd_snapshot!(context.command(), @"
+        success: false
+        exit_code: 1
+        ----- stdout -----
+            Starting 3 tests across 1 worker
+                FAIL [TIME] test::test_too_few
+                FAIL [TIME] test::test_too_many
+
+        diagnostics:
+
+        error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 1
+         --> test.py:5:5
+          |
+        5 | def test_too_few(left, right, fixture):
+          |     ^^^^^^^^^^^^
+          |
+
+        error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 3
+         --> test.py:9:5
+          |
+        9 | def test_too_many(left, right):
+          |     ^^^^^^^^^^^^^
+          |
+
+        ────────────
+             Summary [TIME] 2 tests run: 0 passed, 2 failed, 0 skipped
+
+        ----- stderr -----
+        ");
+    }
+}
+
+#[rstest]
+fn test_parametrize_rejects_duplicate_name(#[values("pytest", "karva")] framework: &str) {
+    let context = TestContext::with_file(
+        "test.py",
+        &format!(
+            r#"
+import {framework}
+
+@{parametrize}("value,value", [(1, 2)])
+def test_value(value):
+    pass
+"#,
+            parametrize = get_parametrize_function(framework),
+        ),
+    );
+
+    allow_duplicates! {
+        assert_cmd_snapshot!(context.command(), @"
+        success: false
+        exit_code: 1
+        ----- stdout -----
+            Starting 1 test across 1 worker
+                FAIL [TIME] test::test_value
+
+        diagnostics:
+
+        error[invalid-parametrize]: Parameter `value` is parametrized more than once
+         --> test.py:5:5
+          |
+        5 | def test_value(value):
+          |     ^^^^^^^^^^
+          |
+
+        ────────────
+             Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+        ----- stderr -----
+        ");
+    }
+}
+
+#[rstest]
+fn test_parametrize_rejects_duplicate_name_across_decorators(
+    #[values("pytest", "karva")] framework: &str,
+) {
+    let context = TestContext::with_file(
+        "test.py",
+        &format!(
+            r#"
+import {framework}
+
+@{parametrize}("value", [1])
+@{parametrize}("value", [2])
+def test_value(value):
+    pass
+"#,
+            parametrize = get_parametrize_function(framework),
+        ),
+    );
+
+    allow_duplicates! {
+        assert_cmd_snapshot!(context.command(), @"
+        success: false
+        exit_code: 1
+        ----- stdout -----
+            Starting 1 test across 1 worker
+                FAIL [TIME] test::test_value
+
+        diagnostics:
+
+        error[invalid-parametrize]: Parameter `value` is parametrized more than once
+         --> test.py:6:5
+          |
+        6 | def test_value(value):
+          |     ^^^^^^^^^^
+          |
+
+        ────────────
+             Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+        ----- stderr -----
+        ");
+    }
+}
+
+#[rstest]
+fn test_parametrize_rejects_unknown_name(#[values("pytest", "karva")] framework: &str) {
+    let context = TestContext::with_file(
+        "test.py",
+        &format!(
+            r#"
+import {framework}
+
+@{parametrize}("missing", [1])
+def test_value(value):
+    pass
+"#,
+            parametrize = get_parametrize_function(framework),
+        ),
+    );
+
+    allow_duplicates! {
+        assert_cmd_snapshot!(context.command(), @"
+        success: false
+        exit_code: 1
+        ----- stdout -----
+            Starting 1 test across 1 worker
+                FAIL [TIME] test::test_value
+
+        diagnostics:
+
+        error[invalid-parametrize]: Parameter `missing` does not exist in the test function signature
+         --> test.py:5:5
+          |
+        5 | def test_value(value):
+          |     ^^^^^^^^^^
+          |
+
+        ────────────
+             Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+        ----- stderr -----
+        ");
+    }
+}
+
+#[rstest]
+fn test_parametrize_rejects_empty_cases(#[values("pytest", "karva")] framework: &str) {
+    let context = TestContext::with_file(
+        "test.py",
+        &format!(
+            r#"
+import {framework}
+
+@{parametrize}("value", [])
+def test_value(value):
+    pass
+"#,
+            parametrize = get_parametrize_function(framework),
+        ),
+    );
+
+    allow_duplicates! {
+        assert_cmd_snapshot!(context.command(), @"
+        success: false
+        exit_code: 1
+        ----- stdout -----
+            Starting 1 test across 1 worker
+                FAIL [TIME] test::test_value
+
+        diagnostics:
+
+        error[invalid-parametrize]: Parametrization has no cases
+         --> test.py:5:5
+          |
+        5 | def test_value(value):
+          |     ^^^^^^^^^^
+          |
+
+        ────────────
+             Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+        ----- stderr -----
+        ");
+    }
+}
+
+#[rstest]
+fn test_parametrize_rejects_empty_name(#[values("pytest", "karva")] framework: &str) {
+    let context = TestContext::with_file(
+        "test.py",
+        &format!(
+            r#"
+import {framework}
+
+@{parametrize}("", [1])
+def test_value(value):
+    pass
+"#,
+            parametrize = get_parametrize_function(framework),
+        ),
+    );
+
+    allow_duplicates! {
+        assert_cmd_snapshot!(context.command(), @"
+        success: false
+        exit_code: 1
+        ----- stdout -----
+            Starting 1 test across 1 worker
+                FAIL [TIME] test::test_value
+
+        diagnostics:
+
+        error[invalid-parametrize]: Parameter name cannot be empty
+         --> test.py:5:5
+          |
+        5 | def test_value(value):
+          |     ^^^^^^^^^^
+          |
+
+        ────────────
+             Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+        ----- stderr -----
+        ");
+    }
+}
+
+#[rstest]
+fn test_parametrize_rejects_invalid_name(#[values("pytest", "karva")] framework: &str) {
+    let context = TestContext::with_file(
+        "test.py",
+        &format!(
+            r#"
+import {framework}
+
+@{parametrize}("not valid", [1])
+def test_value(value):
+    pass
+"#,
+            parametrize = get_parametrize_function(framework),
+        ),
+    );
+
+    allow_duplicates! {
+        assert_cmd_snapshot!(context.command(), @"
+        success: false
+        exit_code: 1
+        ----- stdout -----
+            Starting 1 test across 1 worker
+                FAIL [TIME] test::test_value
+
+        diagnostics:
+
+        error[invalid-parametrize]: `not valid` is not a valid Python identifier
+         --> test.py:5:5
+          |
+        5 | def test_value(value):
+          |     ^^^^^^^^^^
+          |
+
+        ────────────
+             Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+        ----- stderr -----
+        ");
+    }
+}
+
 #[test]
 fn test_parametrize_with_fixture() {
     let test_context = TestContext::with_file(

--- a/crates/karva/tests/it/extensions/tags/parametrize.rs
+++ b/crates/karva/tests/it/extensions/tags/parametrize.rs
@@ -194,7 +194,7 @@ def test_value(left, right):
      --> test.py:7:8
       |
     7 | @cases(("left", "right"), CASES)
-      |        -----------------  ^^^^^ contains 1 value
+      |        -----------------  ^^^^^ case 2 contains 1 value
       |        |
       |        expects 2 values
       |

--- a/crates/karva_test_semantic/Cargo.toml
+++ b/crates/karva_test_semantic/Cargo.toml
@@ -28,9 +28,11 @@ ruff_db = { workspace = true }
 ruff_macros = { workspace = true }
 ruff_python_ast = { workspace = true }
 ruff_python_parser = { workspace = true }
+ruff_python_stdlib = { workspace = true }
 ruff_source_file = { workspace = true }
+ruff_text_size = { workspace = true }
+thiserror = { workspace = true }
 tracing = { workspace = true }
-unicode-ident = { workspace = true }
 
 [dev-dependencies]
 regex = { workspace = true }

--- a/crates/karva_test_semantic/Cargo.toml
+++ b/crates/karva_test_semantic/Cargo.toml
@@ -30,6 +30,7 @@ ruff_python_ast = { workspace = true }
 ruff_python_parser = { workspace = true }
 ruff_source_file = { workspace = true }
 tracing = { workspace = true }
+unicode-ident = { workspace = true }
 
 [dev-dependencies]
 regex = { workspace = true }

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -19,6 +19,7 @@ mod metadata;
 
 pub use metadata::{DiagnosticGuardBuilder, DiagnosticType};
 
+use crate::extensions::tags::parametrize::InvalidParametrizeError;
 use crate::runner::{FixtureArguments, FixtureCallError, FixtureChainEntry, FixtureCycleError};
 use crate::utils::truncate_string;
 use crate::{Context, declare_diagnostic_type};
@@ -31,6 +32,16 @@ declare_diagnostic_type! {
     /// because its source text was unavailable.
     pub static FAILED_TO_COLLECT_MODULE = {
         summary: "Failed to collect python module",
+        severity: Severity::Error,
+    }
+}
+
+declare_diagnostic_type! {
+    /// ## Invalid parametrization
+    ///
+    /// Raised when a parametrization cannot produce valid test arguments.
+    pub static INVALID_PARAMETRIZE = {
+        summary: "Invalid parametrization",
         severity: Severity::Error,
     }
 }
@@ -455,6 +466,17 @@ pub fn report_generator_test(
 
     annotate_function_name(&mut diagnostic, source_file, stmt_function_def);
     diagnostic.info("Use `@karva.tags.parametrize` to define multiple test cases.");
+}
+
+pub fn report_invalid_parametrize(
+    context: &Context,
+    source_file: SourceFile,
+    stmt_function_def: &StmtFunctionDef,
+    error: &InvalidParametrizeError,
+) {
+    let builder = context.report_diagnostic(&INVALID_PARAMETRIZE);
+    let mut diagnostic = builder.into_diagnostic(error.to_string());
+    annotate_function_name(&mut diagnostic, source_file, stmt_function_def);
 }
 
 pub fn report_test_returned_value(

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -476,7 +476,23 @@ pub fn report_invalid_parametrize(
 ) {
     let builder = context.report_diagnostic(&INVALID_PARAMETRIZE);
     let mut diagnostic = builder.into_diagnostic(error.to_string());
-    annotate_function_name(&mut diagnostic, source_file, stmt_function_def);
+    let Some(location) = error.diagnostic_location(stmt_function_def) else {
+        annotate_function_name(&mut diagnostic, source_file, stmt_function_def);
+        return;
+    };
+
+    diagnostic.annotate(
+        Annotation::primary(Span::from(source_file.clone()).with_range(location.primary))
+            .message(location.primary_message),
+    );
+
+    for (range, message) in location.related {
+        let mut sub = SubDiagnostic::new(SubDiagnosticSeverity::Info, message);
+        sub.annotate(Annotation::primary(
+            Span::from(source_file.clone()).with_range(range),
+        ));
+        diagnostic.sub(sub);
+    }
 }
 
 pub fn report_test_returned_value(

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -485,6 +485,12 @@ pub fn report_invalid_parametrize(
         Annotation::primary(Span::from(source_file.clone()).with_range(location.primary))
             .message(location.primary_message),
     );
+    if let Some((range, message)) = location.secondary {
+        diagnostic.annotate(
+            Annotation::secondary(Span::from(source_file.clone()).with_range(range))
+                .message(message),
+        );
+    }
 
     for (range, message) in location.related {
         let mut sub = SubDiagnostic::new(SubDiagnosticSeverity::Info, message);
@@ -492,9 +498,6 @@ pub fn report_invalid_parametrize(
             Span::from(source_file.clone()).with_range(range),
         ));
         diagnostic.sub(sub);
-    }
-    if let Some(info) = location.info {
-        diagnostic.info(info);
     }
 }
 

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -493,6 +493,9 @@ pub fn report_invalid_parametrize(
         ));
         diagnostic.sub(sub);
     }
+    if let Some(info) = location.info {
+        diagnostic.info(info);
+    }
 }
 
 pub fn report_test_returned_value(

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -482,22 +482,14 @@ pub fn report_invalid_parametrize(
     };
 
     diagnostic.annotate(
-        Annotation::primary(Span::from(source_file.clone()).with_range(location.primary))
-            .message(location.primary_message),
+        Annotation::primary(Span::from(source_file.clone()).with_range(location.primary.range))
+            .message(location.primary.message),
     );
-    if let Some((range, message)) = location.secondary {
+    for secondary in location.secondary {
         diagnostic.annotate(
-            Annotation::secondary(Span::from(source_file.clone()).with_range(range))
-                .message(message),
+            Annotation::secondary(Span::from(source_file.clone()).with_range(secondary.range))
+                .message(secondary.message),
         );
-    }
-
-    for (range, message) in location.related {
-        let mut sub = SubDiagnostic::new(SubDiagnosticSeverity::Info, message);
-        sub.annotate(Annotation::primary(
-            Span::from(source_file.clone()).with_range(range),
-        ));
-        diagnostic.sub(sub);
     }
 }
 

--- a/crates/karva_test_semantic/src/extensions/tags/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/mod.rs
@@ -1,4 +1,4 @@
-use std::{ffi::CString, ops::Deref, sync::Arc};
+use std::{collections::HashSet, ffi::CString, ops::Deref, sync::Arc};
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -17,7 +17,7 @@ mod use_fixtures;
 
 use custom::CustomTag;
 use expect_fail::ExpectFailTag;
-use parametrize::{ParametrizationArgs, ParametrizeTag};
+use parametrize::{InvalidParametrizeError, ParametrizationArgs, ParametrizeTag};
 use skip::SkipTag;
 use timeout::TimeoutTag;
 use use_fixtures::UseFixturesTag;
@@ -316,6 +316,26 @@ impl Tags {
             }
         }
         param_args
+    }
+
+    pub(crate) fn validate_parametrize(
+        &self,
+        function: &StmtFunctionDef,
+    ) -> Result<(), InvalidParametrizeError> {
+        let function_parameter_names = function
+            .parameters
+            .iter_non_variadic_params()
+            .map(|parameter| parameter.parameter.name.as_str())
+            .collect();
+        let mut seen_names = HashSet::new();
+
+        for tag in &self.inner {
+            if let Tag::Parametrize(parametrize) = tag {
+                parametrize.validate(&function_parameter_names, &mut seen_names)?;
+            }
+        }
+
+        Ok(())
     }
 
     /// Get all required fixture names for the given test.

--- a/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
@@ -1,68 +1,239 @@
 use std::collections::{HashMap, HashSet};
-use std::fmt;
 use std::sync::Arc;
 
 use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
-use unicode_ident::{is_xid_continue, is_xid_start};
+use ruff_python_ast::{Expr, StmtFunctionDef};
+use ruff_python_stdlib::identifiers::is_identifier;
+use ruff_text_size::{Ranged, TextRange};
+use thiserror::Error;
 
 use crate::extensions::functions::Param;
 use crate::extensions::tags::Tags;
 
-fn is_identifier(name: &str) -> bool {
-    let mut characters = name.chars();
-    characters
-        .next()
-        .is_some_and(|character| character == '_' || is_xid_start(character))
-        && characters.all(|character| character == '_' || is_xid_continue(character))
+#[derive(Debug)]
+pub struct ParametrizeDiagnosticLocation {
+    pub primary: TextRange,
+    pub primary_message: String,
+    pub related: Vec<(TextRange, String)>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum InvalidParametrizeError {
-    InvalidName(String),
-    DuplicateName(String),
-    EmptyCases,
+    #[error("Parameter name cannot be empty")]
+    EmptyName,
+    #[error("`{name}` is not a valid Python identifier")]
+    InvalidName { name: String },
+    #[error("Parameter `{name}` is parametrized more than once")]
+    DuplicateName { name: String },
+    #[error("Parametrization has no cases")]
+    EmptyCases { names: String },
+    #[error("Expected {expected} values for `{names}`, but case {case} contains {actual}")]
     WrongArity {
         names: String,
         case: usize,
         expected: usize,
         actual: usize,
     },
-    UnknownName(String),
+    #[error("Parameter `{name}` does not exist in the test function signature")]
+    UnknownName { name: String },
 }
 
-impl fmt::Display for InvalidParametrizeError {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+struct ParametrizeSyntax<'a> {
+    decorator_range: TextRange,
+    names: Option<&'a Expr>,
+    values: Option<&'a Expr>,
+}
+
+impl InvalidParametrizeError {
+    pub fn diagnostic_location(
+        &self,
+        function: &StmtFunctionDef,
+    ) -> Option<ParametrizeDiagnosticLocation> {
+        let syntaxes = parametrize_syntaxes(function);
+
         match self {
-            Self::InvalidName(name) if name.is_empty() => {
-                formatter.write_str("Parameter name cannot be empty")
+            Self::EmptyName => {
+                name_diagnostic_location(&syntaxes, "", "empty parameter name", function)
             }
-            Self::InvalidName(name) => {
-                write!(formatter, "`{name}` is not a valid Python identifier")
+            Self::InvalidName { name } => {
+                name_diagnostic_location(&syntaxes, name, "invalid parameter name", function)
             }
-            Self::DuplicateName(name) => {
-                write!(
-                    formatter,
-                    "Parameter `{name}` is parametrized more than once"
-                )
+            Self::DuplicateName { name } => {
+                let mut ranges = Vec::new();
+                for syntax in &syntaxes {
+                    for range in name_ranges(syntax.names, name) {
+                        if !ranges.contains(&range) {
+                            ranges.push(range);
+                        }
+                    }
+                }
+
+                let primary = ranges.pop()?;
+                Some(ParametrizeDiagnosticLocation {
+                    primary,
+                    primary_message: "duplicate parameter".to_string(),
+                    related: ranges
+                        .into_iter()
+                        .map(|range| (range, "first parametrized here".to_string()))
+                        .collect(),
+                })
             }
-            Self::EmptyCases => formatter.write_str("Parametrization has no cases"),
+            Self::EmptyCases { names } => {
+                let syntax = syntax_for_names(&syntaxes, names)?;
+                Some(ParametrizeDiagnosticLocation {
+                    primary: syntax.values.map_or(syntax.decorator_range, Ranged::range),
+                    primary_message: "no cases provided".to_string(),
+                    related: syntax
+                        .names
+                        .map(|names| vec![(names.range(), "parameters declared here".to_string())])
+                        .unwrap_or_default(),
+                })
+            }
             Self::WrongArity {
                 names,
                 case,
                 expected,
                 actual,
-            } => write!(
-                formatter,
-                "Expected {expected} values for `{names}`, but case {case} contains {actual}"
-            ),
-            Self::UnknownName(name) => write!(
-                formatter,
-                "Parameter `{name}` does not exist in the test function signature"
-            ),
+            } => {
+                let syntax = syntax_for_names(&syntaxes, names)?;
+                let primary = syntax
+                    .values
+                    .and_then(sequence_elements)
+                    .and_then(|rows| rows.get(case - 1))
+                    .map_or_else(
+                        || syntax.values.map_or(syntax.decorator_range, Ranged::range),
+                        Ranged::range,
+                    );
+                Some(ParametrizeDiagnosticLocation {
+                    primary,
+                    primary_message: format!("contains {actual} values"),
+                    related: syntax
+                        .names
+                        .map(|names| vec![(names.range(), format!("expects {expected} values"))])
+                        .unwrap_or_default(),
+                })
+            }
+            Self::UnknownName { name } => {
+                name_diagnostic_location(&syntaxes, name, "unknown parameter", function)
+            }
         }
+    }
+}
+
+fn name_diagnostic_location(
+    syntaxes: &[ParametrizeSyntax<'_>],
+    name: &str,
+    primary_message: &str,
+    function: &StmtFunctionDef,
+) -> Option<ParametrizeDiagnosticLocation> {
+    let primary = syntaxes
+        .iter()
+        .find_map(|syntax| name_ranges(syntax.names, name).into_iter().next())?;
+    Some(ParametrizeDiagnosticLocation {
+        primary,
+        primary_message: primary_message.to_string(),
+        related: vec![(
+            function.parameters.range,
+            "test parameters declared here".to_string(),
+        )],
+    })
+}
+
+fn parametrize_syntaxes(function: &StmtFunctionDef) -> Vec<ParametrizeSyntax<'_>> {
+    function
+        .decorator_list
+        .iter()
+        .filter_map(|decorator| {
+            let Expr::Call(call) = &decorator.expression else {
+                return None;
+            };
+            if !is_parametrize_function(&call.func) {
+                return None;
+            }
+            Some(ParametrizeSyntax {
+                decorator_range: decorator.range,
+                names: call.arguments.find_argument_value("argnames", 0),
+                values: call.arguments.find_argument_value("argvalues", 1),
+            })
+        })
+        .collect()
+}
+
+fn is_parametrize_function(expression: &Expr) -> bool {
+    match expression {
+        Expr::Name(name) => name.id == "parametrize",
+        Expr::Attribute(attribute) => attribute.attr.id == "parametrize",
+        _ => false,
+    }
+}
+
+fn syntax_for_names<'a>(
+    syntaxes: &'a [ParametrizeSyntax<'a>],
+    names: &str,
+) -> Option<&'a ParametrizeSyntax<'a>> {
+    syntaxes.iter().find(|syntax| {
+        syntax
+            .names
+            .and_then(normalized_names)
+            .is_some_and(|syntax_names| syntax_names.join(",") == names)
+    })
+}
+
+fn normalized_names(expression: &Expr) -> Option<Vec<&str>> {
+    match expression {
+        Expr::StringLiteral(string) => {
+            Some(string.value.to_str().split(',').map(str::trim).collect())
+        }
+        Expr::List(list) => list.elts.iter().map(string_value).collect(),
+        Expr::Tuple(tuple) => tuple.elts.iter().map(string_value).collect(),
+        _ => None,
+    }
+}
+
+fn string_value(expression: &Expr) -> Option<&str> {
+    let Expr::StringLiteral(string) = expression else {
+        return None;
+    };
+    Some(string.value.to_str())
+}
+
+fn name_ranges(expression: Option<&Expr>, target: &str) -> Vec<TextRange> {
+    let Some(expression) = expression else {
+        return Vec::new();
+    };
+    match expression {
+        Expr::StringLiteral(string) => string
+            .value
+            .to_str()
+            .split(',')
+            .map(str::trim)
+            .filter(|name| *name == target)
+            .map(|_| expression.range())
+            .collect(),
+        Expr::List(list) => list
+            .elts
+            .iter()
+            .filter(|element| string_value(element) == Some(target))
+            .map(Ranged::range)
+            .collect(),
+        Expr::Tuple(tuple) => tuple
+            .elts
+            .iter()
+            .filter(|element| string_value(element) == Some(target))
+            .map(Ranged::range)
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn sequence_elements(expression: &Expr) -> Option<&[Expr]> {
+    match expression {
+        Expr::List(list) => Some(&list.elts),
+        Expr::Tuple(tuple) => Some(&tuple.elts),
+        _ => None,
     }
 }
 
@@ -252,16 +423,21 @@ impl ParametrizeTag {
         seen_names: &mut HashSet<&'a str>,
     ) -> Result<(), InvalidParametrizeError> {
         for name in &self.names {
+            if name.is_empty() {
+                return Err(InvalidParametrizeError::EmptyName);
+            }
             if !is_identifier(name) {
-                return Err(InvalidParametrizeError::InvalidName(name.clone()));
+                return Err(InvalidParametrizeError::InvalidName { name: name.clone() });
             }
             if !seen_names.insert(name) {
-                return Err(InvalidParametrizeError::DuplicateName(name.clone()));
+                return Err(InvalidParametrizeError::DuplicateName { name: name.clone() });
             }
         }
 
         if self.parametrizations.is_empty() {
-            return Err(InvalidParametrizeError::EmptyCases);
+            return Err(InvalidParametrizeError::EmptyCases {
+                names: self.names.join(","),
+            });
         }
 
         let expected = self.names.len();
@@ -280,7 +456,7 @@ impl ParametrizeTag {
 
         for name in &self.names {
             if !function_parameter_names.contains(name.as_str()) {
-                return Err(InvalidParametrizeError::UnknownName(name.clone()));
+                return Err(InvalidParametrizeError::UnknownName { name: name.clone() });
             }
         }
 

--- a/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
@@ -17,8 +17,8 @@ use crate::extensions::tags::Tags;
 pub struct ParametrizeDiagnosticLocation {
     pub primary: TextRange,
     pub primary_message: String,
+    pub secondary: Option<(TextRange, String)>,
     pub related: Vec<(TextRange, String)>,
-    pub info: Option<String>,
 }
 
 #[derive(Debug, Error)]
@@ -76,11 +76,11 @@ impl InvalidParametrizeError {
                 Some(ParametrizeDiagnosticLocation {
                     primary,
                     primary_message: "duplicate parameter".to_string(),
+                    secondary: None,
                     related: ranges
                         .into_iter()
                         .map(|range| (range, "first parametrized here".to_string()))
                         .collect(),
-                    info: None,
                 })
             }
             Self::EmptyCases { names } => {
@@ -88,11 +88,11 @@ impl InvalidParametrizeError {
                 Some(ParametrizeDiagnosticLocation {
                     primary: syntax.values.map_or(syntax.decorator_range, Ranged::range),
                     primary_message: "no cases provided".to_string(),
+                    secondary: None,
                     related: syntax
                         .names
                         .map(|names| vec![(names.range(), "parameters declared here".to_string())])
                         .unwrap_or_default(),
-                    info: None,
                 })
             }
             Self::WrongArity {
@@ -116,11 +116,16 @@ impl InvalidParametrizeError {
                         "contains {actual} {}",
                         if *actual == 1 { "value" } else { "values" }
                     ),
+                    secondary: syntax.names.map(|names| {
+                        (
+                            names.range(),
+                            format!(
+                                "expects {expected} {}",
+                                if *expected == 1 { "value" } else { "values" }
+                            ),
+                        )
+                    }),
                     related: Vec::new(),
-                    info: Some(format!(
-                        "expects {expected} {}",
-                        if *expected == 1 { "value" } else { "values" }
-                    )),
                 })
             }
             Self::UnknownName { name } => {
@@ -142,11 +147,11 @@ fn name_diagnostic_location(
     Some(ParametrizeDiagnosticLocation {
         primary,
         primary_message: primary_message.to_string(),
+        secondary: None,
         related: vec![(
             function.parameters.range,
             "test parameters declared here".to_string(),
         )],
-        info: None,
     })
 }
 

--- a/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
@@ -14,11 +14,28 @@ use crate::extensions::functions::Param;
 use crate::extensions::tags::Tags;
 
 #[derive(Debug)]
+pub struct ParametrizeAnnotation {
+    pub(crate) range: TextRange,
+    pub(crate) message: String,
+}
+
+impl ParametrizeAnnotation {
+    fn new(range: TextRange, message: impl Into<String>) -> Self {
+        Self {
+            range,
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct ParametrizeDiagnosticLocation {
-    pub primary: TextRange,
-    pub primary_message: String,
-    pub secondary: Option<(TextRange, String)>,
-    pub related: Vec<(TextRange, String)>,
+    pub(crate) primary: ParametrizeAnnotation,
+    pub(crate) secondary: Vec<ParametrizeAnnotation>,
+}
+
+const fn value_noun(count: usize) -> &'static str {
+    if count == 1 { "value" } else { "values" }
 }
 
 #[derive(Debug, Error)]
@@ -31,7 +48,10 @@ pub enum InvalidParametrizeError {
     DuplicateName { name: String },
     #[error("Parametrization has no cases")]
     EmptyCases { names: String },
-    #[error("Expected {expected} values for `{names}`, but case {case} contains {actual}")]
+    #[error(
+        "Expected {expected} {} for `{names}`, but case {case} contains {actual}",
+        value_noun(*expected)
+    )]
     WrongArity {
         names: String,
         case: usize,
@@ -43,9 +63,9 @@ pub enum InvalidParametrizeError {
 }
 
 struct ParametrizeSyntax<'a> {
-    decorator_range: TextRange,
-    names: Option<&'a Expr>,
-    values: Option<&'a Expr>,
+    names: &'a Expr,
+    values: &'a Expr,
+    has_known_callee: bool,
 }
 
 impl InvalidParametrizeError {
@@ -63,36 +83,48 @@ impl InvalidParametrizeError {
                 name_diagnostic_location(&syntaxes, name, "invalid parameter name", function)
             }
             Self::DuplicateName { name } => {
-                let mut ranges = Vec::new();
-                for syntax in &syntaxes {
-                    for range in name_ranges(syntax.names, name) {
-                        if !ranges.contains(&range) {
-                            ranges.push(range);
+                let matching = syntaxes
+                    .iter()
+                    .map(|syntax| (syntax, name_ranges(syntax.names, name)))
+                    .filter(|(_, ranges)| !ranges.is_empty())
+                    .collect::<Vec<_>>();
+                let known_range_count = matching
+                    .iter()
+                    .filter(|(syntax, _)| syntax.has_known_callee)
+                    .map(|(_, ranges)| ranges.len())
+                    .sum::<usize>();
+
+                let mut ranges: Vec<TextRange> = Vec::new();
+                for (_, syntax_ranges) in matching
+                    .iter()
+                    .filter(|(syntax, _)| known_range_count < 2 || syntax.has_known_callee)
+                {
+                    for range in syntax_ranges {
+                        if !ranges.contains(range) {
+                            ranges.push(*range);
                         }
                     }
                 }
 
                 let primary = ranges.pop()?;
                 Some(ParametrizeDiagnosticLocation {
-                    primary,
-                    primary_message: "duplicate parameter".to_string(),
-                    secondary: None,
-                    related: ranges
+                    primary: ParametrizeAnnotation::new(primary, "duplicate parameter"),
+                    secondary: ranges
                         .into_iter()
-                        .map(|range| (range, "first parametrized here".to_string()))
+                        .map(|range| ParametrizeAnnotation::new(range, "first parametrized here"))
                         .collect(),
                 })
             }
             Self::EmptyCases { names } => {
-                let syntax = syntax_for_names(&syntaxes, names)?;
+                let syntax = select_matching_syntax(&syntaxes, names, |syntax| {
+                    sequence_elements(syntax.values).is_some_and(<[Expr]>::is_empty)
+                })?;
                 Some(ParametrizeDiagnosticLocation {
-                    primary: syntax.values.map_or(syntax.decorator_range, Ranged::range),
-                    primary_message: "no cases provided".to_string(),
-                    secondary: None,
-                    related: syntax
-                        .names
-                        .map(|names| vec![(names.range(), "parameters declared here".to_string())])
-                        .unwrap_or_default(),
+                    primary: ParametrizeAnnotation::new(syntax.values.range(), "no cases provided"),
+                    secondary: vec![ParametrizeAnnotation::new(
+                        syntax.names.range(),
+                        "parameters declared here",
+                    )],
                 })
             }
             Self::WrongArity {
@@ -101,31 +133,22 @@ impl InvalidParametrizeError {
                 expected,
                 actual,
             } => {
-                let syntax = syntax_for_names(&syntaxes, names)?;
-                let primary = syntax
-                    .values
-                    .and_then(sequence_elements)
-                    .and_then(|rows| rows.get(case - 1))
-                    .map_or_else(
-                        || syntax.values.map_or(syntax.decorator_range, Ranged::range),
-                        Ranged::range,
-                    );
+                let syntax = select_matching_syntax(&syntaxes, names, |syntax| {
+                    case_expression(syntax, *case)
+                        .and_then(expression_arity)
+                        .is_some_and(|arity| arity == *actual)
+                })?;
+                let primary = case_expression(syntax, *case)
+                    .map_or_else(|| syntax.values.range(), Ranged::range);
                 Some(ParametrizeDiagnosticLocation {
-                    primary,
-                    primary_message: format!(
-                        "contains {actual} {}",
-                        if *actual == 1 { "value" } else { "values" }
+                    primary: ParametrizeAnnotation::new(
+                        primary,
+                        format!("contains {actual} {}", value_noun(*actual)),
                     ),
-                    secondary: syntax.names.map(|names| {
-                        (
-                            names.range(),
-                            format!(
-                                "expects {expected} {}",
-                                if *expected == 1 { "value" } else { "values" }
-                            ),
-                        )
-                    }),
-                    related: Vec::new(),
+                    secondary: vec![ParametrizeAnnotation::new(
+                        syntax.names.range(),
+                        format!("expects {expected} {}", value_noun(*expected)),
+                    )],
                 })
             }
             Self::UnknownName { name } => {
@@ -141,16 +164,17 @@ fn name_diagnostic_location(
     primary_message: &str,
     function: &StmtFunctionDef,
 ) -> Option<ParametrizeDiagnosticLocation> {
-    let primary = syntaxes
+    let matching = syntaxes
         .iter()
-        .find_map(|syntax| name_ranges(syntax.names, name).into_iter().next())?;
+        .filter(|syntax| !name_ranges(syntax.names, name).is_empty())
+        .collect::<Vec<_>>();
+    let syntax = select_unambiguous_syntax(matching)?;
+    let primary = name_ranges(syntax.names, name).into_iter().next()?;
     Some(ParametrizeDiagnosticLocation {
-        primary,
-        primary_message: primary_message.to_string(),
-        secondary: None,
-        related: vec![(
+        primary: ParametrizeAnnotation::new(primary, primary_message),
+        secondary: vec![ParametrizeAnnotation::new(
             function.parameters.range,
-            "test parameters declared here".to_string(),
+            "test parameters declared here",
         )],
     })
 }
@@ -163,13 +187,18 @@ fn parametrize_syntaxes(function: &StmtFunctionDef) -> Vec<ParametrizeSyntax<'_>
             let Expr::Call(call) = &decorator.expression else {
                 return None;
             };
-            if !is_parametrize_function(&call.func) {
-                return None;
-            }
+            let names = call
+                .arguments
+                .find_argument_value("argnames", 0)
+                .or_else(|| call.arguments.find_argument_value("arg_names", 0))?;
+            let values = call
+                .arguments
+                .find_argument_value("argvalues", 1)
+                .or_else(|| call.arguments.find_argument_value("arg_values", 1))?;
             Some(ParametrizeSyntax {
-                decorator_range: decorator.range,
-                names: call.arguments.find_argument_value("argnames", 0),
-                values: call.arguments.find_argument_value("argvalues", 1),
+                names,
+                values,
+                has_known_callee: is_parametrize_function(&call.func),
             })
         })
         .collect()
@@ -183,16 +212,48 @@ fn is_parametrize_function(expression: &Expr) -> bool {
     }
 }
 
-fn syntax_for_names<'a>(
-    syntaxes: &'a [ParametrizeSyntax<'a>],
+/// Selects the decorator whose literal names and error-specific shape match.
+///
+/// Dynamic syntax cannot always be resolved from the AST. In that case, a
+/// location is returned only when the decorator call is otherwise unambiguous.
+fn select_matching_syntax<'a, 'ast>(
+    syntaxes: &'a [ParametrizeSyntax<'ast>],
     names: &str,
-) -> Option<&'a ParametrizeSyntax<'a>> {
-    syntaxes.iter().find(|syntax| {
-        syntax
-            .names
-            .and_then(normalized_names)
-            .is_some_and(|syntax_names| syntax_names.join(",") == names)
-    })
+    predicate: impl Fn(&ParametrizeSyntax<'_>) -> bool,
+) -> Option<&'a ParametrizeSyntax<'ast>> {
+    let matching_names = syntaxes
+        .iter()
+        .filter(|syntax| {
+            normalized_names(syntax.names)
+                .is_some_and(|syntax_names| syntax_names.join(",") == names)
+        })
+        .collect::<Vec<_>>();
+
+    let matching_error = matching_names
+        .iter()
+        .copied()
+        .filter(|syntax| predicate(syntax))
+        .collect::<Vec<_>>();
+    select_unambiguous_syntax(matching_error)
+        .or_else(|| select_unambiguous_syntax(matching_names))
+        .or_else(|| {
+            select_unambiguous_syntax(syntaxes.iter().filter(|syntax| predicate(syntax)).collect())
+        })
+        .or_else(|| select_unambiguous_syntax(syntaxes.iter().collect()))
+}
+
+fn select_unambiguous_syntax<'a, 'ast>(
+    syntaxes: Vec<&'a ParametrizeSyntax<'ast>>,
+) -> Option<&'a ParametrizeSyntax<'ast>> {
+    if syntaxes.len() == 1 {
+        return syntaxes.first().copied();
+    }
+
+    let mut recognized = syntaxes
+        .into_iter()
+        .filter(|syntax| syntax.has_known_callee);
+    let syntax = recognized.next()?;
+    recognized.next().is_none().then_some(syntax)
 }
 
 fn normalized_names(expression: &Expr) -> Option<Vec<&str>> {
@@ -213,10 +274,7 @@ fn string_value(expression: &Expr) -> Option<&str> {
     Some(string.value.to_str())
 }
 
-fn name_ranges(expression: Option<&Expr>, target: &str) -> Vec<TextRange> {
-    let Some(expression) = expression else {
-        return Vec::new();
-    };
+fn name_ranges(expression: &Expr, target: &str) -> Vec<TextRange> {
     match expression {
         Expr::StringLiteral(string) => string
             .value
@@ -247,6 +305,28 @@ fn sequence_elements(expression: &Expr) -> Option<&[Expr]> {
         Expr::List(list) => Some(&list.elts),
         Expr::Tuple(tuple) => Some(&tuple.elts),
         _ => None,
+    }
+}
+
+fn case_expression<'a>(syntax: &'a ParametrizeSyntax<'_>, case: usize) -> Option<&'a Expr> {
+    sequence_elements(syntax.values)?.get(case - 1)
+}
+
+fn expression_arity(expression: &Expr) -> Option<usize> {
+    match expression {
+        Expr::List(list) => Some(list.elts.len()),
+        Expr::Tuple(tuple) => Some(tuple.elts.len()),
+        Expr::Call(call) if is_param_function(&call.func) => Some(call.arguments.args.len()),
+        Expr::Name(_) | Expr::Attribute(_) | Expr::Subscript(_) | Expr::Call(_) => None,
+        _ => Some(1),
+    }
+}
+
+fn is_param_function(expression: &Expr) -> bool {
+    match expression {
+        Expr::Name(name) => name.id == "param",
+        Expr::Attribute(attribute) => attribute.attr.id == "param",
+        _ => false,
     }
 }
 

--- a/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
@@ -18,6 +18,7 @@ pub struct ParametrizeDiagnosticLocation {
     pub primary: TextRange,
     pub primary_message: String,
     pub related: Vec<(TextRange, String)>,
+    pub info: Option<String>,
 }
 
 #[derive(Debug, Error)]
@@ -79,6 +80,7 @@ impl InvalidParametrizeError {
                         .into_iter()
                         .map(|range| (range, "first parametrized here".to_string()))
                         .collect(),
+                    info: None,
                 })
             }
             Self::EmptyCases { names } => {
@@ -90,6 +92,7 @@ impl InvalidParametrizeError {
                         .names
                         .map(|names| vec![(names.range(), "parameters declared here".to_string())])
                         .unwrap_or_default(),
+                    info: None,
                 })
             }
             Self::WrongArity {
@@ -109,11 +112,15 @@ impl InvalidParametrizeError {
                     );
                 Some(ParametrizeDiagnosticLocation {
                     primary,
-                    primary_message: format!("contains {actual} values"),
-                    related: syntax
-                        .names
-                        .map(|names| vec![(names.range(), format!("expects {expected} values"))])
-                        .unwrap_or_default(),
+                    primary_message: format!(
+                        "contains {actual} {}",
+                        if *actual == 1 { "value" } else { "values" }
+                    ),
+                    related: Vec::new(),
+                    info: Some(format!(
+                        "expects {expected} {}",
+                        if *expected == 1 { "value" } else { "values" }
+                    )),
                 })
             }
             Self::UnknownName { name } => {
@@ -139,6 +146,7 @@ fn name_diagnostic_location(
             function.parameters.range,
             "test parameters declared here".to_string(),
         )],
+        info: None,
     })
 }
 

--- a/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
@@ -49,8 +49,9 @@ pub enum InvalidParametrizeError {
     #[error("Parametrization has no cases")]
     EmptyCases { names: String },
     #[error(
-        "Expected {expected} {} for `{names}`, but case {case} contains {actual}",
-        value_noun(*expected)
+        "Expected {expected} {} for `{names}`, but case {case} contains {actual} {}",
+        value_noun(*expected),
+        value_noun(*actual)
     )]
     WrongArity {
         names: String,
@@ -159,7 +160,7 @@ impl InvalidParametrizeError {
                 })
             }
             Self::UnknownName { name } => {
-                name_diagnostic_location(&syntaxes, name, "unknown parameter", function)
+                name_diagnostic_location(&syntaxes, name, "not accepted by test", function)
             }
         }
     }
@@ -177,11 +178,17 @@ fn name_diagnostic_location(
         .collect::<Vec<_>>();
     let syntax = select_unambiguous_syntax(matching)?;
     let primary = name_ranges(syntax.names, name).into_iter().next()?;
+    let parameter_count = function.parameters.iter_non_variadic_params().count();
+    let parameters_message = match parameter_count {
+        0 => "test accepts no parameters",
+        1 => "available parameter",
+        _ => "available parameters",
+    };
     Some(ParametrizeDiagnosticLocation {
         primary: ParametrizeAnnotation::new(primary, primary_message),
         secondary: vec![ParametrizeAnnotation::new(
             function.parameters.range,
-            "test parameters declared here",
+            parameters_message,
         )],
     })
 }

--- a/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
@@ -138,13 +138,20 @@ impl InvalidParametrizeError {
                         .and_then(expression_arity)
                         .is_some_and(|arity| arity == *actual)
                 })?;
-                let primary = case_expression(syntax, *case)
-                    .map_or_else(|| syntax.values.range(), Ranged::range);
+                let (primary, primary_message) =
+                    if let Some(expression) = case_expression(syntax, *case) {
+                        (
+                            expression.range(),
+                            format!("contains {actual} {}", value_noun(*actual)),
+                        )
+                    } else {
+                        (
+                            syntax.values.range(),
+                            format!("case {case} contains {actual} {}", value_noun(*actual)),
+                        )
+                    };
                 Some(ParametrizeDiagnosticLocation {
-                    primary: ParametrizeAnnotation::new(
-                        primary,
-                        format!("contains {actual} {}", value_noun(*actual)),
-                    ),
+                    primary: ParametrizeAnnotation::new(primary, primary_message),
                     secondary: vec![ParametrizeAnnotation::new(
                         syntax.names.range(),
                         format!("expects {expected} {}", value_noun(*expected)),

--- a/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
@@ -1,13 +1,70 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::sync::Arc;
 
 use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
+use unicode_ident::{is_xid_continue, is_xid_start};
 
 use crate::extensions::functions::Param;
 use crate::extensions::tags::Tags;
+
+fn is_identifier(name: &str) -> bool {
+    let mut characters = name.chars();
+    characters
+        .next()
+        .is_some_and(|character| character == '_' || is_xid_start(character))
+        && characters.all(|character| character == '_' || is_xid_continue(character))
+}
+
+#[derive(Debug)]
+pub enum InvalidParametrizeError {
+    InvalidName(String),
+    DuplicateName(String),
+    EmptyCases,
+    WrongArity {
+        names: String,
+        case: usize,
+        expected: usize,
+        actual: usize,
+    },
+    UnknownName(String),
+}
+
+impl fmt::Display for InvalidParametrizeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidName(name) if name.is_empty() => {
+                formatter.write_str("Parameter name cannot be empty")
+            }
+            Self::InvalidName(name) => {
+                write!(formatter, "`{name}` is not a valid Python identifier")
+            }
+            Self::DuplicateName(name) => {
+                write!(
+                    formatter,
+                    "Parameter `{name}` is parametrized more than once"
+                )
+            }
+            Self::EmptyCases => formatter.write_str("Parametrization has no cases"),
+            Self::WrongArity {
+                names,
+                case,
+                expected,
+                actual,
+            } => write!(
+                formatter,
+                "Expected {expected} values for `{names}`, but case {case} contains {actual}"
+            ),
+            Self::UnknownName(name) => write!(
+                formatter,
+                "Parameter `{name}` does not exist in the test function signature"
+            ),
+        }
+    }
+}
 
 /// A single set of parameter values for a parametrized test.
 ///
@@ -187,6 +244,47 @@ impl ParametrizeTag {
             parse_parametrize_args(&arg_names, &arg_values, globals)?;
 
         Ok(Some(Self::new(arg_names, parametrizations)))
+    }
+
+    pub(crate) fn validate<'a>(
+        &'a self,
+        function_parameter_names: &HashSet<&str>,
+        seen_names: &mut HashSet<&'a str>,
+    ) -> Result<(), InvalidParametrizeError> {
+        for name in &self.names {
+            if !is_identifier(name) {
+                return Err(InvalidParametrizeError::InvalidName(name.clone()));
+            }
+            if !seen_names.insert(name) {
+                return Err(InvalidParametrizeError::DuplicateName(name.clone()));
+            }
+        }
+
+        if self.parametrizations.is_empty() {
+            return Err(InvalidParametrizeError::EmptyCases);
+        }
+
+        let expected = self.names.len();
+        let names = self.names.join(",");
+        for (index, parametrization) in self.parametrizations.iter().enumerate() {
+            let actual = parametrization.values.len();
+            if actual != expected {
+                return Err(InvalidParametrizeError::WrongArity {
+                    names,
+                    case: index + 1,
+                    expected,
+                    actual,
+                });
+            }
+        }
+
+        for name in &self.names {
+            if !function_parameter_names.contains(name.as_str()) {
+                return Err(InvalidParametrizeError::UnknownName(name.clone()));
+            }
+        }
+
+        Ok(())
     }
 
     /// Returns each parameterize case.

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -15,8 +15,9 @@ use ruff_source_file::SourceFile;
 
 use crate::Context;
 use crate::diagnostic::{
-    report_fixture_cycle, report_fixture_failure, report_missing_fixtures, report_test_failure,
-    report_test_pass_on_expect_failure, report_test_returned_value,
+    report_fixture_cycle, report_fixture_failure, report_invalid_parametrize,
+    report_missing_fixtures, report_test_failure, report_test_pass_on_expect_failure,
+    report_test_returned_value,
 };
 use crate::discovery::{DiscoveredModule, DiscoveredPackage, DiscoveredTestFunction};
 use crate::extensions::fixtures::{
@@ -139,6 +140,40 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         }
     }
 
+    fn validate_parametrization(&self, package: &DiscoveredPackage) -> bool {
+        let mut valid = true;
+
+        for module in package.modules().values() {
+            for test_function in module.test_functions() {
+                if let Err(error) = test_function
+                    .tags
+                    .validate_parametrize(&test_function.stmt_function_def)
+                {
+                    report_invalid_parametrize(
+                        self.context,
+                        test_function.source_file.clone(),
+                        &test_function.stmt_function_def,
+                        &error,
+                    );
+                    self.register_failed_test(test_function);
+                    valid = false;
+                    if self.max_fail_reached() {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        for child_package in package.packages().values() {
+            valid &= self.validate_parametrization(child_package);
+            if self.max_fail_reached() {
+                return false;
+            }
+        }
+
+        valid
+    }
+
     fn start_output_capture(&self, py: Python<'_>) -> Option<PythonOutputCapture> {
         if self.context.settings().terminal().show_python_output {
             return None;
@@ -179,6 +214,10 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
     ///
     /// The main entrypoint for actual test execution.
     pub(crate) fn execute(&self, py: Python<'_>, session: &DiscoveredPackage) {
+        if !self.validate_parametrization(session) {
+            return;
+        }
+
         // Resolve session-scoped auto-use fixtures using the session package
         // itself as the `HasFixtures` source so that the walk includes both
         // the user conftest at the session root and the framework module. No


### PR DESCRIPTION
## Summary

Validates Karva and pytest parametrization after collection and before fixture setup or test execution. Invalid definitions now use exact primary and secondary AST spans, including aliases, keyword arguments, multiline forms, and stacked decorators, while ambiguous dynamic syntax safely falls back to the function. Closes #967.

## Test Plan

Ran parametrization integration tests and `uvx prek run -a`; the full suite is blocked by an existing macOS worker-termination warning in max-fail tests.