### PR TITLE
Report unhandled thread and unraisable exceptions

### DIFF
--- a/crates/karva/tests/it/main.rs
+++ b/crates/karva/tests/it/main.rs
@@ -17,5 +17,6 @@ mod result_report;
 mod run_ignored;
 mod run_timeout;
 mod show_config;
+mod unhandled_exceptions;
 mod version;
 mod watch;

--- a/crates/karva/tests/it/result_report.rs
+++ b/crates/karva/tests/it/result_report.rs
@@ -621,6 +621,95 @@ fn writes_jsonl_run_diagnostic_records() {
 }
 
 #[test]
+fn unhandled_thread_exception_is_failed_in_json_result_report() {
+    let context = TestContext::with_file(
+        "test_thread.py",
+        r#"
+from threading import Thread
+
+
+def test_background_work():
+    thread = Thread(
+        target=lambda: 1 / 0,
+        name="background",
+    )
+    thread.start()
+    thread.join()
+"#,
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
+            "--status-level=none",
+            "--result-output=reports/results.json",
+        ]),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    failures:
+
+    test_thread::test_background_work:
+
+    error[unhandled-thread-exception]: Unhandled exception `ZeroDivisionError` in thread `background`
+     --> test_thread.py:5:5
+      |
+    5 | def test_background_work():
+      |     ^^^^^^^^^^^^^^^^^^^^
+      |
+    info: Exception raised here
+     --> test_thread.py:7:9
+      |
+    7 |         target=lambda: 1 / 0,
+      |         ^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: ZeroDivisionError: division by zero
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+
+    assert_snapshot!(
+        context.read_file("reports/results.json"),
+        @r#"
+    {
+      "schema_version": 2,
+      "status": "failed",
+      "elapsed_seconds": "[TIME]",
+      "stats": {
+        "total": 1,
+        "passed": 0,
+        "failed": 1,
+        "errors": 0,
+        "skipped": 0,
+        "flaky": 0,
+        "slow": 0
+      },
+      "tests": [
+        {
+          "module": "test_thread",
+          "name": "test_background_work",
+          "full_name": "test_thread::test_background_work",
+          "status": "failed",
+          "duration_seconds": "[TIME]",
+          "diagnostic": {
+            "code": "unhandled-thread-exception",
+            "severity": "error",
+            "message": "Unhandled exception `ZeroDivisionError` in thread `background`",
+            "rendered": "error[unhandled-thread-exception]: Unhandled exception `ZeroDivisionError` in thread `background`\n --> test_thread.py:5:5\n  |/n5 | def test_background_work():\n  |     ^^^^^^^^^^^^^^^^^^^^\n  |/ninfo: Exception raised here\n --> test_thread.py:7:9\n  |/n7 |         target=lambda: 1 / 0,\n  |         ^^^^^^^^^^^^^^^^^^^^^\n  |/ninfo: ZeroDivisionError: division by zero\n\n"
+          }
+        }
+      ]
+    }
+    "#
+    );
+}
+
+#[test]
 fn result_report_status_matches_no_tests_failure() {
     let context = TestContext::new();
 

--- a/crates/karva/tests/it/unhandled_exceptions.rs
+++ b/crates/karva/tests/it/unhandled_exceptions.rs
@@ -1,0 +1,436 @@
+use insta_cmd::assert_cmd_snapshot;
+
+use crate::common::TestContext;
+
+#[test]
+fn test_unhandled_thread_exceptions_fail_the_active_test() {
+    let context = TestContext::with_file(
+        "test_thread.py",
+        r#"
+from threading import Thread
+
+
+def raise_in_thread(message):
+    raise RuntimeError(message)
+
+
+def test_background_work():
+    for index in range(2):
+        thread = Thread(
+            target=raise_in_thread,
+            args=(f"failure {index}",),
+            name=f"background-{index}",
+        )
+        thread.start()
+        thread.join()
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test_thread::test_background_work
+
+    failures:
+
+    test_thread::test_background_work:
+
+    error[unhandled-thread-exception]: Unhandled exception `RuntimeError` in thread `background-0`
+     --> test_thread.py:9:5
+      |
+    9 | def test_background_work():
+      |     ^^^^^^^^^^^^^^^^^^^^
+      |
+    info: Exception raised here
+     --> test_thread.py:6:5
+      |
+    6 |     raise RuntimeError(message)
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: RuntimeError: failure 0
+
+    error[unhandled-thread-exception]: Unhandled exception `RuntimeError` in thread `background-1`
+     --> test_thread.py:9:5
+      |
+    9 | def test_background_work():
+      |     ^^^^^^^^^^^^^^^^^^^^
+      |
+    info: Exception raised here
+     --> test_thread.py:6:5
+      |
+    6 |     raise RuntimeError(message)
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: RuntimeError: failure 1
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_unraisable_exception_fails_the_active_test() {
+    let context = TestContext::with_file(
+        "test_unraisable.py",
+        r#"
+import gc
+
+
+class BrokenCleanup:
+    def __del__(self):
+        raise RuntimeError("cleanup failed")
+
+    def __repr__(self):
+        return "BrokenCleanup()"
+
+
+def test_cleanup():
+    value = BrokenCleanup()
+    del value
+    gc.collect()
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test_unraisable::test_cleanup
+
+    failures:
+
+    test_unraisable::test_cleanup:
+
+    error[unraisable-exception]: Unraisable exception `RuntimeError`
+      --> test_unraisable.py:13:5
+       |
+    13 | def test_cleanup():
+       |     ^^^^^^^^^^^^
+       |
+    info: Object: `BrokenCleanup.__del__`
+    info: Exception raised here
+     --> test_unraisable.py:7:9
+      |
+    7 |         raise RuntimeError("cleanup failed")
+      |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: RuntimeError: cleanup failed
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    "#);
+}
+
+#[test]
+fn test_fixture_lifecycle_exceptions_fail_the_active_test() {
+    let context = TestContext::with_file(
+        "test_fixture.py",
+        r#"
+from threading import Thread
+
+import karva
+
+
+def raise_in_thread(message):
+    raise RuntimeError(message)
+
+
+@karva.fixture
+def resource():
+    setup_thread = Thread(
+        target=raise_in_thread,
+        args=("setup failed",),
+        name="fixture-setup",
+    )
+    setup_thread.start()
+    setup_thread.join()
+    yield "resource"
+    teardown_thread = Thread(
+        target=raise_in_thread,
+        args=("teardown failed",),
+        name="fixture-teardown",
+    )
+    teardown_thread.start()
+    teardown_thread.join()
+
+
+def test_resource(resource):
+    assert resource == "resource"
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test_fixture::test_resource(resource=resource)
+
+    failures:
+
+    test_fixture::test_resource(resource=resource):
+
+    error[unhandled-thread-exception]: Unhandled exception `RuntimeError` in thread `fixture-setup`
+      --> test_fixture.py:30:5
+       |
+    30 | def test_resource(resource):
+       |     ^^^^^^^^^^^^^
+       |
+    info: Exception raised here
+     --> test_fixture.py:8:5
+      |
+    8 |     raise RuntimeError(message)
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: RuntimeError: setup failed
+
+    error[unhandled-thread-exception]: Unhandled exception `RuntimeError` in thread `fixture-teardown`
+      --> test_fixture.py:30:5
+       |
+    30 | def test_resource(resource):
+       |     ^^^^^^^^^^^^^
+       |
+    info: Exception raised here
+     --> test_fixture.py:8:5
+      |
+    8 |     raise RuntimeError(message)
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: RuntimeError: teardown failed
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_unattributed_exception_fails_the_run() {
+    let context = TestContext::with_file(
+        "test_import.py",
+        r#"
+from threading import Thread
+
+
+def raise_during_import():
+    raise RuntimeError("import thread failed")
+
+
+thread = Thread(target=raise_during_import, name="import-thread")
+thread.start()
+thread.join()
+
+
+def test_still_runs():
+    pass
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test_import::test_still_runs
+
+    diagnostics:
+
+    error[unhandled-thread-exception]: Unhandled exception `RuntimeError` in thread `import-thread`
+    info: Exception raised here
+     --> test_import.py:6:5
+      |
+    6 |     raise RuntimeError("import thread failed")
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: RuntimeError: import thread failed
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    "#);
+}
+
+#[test]
+fn test_handled_thread_exception_is_ignored() {
+    let context = TestContext::with_file(
+        "test_handled.py",
+        r#"
+from threading import Thread
+
+
+def handle_exception():
+    try:
+        raise RuntimeError("handled")
+    except RuntimeError:
+        pass
+
+
+def exit_thread():
+    raise SystemExit
+
+
+def test_handled_exception():
+    for target in (handle_exception, exit_thread):
+        thread = Thread(target=target)
+        thread.start()
+        thread.join()
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test_handled::test_handled_exception
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_unhandled_thread_exception_cannot_be_retried_away() {
+    let context = TestContext::with_file(
+        "test_retry.py",
+        r#"
+from threading import Thread
+
+
+def test_background_work():
+    thread = Thread(
+        target=lambda: 1 / 0,
+        name="retry-thread",
+    )
+    thread.start()
+    thread.join()
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--retry=1"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test_retry::test_background_work
+
+    failures:
+
+    test_retry::test_background_work:
+
+    error[unhandled-thread-exception]: Unhandled exception `ZeroDivisionError` in thread `retry-thread`
+     --> test_retry.py:5:5
+      |
+    5 | def test_background_work():
+      |     ^^^^^^^^^^^^^^^^^^^^
+      |
+    info: Exception raised here
+     --> test_retry.py:7:9
+      |
+    7 |         target=lambda: 1 / 0,
+      |         ^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: ZeroDivisionError: division by zero
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_unhandled_thread_exceptions_fail_parallel_workers() {
+    let context = TestContext::with_files([
+        (
+            "test_one.py",
+            r#"
+from threading import Thread
+
+
+def test_one():
+    thread = Thread(
+        target=lambda: 1 / 0,
+        name="first-worker-thread",
+    )
+    thread.start()
+    thread.join()
+"#,
+        ),
+        (
+            "test_two.py",
+            r#"
+from threading import Thread
+
+
+def test_two():
+    thread = Thread(
+        target=lambda: 1 / 0,
+        name="second-worker-thread",
+    )
+    thread.start()
+    thread.join()
+"#,
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context
+            .command()
+            .args(["--num-workers=2", "--status-level=none"]),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    failures:
+
+    test_one::test_one:
+
+    error[unhandled-thread-exception]: Unhandled exception `ZeroDivisionError` in thread `first-worker-thread`
+     --> test_one.py:5:5
+      |
+    5 | def test_one():
+      |     ^^^^^^^^
+      |
+    info: Exception raised here
+     --> test_one.py:7:9
+      |
+    7 |         target=lambda: 1 / 0,
+      |         ^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: ZeroDivisionError: division by zero
+
+    test_two::test_two:
+
+    error[unhandled-thread-exception]: Unhandled exception `ZeroDivisionError` in thread `second-worker-thread`
+     --> test_two.py:5:5
+      |
+    5 | def test_two():
+      |     ^^^^^^^^
+      |
+    info: Exception raised here
+     --> test_two.py:7:9
+      |
+    7 |         target=lambda: 1 / 0,
+      |         ^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: ZeroDivisionError: division by zero
+
+    ────────────
+         Summary [TIME] 2 tests run: 0 passed, 2 failed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+}

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -9,6 +9,7 @@ use karva_collector::CollectionError;
 use karva_diagnostic::Traceback;
 use karva_logging::time::format_duration;
 use karva_python_semantic::FunctionKind;
+use pyo3::types::PyTypeMethods;
 use pyo3::{PyErr, Python};
 use ruff_db::diagnostic::{
     Annotation, Diagnostic, Severity, Span, SubDiagnostic, SubDiagnosticSeverity,
@@ -23,6 +24,7 @@ use crate::runner::{
     FixtureArguments, FixtureCallError, FixtureChainEntry, FixtureResolutionEntry,
     FixtureResolutionError,
 };
+use crate::unhandled_exceptions::{UnhandledExceptionEvent, UnhandledExceptionKind};
 use crate::utils::truncate_string;
 use crate::{Context, declare_diagnostic_type};
 
@@ -153,6 +155,26 @@ declare_diagnostic_type! {
     /// If a test raises an exception, we will raise this error.
     pub static TEST_FAILURE = {
         summary: "Test raises exception when run",
+        severity: Severity::Error,
+    }
+}
+
+declare_diagnostic_type! {
+    /// ## Unhandled thread exception
+    ///
+    /// Raised when a background thread exits because of an unhandled exception.
+    pub static UNHANDLED_THREAD_EXCEPTION = {
+        summary: "A thread raised an unhandled exception",
+        severity: Severity::Error,
+    }
+}
+
+declare_diagnostic_type! {
+    /// ## Unraisable exception
+    ///
+    /// Raised when Python reports an exception through `sys.unraisablehook`.
+    pub static UNRAISABLE_EXCEPTION = {
+        summary: "Python could not raise an exception normally",
         severity: Severity::Error,
     }
 }
@@ -480,6 +502,74 @@ pub fn test_failure_diagnostic(
         FunctionKind::Test,
         error,
     );
+    diagnostic
+}
+
+pub fn unhandled_exception_diagnostic(
+    py: Python<'_>,
+    event: &UnhandledExceptionEvent,
+    test: Option<(&SourceFile, &StmtFunctionDef)>,
+) -> Diagnostic {
+    let exception_type = event
+        .error
+        .get_type(py)
+        .name()
+        .map_or_else(|_| "Python exception".to_string(), |name| name.to_string());
+    let (diagnostic_type, message) = match &event.kind {
+        UnhandledExceptionKind::Thread { name } => (
+            &UNHANDLED_THREAD_EXCEPTION,
+            format!(
+                "Unhandled exception `{exception_type}` in thread `{}`",
+                truncate_string(name)
+            ),
+        ),
+        UnhandledExceptionKind::Unraisable { .. } => (
+            &UNRAISABLE_EXCEPTION,
+            format!("Unraisable exception `{exception_type}`"),
+        ),
+    };
+    let mut diagnostic = diagnostic_type.diagnostic(message);
+
+    if let Some((source_file, stmt_function_def)) = test {
+        annotate_function_name(&mut diagnostic, source_file.clone(), stmt_function_def);
+    }
+
+    match &event.kind {
+        UnhandledExceptionKind::Thread { .. } => {}
+        UnhandledExceptionKind::Unraisable {
+            context, object, ..
+        } => {
+            if let Some(context) = context {
+                diagnostic.info(context);
+            }
+            diagnostic.info(format!("Object: `{}`", truncate_string(object)));
+        }
+    }
+
+    let traceback = match test {
+        Some((source_file, _)) => Traceback::from_error_with_source(py, &event.error, source_file),
+        None => Traceback::from_error(py, &event.error),
+    };
+    if let Some(Traceback {
+        lines: _,
+        error_source_file,
+        location,
+    }) = traceback
+    {
+        let mut sub = SubDiagnostic::new(
+            SubDiagnosticSeverity::Info,
+            "Exception raised here".to_string(),
+        );
+        sub.annotate(Annotation::primary(
+            Span::from(error_source_file).with_range(location),
+        ));
+        diagnostic.sub(sub);
+    }
+
+    let error_message = event.error.value(py).to_string();
+    if !error_message.is_empty() {
+        diagnostic.info(format!("{exception_type}: {error_message}"));
+    }
     diagnostic
 }
 

--- a/crates/karva_test_semantic/src/lib.rs
+++ b/crates/karva_test_semantic/src/lib.rs
@@ -7,6 +7,7 @@ mod output_capture;
 mod py_attach;
 mod python;
 mod runner;
+mod unhandled_exceptions;
 pub mod utils;
 
 pub(crate) use context::Context;
@@ -20,9 +21,11 @@ use karva_metadata::ProjectSettings;
 use karva_project::path::{TestPath, TestPathError};
 use ruff_python_ast::PythonVersion;
 
+use crate::diagnostic::unhandled_exception_diagnostic;
 use crate::discovery::StandardDiscoverer;
 use crate::py_attach::attach_with_output;
 use crate::runner::PackageRunner;
+use crate::unhandled_exceptions::UnhandledExceptionCapture;
 
 /// Run tests given the system, settings, Python version, reporter, and test paths.
 ///
@@ -39,6 +42,13 @@ pub fn run_tests(
     let context = Context::new(cwd, settings, python_version, reporter);
 
     attach_with_output(settings.terminal().show_python_output, |py| {
+        let exception_capture = match UnhandledExceptionCapture::start(py) {
+            Ok(capture) => Some(capture),
+            Err(err) => {
+                tracing::warn!("failed to install Python exception hooks: {err}");
+                None
+            }
+        };
         let cov_session = coverage.and_then(|cfg| match CoverageSession::start(py, cwd, cfg) {
             Ok(session) => Some(session),
             Err(err) => {
@@ -49,12 +59,25 @@ pub fn run_tests(
 
         let session = StandardDiscoverer::new(&context).discover_with_py(py, test_paths);
 
-        PackageRunner::new(&context, cov_session.as_ref()).execute(py, &session);
+        PackageRunner::new(&context, cov_session.as_ref(), exception_capture.as_ref())
+            .execute(py, &session);
 
         if let Some(cov_session) = cov_session
             && let Err(err) = cov_session.stop_and_save(py)
         {
             tracing::error!("Failed to save coverage data: {err}");
+        }
+
+        if let Some(exception_capture) = exception_capture {
+            match exception_capture.finish(py) {
+                Ok(events) => {
+                    for event in events {
+                        context
+                            .add_run_diagnostic(unhandled_exception_diagnostic(py, &event, None));
+                    }
+                }
+                Err(err) => tracing::warn!("failed to restore Python exception hooks: {err}"),
+            }
         }
 
         context.into_result()

--- a/crates/karva_test_semantic/src/runner/package_runner/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/mod.rs
@@ -15,6 +15,7 @@ use crate::extensions::fixtures::FixtureScope;
 use crate::runner::fixture_resolver::RuntimeFixtureResolver;
 use crate::runner::test_iterator::TestVariantIterator;
 use crate::runner::{FinalizerCache, FixtureCache};
+use crate::unhandled_exceptions::UnhandledExceptionCapture;
 
 mod fixture;
 mod outcome;
@@ -36,6 +37,8 @@ pub struct PackageRunner<'context, 'settings> {
     finalizer_cache: FinalizerCache,
     /// Active coverage session for this worker, when coverage is enabled.
     coverage: Option<&'context CoverageSession>,
+    /// Captures exceptions that Python cannot propagate through the test call.
+    exception_capture: Option<&'context UnhandledExceptionCapture>,
     /// Failed variants observed so far, used to enforce `max-fail`.
     failed_count: Cell<u32>,
 }
@@ -45,12 +48,14 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
     pub(crate) fn new(
         context: &'context Context<'settings>,
         coverage: Option<&'context CoverageSession>,
+        exception_capture: Option<&'context UnhandledExceptionCapture>,
     ) -> Self {
         Self {
             context,
             fixture_cache: FixtureCache::default(),
             finalizer_cache: FinalizerCache::default(),
             coverage,
+            exception_capture,
             failed_count: Cell::new(0),
         }
     }

--- a/crates/karva_test_semantic/src/runner/package_runner/outcome.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/outcome.rs
@@ -210,6 +210,46 @@ pub(super) fn attach_finalizer_diagnostics(
     }
 }
 
+/// Attaches unhandled Python exceptions while preserving an existing primary failure.
+pub(super) fn attach_unhandled_diagnostics(
+    outcome: TestExecutionOutcome,
+    mut diagnostics: Vec<Diagnostic>,
+) -> TestExecutionOutcome {
+    if diagnostics.is_empty() {
+        return outcome;
+    }
+
+    match outcome {
+        TestExecutionOutcome::Failed {
+            diagnostic,
+            mut related,
+        } => {
+            related.append(&mut diagnostics);
+            TestExecutionOutcome::Failed {
+                diagnostic,
+                related,
+            }
+        }
+        TestExecutionOutcome::Error {
+            diagnostic,
+            mut related,
+        } => {
+            related.append(&mut diagnostics);
+            TestExecutionOutcome::Error {
+                diagnostic,
+                related,
+            }
+        }
+        TestExecutionOutcome::Passed | TestExecutionOutcome::Skipped { .. } => {
+            let diagnostic = diagnostics.remove(0);
+            TestExecutionOutcome::Failed {
+                diagnostic,
+                related: diagnostics,
+            }
+        }
+    }
+}
+
 /// Applies a full-lifecycle `fail-slow` budget to one attempt outcome.
 pub(super) fn apply_fail_slow_budget(
     outcome: TestExecutionOutcome,

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
@@ -28,6 +28,8 @@ mod attempt;
 
 use attempt::{PreparedTestAttempt, TestLifecycleAttempt};
 
+use super::outcome::attach_unhandled_diagnostics;
+
 impl PackageRunner<'_, '_> {
     /// Runs one concrete parameter and fixture combination.
     pub(super) fn execute_test_variant(&self, py: Python<'_>, variant: TestVariant<'_>) -> bool {
@@ -100,6 +102,10 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             return result;
         }
 
+        let active_test_name = self.test.name.to_string();
+        if let Some(capture) = self.package_runner.exception_capture {
+            capture.set_active_test(Some(&active_test_name));
+        }
         let output_capture = self.start_output_capture();
         let retry_params = self.params.clone();
         let first_params = std::mem::take(&mut self.params);
@@ -284,8 +290,27 @@ impl<'runner, 'context, 'settings, 'test, 'py>
         settings: &VariantSettings,
         output_capture: Option<PythonOutputCapture>,
         prior_attempts: Vec<TestLifecycleAttempt>,
-        final_attempt: TestLifecycleAttempt,
+        mut final_attempt: TestLifecycleAttempt,
     ) -> bool {
+        let unhandled_diagnostics =
+            self.package_runner
+                .exception_capture
+                .map_or_else(Vec::new, |capture| {
+                    capture.set_active_test(None);
+                    capture
+                        .take_events_for(&self.test.name.to_string())
+                        .iter()
+                        .map(|event| {
+                            crate::diagnostic::unhandled_exception_diagnostic(
+                                self.py,
+                                event,
+                                Some((&self.test.source_file, &self.test.stmt_function_def)),
+                            )
+                        })
+                        .collect()
+                });
+        final_attempt.outcome =
+            attach_unhandled_diagnostics(final_attempt.outcome, unhandled_diagnostics);
         self.set_coverage_context(None);
         let captured_output = finish_output_capture(self.py, output_capture);
         let total_duration = prior_attempts

--- a/crates/karva_test_semantic/src/unhandled_exceptions.rs
+++ b/crates/karva_test_semantic/src/unhandled_exceptions.rs
@@ -1,0 +1,165 @@
+use std::sync::{Mutex, MutexGuard, PoisonError};
+
+use pyo3::exceptions::PySystemExit;
+use pyo3::prelude::*;
+
+#[derive(Debug)]
+pub enum UnhandledExceptionKind {
+    Thread {
+        name: String,
+    },
+    Unraisable {
+        context: Option<String>,
+        object: String,
+    },
+}
+
+#[derive(Debug)]
+pub struct UnhandledExceptionEvent {
+    pub(crate) test_name: Option<String>,
+    pub(crate) kind: UnhandledExceptionKind,
+    pub(crate) error: PyErr,
+}
+
+#[derive(Default)]
+struct HookState {
+    active_test: Option<String>,
+    events: Vec<UnhandledExceptionEvent>,
+}
+
+#[pyclass(frozen)]
+struct ExceptionHooks {
+    state: Mutex<HookState>,
+}
+
+impl ExceptionHooks {
+    fn state(&self) -> MutexGuard<'_, HookState> {
+        self.state.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    fn set_active_test(&self, test_name: Option<&str>) {
+        self.state().active_test = test_name.map(String::from);
+    }
+
+    fn take_events_for(&self, test_name: &str) -> Vec<UnhandledExceptionEvent> {
+        let mut state = self.state();
+        let events = std::mem::take(&mut state.events);
+        let (matching, remaining) = events
+            .into_iter()
+            .partition(|event| event.test_name.as_deref() == Some(test_name));
+        state.events = remaining;
+        matching
+    }
+
+    fn take_all_events(&self) -> Vec<UnhandledExceptionEvent> {
+        std::mem::take(&mut self.state().events)
+    }
+
+    fn push(&self, kind: UnhandledExceptionKind, error: PyErr) {
+        let mut state = self.state();
+        let test_name = state.active_test.clone();
+        state.events.push(UnhandledExceptionEvent {
+            test_name,
+            kind,
+            error,
+        });
+    }
+}
+
+#[pymethods]
+impl ExceptionHooks {
+    fn thread_excepthook(&self, args: &Bound<'_, PyAny>) -> PyResult<()> {
+        let exception = args.getattr("exc_value")?;
+        if exception.is_instance_of::<PySystemExit>() {
+            return Ok(());
+        }
+
+        let thread_name = args
+            .getattr("thread")
+            .and_then(|thread| thread.getattr("name"))
+            .and_then(|name| name.extract::<String>())
+            .unwrap_or_else(|_| "<unknown>".to_string());
+        self.push(
+            UnhandledExceptionKind::Thread { name: thread_name },
+            PyErr::from_value(exception),
+        );
+        Ok(())
+    }
+
+    fn unraisablehook(&self, args: &Bound<'_, PyAny>) -> PyResult<()> {
+        let exception = args.getattr("exc_value")?;
+        let context = args.getattr("err_msg")?.extract::<Option<String>>()?;
+        let object = args.getattr("object")?;
+        let object = object
+            .getattr("__qualname__")
+            .and_then(|name| name.extract::<String>())
+            .or_else(|_| object.repr().and_then(|repr| repr.extract::<String>()))
+            .unwrap_or_else(|_| "<unrepresentable object>".to_string());
+        self.push(
+            UnhandledExceptionKind::Unraisable { context, object },
+            PyErr::from_value(exception),
+        );
+        Ok(())
+    }
+}
+
+pub struct UnhandledExceptionCapture {
+    hooks: Py<ExceptionHooks>,
+    previous_thread_hook: Py<PyAny>,
+    previous_unraisable_hook: Py<PyAny>,
+}
+
+impl UnhandledExceptionCapture {
+    pub(crate) fn start(py: Python<'_>) -> PyResult<Self> {
+        let threading = py.import("threading")?;
+        let sys = py.import("sys")?;
+        let previous_thread_hook = threading.getattr("excepthook")?.unbind();
+        let previous_unraisable_hook = sys.getattr("unraisablehook")?.unbind();
+        let hooks = Py::new(
+            py,
+            ExceptionHooks {
+                state: Mutex::new(HookState::default()),
+            },
+        )?;
+
+        threading.setattr("excepthook", hooks.bind(py).getattr("thread_excepthook")?)?;
+        if let Err(error) = sys.setattr("unraisablehook", hooks.bind(py).getattr("unraisablehook")?)
+        {
+            if let Err(restore_error) =
+                threading.setattr("excepthook", previous_thread_hook.bind(py))
+            {
+                tracing::warn!(
+                    "failed to restore threading.excepthook after hook setup error: {restore_error}"
+                );
+            }
+            return Err(error);
+        }
+
+        Ok(Self {
+            hooks,
+            previous_thread_hook,
+            previous_unraisable_hook,
+        })
+    }
+
+    pub(crate) fn set_active_test(&self, test_name: Option<&str>) {
+        self.hooks.get().set_active_test(test_name);
+    }
+
+    pub(crate) fn take_events_for(&self, test_name: &str) -> Vec<UnhandledExceptionEvent> {
+        self.hooks.get().take_events_for(test_name)
+    }
+
+    pub(crate) fn finish(self, py: Python<'_>) -> PyResult<Vec<UnhandledExceptionEvent>> {
+        self.set_active_test(None);
+        let threading = py.import("threading")?;
+        let sys = py.import("sys")?;
+        let thread_result = threading.setattr("excepthook", self.previous_thread_hook.bind(py));
+        let unraisable_result =
+            sys.setattr("unraisablehook", self.previous_unraisable_hook.bind(py));
+        let events = self.hooks.get().take_all_events();
+        thread_result?;
+        unraisable_result?;
+        Ok(events)
+    }
+}


### PR DESCRIPTION
## Summary

Capture unhandled thread and unraisable exceptions at worker startup, attach lifecycle events to active tests, and report unattributed events as worker diagnostics. Multiple events are retained, hooks are restored at shutdown, and affected runs fail. Closes #969.

## Test Plan

Ran `just test` and `uvx prek run -a`.