### PR TITLE
Enforce fixture scope compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,9 @@ pinact run
   crate, Python, worker, or CLI boundaries. Command integration tests should
   use snapshots. Do not call `.output()` only to assert the exit status;
   snapshot the exit code, stdout, and stderr together.
+- Use `#[rstest]` with `#[values(...)]` when an integration test exercises the
+  same behavior across frameworks or inputs. Do not loop over those cases
+  inside the test body.
 - Keep changes focused. Do not expand the task to unrelated issues.
 - Before writing significant new code, look for existing utilities or
   mechanisms that solve the problem. Prefer fixing the underlying

--- a/crates/karva/tests/it/extensions/fixtures/invalid.rs
+++ b/crates/karva/tests/it/extensions/fixtures/invalid.rs
@@ -696,3 +696,69 @@ def test_database(database):
     assert!(!context.root().join("fixture-ran").exists());
     assert!(!context.root().join("test-ran").exists());
 }
+
+#[test]
+fn test_fixture_scope_mismatch_reports_first_invalid_edge() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+from pathlib import Path
+
+@karva.fixture
+def function_fixture():
+    Path("fixture-ran").touch()
+
+@karva.fixture(scope="module")
+def module_fixture(function_fixture):
+    Path("fixture-ran").touch()
+
+@karva.fixture(scope="session")
+def session_fixture(module_fixture):
+    Path("fixture-ran").touch()
+
+@karva.fixture(scope="package")
+def package_fixture(session_fixture):
+    Path("fixture-ran").touch()
+
+def test_scopes(package_fixture):
+    Path("test-ran").touch()
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_scopes
+
+    diagnostics:
+
+    error[fixture-scope-mismatch]: Fixture `session_fixture` with `session` scope cannot depend on fixture `module_fixture` with `module` scope
+      --> test.py:14:5
+       |
+    14 | def session_fixture(module_fixture):
+       |     ^^^^^^^^^^^^^^^
+       |
+    info: Fixture `package_fixture` depends on fixture `session_fixture`
+      --> test.py:18:5
+       |
+    18 | def package_fixture(session_fixture):
+       |     ^^^^^^^^^^^^^^^
+       |
+    info: Fixture `module_fixture` has `module` scope
+      --> test.py:10:5
+       |
+    10 | def module_fixture(function_fixture):
+       |     ^^^^^^^^^^^^^^
+       |
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+    assert!(!context.root().join("fixture-ran").exists());
+    assert!(!context.root().join("test-ran").exists());
+}

--- a/crates/karva/tests/it/extensions/fixtures/invalid.rs
+++ b/crates/karva/tests/it/extensions/fixtures/invalid.rs
@@ -1,3 +1,4 @@
+use insta::allow_duplicates;
 use insta_cmd::assert_cmd_snapshot;
 
 use crate::common::TestContext;
@@ -509,4 +510,193 @@ def test_with_fixture(my_fixture):
 
     ----- stderr -----
     ");
+}
+
+#[test]
+fn test_fixture_scope_mismatch() {
+    for framework in ["karva", "pytest"] {
+        let context = TestContext::with_file(
+            "test.py",
+            &format!(
+                r#"
+import {framework} as framework
+from pathlib import Path
+
+@framework.fixture
+def connection():
+    Path("connection-ran").touch()
+
+@framework.fixture(scope="session")
+def database(connection):
+    Path("database-ran").touch()
+
+def test_database(database):
+    Path("test-ran").touch()
+"#,
+            ),
+        );
+
+        allow_duplicates! {
+            assert_cmd_snapshot!(context.command(), @"
+            success: false
+            exit_code: 1
+            ----- stdout -----
+                Starting 1 test across 1 worker
+                    FAIL [TIME] test::test_database
+
+            diagnostics:
+
+            error[fixture-scope-mismatch]: Session-scoped fixture `database` cannot use function-scoped fixture `connection`
+              --> test.py:10:5
+               |
+            10 | def database(connection):
+               |     ^^^^^^^^
+               |
+            info: Fixture `connection` has function scope
+             --> test.py:6:5
+              |
+            6 | def connection():
+              |     ^^^^^^^^^^
+              |
+            info: database -> connection
+
+            ────────────
+                 Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+            ----- stderr -----
+            ");
+        }
+        assert!(!context.root().join("connection-ran").exists());
+        assert!(!context.root().join("database-ran").exists());
+        assert!(!context.root().join("test-ran").exists());
+    }
+}
+
+#[test]
+fn test_nested_async_generator_autouse_fixture_scope_mismatch() {
+    let context = TestContext::with_files([
+        (
+            "nested/conftest.py",
+            r#"
+import karva
+from pathlib import Path
+
+@karva.fixture
+def connection():
+    Path("connection-ran").touch()
+
+@karva.fixture(scope="package", auto_use=True)
+async def database(connection):
+    Path("database-ran").touch()
+    yield
+"#,
+        ),
+        (
+            "nested/test.py",
+            r#"
+from pathlib import Path
+
+def test_database():
+    Path("test-ran").touch()
+"#,
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] nested.test::test_database
+
+    diagnostics:
+
+    error[fixture-scope-mismatch]: Package-scoped fixture `database` cannot use function-scoped fixture `connection`
+      --> nested/conftest.py:10:11
+       |
+    10 | async def database(connection):
+       |           ^^^^^^^^
+       |
+    info: Fixture `connection` has function scope
+     --> nested/conftest.py:6:5
+      |
+    6 | def connection():
+      |     ^^^^^^^^^^
+      |
+    info: database -> connection
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+    assert!(!context.root().join("connection-ran").exists());
+    assert!(!context.root().join("database-ran").exists());
+    assert!(!context.root().join("test-ran").exists());
+}
+
+#[test]
+fn test_fixture_scope_mismatch_reports_dependency_chain() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+from pathlib import Path
+
+def dynamic_scope(*, fixture_name, config):
+    return "function"
+
+@karva.fixture(scope=dynamic_scope)
+def connection():
+    Path("fixture-ran").touch()
+
+@karva.fixture(scope="session")
+def repository(connection):
+    Path("fixture-ran").touch()
+
+@karva.fixture(scope="session")
+def database(repository):
+    Path("fixture-ran").touch()
+
+def test_database(database):
+    Path("test-ran").touch()
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_database
+
+    diagnostics:
+
+    error[fixture-scope-mismatch]: Session-scoped fixture `repository` cannot use function-scoped fixture `connection`
+      --> test.py:13:5
+       |
+    13 | def repository(connection):
+       |     ^^^^^^^^^^
+       |
+    info: Fixture `database` requires `repository`
+      --> test.py:17:5
+       |
+    17 | def database(repository):
+       |     ^^^^^^^^
+       |
+    info: Fixture `connection` has function scope
+     --> test.py:9:5
+      |
+    9 | def connection():
+      |     ^^^^^^^^^^
+      |
+    info: database -> repository -> connection
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+    assert!(!context.root().join("fixture-ran").exists());
+    assert!(!context.root().join("test-ran").exists());
 }

--- a/crates/karva/tests/it/extensions/fixtures/invalid.rs
+++ b/crates/karva/tests/it/extensions/fixtures/invalid.rs
@@ -1,5 +1,6 @@
 use insta::allow_duplicates;
 use insta_cmd::assert_cmd_snapshot;
+use rstest::rstest;
 
 use crate::common::TestContext;
 
@@ -512,13 +513,12 @@ def test_with_fixture(my_fixture):
     ");
 }
 
-#[test]
-fn test_fixture_scope_mismatch() {
-    for framework in ["karva", "pytest"] {
-        let context = TestContext::with_file(
-            "test.py",
-            &format!(
-                r#"
+#[rstest]
+fn test_fixture_scope_mismatch(#[values("pytest", "karva")] framework: &str) {
+    let context = TestContext::with_file(
+        "test.py",
+        &format!(
+            r#"
 import {framework} as framework
 from pathlib import Path
 
@@ -533,42 +533,41 @@ def database(connection):
 def test_database(database):
     Path("test-ran").touch()
 "#,
-            ),
-        );
+        ),
+    );
 
-        allow_duplicates! {
-            assert_cmd_snapshot!(context.command(), @"
-            success: false
-            exit_code: 1
-            ----- stdout -----
-                Starting 1 test across 1 worker
-                    FAIL [TIME] test::test_database
+    allow_duplicates! {
+        assert_cmd_snapshot!(context.command(), @"
+        success: false
+        exit_code: 1
+        ----- stdout -----
+            Starting 1 test across 1 worker
+                FAIL [TIME] test::test_database
 
-            diagnostics:
+        diagnostics:
 
-            error[fixture-scope-mismatch]: Fixture `database` with `session` scope cannot depend on fixture `connection` with `function` scope
-              --> test.py:10:5
-               |
-            10 | def database(connection):
-               |     ^^^^^^^^
-               |
-            info: Fixture `connection` has `function` scope
-             --> test.py:6:5
-              |
-            6 | def connection():
-              |     ^^^^^^^^^^
-              |
+        error[fixture-scope-mismatch]: Fixture `database` with `session` scope cannot depend on fixture `connection` with `function` scope
+          --> test.py:10:5
+           |
+        10 | def database(connection):
+           |     ^^^^^^^^
+           |
+        info: Fixture `connection` has `function` scope
+         --> test.py:6:5
+          |
+        6 | def connection():
+          |     ^^^^^^^^^^
+          |
 
-            ────────────
-                 Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+        ────────────
+             Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
 
-            ----- stderr -----
-            ");
-        }
-        assert!(!context.root().join("connection-ran").exists());
-        assert!(!context.root().join("database-ran").exists());
-        assert!(!context.root().join("test-ran").exists());
+        ----- stderr -----
+        ");
     }
+    assert!(!context.root().join("connection-ran").exists());
+    assert!(!context.root().join("database-ran").exists());
+    assert!(!context.root().join("test-ran").exists());
 }
 
 #[test]

--- a/crates/karva/tests/it/extensions/fixtures/invalid.rs
+++ b/crates/karva/tests/it/extensions/fixtures/invalid.rs
@@ -546,13 +546,13 @@ def test_database(database):
 
             diagnostics:
 
-            error[fixture-scope-mismatch]: Fixture `database` with session scope cannot depend on fixture `connection` with function scope
+            error[fixture-scope-mismatch]: Fixture `database` with `session` scope cannot depend on fixture `connection` with `function` scope
               --> test.py:10:5
                |
             10 | def database(connection):
                |     ^^^^^^^^
                |
-            info: Fixture `connection` is defined with function scope
+            info: Fixture `connection` has `function` scope
              --> test.py:6:5
               |
             6 | def connection():
@@ -610,13 +610,13 @@ def test_database():
 
     diagnostics:
 
-    error[fixture-scope-mismatch]: Fixture `database` with package scope cannot depend on fixture `connection` with function scope
+    error[fixture-scope-mismatch]: Fixture `database` with `package` scope cannot depend on fixture `connection` with `function` scope
       --> nested/conftest.py:10:11
        |
     10 | async def database(connection):
        |           ^^^^^^^^
        |
-    info: Fixture `connection` is defined with function scope
+    info: Fixture `connection` has `function` scope
      --> nested/conftest.py:6:5
       |
     6 | def connection():
@@ -670,7 +670,7 @@ def test_database(database):
 
     diagnostics:
 
-    error[fixture-scope-mismatch]: Fixture `repository` with session scope cannot depend on fixture `connection` with function scope
+    error[fixture-scope-mismatch]: Fixture `repository` with `session` scope cannot depend on fixture `connection` with `function` scope
       --> test.py:13:5
        |
     13 | def repository(connection):
@@ -682,7 +682,7 @@ def test_database(database):
     17 | def database(repository):
        |     ^^^^^^^^
        |
-    info: Fixture `connection` is defined with function scope
+    info: Fixture `connection` has `function` scope
      --> test.py:9:5
       |
     9 | def connection():

--- a/crates/karva/tests/it/extensions/fixtures/invalid.rs
+++ b/crates/karva/tests/it/extensions/fixtures/invalid.rs
@@ -546,19 +546,18 @@ def test_database(database):
 
             diagnostics:
 
-            error[fixture-scope-mismatch]: Session-scoped fixture `database` cannot use function-scoped fixture `connection`
+            error[fixture-scope-mismatch]: Fixture `database` with session scope cannot depend on fixture `connection` with function scope
               --> test.py:10:5
                |
             10 | def database(connection):
                |     ^^^^^^^^
                |
-            info: Fixture `connection` has function scope
+            info: Fixture `connection` is defined with function scope
              --> test.py:6:5
               |
             6 | def connection():
               |     ^^^^^^^^^^
               |
-            info: database -> connection
 
             ────────────
                  Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -611,19 +610,18 @@ def test_database():
 
     diagnostics:
 
-    error[fixture-scope-mismatch]: Package-scoped fixture `database` cannot use function-scoped fixture `connection`
+    error[fixture-scope-mismatch]: Fixture `database` with package scope cannot depend on fixture `connection` with function scope
       --> nested/conftest.py:10:11
        |
     10 | async def database(connection):
        |           ^^^^^^^^
        |
-    info: Fixture `connection` has function scope
+    info: Fixture `connection` is defined with function scope
      --> nested/conftest.py:6:5
       |
     6 | def connection():
       |     ^^^^^^^^^^
       |
-    info: database -> connection
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -672,25 +670,24 @@ def test_database(database):
 
     diagnostics:
 
-    error[fixture-scope-mismatch]: Session-scoped fixture `repository` cannot use function-scoped fixture `connection`
+    error[fixture-scope-mismatch]: Fixture `repository` with session scope cannot depend on fixture `connection` with function scope
       --> test.py:13:5
        |
     13 | def repository(connection):
        |     ^^^^^^^^^^
        |
-    info: Fixture `database` requires `repository`
+    info: Fixture `database` depends on fixture `repository`
       --> test.py:17:5
        |
     17 | def database(repository):
        |     ^^^^^^^^
        |
-    info: Fixture `connection` has function scope
+    info: Fixture `connection` is defined with function scope
      --> test.py:9:5
       |
     9 | def connection():
       |     ^^^^^^^^^^
       |
-    info: database -> repository -> connection
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -370,7 +370,7 @@ fn report_fixture_scope_mismatch(
 ) {
     let builder = context.report_diagnostic(&FIXTURE_SCOPE_MISMATCH);
     let mut diagnostic = builder.into_diagnostic(format!(
-        "Fixture `{}` with {} scope cannot depend on fixture `{}` with {} scope",
+        "Fixture `{}` with `{}` scope cannot depend on fixture `{}` with `{}` scope",
         fixture.name,
         fixture.scope.name(),
         dependency.name,
@@ -401,7 +401,7 @@ fn report_fixture_scope_mismatch(
     let mut dependency_sub = SubDiagnostic::new(
         SubDiagnosticSeverity::Info,
         format!(
-            "Fixture `{}` is defined with {} scope",
+            "Fixture `{}` has `{}` scope",
             dependency.name,
             dependency.scope.name()
         ),

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -317,9 +317,11 @@ pub fn report_fixture_failure(context: &Context, py: Python, error: FixtureCallE
 pub fn report_fixture_resolution_error(context: &Context, error: FixtureResolutionError) {
     match error {
         FixtureResolutionError::Cycle { cycle } => report_fixture_cycle(context, &cycle),
-        FixtureResolutionError::ScopeMismatch { chain } => {
-            report_fixture_scope_mismatch(context, &chain);
-        }
+        FixtureResolutionError::ScopeMismatch {
+            dependency_path,
+            fixture,
+            dependency,
+        } => report_fixture_scope_mismatch(context, &dependency_path, &fixture, &dependency),
     }
 }
 
@@ -360,36 +362,38 @@ fn report_fixture_cycle(context: &Context, cycle: &[FixtureResolutionEntry]) {
     );
 }
 
-fn report_fixture_scope_mismatch(context: &Context, chain: &[FixtureResolutionEntry]) {
-    let Some([dependent, dependency]) = chain.last_chunk::<2>() else {
-        return;
-    };
-
+fn report_fixture_scope_mismatch(
+    context: &Context,
+    dependency_path: &[FixtureResolutionEntry],
+    fixture: &FixtureResolutionEntry,
+    dependency: &FixtureResolutionEntry,
+) {
     let builder = context.report_diagnostic(&FIXTURE_SCOPE_MISMATCH);
     let mut diagnostic = builder.into_diagnostic(format!(
-        "{}-scoped fixture `{}` cannot use {}-scoped fixture `{}`",
-        dependent.scope.capitalised_name(),
-        dependent.name,
-        dependency.scope.name(),
+        "Fixture `{}` with {} scope cannot depend on fixture `{}` with {} scope",
+        fixture.name,
+        fixture.scope.name(),
         dependency.name,
+        dependency.scope.name(),
     ));
 
     annotate_function_name(
         &mut diagnostic,
-        dependent.source_file.clone(),
-        &dependent.stmt_function_def,
+        fixture.source_file.clone(),
+        &fixture.stmt_function_def,
     );
 
-    for edge in chain.windows(2).take(chain.len().saturating_sub(2)) {
-        let [fixture, dependency] = edge else {
-            continue;
-        };
+    for (index, path_fixture) in dependency_path.iter().enumerate() {
+        let next_fixture = dependency_path.get(index + 1).unwrap_or(fixture);
         let mut sub = SubDiagnostic::new(
             SubDiagnosticSeverity::Info,
-            format!("Fixture `{}` requires `{}`", fixture.name, dependency.name),
+            format!(
+                "Fixture `{}` depends on fixture `{}`",
+                path_fixture.name, next_fixture.name
+            ),
         );
-        let span = Span::from(fixture.source_file.clone())
-            .with_range(fixture.stmt_function_def.name.range);
+        let span = Span::from(path_fixture.source_file.clone())
+            .with_range(path_fixture.stmt_function_def.name.range);
         sub.annotate(Annotation::primary(span));
         diagnostic.sub(sub);
     }
@@ -397,7 +401,7 @@ fn report_fixture_scope_mismatch(context: &Context, chain: &[FixtureResolutionEn
     let mut dependency_sub = SubDiagnostic::new(
         SubDiagnosticSeverity::Info,
         format!(
-            "Fixture `{}` has {} scope",
+            "Fixture `{}` is defined with {} scope",
             dependency.name,
             dependency.scope.name()
         ),
@@ -406,14 +410,6 @@ fn report_fixture_scope_mismatch(context: &Context, chain: &[FixtureResolutionEn
         .with_range(dependency.stmt_function_def.name.range);
     dependency_sub.annotate(Annotation::primary(span));
     diagnostic.sub(dependency_sub);
-
-    diagnostic.info(
-        chain
-            .iter()
-            .map(|fixture| fixture.name.as_str())
-            .collect::<Vec<_>>()
-            .join(" -> "),
-    );
 }
 
 pub fn report_missing_fixtures(

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -20,7 +20,10 @@ mod metadata;
 pub use metadata::{DiagnosticGuardBuilder, DiagnosticType};
 
 use crate::extensions::tags::parametrize::InvalidParametrizeError;
-use crate::runner::{FixtureArguments, FixtureCallError, FixtureChainEntry, FixtureCycleError};
+use crate::runner::{
+    FixtureArguments, FixtureCallError, FixtureChainEntry, FixtureResolutionEntry,
+    FixtureResolutionError,
+};
 use crate::utils::truncate_string;
 use crate::{Context, declare_diagnostic_type};
 
@@ -100,6 +103,16 @@ declare_diagnostic_type! {
     /// Raised when fixture dependencies form a cycle and cannot be resolved.
     pub static FIXTURE_CYCLE = {
         summary: "Fixture dependency cycle detected",
+        severity: Severity::Error,
+    }
+}
+
+declare_diagnostic_type! {
+    /// ## Fixture scope mismatch
+    ///
+    /// Raised when a fixture depends on another fixture with a shorter lifetime.
+    pub static FIXTURE_SCOPE_MISMATCH = {
+        summary: "Fixture scope mismatch detected",
         severity: Severity::Error,
     }
 }
@@ -301,8 +314,16 @@ pub fn report_fixture_failure(context: &Context, py: Python, error: FixtureCallE
     );
 }
 
-pub fn report_fixture_cycle(context: &Context, error: FixtureCycleError) {
-    let FixtureCycleError { cycle } = error;
+pub fn report_fixture_resolution_error(context: &Context, error: FixtureResolutionError) {
+    match error {
+        FixtureResolutionError::Cycle { cycle } => report_fixture_cycle(context, &cycle),
+        FixtureResolutionError::ScopeMismatch { chain } => {
+            report_fixture_scope_mismatch(context, &chain);
+        }
+    }
+}
+
+fn report_fixture_cycle(context: &Context, cycle: &[FixtureResolutionEntry]) {
     let Some(first_fixture) = cycle.first() else {
         return;
     };
@@ -332,6 +353,62 @@ pub fn report_fixture_cycle(context: &Context, error: FixtureCycleError) {
 
     diagnostic.info(
         cycle
+            .iter()
+            .map(|fixture| fixture.name.as_str())
+            .collect::<Vec<_>>()
+            .join(" -> "),
+    );
+}
+
+fn report_fixture_scope_mismatch(context: &Context, chain: &[FixtureResolutionEntry]) {
+    let Some([dependent, dependency]) = chain.last_chunk::<2>() else {
+        return;
+    };
+
+    let builder = context.report_diagnostic(&FIXTURE_SCOPE_MISMATCH);
+    let mut diagnostic = builder.into_diagnostic(format!(
+        "{}-scoped fixture `{}` cannot use {}-scoped fixture `{}`",
+        dependent.scope.capitalised_name(),
+        dependent.name,
+        dependency.scope.name(),
+        dependency.name,
+    ));
+
+    annotate_function_name(
+        &mut diagnostic,
+        dependent.source_file.clone(),
+        &dependent.stmt_function_def,
+    );
+
+    for edge in chain.windows(2).take(chain.len().saturating_sub(2)) {
+        let [fixture, dependency] = edge else {
+            continue;
+        };
+        let mut sub = SubDiagnostic::new(
+            SubDiagnosticSeverity::Info,
+            format!("Fixture `{}` requires `{}`", fixture.name, dependency.name),
+        );
+        let span = Span::from(fixture.source_file.clone())
+            .with_range(fixture.stmt_function_def.name.range);
+        sub.annotate(Annotation::primary(span));
+        diagnostic.sub(sub);
+    }
+
+    let mut dependency_sub = SubDiagnostic::new(
+        SubDiagnosticSeverity::Info,
+        format!(
+            "Fixture `{}` has {} scope",
+            dependency.name,
+            dependency.scope.name()
+        ),
+    );
+    let span = Span::from(dependency.source_file.clone())
+        .with_range(dependency.stmt_function_def.name.range);
+    dependency_sub.annotate(Annotation::primary(span));
+    diagnostic.sub(dependency_sub);
+
+    diagnostic.info(
+        chain
             .iter()
             .map(|fixture| fixture.name.as_str())
             .collect::<Vec<_>>()

--- a/crates/karva_test_semantic/src/extensions/fixtures/scope.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/scope.rs
@@ -36,15 +36,6 @@ impl FixtureScope {
             Self::Session => "session",
         }
     }
-
-    pub(crate) fn capitalised_name(self) -> &'static str {
-        match self {
-            Self::Function => "Function",
-            Self::Module => "Module",
-            Self::Package => "Package",
-            Self::Session => "Session",
-        }
-    }
 }
 
 impl TryFrom<String> for FixtureScope {

--- a/crates/karva_test_semantic/src/extensions/fixtures/scope.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/scope.rs
@@ -22,6 +22,29 @@ impl FixtureScope {
             Session => &[Session],
         }
     }
+
+    /// Return whether a fixture with this scope may use `dependency`.
+    pub(crate) fn can_use(self, dependency: Self) -> bool {
+        self.scopes_above().contains(&dependency)
+    }
+
+    pub(crate) fn name(self) -> &'static str {
+        match self {
+            Self::Function => "function",
+            Self::Module => "module",
+            Self::Package => "package",
+            Self::Session => "session",
+        }
+    }
+
+    pub(crate) fn capitalised_name(self) -> &'static str {
+        match self {
+            Self::Function => "Function",
+            Self::Module => "Module",
+            Self::Package => "Package",
+            Self::Session => "Session",
+        }
+    }
 }
 
 impl TryFrom<String> for FixtureScope {
@@ -92,5 +115,28 @@ mod tests {
         assert_eq!(Module.scopes_above(), &[Module, Package, Session]);
         assert_eq!(Package.scopes_above(), &[Package, Session]);
         assert_eq!(Session.scopes_above(), &[Session]);
+    }
+
+    #[test]
+    fn fixtures_can_only_use_same_or_broader_scopes() {
+        assert!(Function.can_use(Function));
+        assert!(Function.can_use(Module));
+        assert!(Function.can_use(Package));
+        assert!(Function.can_use(Session));
+
+        assert!(!Module.can_use(Function));
+        assert!(Module.can_use(Module));
+        assert!(Module.can_use(Package));
+        assert!(Module.can_use(Session));
+
+        assert!(!Package.can_use(Function));
+        assert!(!Package.can_use(Module));
+        assert!(Package.can_use(Package));
+        assert!(Package.can_use(Session));
+
+        assert!(!Session.can_use(Function));
+        assert!(!Session.can_use(Module));
+        assert!(!Session.can_use(Package));
+        assert!(Session.can_use(Session));
     }
 }

--- a/crates/karva_test_semantic/src/runner/fixture_resolver.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_resolver.rs
@@ -26,30 +26,50 @@ pub(super) struct RuntimeFixtureResolver<'a> {
     fixture_cache: HashMap<String, Rc<NormalizedFixture>>,
 }
 
-pub struct FixtureCycleEntry {
+pub struct FixtureResolutionEntry {
     pub(crate) name: String,
+    pub(crate) scope: FixtureScope,
     pub(crate) stmt_function_def: Rc<StmtFunctionDef>,
     pub(crate) source_file: SourceFile,
 }
 
-pub struct FixtureCycleError {
-    pub(crate) cycle: Vec<FixtureCycleEntry>,
+pub enum FixtureResolutionError {
+    Cycle { cycle: Vec<FixtureResolutionEntry> },
+    ScopeMismatch { chain: Vec<FixtureResolutionEntry> },
 }
 
-impl FixtureCycleError {
-    fn new(cycle: &[&DiscoveredFixture], repeated: &DiscoveredFixture) -> Self {
+impl FixtureResolutionEntry {
+    fn new(fixture: &DiscoveredFixture) -> Self {
+        Self {
+            name: fixture.name().function_name().to_string(),
+            scope: fixture.scope(),
+            stmt_function_def: Rc::clone(fixture.stmt_function_def()),
+            source_file: fixture.source_file().clone(),
+        }
+    }
+}
+
+impl FixtureResolutionError {
+    fn cycle(cycle: &[&DiscoveredFixture], repeated: &DiscoveredFixture) -> Self {
         let cycle = cycle
             .iter()
             .copied()
             .chain(std::iter::once(repeated))
-            .map(|fixture| FixtureCycleEntry {
-                name: fixture.name().function_name().to_string(),
-                stmt_function_def: Rc::clone(fixture.stmt_function_def()),
-                source_file: fixture.source_file().clone(),
-            })
+            .map(FixtureResolutionEntry::new)
             .collect();
 
-        Self { cycle }
+        Self::Cycle { cycle }
+    }
+
+    fn scope_mismatch(path: &[&DiscoveredFixture], dependency: &DiscoveredFixture) -> Self {
+        let chain = path
+            .iter()
+            .copied()
+            .chain(std::iter::once(dependency))
+            .map(FixtureResolutionEntry::new)
+            .collect();
+
+        Self::ScopeMismatch { chain }
     }
 }
 
@@ -62,14 +82,14 @@ impl<'a> FixturePath<'a> {
     fn enter<T>(
         &mut self,
         fixture: &'a DiscoveredFixture,
-        resolve: impl FnOnce(&mut Self) -> Result<T, FixtureCycleError>,
-    ) -> Result<T, FixtureCycleError> {
+        resolve: impl FnOnce(&mut Self) -> Result<T, FixtureResolutionError>,
+    ) -> Result<T, FixtureResolutionError> {
         if let Some(cycle_start) = self
             .fixtures
             .iter()
             .position(|active_fixture| std::ptr::eq(*active_fixture, fixture))
         {
-            return Err(FixtureCycleError::new(
+            return Err(FixtureResolutionError::cycle(
                 &self.fixtures[cycle_start..],
                 fixture,
             ));
@@ -105,7 +125,7 @@ impl<'a> RuntimeFixtureResolver<'a> {
         py: Python,
         fixture: &'a DiscoveredFixture,
         path: &mut FixturePath<'a>,
-    ) -> Result<Rc<NormalizedFixture>, FixtureCycleError> {
+    ) -> Result<Rc<NormalizedFixture>, FixtureResolutionError> {
         let cache_key = fixture.name().to_string();
 
         if fixture.scope() != FixtureScope::Function {
@@ -141,7 +161,7 @@ impl<'a> RuntimeFixtureResolver<'a> {
         &mut self,
         py: Python,
         scope: FixtureScope,
-    ) -> Result<Vec<Rc<NormalizedFixture>>, FixtureCycleError> {
+    ) -> Result<Vec<Rc<NormalizedFixture>>, FixtureResolutionError> {
         let auto_use_fixtures = get_auto_use_fixtures(self.parents, self.current, scope);
         let mut path = FixturePath::default();
 
@@ -157,7 +177,7 @@ impl<'a> RuntimeFixtureResolver<'a> {
         py: Python,
         fixture_names: &[String],
         parametrize_param_names: &HashSet<&str>,
-    ) -> Result<Vec<Rc<NormalizedFixture>>, FixtureCycleError> {
+    ) -> Result<Vec<Rc<NormalizedFixture>>, FixtureResolutionError> {
         let regular_fixture_names: Vec<String> = fixture_names
             .iter()
             .filter(|name| !parametrize_param_names.contains(name.as_str()))
@@ -173,7 +193,7 @@ impl<'a> RuntimeFixtureResolver<'a> {
         &mut self,
         py: Python,
         fixture_names: &[String],
-    ) -> Result<Vec<Rc<NormalizedFixture>>, FixtureCycleError> {
+    ) -> Result<Vec<Rc<NormalizedFixture>>, FixtureResolutionError> {
         let mut path = FixturePath::default();
         self.get_dependent_fixtures(py, None, fixture_names, &mut path)
     }
@@ -185,13 +205,21 @@ impl<'a> RuntimeFixtureResolver<'a> {
         current_fixture: Option<&'a DiscoveredFixture>,
         fixture_names: &[String],
         path: &mut FixturePath<'a>,
-    ) -> Result<Vec<Rc<NormalizedFixture>>, FixtureCycleError> {
+    ) -> Result<Vec<Rc<NormalizedFixture>>, FixtureResolutionError> {
         let mut normalized_fixtures = Vec::with_capacity(fixture_names.len());
 
         for dep_name in fixture_names {
             if let Some(fixture) =
                 find_fixture(current_fixture, dep_name, self.parents, self.current)
             {
+                if let Some(current_fixture) = current_fixture
+                    && !current_fixture.scope().can_use(fixture.scope())
+                {
+                    return Err(FixtureResolutionError::scope_mismatch(
+                        &path.fixtures,
+                        fixture,
+                    ));
+                }
                 let normalized = self.normalize_fixture(py, fixture, path)?;
                 normalized_fixtures.push(normalized);
             } else if let Some(fixture) = current_fixture

--- a/crates/karva_test_semantic/src/runner/fixture_resolver.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_resolver.rs
@@ -34,8 +34,14 @@ pub struct FixtureResolutionEntry {
 }
 
 pub enum FixtureResolutionError {
-    Cycle { cycle: Vec<FixtureResolutionEntry> },
-    ScopeMismatch { chain: Vec<FixtureResolutionEntry> },
+    Cycle {
+        cycle: Vec<FixtureResolutionEntry>,
+    },
+    ScopeMismatch {
+        dependency_path: Vec<FixtureResolutionEntry>,
+        fixture: FixtureResolutionEntry,
+        dependency: FixtureResolutionEntry,
+    },
 }
 
 impl FixtureResolutionEntry {
@@ -61,15 +67,22 @@ impl FixtureResolutionError {
         Self::Cycle { cycle }
     }
 
-    fn scope_mismatch(path: &[&DiscoveredFixture], dependency: &DiscoveredFixture) -> Self {
-        let chain = path
+    fn scope_mismatch(
+        dependency_path: &[&DiscoveredFixture],
+        fixture: &DiscoveredFixture,
+        dependency: &DiscoveredFixture,
+    ) -> Self {
+        let dependency_path = dependency_path
             .iter()
             .copied()
-            .chain(std::iter::once(dependency))
             .map(FixtureResolutionEntry::new)
             .collect();
 
-        Self::ScopeMismatch { chain }
+        Self::ScopeMismatch {
+            dependency_path,
+            fixture: FixtureResolutionEntry::new(fixture),
+            dependency: FixtureResolutionEntry::new(dependency),
+        }
     }
 }
 
@@ -215,8 +228,13 @@ impl<'a> RuntimeFixtureResolver<'a> {
                 if let Some(current_fixture) = current_fixture
                     && !current_fixture.scope().can_use(fixture.scope())
                 {
+                    let dependency_path = path
+                        .fixtures
+                        .split_last()
+                        .map_or(&[][..], |(_, dependency_path)| dependency_path);
                     return Err(FixtureResolutionError::scope_mismatch(
-                        &path.fixtures,
+                        dependency_path,
+                        current_fixture,
                         fixture,
                     ));
                 }

--- a/crates/karva_test_semantic/src/runner/fixture_resolver.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_resolver.rs
@@ -44,6 +44,8 @@ pub enum FixtureResolutionError {
     },
 }
 
+pub type FixtureResolutionResult<T> = Result<T, FixtureResolutionError>;
+
 impl FixtureResolutionEntry {
     fn new(fixture: &DiscoveredFixture) -> Self {
         Self {
@@ -95,8 +97,8 @@ impl<'a> FixturePath<'a> {
     fn enter<T>(
         &mut self,
         fixture: &'a DiscoveredFixture,
-        resolve: impl FnOnce(&mut Self) -> Result<T, FixtureResolutionError>,
-    ) -> Result<T, FixtureResolutionError> {
+        resolve: impl FnOnce(&mut Self) -> FixtureResolutionResult<T>,
+    ) -> FixtureResolutionResult<T> {
         if let Some(cycle_start) = self
             .fixtures
             .iter()
@@ -138,7 +140,7 @@ impl<'a> RuntimeFixtureResolver<'a> {
         py: Python,
         fixture: &'a DiscoveredFixture,
         path: &mut FixturePath<'a>,
-    ) -> Result<Rc<NormalizedFixture>, FixtureResolutionError> {
+    ) -> FixtureResolutionResult<Rc<NormalizedFixture>> {
         let cache_key = fixture.name().to_string();
 
         if fixture.scope() != FixtureScope::Function {
@@ -174,7 +176,7 @@ impl<'a> RuntimeFixtureResolver<'a> {
         &mut self,
         py: Python,
         scope: FixtureScope,
-    ) -> Result<Vec<Rc<NormalizedFixture>>, FixtureResolutionError> {
+    ) -> FixtureResolutionResult<Vec<Rc<NormalizedFixture>>> {
         let auto_use_fixtures = get_auto_use_fixtures(self.parents, self.current, scope);
         let mut path = FixturePath::default();
 
@@ -190,7 +192,7 @@ impl<'a> RuntimeFixtureResolver<'a> {
         py: Python,
         fixture_names: &[String],
         parametrize_param_names: &HashSet<&str>,
-    ) -> Result<Vec<Rc<NormalizedFixture>>, FixtureResolutionError> {
+    ) -> FixtureResolutionResult<Vec<Rc<NormalizedFixture>>> {
         let regular_fixture_names: Vec<String> = fixture_names
             .iter()
             .filter(|name| !parametrize_param_names.contains(name.as_str()))
@@ -206,7 +208,7 @@ impl<'a> RuntimeFixtureResolver<'a> {
         &mut self,
         py: Python,
         fixture_names: &[String],
-    ) -> Result<Vec<Rc<NormalizedFixture>>, FixtureResolutionError> {
+    ) -> FixtureResolutionResult<Vec<Rc<NormalizedFixture>>> {
         let mut path = FixturePath::default();
         self.get_dependent_fixtures(py, None, fixture_names, &mut path)
     }
@@ -218,7 +220,7 @@ impl<'a> RuntimeFixtureResolver<'a> {
         current_fixture: Option<&'a DiscoveredFixture>,
         fixture_names: &[String],
         path: &mut FixturePath<'a>,
-    ) -> Result<Vec<Rc<NormalizedFixture>>, FixtureResolutionError> {
+    ) -> FixtureResolutionResult<Vec<Rc<NormalizedFixture>>> {
         let mut normalized_fixtures = Vec::with_capacity(fixture_names.len());
 
         for dep_name in fixture_names {

--- a/crates/karva_test_semantic/src/runner/mod.rs
+++ b/crates/karva_test_semantic/src/runner/mod.rs
@@ -9,5 +9,5 @@ mod test_iterator;
 use finalizer_cache::FinalizerCache;
 pub use fixture_arguments::FixtureArguments;
 use fixture_cache::FixtureCache;
-pub use fixture_resolver::FixtureCycleError;
+pub use fixture_resolver::{FixtureResolutionEntry, FixtureResolutionError};
 pub use package_runner::{FixtureCallError, FixtureChainEntry, PackageRunner};

--- a/crates/karva_test_semantic/src/runner/mod.rs
+++ b/crates/karva_test_semantic/src/runner/mod.rs
@@ -9,5 +9,7 @@ mod test_iterator;
 use finalizer_cache::FinalizerCache;
 pub use fixture_arguments::FixtureArguments;
 use fixture_cache::FixtureCache;
-pub use fixture_resolver::{FixtureResolutionEntry, FixtureResolutionError};
+pub use fixture_resolver::{
+    FixtureResolutionEntry, FixtureResolutionError, FixtureResolutionResult,
+};
 pub use package_runner::{FixtureCallError, FixtureChainEntry, PackageRunner};

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -30,7 +30,7 @@ use crate::extensions::tags::timeout::TimeoutTag;
 use crate::output_capture::PythonOutputCapture;
 use crate::runner::fixture_resolver::RuntimeFixtureResolver;
 use crate::runner::test_iterator::{TestVariant, TestVariantIterator};
-use crate::runner::{FinalizerCache, FixtureArguments, FixtureCache, FixtureResolutionError};
+use crate::runner::{FinalizerCache, FixtureArguments, FixtureCache, FixtureResolutionResult};
 use crate::utils::{
     full_test_name, run_coroutine, run_test_with_timeout, set_attempt_env, set_test_name_env,
     truncate_string,
@@ -244,7 +244,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         parents: &'b [&'b DiscoveredPackage],
         current: &'b (dyn HasFixtures<'b> + 'b),
         scope: FixtureScope,
-    ) -> Result<(), FixtureResolutionError> {
+    ) -> FixtureResolutionResult<()> {
         let mut resolver = RuntimeFixtureResolver::new(parents, current);
         let auto_use_fixtures = resolver.get_normalized_auto_use_fixtures(py, scope)?;
         let auto_use_errors = self.run_fixtures(py, &auto_use_fixtures);

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -15,7 +15,7 @@ use ruff_source_file::SourceFile;
 
 use crate::Context;
 use crate::diagnostic::{
-    report_fixture_cycle, report_fixture_failure, report_invalid_parametrize,
+    report_fixture_failure, report_fixture_resolution_error, report_invalid_parametrize,
     report_missing_fixtures, report_test_failure, report_test_pass_on_expect_failure,
     report_test_returned_value,
 };
@@ -30,7 +30,7 @@ use crate::extensions::tags::timeout::TimeoutTag;
 use crate::output_capture::PythonOutputCapture;
 use crate::runner::fixture_resolver::RuntimeFixtureResolver;
 use crate::runner::test_iterator::{TestVariant, TestVariantIterator};
-use crate::runner::{FinalizerCache, FixtureArguments, FixtureCache, FixtureCycleError};
+use crate::runner::{FinalizerCache, FixtureArguments, FixtureCache, FixtureResolutionError};
 use crate::utils::{
     full_test_name, run_coroutine, run_test_with_timeout, set_attempt_env, set_test_name_env,
     truncate_string,
@@ -224,7 +224,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         // `if let Some(...)` gate: the session always exists, and if neither
         // slot contributes any autouse fixtures the walk returns an empty vec.
         if let Err(error) = self.run_auto_use_fixtures(py, &[], session, FixtureScope::Session) {
-            report_fixture_cycle(self.context, error);
+            report_fixture_resolution_error(self.context, error);
             self.register_failed_package_tests(session);
             return;
         }
@@ -244,7 +244,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         parents: &'b [&'b DiscoveredPackage],
         current: &'b (dyn HasFixtures<'b> + 'b),
         scope: FixtureScope,
-    ) -> Result<(), FixtureCycleError> {
+    ) -> Result<(), FixtureResolutionError> {
         let mut resolver = RuntimeFixtureResolver::new(parents, current);
         let auto_use_fixtures = resolver.get_normalized_auto_use_fixtures(py, scope)?;
         let auto_use_errors = self.run_fixtures(py, &auto_use_fixtures);
@@ -267,7 +267,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         parents: &[&DiscoveredPackage],
     ) -> bool {
         if let Err(error) = self.run_auto_use_fixtures(py, parents, module, FixtureScope::Module) {
-            report_fixture_cycle(self.context, error);
+            report_fixture_resolution_error(self.context, error);
             self.register_failed_module_tests(module);
             return false;
         }
@@ -281,7 +281,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             let variants = match TestVariantIterator::new(py, test_function, &mut test_resolver) {
                 Ok(variants) => variants,
                 Err(error) => {
-                    report_fixture_cycle(self.context, error);
+                    report_fixture_resolution_error(self.context, error);
                     self.register_failed_test(test_function);
                     passed = false;
                     if self.max_fail_reached() {
@@ -330,7 +330,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             if let Err(error) =
                 self.run_auto_use_fixtures(py, parents, config_module, FixtureScope::Package)
             {
-                report_fixture_cycle(self.context, error);
+                report_fixture_resolution_error(self.context, error);
                 self.register_failed_package_tests(package);
                 return false;
             }

--- a/crates/karva_test_semantic/src/runner/test_iterator.rs
+++ b/crates/karva_test_semantic/src/runner/test_iterator.rs
@@ -8,7 +8,7 @@ use crate::discovery::DiscoveredTestFunction;
 use crate::extensions::fixtures::{NormalizedFixture, RequiresFixtures};
 use crate::extensions::tags::Tags;
 use crate::extensions::tags::parametrize::ParametrizationArgs;
-use crate::runner::fixture_resolver::{FixtureResolutionError, RuntimeFixtureResolver};
+use crate::runner::fixture_resolver::{FixtureResolutionResult, RuntimeFixtureResolver};
 
 /// A single variant of a test to be executed.
 ///
@@ -93,7 +93,7 @@ impl<'a> TestVariantIterator<'a> {
         py: Python,
         test: &'a DiscoveredTestFunction,
         resolver: &mut RuntimeFixtureResolver,
-    ) -> Result<Self, FixtureResolutionError> {
+    ) -> FixtureResolutionResult<Self> {
         let test_params = test.tags.parametrize_args();
 
         let parametrize_param_names: HashSet<&str> = test_params

--- a/crates/karva_test_semantic/src/runner/test_iterator.rs
+++ b/crates/karva_test_semantic/src/runner/test_iterator.rs
@@ -8,7 +8,7 @@ use crate::discovery::DiscoveredTestFunction;
 use crate::extensions::fixtures::{NormalizedFixture, RequiresFixtures};
 use crate::extensions::tags::Tags;
 use crate::extensions::tags::parametrize::ParametrizationArgs;
-use crate::runner::fixture_resolver::{FixtureCycleError, RuntimeFixtureResolver};
+use crate::runner::fixture_resolver::{FixtureResolutionError, RuntimeFixtureResolver};
 
 /// A single variant of a test to be executed.
 ///
@@ -93,7 +93,7 @@ impl<'a> TestVariantIterator<'a> {
         py: Python,
         test: &'a DiscoveredTestFunction,
         resolver: &mut RuntimeFixtureResolver,
-    ) -> Result<Self, FixtureCycleError> {
+    ) -> Result<Self, FixtureResolutionError> {
         let test_params = test.tags.parametrize_args();
 
         let parametrize_param_names: HashSet<&str> = test_params


### PR DESCRIPTION
## Summary

Reject fixture dependency edges where a longer-lived fixture consumes a shorter-lived fixture before any fixture body runs. Scope mismatch diagnostics show the full dependency path and source locations for Karva, pytest, dynamic, autouse, and nested fixtures.

Fixes #968

## Test Plan

Fixture and snapshot integration suites, strict workspace Clippy, and all pre-commit hooks pass.