### PR TITLE
Fix diagnostic sort panic with multiple import failures

### DIFF
--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -1660,6 +1660,47 @@ def test_pass():
     ");
 }
 
+#[test]
+fn test_two_failed_imports_both_reported() {
+    let context = TestContext::with_files([
+        (
+            "test_bad_a.py",
+            r"
+import nonexistent_module_abc
+
+def test_a():
+    assert True
+            ",
+        ),
+        (
+            "test_bad_b.py",
+            r"
+import nonexistent_module_xyz
+
+def test_b():
+    assert True
+            ",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+    diagnostics:
+
+    error[failed-to-import-module]: Failed to import python module `test_bad_a`: No module named 'nonexistent_module_abc'
+
+    error[failed-to-import-module]: Failed to import python module `test_bad_b`: No module named 'nonexistent_module_xyz'
+
+    ────────────
+         Summary [TIME] 0 tests run: 0 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
 /// `--max-fail=2` should run exactly two failing tests and then stop scheduling
 /// the rest. The summary reflects only the tests that actually ran.
 #[test]

--- a/crates/karva_diagnostic/src/result/mod.rs
+++ b/crates/karva_diagnostic/src/result/mod.rs
@@ -45,6 +45,27 @@ pub struct TestRunResult {
     captured_outputs: Vec<CapturedTestOutput>,
 }
 
+/// Orders diagnostics for display.
+///
+/// `Diagnostic::ruff_start_ordering` panics when either diagnostic has no
+/// primary span pointing at a `SourceFile`, which is the case for karva
+/// diagnostics like `failed-to-import-module` that describe a whole module
+/// rather than a location within it. Diagnostics with a source file sort by
+/// that ordering first; span-less diagnostics sort after them, by id and
+/// then message, so they still appear rather than being dropped or causing
+/// the sort to panic.
+fn diagnostic_display_ordering(a: &Diagnostic, b: &Diagnostic) -> std::cmp::Ordering {
+    match (a.ruff_source_file(), b.ruff_source_file()) {
+        (Some(_), Some(_)) => a.ruff_start_ordering(b),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => a
+            .id()
+            .cmp(&b.id())
+            .then_with(|| a.primary_message().cmp(b.primary_message())),
+    }
+}
+
 impl TestRunResult {
     pub fn diagnostics(&self) -> &[Diagnostic] {
         &self.diagnostics
@@ -186,7 +207,7 @@ impl TestRunResult {
 
     #[must_use]
     pub fn into_sorted(mut self) -> Self {
-        self.diagnostics.sort_by(Diagnostic::ruff_start_ordering);
+        self.diagnostics.sort_by(diagnostic_display_ordering);
         self.test_cases.sort_by(|a, b| {
             a.module_name()
                 .cmp(b.module_name())


### PR DESCRIPTION
Fixes #1031.

Sorting collected diagnostics panicked when more than one module failed to import. Those failures are span-less, and `Diagnostic::ruff_start_ordering` expects a Ruff source file, so the comparator blew up before any errors were shown.

This change introduces a display ordering helper that still uses `ruff_start_ordering` when both diagnostics have a source file, and otherwise orders span-less diagnostics after spanned ones (then by id and primary message). An integration test covers two failing imports and checks that both `failed-to-import-module` diagnostics are reported without a panic.

Verified with `cargo test -p karva test_two_failed_imports_both_reported`, the related collection-error integration test, and `cargo test -p karva_diagnostic`.