### PR TITLE
Reject stdin reads while output is captured

### DIFF
--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -659,6 +659,85 @@ fn test_stdout() {
 }
 
 #[test]
+fn test_stdin_is_unavailable_while_captured() {
+    let context = TestContext::with_file(
+        "test_stdin.py",
+        r#"
+        import subprocess
+        import sys
+
+        MESSAGE = """stdin is unavailable while test output is captured
+
+        Pass input explicitly to the code under test, or use --no-capture for an
+        intentional interactive debugging session."""
+
+        def test_stdin():
+            readers = (
+                input,
+                sys.stdin.read,
+                sys.stdin.readline,
+                sys.stdin.readlines,
+                sys.stdin.fileno,
+                sys.stdin.buffer.read,
+                lambda: next(iter(sys.stdin)),
+            )
+            for read in readers:
+                try:
+                    read()
+                except OSError as error:
+                    assert str(error) == MESSAGE
+                else:
+                    raise AssertionError("stdin read succeeded")
+
+            child = subprocess.run(
+                [sys.executable, "-c", "import os; os.write(1, os.read(0, 1))"],
+                check=True,
+                stdout=subprocess.PIPE,
+                timeout=1,
+            )
+            assert child.stdout == b""
+        "#,
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test_stdin::test_stdin
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_no_capture_preserves_stdin() {
+    let context = TestContext::with_file(
+        "test_stdin.py",
+        r"
+        import sys
+
+        def test_stdin():
+            assert sys.stdin is sys.__stdin__
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command().arg("--no-capture"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test_stdin::test_stdin
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_failed_output_is_captured() {
     let context = TestContext::with_file(
         "test_failed_output.py",

--- a/crates/karva_test_semantic/src/output_capture.rs
+++ b/crates/karva_test_semantic/src/output_capture.rs
@@ -5,6 +5,7 @@ pub struct PythonOutputCapture {
     old_stderr: Py<PyAny>,
     stdout: Py<PyAny>,
     stderr: Py<PyAny>,
+    stdin: StdinCapture,
 }
 
 impl PythonOutputCapture {
@@ -26,12 +27,24 @@ impl PythonOutputCapture {
             }
             return Err(err);
         }
+        let stdin = match StdinCapture::start(py) {
+            Ok(capture) => capture,
+            Err(err) => {
+                if let Err(restore_err) = restore_stdio(&sys, &old_stdout, &old_stderr, py) {
+                    tracing::warn!(
+                        "failed to restore Python output after stdin capture setup error: {restore_err}"
+                    );
+                }
+                return Err(err);
+            }
+        };
 
         Ok(Self {
             old_stdout,
             old_stderr,
             stdout,
             stderr,
+            stdin,
         })
     }
 
@@ -40,9 +53,11 @@ impl PythonOutputCapture {
         flush_current_streams(&sys);
 
         let restore_result = restore_stdio(&sys, &self.old_stdout, &self.old_stderr, py);
+        let stdin_result = self.stdin.finish(py);
         let stdout = self.stdout.bind(py).call_method0("getvalue")?.extract()?;
         let stderr = self.stderr.bind(py).call_method0("getvalue")?.extract()?;
         restore_result?;
+        stdin_result?;
 
         Ok(CapturedPythonOutput { stdout, stderr })
     }
@@ -51,6 +66,56 @@ impl PythonOutputCapture {
 pub struct CapturedPythonOutput {
     pub stdout: String,
     pub stderr: String,
+}
+
+struct StdinCapture {
+    old_stdin: Py<PyAny>,
+    old_stdin_fd: i64,
+}
+
+impl StdinCapture {
+    fn start(py: Python<'_>) -> PyResult<Self> {
+        let os = py.import("os")?;
+        let sys = py.import("sys")?;
+        let builtins = py.import("builtins")?;
+        let old_stdin = sys.getattr("stdin")?.unbind();
+        let eof = builtins
+            .getattr("open")?
+            .call1((os.getattr("devnull")?, "rb"))?;
+        let unreadable = py
+            .import("karva._builtins")?
+            .getattr("_CapturedStdin")?
+            .call0()?;
+        let eof_fd: i64 = eof.call_method0("fileno")?.extract()?;
+        let old_stdin_fd = os.call_method1("dup", (0,))?.extract()?;
+        let capture = Self {
+            old_stdin,
+            old_stdin_fd,
+        };
+
+        let start_result = os
+            .call_method1("dup2", (eof_fd, 0))
+            .and_then(|_| sys.setattr("stdin", unreadable));
+        if let Err(err) = start_result {
+            if let Err(restore_err) = capture.finish(py) {
+                tracing::warn!("failed to restore stdin after capture setup error: {restore_err}");
+            }
+            return Err(err);
+        }
+
+        Ok(capture)
+    }
+
+    fn finish(self, py: Python<'_>) -> PyResult<()> {
+        let os = py.import("os")?;
+        let sys = py.import("sys")?;
+        let descriptor_result = os.call_method1("dup2", (self.old_stdin_fd, 0)).map(|_| ());
+        let stdin_result = sys.setattr("stdin", self.old_stdin.bind(py));
+        let close_result = os.call_method1("close", (self.old_stdin_fd,)).map(|_| ());
+        descriptor_result?;
+        stdin_result?;
+        close_result
+    }
 }
 
 fn flush_current_streams(sys: &Bound<'_, PyModule>) {

--- a/docs/usage/running-tests/parallel.md
+++ b/docs/usage/running-tests/parallel.md
@@ -35,6 +35,8 @@ def database_url():
 
 By default, stdout/stderr from a test is captured and emitted only when the test fails or when `--show-output` / `-s` is set. This keeps parallel output legible — without capture, output from concurrent tests would interleave on the terminal.
 
+Captured tests cannot read from stdin, and child processes receive immediate EOF. Pass input explicitly to the code under test, or use `--no-capture` for an intentional interactive session.
+
 `--no-capture` disables capture entirely and forces a single worker, since uncaptured output from concurrent workers cannot safely interleave:
 
 ```bash

--- a/python/karva/_builtins.py
+++ b/python/karva/_builtins.py
@@ -67,6 +67,47 @@ class CaptureResult(NamedTuple):
     err: str
 
 
+class _CapturedStdin:
+    """Reject reads while Karva captures test output."""
+
+    _message = (
+        "stdin is unavailable while test output is captured\n\n"
+        "Pass input explicitly to the code under test, or use --no-capture for an\n"
+        "intentional interactive debugging session."
+    )
+
+    @property
+    def buffer(self) -> Self:
+        return self
+
+    def read(self, _size: int = -1) -> str:
+        raise OSError(self._message)
+
+    def read1(self, _size: int = -1) -> str:
+        raise OSError(self._message)
+
+    def readinto(self, _buffer: object) -> int:
+        raise OSError(self._message)
+
+    def readline(self, _size: int = -1) -> str:
+        raise OSError(self._message)
+
+    def readlines(self, _hint: int = -1) -> list[str]:
+        raise OSError(self._message)
+
+    def __iter__(self) -> Self:
+        return self
+
+    def __next__(self) -> str:
+        raise OSError(self._message)
+
+    def fileno(self) -> int:
+        raise OSError(self._message)
+
+    def isatty(self) -> bool:
+        return False
+
+
 class _CapsysDisabled:
     """Context manager that temporarily restores real stdout/stderr during capture."""
 


### PR DESCRIPTION
## Summary

Reject Python stdin reads with an actionable error while output capture is active, and redirect file descriptor 0 to immediate EOF for child processes. Preserve real stdin under `--no-capture`. Closes #983.

## Test Plan

Ran `just test` and `uvx prek run -a`.