### PR TITLE
Tie failure diagnostics to test results

### DIFF
--- a/crates/karva/src/commands/test/junit.rs
+++ b/crates/karva/src/commands/test/junit.rs
@@ -32,26 +32,34 @@ pub(super) fn write_junit_report(
 
 fn build_junit_xml(settings: &JunitSettings, results: &AggregatedResults) -> Result<String> {
     let suites = test_cases_by_module(&results.test_cases);
+    let run_errors = results
+        .run_diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.is_error())
+        .count();
     let total_time = results
         .test_cases
         .iter()
-        .map(|case| case.duration().as_secs_f64())
-        .sum::<f64>();
+        .map(TestCaseResult::duration)
+        .sum::<std::time::Duration>()
+        .as_secs_f64();
 
     let mut xml = String::new();
     xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
     writeln!(
         xml,
-        "<testsuites name=\"{}\" tests=\"{}\" failures=\"{}\" skipped=\"{}\" errors=\"0\" time=\"{total_time:.6}\">",
+        "<testsuites name=\"{}\" tests=\"{}\" failures=\"{}\" skipped=\"{}\" errors=\"{}\" time=\"{total_time:.6}\">",
         escape_xml(&settings.report_name),
-        results.stats.total(),
+        results.stats.total() + run_errors,
         results.stats.failed(),
         results.stats.skipped(),
+        results.stats.errors() + run_errors,
     )?;
 
     for (module_name, cases) in suites {
         write_suite(&mut xml, settings, module_name, cases)?;
     }
+    write_run_diagnostics_suite(&mut xml, settings, &results.run_diagnostics)?;
 
     xml.push_str("</testsuites>\n");
     Ok(xml)
@@ -72,14 +80,19 @@ fn write_suite(
         .iter()
         .filter(|case| case.outcome().is_skipped())
         .count();
+    let errors = cases
+        .iter()
+        .filter(|case| case.outcome().is_error())
+        .count();
     let time = cases
         .iter()
-        .map(|case| case.duration().as_secs_f64())
-        .sum::<f64>();
+        .map(|case| case.duration())
+        .sum::<std::time::Duration>()
+        .as_secs_f64();
 
     writeln!(
         xml,
-        "  <testsuite name=\"{}\" tests=\"{tests}\" failures=\"{failures}\" skipped=\"{skipped}\" errors=\"0\" time=\"{time:.6}\">",
+        "  <testsuite name=\"{}\" tests=\"{tests}\" failures=\"{failures}\" skipped=\"{skipped}\" errors=\"{errors}\" time=\"{time:.6}\">",
         escape_xml(module_name),
     )?;
 
@@ -96,12 +109,16 @@ fn write_case(xml: &mut String, settings: &JunitSettings, case: &TestCaseResult)
     let output = case.captured_output();
     let include_output = match case.outcome() {
         TestCaseOutcome::Passed => settings.store_success_output,
-        TestCaseOutcome::Failed { .. } => settings.store_failure_output,
+        TestCaseOutcome::Failed { .. } | TestCaseOutcome::Error { .. } => {
+            settings.store_failure_output
+        }
         TestCaseOutcome::Skipped { .. } => false,
     };
     let has_output = include_output
         && output.is_some_and(|output| !output.stdout().is_empty() || !output.stderr().is_empty());
-    let is_self_closing = matches!(case.outcome(), TestCaseOutcome::Passed) && !has_output;
+    let has_reruns = case.attempts().len() > 1;
+    let is_self_closing =
+        matches!(case.outcome(), TestCaseOutcome::Passed) && !has_output && !has_reruns;
 
     write!(
         xml,
@@ -118,15 +135,14 @@ fn write_case(xml: &mut String, settings: &JunitSettings, case: &TestCaseResult)
     xml.push_str(">\n");
     match case.outcome() {
         TestCaseOutcome::Passed => {}
-        TestCaseOutcome::Failed { diagnostic } => {
-            writeln!(
-                xml,
-                "      <failure message=\"{}\" type=\"{}\">{}</failure>",
-                escape_xml(diagnostic.message()),
-                escape_xml(diagnostic.code()),
-                escape_xml(diagnostic.rendered()),
-            )?;
-        }
+        TestCaseOutcome::Failed {
+            diagnostic,
+            related,
+        } => write_diagnostic_element(xml, "failure", diagnostic, related)?,
+        TestCaseOutcome::Error {
+            diagnostic,
+            related,
+        } => write_diagnostic_element(xml, "error", diagnostic, related)?,
         TestCaseOutcome::Skipped { reason } => {
             if let Some(reason) = reason {
                 writeln!(xml, "      <skipped message=\"{}\"/>", escape_xml(reason))?;
@@ -135,6 +151,7 @@ fn write_case(xml: &mut String, settings: &JunitSettings, case: &TestCaseResult)
             }
         }
     }
+    write_attempts(xml, case)?;
 
     if has_output && let Some(output) = output {
         write_captured_stream(xml, "system-out", output.stdout())?;
@@ -142,6 +159,83 @@ fn write_case(xml: &mut String, settings: &JunitSettings, case: &TestCaseResult)
     }
 
     xml.push_str("    </testcase>\n");
+    Ok(())
+}
+
+fn write_attempts(xml: &mut String, case: &TestCaseResult) -> Result<()> {
+    let element = if matches!(case.outcome(), TestCaseOutcome::Passed) {
+        "flakyFailure"
+    } else {
+        "rerunFailure"
+    };
+    for attempt in case
+        .attempts()
+        .iter()
+        .take(case.attempts().len().saturating_sub(1))
+    {
+        if let Some(diagnostic) = attempt.outcome().diagnostic() {
+            write_diagnostic_element(
+                xml,
+                element,
+                diagnostic,
+                attempt.outcome().related_diagnostics(),
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn write_diagnostic_element(
+    xml: &mut String,
+    element: &str,
+    diagnostic: &karva_diagnostic::RenderedDiagnostic,
+    related: &[karva_diagnostic::RenderedDiagnostic],
+) -> Result<()> {
+    write!(
+        xml,
+        "      <{element} message=\"{}\" type=\"{}\">{}",
+        escape_xml(diagnostic.message()),
+        escape_xml(diagnostic.code()),
+        escape_xml(diagnostic.rendered()),
+    )?;
+    for diagnostic in related {
+        write!(xml, "{}", escape_xml(diagnostic.rendered()))?;
+    }
+    writeln!(xml, "</{element}>")?;
+    Ok(())
+}
+
+fn write_run_diagnostics_suite(
+    xml: &mut String,
+    settings: &JunitSettings,
+    diagnostics: &[karva_diagnostic::RenderedDiagnostic],
+) -> Result<()> {
+    let diagnostics = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.is_error())
+        .collect::<Vec<_>>();
+    if diagnostics.is_empty() {
+        return Ok(());
+    }
+
+    writeln!(
+        xml,
+        "  <testsuite name=\"{}::run\" tests=\"{}\" failures=\"0\" skipped=\"0\" errors=\"{}\" time=\"0.000000\">",
+        escape_xml(&settings.report_name),
+        diagnostics.len(),
+        diagnostics.len(),
+    )?;
+    for (index, diagnostic) in diagnostics.iter().enumerate() {
+        writeln!(
+            xml,
+            "    <testcase classname=\"karva.run\" name=\"{}-{}\" time=\"0.000000\">",
+            escape_xml(diagnostic.code()),
+            index + 1,
+        )?;
+        write_diagnostic_element(xml, "error", diagnostic, &[])?;
+        xml.push_str("    </testcase>\n");
+    }
+    xml.push_str("  </testsuite>\n");
     Ok(())
 }
 

--- a/crates/karva/src/commands/test/junit.rs
+++ b/crates/karva/src/commands/test/junit.rs
@@ -4,7 +4,7 @@ use std::fmt::Write as _;
 use anyhow::{Context as _, Result};
 use camino::Utf8Path;
 use karva_cache::AggregatedResults;
-use karva_diagnostic::{TestCaseOutcome, TestCaseResult};
+use karva_diagnostic::{RenderedDiagnostic, TestCaseAttempt, TestCaseOutcome, TestCaseResult};
 use karva_metadata::JunitSettings;
 use karva_project::path::absolute;
 
@@ -105,7 +105,7 @@ fn write_suite(
 }
 
 fn write_case(xml: &mut String, settings: &JunitSettings, case: &TestCaseResult) -> Result<()> {
-    let time = case.duration().as_secs_f64();
+    let time = junit_case_duration(case).as_secs_f64();
     let output = case.captured_output();
     let include_output = match case.outcome() {
         TestCaseOutcome::Passed => settings.store_success_output,
@@ -138,11 +138,30 @@ fn write_case(xml: &mut String, settings: &JunitSettings, case: &TestCaseResult)
         TestCaseOutcome::Failed {
             diagnostic,
             related,
-        } => write_diagnostic_element(xml, "failure", diagnostic, related)?,
+        } => {
+            if case.attempts().len() > 1
+                && let Some(first_attempt) = case.attempts().first()
+                && let Some(first_diagnostic) = first_attempt.outcome().diagnostic()
+            {
+                write_diagnostic_element(
+                    xml,
+                    "failure",
+                    first_diagnostic,
+                    first_attempt
+                        .outcome()
+                        .related_diagnostics()
+                        .iter()
+                        .chain(related),
+                    None,
+                )?;
+            } else {
+                write_diagnostic_element(xml, "failure", diagnostic, related, None)?;
+            }
+        }
         TestCaseOutcome::Error {
             diagnostic,
             related,
-        } => write_diagnostic_element(xml, "error", diagnostic, related)?,
+        } => write_diagnostic_element(xml, "error", diagnostic, related, None)?,
         TestCaseOutcome::Skipped { reason } => {
             if let Some(reason) = reason {
                 writeln!(xml, "      <skipped message=\"{}\"/>", escape_xml(reason))?;
@@ -163,41 +182,59 @@ fn write_case(xml: &mut String, settings: &JunitSettings, case: &TestCaseResult)
 }
 
 fn write_attempts(xml: &mut String, case: &TestCaseResult) -> Result<()> {
-    let element = if matches!(case.outcome(), TestCaseOutcome::Passed) {
-        "flakyFailure"
-    } else {
-        "rerunFailure"
-    };
-    for attempt in case
-        .attempts()
-        .iter()
-        .take(case.attempts().len().saturating_sub(1))
-    {
+    let attempts = case.attempts();
+    if attempts.len() <= 1 {
+        return Ok(());
+    }
+    match case.outcome() {
+        TestCaseOutcome::Passed => {
+            write_attempt_diagnostics(xml, "flakyFailure", &attempts[..attempts.len() - 1])
+        }
+        TestCaseOutcome::Failed { .. } => {
+            write_attempt_diagnostics(xml, "rerunFailure", &attempts[1..])
+        }
+        TestCaseOutcome::Error { .. } | TestCaseOutcome::Skipped { .. } => {
+            write_attempt_diagnostics(xml, "rerunFailure", &attempts[..attempts.len() - 1])
+        }
+    }
+}
+
+fn write_attempt_diagnostics(
+    xml: &mut String,
+    element: &str,
+    attempts: &[TestCaseAttempt],
+) -> Result<()> {
+    for attempt in attempts {
         if let Some(diagnostic) = attempt.outcome().diagnostic() {
             write_diagnostic_element(
                 xml,
                 element,
                 diagnostic,
                 attempt.outcome().related_diagnostics(),
+                Some(attempt.duration()),
             )?;
         }
     }
     Ok(())
 }
 
-fn write_diagnostic_element(
+fn write_diagnostic_element<'a>(
     xml: &mut String,
     element: &str,
-    diagnostic: &karva_diagnostic::RenderedDiagnostic,
-    related: &[karva_diagnostic::RenderedDiagnostic],
+    diagnostic: &RenderedDiagnostic,
+    related: impl IntoIterator<Item = &'a RenderedDiagnostic>,
+    duration: Option<std::time::Duration>,
 ) -> Result<()> {
     write!(
         xml,
-        "      <{element} message=\"{}\" type=\"{}\">{}",
+        "      <{element} message=\"{}\" type=\"{}\"",
         escape_xml(diagnostic.message()),
         escape_xml(diagnostic.code()),
-        escape_xml(diagnostic.rendered()),
     )?;
+    if let Some(duration) = duration {
+        write!(xml, " time=\"{:.6}\"", duration.as_secs_f64())?;
+    }
+    write!(xml, ">{}", escape_xml(diagnostic.rendered()))?;
     for diagnostic in related {
         write!(xml, "{}", escape_xml(diagnostic.rendered()))?;
     }
@@ -232,11 +269,32 @@ fn write_run_diagnostics_suite(
             escape_xml(diagnostic.code()),
             index + 1,
         )?;
-        write_diagnostic_element(xml, "error", diagnostic, &[])?;
+        write_diagnostic_element(xml, "error", diagnostic, &[], None)?;
         xml.push_str("    </testcase>\n");
     }
     xml.push_str("  </testsuite>\n");
     Ok(())
+}
+
+fn junit_case_duration(case: &TestCaseResult) -> std::time::Duration {
+    if case.attempts().len() > 1 {
+        match case.outcome() {
+            TestCaseOutcome::Passed => {
+                return case
+                    .attempts()
+                    .last()
+                    .map_or_else(|| case.duration(), TestCaseAttempt::duration);
+            }
+            TestCaseOutcome::Failed { .. } => {
+                return case
+                    .attempts()
+                    .first()
+                    .map_or_else(|| case.duration(), TestCaseAttempt::duration);
+            }
+            TestCaseOutcome::Error { .. } | TestCaseOutcome::Skipped { .. } => {}
+        }
+    }
+    case.duration()
 }
 
 fn write_captured_stream(xml: &mut String, element: &str, content: &str) -> Result<()> {

--- a/crates/karva/src/commands/test/junit.rs
+++ b/crates/karva/src/commands/test/junit.rs
@@ -1,10 +1,10 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::fmt::Write as _;
 
 use anyhow::{Context as _, Result};
 use camino::Utf8Path;
 use karva_cache::AggregatedResults;
-use karva_diagnostic::{CapturedTestOutput, TestCaseOutcome, TestCaseResult};
+use karva_diagnostic::{TestCaseOutcome, TestCaseResult};
 use karva_metadata::JunitSettings;
 use karva_project::path::absolute;
 
@@ -31,7 +31,6 @@ pub(super) fn write_junit_report(
 }
 
 fn build_junit_xml(settings: &JunitSettings, results: &AggregatedResults) -> Result<String> {
-    let captured_outputs = captured_outputs_by_test(results);
     let suites = test_cases_by_module(&results.test_cases);
     let total_time = results
         .test_cases
@@ -51,7 +50,7 @@ fn build_junit_xml(settings: &JunitSettings, results: &AggregatedResults) -> Res
     )?;
 
     for (module_name, cases) in suites {
-        write_suite(&mut xml, settings, &captured_outputs, module_name, cases)?;
+        write_suite(&mut xml, settings, module_name, cases)?;
     }
 
     xml.push_str("</testsuites>\n");
@@ -61,7 +60,6 @@ fn build_junit_xml(settings: &JunitSettings, results: &AggregatedResults) -> Res
 fn write_suite(
     xml: &mut String,
     settings: &JunitSettings,
-    captured_outputs: &HashMap<&str, &CapturedTestOutput>,
     module_name: &str,
     cases: Vec<&TestCaseResult>,
 ) -> Result<()> {
@@ -86,21 +84,16 @@ fn write_suite(
     )?;
 
     for case in cases {
-        write_case(xml, settings, captured_outputs, case)?;
+        write_case(xml, settings, case)?;
     }
 
     xml.push_str("  </testsuite>\n");
     Ok(())
 }
 
-fn write_case(
-    xml: &mut String,
-    settings: &JunitSettings,
-    captured_outputs: &HashMap<&str, &CapturedTestOutput>,
-    case: &TestCaseResult,
-) -> Result<()> {
+fn write_case(xml: &mut String, settings: &JunitSettings, case: &TestCaseResult) -> Result<()> {
     let time = case.duration().as_secs_f64();
-    let output = captured_outputs.get(case.full_name()).copied();
+    let output = case.captured_output();
     let include_output = match case.outcome() {
         TestCaseOutcome::Passed => settings.store_success_output,
         TestCaseOutcome::Failed { .. } => settings.store_failure_output,
@@ -170,14 +163,6 @@ fn test_cases_by_module(cases: &[TestCaseResult]) -> BTreeMap<&str, Vec<&TestCas
             .push(case);
     }
     by_module
-}
-
-fn captured_outputs_by_test(results: &AggregatedResults) -> HashMap<&str, &CapturedTestOutput> {
-    results
-        .captured_outputs
-        .iter()
-        .map(|output| (output.test_name(), output))
-        .collect()
 }
 
 fn escape_xml(value: &str) -> String {

--- a/crates/karva/src/commands/test/junit.rs
+++ b/crates/karva/src/commands/test/junit.rs
@@ -103,7 +103,7 @@ fn write_case(
     let output = captured_outputs.get(case.full_name()).copied();
     let include_output = match case.outcome() {
         TestCaseOutcome::Passed => settings.store_success_output,
-        TestCaseOutcome::Failed => settings.store_failure_output,
+        TestCaseOutcome::Failed { .. } => settings.store_failure_output,
         TestCaseOutcome::Skipped { .. } => false,
     };
     let has_output = include_output
@@ -125,8 +125,14 @@ fn write_case(
     xml.push_str(">\n");
     match case.outcome() {
         TestCaseOutcome::Passed => {}
-        TestCaseOutcome::Failed => {
-            xml.push_str("      <failure message=\"test failed\"/>\n");
+        TestCaseOutcome::Failed { diagnostic } => {
+            writeln!(
+                xml,
+                "      <failure message=\"{}\" type=\"{}\">{}</failure>",
+                escape_xml(diagnostic.message()),
+                escape_xml(diagnostic.code()),
+                escape_xml(diagnostic.rendered()),
+            )?;
         }
         TestCaseOutcome::Skipped { reason } => {
             if let Some(reason) = reason {

--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -273,7 +273,7 @@ pub(super) fn print_run_timed_out(printer: Printer) -> std::io::Result<()> {
     writeln!(stdout, "\nerror: run timed out before all tests completed")
 }
 
-/// Print test output: diagnostics, durations, and result summary.
+/// Print test output: failures, run diagnostics, durations, and result summary.
 pub fn print_test_output(
     printer: Printer,
     start_time: Instant,
@@ -282,11 +282,21 @@ pub fn print_test_output(
 ) -> Result<()> {
     let mut details = printer.stream_for_details().lock();
 
-    let has_diagnostics = !result.diagnostics.is_empty();
+    let has_test_diagnostics = result
+        .test_cases
+        .iter()
+        .any(|case| case.outcome().is_failed());
+    let has_run_diagnostics = !result.diagnostics.is_empty();
+    let has_diagnostics = has_test_diagnostics || has_run_diagnostics;
     let has_captured_output = has_failed_captured_output(result);
     let has_preceding_test_lines = result.stats.total() > 0;
 
-    write_diagnostics_block(&mut details, result, has_preceding_test_lines)?;
+    write_test_failures_block(&mut details, result, has_preceding_test_lines)?;
+    write_run_diagnostics_block(
+        &mut details,
+        result,
+        has_preceding_test_lines && !has_test_diagnostics,
+    )?;
     write_captured_output_block(
         &mut details,
         result,
@@ -319,7 +329,39 @@ fn has_failed_captured_output(result: &AggregatedResults) -> bool {
         .any(|output| output.outcome().is_failed() && !output.is_empty())
 }
 
-fn write_diagnostics_block(
+fn write_test_failures_block(
+    stdout: &mut Stdout,
+    result: &AggregatedResults,
+    needs_leading_blank: bool,
+) -> Result<()> {
+    let failed_tests = result
+        .test_cases
+        .iter()
+        .filter_map(|case| {
+            case.outcome()
+                .diagnostic()
+                .map(|diagnostic| (case, diagnostic))
+        })
+        .collect::<Vec<_>>();
+    if failed_tests.is_empty() {
+        return Ok(());
+    }
+
+    if needs_leading_blank && stdout.is_enabled() {
+        writeln!(stdout)?;
+    }
+    writeln!(stdout, "failures:")?;
+    writeln!(stdout)?;
+    for (case, diagnostic) in failed_tests {
+        writeln!(stdout, "{}:", case.full_name())?;
+        writeln!(stdout)?;
+        write_rendered_diagnostic(stdout, diagnostic.rendered())?;
+    }
+
+    Ok(())
+}
+
+fn write_run_diagnostics_block(
     stdout: &mut Stdout,
     result: &AggregatedResults,
     needs_leading_blank: bool,
@@ -333,8 +375,21 @@ fn write_diagnostics_block(
     }
     writeln!(stdout, "diagnostics:")?;
     writeln!(stdout)?;
-    write!(stdout, "{}", result.diagnostics)?;
+    for diagnostic in &result.diagnostics {
+        write_rendered_diagnostic(stdout, diagnostic.rendered())?;
+    }
 
+    Ok(())
+}
+
+fn write_rendered_diagnostic(stdout: &mut Stdout, rendered: &str) -> Result<()> {
+    write!(stdout, "{rendered}")?;
+    if !rendered.ends_with('\n') {
+        writeln!(stdout)?;
+    }
+    if !rendered.ends_with("\n\n") {
+        writeln!(stdout)?;
+    }
     Ok(())
 }
 

--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -242,7 +242,7 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
     }
 
     let exit_status = if result.stats.is_success()
-        && result.diagnostics.is_empty()
+        && result.run_diagnostics.is_empty()
         && !coverage_below_threshold
     {
         ExitStatus::Success
@@ -262,7 +262,7 @@ fn coverage_report_path(
 }
 
 fn no_tests_collected(result: &AggregatedResults) -> bool {
-    result.stats.total() == 0 && result.diagnostics.is_empty()
+    result.stats.total() == 0 && result.run_diagnostics.is_empty()
 }
 
 /// Print the message shown when a run is stopped by `--run-timeout`.
@@ -286,9 +286,8 @@ pub fn print_test_output(
         .test_cases
         .iter()
         .any(|case| case.outcome().is_failed());
-    let has_run_diagnostics = !result.diagnostics.is_empty();
+    let has_run_diagnostics = !result.run_diagnostics.is_empty();
     let has_diagnostics = has_test_diagnostics || has_run_diagnostics;
-    let has_captured_output = has_failed_captured_output(result);
     let has_preceding_test_lines = result.stats.total() > 0;
 
     write_test_failures_block(&mut details, result, has_preceding_test_lines)?;
@@ -297,17 +296,12 @@ pub fn print_test_output(
         result,
         has_preceding_test_lines && !has_test_diagnostics,
     )?;
-    write_captured_output_block(
-        &mut details,
-        result,
-        has_preceding_test_lines && !has_diagnostics,
-    )?;
 
     write_durations_block(
         &mut details,
         &result.durations,
         durations,
-        has_preceding_test_lines && !has_diagnostics && !has_captured_output,
+        has_preceding_test_lines && !has_diagnostics,
     )?;
 
     drop(details);
@@ -320,13 +314,6 @@ pub fn print_test_output(
     write!(summary, "{}", DisplayFlakyTests::new(&result.flaky_tests))?;
 
     Ok(())
-}
-
-fn has_failed_captured_output(result: &AggregatedResults) -> bool {
-    result
-        .captured_outputs
-        .iter()
-        .any(|output| output.outcome().is_failed() && !output.is_empty())
 }
 
 fn write_test_failures_block(
@@ -356,6 +343,11 @@ fn write_test_failures_block(
         writeln!(stdout, "{}:", case.full_name())?;
         writeln!(stdout)?;
         write_rendered_diagnostic(stdout, diagnostic.rendered())?;
+        if let Some(output) = case.captured_output() {
+            write_captured_stream(stdout, "stdout", output.stdout())?;
+            write_captured_stream(stdout, "stderr", output.stderr())?;
+            writeln!(stdout)?;
+        }
     }
 
     Ok(())
@@ -366,7 +358,7 @@ fn write_run_diagnostics_block(
     result: &AggregatedResults,
     needs_leading_blank: bool,
 ) -> Result<()> {
-    if result.diagnostics.is_empty() {
+    if result.run_diagnostics.is_empty() {
         return Ok(());
     }
 
@@ -375,7 +367,7 @@ fn write_run_diagnostics_block(
     }
     writeln!(stdout, "diagnostics:")?;
     writeln!(stdout)?;
-    for diagnostic in &result.diagnostics {
+    for diagnostic in &result.run_diagnostics {
         write_rendered_diagnostic(stdout, diagnostic.rendered())?;
     }
 
@@ -393,46 +385,12 @@ fn write_rendered_diagnostic(stdout: &mut Stdout, rendered: &str) -> Result<()> 
     Ok(())
 }
 
-fn write_captured_output_block(
-    stdout: &mut Stdout,
-    result: &AggregatedResults,
-    needs_leading_blank: bool,
-) -> Result<()> {
-    let mut failed_outputs: Vec<_> = result
-        .captured_outputs
-        .iter()
-        .filter(|output| output.outcome().is_failed() && !output.is_empty())
-        .collect();
-    if failed_outputs.is_empty() {
-        return Ok(());
-    }
-
-    failed_outputs.sort_by_key(|output| output.test_name());
-
-    if needs_leading_blank && stdout.is_enabled() {
-        writeln!(stdout)?;
-    }
-
-    for output in failed_outputs {
-        write_captured_stream(stdout, "stdout", output.test_name(), output.stdout())?;
-        write_captured_stream(stdout, "stderr", output.test_name(), output.stderr())?;
-    }
-    writeln!(stdout)?;
-
-    Ok(())
-}
-
-fn write_captured_stream(
-    stdout: &mut Stdout,
-    stream_name: &str,
-    test_name: &str,
-    content: &str,
-) -> Result<()> {
+fn write_captured_stream(stdout: &mut Stdout, stream_name: &str, content: &str) -> Result<()> {
     if content.is_empty() {
         return Ok(());
     }
 
-    writeln!(stdout, "captured {stream_name} for {test_name}:")?;
+    writeln!(stdout, "captured {stream_name}:")?;
     write!(stdout, "{content}")?;
     if !content.ends_with('\n') {
         writeln!(stdout)?;

--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -279,15 +279,14 @@ pub fn print_test_output(
 ) -> Result<()> {
     let mut details = printer.stream_for_details().lock();
 
-    let has_test_diagnostics = result
-        .test_cases
-        .iter()
-        .any(|case| case.outcome().is_non_success());
+    let has_test_diagnostics = !result.stats.is_success();
     let has_run_diagnostics = !result.run_diagnostics.is_empty();
     let has_diagnostics = has_test_diagnostics || has_run_diagnostics;
     let has_preceding_test_lines = result.stats.total() > 0;
 
-    write_test_failures_block(&mut details, result, has_preceding_test_lines)?;
+    if has_test_diagnostics {
+        write_test_failures_block(&mut details, result, has_preceding_test_lines)?;
+    }
     write_run_diagnostics_block(
         &mut details,
         result,

--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -241,10 +241,7 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
         return Ok(exit_status);
     }
 
-    let exit_status = if result.stats.is_success()
-        && result.run_diagnostics.is_empty()
-        && !coverage_below_threshold
-    {
+    let exit_status = if result.is_success() && !coverage_below_threshold {
         ExitStatus::Success
     } else {
         ExitStatus::Failure
@@ -262,7 +259,7 @@ fn coverage_report_path(
 }
 
 fn no_tests_collected(result: &AggregatedResults) -> bool {
-    result.stats.total() == 0 && result.run_diagnostics.is_empty()
+    result.stats.total() == 0 && !result.has_run_errors()
 }
 
 /// Print the message shown when a run is stopped by `--run-timeout`.
@@ -285,7 +282,7 @@ pub fn print_test_output(
     let has_test_diagnostics = result
         .test_cases
         .iter()
-        .any(|case| case.outcome().is_failed());
+        .any(|case| case.outcome().is_non_success());
     let has_run_diagnostics = !result.run_diagnostics.is_empty();
     let has_diagnostics = has_test_diagnostics || has_run_diagnostics;
     let has_preceding_test_lines = result.stats.total() > 0;
@@ -306,11 +303,12 @@ pub fn print_test_output(
 
     drop(details);
 
+    let success = result.is_success();
     let mut summary = printer
-        .stream_for_summary(result.stats.is_success(), result.stats.flaky() > 0)
+        .stream_for_summary(success, result.stats.flaky() > 0)
         .lock();
 
-    write!(summary, "{}", result.stats.display(start_time))?;
+    write!(summary, "{}", result.stats.display(start_time, success))?;
     write!(summary, "{}", DisplayFlakyTests::new(&result.flaky_tests))?;
 
     Ok(())
@@ -324,11 +322,7 @@ fn write_test_failures_block(
     let failed_tests = result
         .test_cases
         .iter()
-        .filter_map(|case| {
-            case.outcome()
-                .diagnostic()
-                .map(|diagnostic| (case, diagnostic))
-        })
+        .filter(|case| case.outcome().diagnostic().is_some())
         .collect::<Vec<_>>();
     if failed_tests.is_empty() {
         return Ok(());
@@ -339,10 +333,32 @@ fn write_test_failures_block(
     }
     writeln!(stdout, "failures:")?;
     writeln!(stdout)?;
-    for (case, diagnostic) in failed_tests {
+    let mut emitted = vec![false; failed_tests.len()];
+    for (index, case) in failed_tests.iter().enumerate() {
+        if emitted[index] {
+            continue;
+        }
+        emitted[index] = true;
+        let Some(diagnostic) = case.outcome().diagnostic() else {
+            continue;
+        };
         writeln!(stdout, "{}:", case.full_name())?;
+        if case.captured_output().is_none() {
+            for (other_index, other) in failed_tests.iter().enumerate().skip(index + 1) {
+                if other.captured_output().is_none()
+                    && other.outcome().diagnostic() == Some(diagnostic)
+                    && other.outcome().related_diagnostics() == case.outcome().related_diagnostics()
+                {
+                    emitted[other_index] = true;
+                    writeln!(stdout, "{}:", other.full_name())?;
+                }
+            }
+        }
         writeln!(stdout)?;
-        write_rendered_diagnostic(stdout, diagnostic.rendered())?;
+        write_rendered_diagnostic(stdout, diagnostic.rendered_for_terminal())?;
+        for diagnostic in case.outcome().related_diagnostics() {
+            write_rendered_diagnostic(stdout, diagnostic.rendered_for_terminal())?;
+        }
         if let Some(output) = case.captured_output() {
             write_captured_stream(stdout, "stdout", output.stdout())?;
             write_captured_stream(stdout, "stderr", output.stderr())?;
@@ -368,7 +384,7 @@ fn write_run_diagnostics_block(
     writeln!(stdout, "diagnostics:")?;
     writeln!(stdout)?;
     for diagnostic in &result.run_diagnostics {
-        write_rendered_diagnostic(stdout, diagnostic.rendered())?;
+        write_rendered_diagnostic(stdout, diagnostic.rendered_for_terminal())?;
     }
 
     Ok(())

--- a/crates/karva/src/commands/test/result_report.rs
+++ b/crates/karva/src/commands/test/result_report.rs
@@ -5,13 +5,15 @@ use anyhow::{Context as _, Result};
 use camino::Utf8Path;
 use karva_cache::AggregatedResults;
 use karva_cli::ResultFormat;
-use karva_diagnostic::{CapturedTestOutput, TestCaseOutcome, TestCaseResult, TestCaseRetry};
+use karva_diagnostic::{
+    CapturedTestOutput, RenderedDiagnostic, TestCaseOutcome, TestCaseResult, TestCaseRetry,
+};
 use karva_project::path::absolute;
 use serde::Serialize;
 
 use crate::ExitStatus;
 
-const SCHEMA_VERSION: u8 = 1;
+const SCHEMA_VERSION: u8 = 2;
 
 pub(super) fn write_result_report(
     path: Option<&Utf8Path>,
@@ -99,7 +101,7 @@ struct RunReport<'a> {
     stats: StatsReport,
     tests: Vec<TestReport<'a>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    diagnostics: Option<&'a str>,
+    diagnostics: Option<&'a [RenderedDiagnostic]>,
 }
 
 impl<'a> RunReport<'a> {
@@ -110,7 +112,8 @@ impl<'a> RunReport<'a> {
             .iter()
             .map(|case| TestReport::new(case, captured_outputs.get(case.full_name()).copied()))
             .collect();
-        let diagnostics = (!results.diagnostics.is_empty()).then_some(results.diagnostics.as_str());
+        let diagnostics =
+            (!results.diagnostics.is_empty()).then_some(results.diagnostics.as_slice());
 
         Self {
             schema_version: SCHEMA_VERSION,
@@ -177,14 +180,16 @@ struct TestReport<'a> {
     retry: Option<RetryReport>,
     #[serde(skip_serializing_if = "Option::is_none")]
     captured_output: Option<CapturedOutputReport<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    diagnostic: Option<&'a RenderedDiagnostic>,
 }
 
 impl<'a> TestReport<'a> {
     fn new(case: &'a TestCaseResult, output: Option<&'a CapturedTestOutput>) -> Self {
-        let (status, skip_reason) = match case.outcome() {
-            TestCaseOutcome::Passed => (TestStatus::Passed, None),
-            TestCaseOutcome::Failed => (TestStatus::Failed, None),
-            TestCaseOutcome::Skipped { reason } => (TestStatus::Skipped, reason.as_deref()),
+        let (status, skip_reason, diagnostic) = match case.outcome() {
+            TestCaseOutcome::Passed => (TestStatus::Passed, None, None),
+            TestCaseOutcome::Failed { diagnostic } => (TestStatus::Failed, None, Some(diagnostic)),
+            TestCaseOutcome::Skipped { reason } => (TestStatus::Skipped, reason.as_deref(), None),
         };
         let retry = case.retry().map(RetryReport::new);
         let flaky = matches!(case.outcome(), TestCaseOutcome::Passed) && retry.is_some();
@@ -201,6 +206,7 @@ impl<'a> TestReport<'a> {
             captured_output: output
                 .filter(|output| !output.is_empty())
                 .map(CapturedOutputReport::new),
+            diagnostic,
         }
     }
 }
@@ -247,7 +253,7 @@ impl<'a> CapturedOutputReport<'a> {
 
 #[derive(Serialize)]
 struct DiagnosticsEvent<'a> {
-    diagnostics: &'a str,
+    diagnostics: &'a [RenderedDiagnostic],
 }
 
 #[derive(Serialize)]

--- a/crates/karva/src/commands/test/result_report.rs
+++ b/crates/karva/src/commands/test/result_report.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 
 use crate::ExitStatus;
 
-const SCHEMA_VERSION: u8 = 3;
+const SCHEMA_VERSION: u8 = 2;
 
 pub(super) fn write_result_report(
     path: Option<&Utf8Path>,

--- a/crates/karva/src/commands/test/result_report.rs
+++ b/crates/karva/src/commands/test/result_report.rs
@@ -5,14 +5,15 @@ use camino::Utf8Path;
 use karva_cache::AggregatedResults;
 use karva_cli::ResultFormat;
 use karva_diagnostic::{
-    CapturedTestOutput, RenderedDiagnostic, TestCaseOutcome, TestCaseResult, TestCaseRetry,
+    CapturedTestOutput, RenderedDiagnostic, TestCaseAttempt, TestCaseOutcome, TestCaseResult,
+    TestCaseRetry,
 };
 use karva_project::path::absolute;
 use serde::Serialize;
 
 use crate::ExitStatus;
 
-const SCHEMA_VERSION: u8 = 2;
+const SCHEMA_VERSION: u8 = 3;
 
 pub(super) fn write_result_report(
     path: Option<&Utf8Path>,
@@ -51,21 +52,23 @@ pub(super) fn write_result_report(
 fn build_jsonl_report(report: &RunReport<'_>) -> Result<String> {
     let mut output = String::new();
     for test in &report.tests {
-        push_jsonl_event(&mut output, "test", test)?;
+        push_jsonl_record(&mut output, "test", test)?;
     }
-    if let Some(diagnostics) = report.run_diagnostics {
+    if let Some(diagnostics) = &report.run_diagnostics {
         for diagnostic in diagnostics {
-            push_jsonl_event(
+            push_jsonl_record(
                 &mut output,
                 "run_diagnostic",
-                &RunDiagnosticEvent { diagnostic },
+                &RunDiagnosticRecord {
+                    diagnostic: *diagnostic,
+                },
             )?;
         }
     }
-    push_jsonl_event(
+    push_jsonl_record(
         &mut output,
         "run_finished",
-        &RunFinishedEvent {
+        &RunFinishedRecord {
             status: report.status,
             elapsed_seconds: report.elapsed_seconds,
             stats: report.stats,
@@ -74,19 +77,23 @@ fn build_jsonl_report(report: &RunReport<'_>) -> Result<String> {
     Ok(output)
 }
 
-fn push_jsonl_event<T: Serialize>(output: &mut String, kind: &'static str, data: &T) -> Result<()> {
-    let event = JsonlEvent {
+fn push_jsonl_record<T: Serialize>(
+    output: &mut String,
+    kind: &'static str,
+    data: &T,
+) -> Result<()> {
+    let record = JsonlRecord {
         schema_version: SCHEMA_VERSION,
         kind,
         data,
     };
-    output.push_str(&serde_json::to_string(&event)?);
+    output.push_str(&serde_json::to_string(&record)?);
     output.push('\n');
     Ok(())
 }
 
 #[derive(Serialize)]
-struct JsonlEvent<'a, T> {
+struct JsonlRecord<'a, T> {
     schema_version: u8,
     #[serde(rename = "type")]
     kind: &'a str,
@@ -102,14 +109,19 @@ struct RunReport<'a> {
     stats: StatsReport,
     tests: Vec<TestReport<'a>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    run_diagnostics: Option<&'a [RenderedDiagnostic]>,
+    run_diagnostics: Option<Vec<DiagnosticReport<'a>>>,
 }
 
 impl<'a> RunReport<'a> {
     fn new(results: &'a AggregatedResults, elapsed: Duration, status: RunStatus) -> Self {
         let tests = results.test_cases.iter().map(TestReport::new).collect();
-        let run_diagnostics =
-            (!results.run_diagnostics.is_empty()).then_some(results.run_diagnostics.as_slice());
+        let run_diagnostics = (!results.run_diagnostics.is_empty()).then(|| {
+            results
+                .run_diagnostics
+                .iter()
+                .map(DiagnosticReport::new)
+                .collect()
+        });
 
         Self {
             schema_version: SCHEMA_VERSION,
@@ -143,6 +155,7 @@ struct StatsReport {
     total: usize,
     passed: usize,
     failed: usize,
+    errors: usize,
     skipped: usize,
     flaky: usize,
     slow: usize,
@@ -154,6 +167,7 @@ impl StatsReport {
             total: results.stats.total(),
             passed: results.stats.passed(),
             failed: results.stats.failed(),
+            errors: results.stats.errors(),
             skipped: results.stats.skipped(),
             flaky: results.stats.flaky(),
             slow: results.stats.slow(),
@@ -177,14 +191,23 @@ struct TestReport<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     captured_output: Option<CapturedOutputReport<'a>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    diagnostic: Option<&'a RenderedDiagnostic>,
+    diagnostic: Option<DiagnosticReport<'a>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    related_diagnostics: Vec<DiagnosticReport<'a>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    attempts: Vec<AttemptReport<'a>>,
 }
 
 impl<'a> TestReport<'a> {
     fn new(case: &'a TestCaseResult) -> Self {
         let (status, skip_reason, diagnostic) = match case.outcome() {
             TestCaseOutcome::Passed => (TestStatus::Passed, None, None),
-            TestCaseOutcome::Failed { diagnostic } => (TestStatus::Failed, None, Some(diagnostic)),
+            TestCaseOutcome::Failed { diagnostic, .. } => {
+                (TestStatus::Failed, None, Some(diagnostic))
+            }
+            TestCaseOutcome::Error { diagnostic, .. } => {
+                (TestStatus::Error, None, Some(diagnostic))
+            }
             TestCaseOutcome::Skipped { reason } => (TestStatus::Skipped, reason.as_deref(), None),
         };
         let retry = case.retry().map(RetryReport::new);
@@ -200,7 +223,52 @@ impl<'a> TestReport<'a> {
             flaky,
             retry,
             captured_output: case.captured_output().map(CapturedOutputReport::new),
+            diagnostic: diagnostic.map(DiagnosticReport::new),
+            related_diagnostics: case
+                .outcome()
+                .related_diagnostics()
+                .iter()
+                .map(DiagnosticReport::new)
+                .collect(),
+            attempts: case.attempts().iter().map(AttemptReport::new).collect(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct AttemptReport<'a> {
+    attempt: u32,
+    status: TestStatus,
+    duration_seconds: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    diagnostic: Option<DiagnosticReport<'a>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    related_diagnostics: Vec<DiagnosticReport<'a>>,
+}
+
+impl<'a> AttemptReport<'a> {
+    fn new(attempt: &'a TestCaseAttempt) -> Self {
+        let (status, diagnostic) = match attempt.outcome() {
+            TestCaseOutcome::Passed => (TestStatus::Passed, None),
+            TestCaseOutcome::Failed { diagnostic, .. } => {
+                (TestStatus::Failed, Some(DiagnosticReport::new(diagnostic)))
+            }
+            TestCaseOutcome::Error { diagnostic, .. } => {
+                (TestStatus::Error, Some(DiagnosticReport::new(diagnostic)))
+            }
+            TestCaseOutcome::Skipped { .. } => (TestStatus::Skipped, None),
+        };
+        Self {
+            attempt: attempt.attempt(),
+            status,
+            duration_seconds: attempt.duration().as_secs_f64(),
             diagnostic,
+            related_diagnostics: attempt
+                .outcome()
+                .related_diagnostics()
+                .iter()
+                .map(DiagnosticReport::new)
+                .collect(),
         }
     }
 }
@@ -210,6 +278,7 @@ impl<'a> TestReport<'a> {
 enum TestStatus {
     Passed,
     Failed,
+    Error,
     Skipped,
 }
 
@@ -246,12 +315,31 @@ impl<'a> CapturedOutputReport<'a> {
 }
 
 #[derive(Serialize)]
-struct RunDiagnosticEvent<'a> {
-    diagnostic: &'a RenderedDiagnostic,
+struct RunDiagnosticRecord<'a> {
+    diagnostic: DiagnosticReport<'a>,
+}
+
+#[derive(Clone, Copy, Serialize)]
+struct DiagnosticReport<'a> {
+    code: &'a str,
+    severity: &'static str,
+    message: &'a str,
+    rendered: &'a str,
+}
+
+impl<'a> DiagnosticReport<'a> {
+    fn new(diagnostic: &'a RenderedDiagnostic) -> Self {
+        Self {
+            code: diagnostic.code(),
+            severity: diagnostic.severity_name(),
+            message: diagnostic.message(),
+            rendered: diagnostic.rendered(),
+        }
+    }
 }
 
 #[derive(Serialize)]
-struct RunFinishedEvent {
+struct RunFinishedRecord {
     status: RunStatus,
     elapsed_seconds: f64,
     stats: StatsReport,

--- a/crates/karva/src/commands/test/result_report.rs
+++ b/crates/karva/src/commands/test/result_report.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::time::Duration;
 
 use anyhow::{Context as _, Result};
@@ -54,12 +53,14 @@ fn build_jsonl_report(report: &RunReport<'_>) -> Result<String> {
     for test in &report.tests {
         push_jsonl_event(&mut output, "test", test)?;
     }
-    if let Some(diagnostics) = report.diagnostics {
-        push_jsonl_event(
-            &mut output,
-            "diagnostics",
-            &DiagnosticsEvent { diagnostics },
-        )?;
+    if let Some(diagnostics) = report.run_diagnostics {
+        for diagnostic in diagnostics {
+            push_jsonl_event(
+                &mut output,
+                "run_diagnostic",
+                &RunDiagnosticEvent { diagnostic },
+            )?;
+        }
     }
     push_jsonl_event(
         &mut output,
@@ -101,19 +102,14 @@ struct RunReport<'a> {
     stats: StatsReport,
     tests: Vec<TestReport<'a>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    diagnostics: Option<&'a [RenderedDiagnostic]>,
+    run_diagnostics: Option<&'a [RenderedDiagnostic]>,
 }
 
 impl<'a> RunReport<'a> {
     fn new(results: &'a AggregatedResults, elapsed: Duration, status: RunStatus) -> Self {
-        let captured_outputs = captured_outputs_by_test(results);
-        let tests = results
-            .test_cases
-            .iter()
-            .map(|case| TestReport::new(case, captured_outputs.get(case.full_name()).copied()))
-            .collect();
-        let diagnostics =
-            (!results.diagnostics.is_empty()).then_some(results.diagnostics.as_slice());
+        let tests = results.test_cases.iter().map(TestReport::new).collect();
+        let run_diagnostics =
+            (!results.run_diagnostics.is_empty()).then_some(results.run_diagnostics.as_slice());
 
         Self {
             schema_version: SCHEMA_VERSION,
@@ -121,7 +117,7 @@ impl<'a> RunReport<'a> {
             elapsed_seconds: elapsed.as_secs_f64(),
             stats: StatsReport::new(results),
             tests,
-            diagnostics,
+            run_diagnostics,
         }
     }
 }
@@ -185,7 +181,7 @@ struct TestReport<'a> {
 }
 
 impl<'a> TestReport<'a> {
-    fn new(case: &'a TestCaseResult, output: Option<&'a CapturedTestOutput>) -> Self {
+    fn new(case: &'a TestCaseResult) -> Self {
         let (status, skip_reason, diagnostic) = match case.outcome() {
             TestCaseOutcome::Passed => (TestStatus::Passed, None, None),
             TestCaseOutcome::Failed { diagnostic } => (TestStatus::Failed, None, Some(diagnostic)),
@@ -203,9 +199,7 @@ impl<'a> TestReport<'a> {
             skip_reason,
             flaky,
             retry,
-            captured_output: output
-                .filter(|output| !output.is_empty())
-                .map(CapturedOutputReport::new),
+            captured_output: case.captured_output().map(CapturedOutputReport::new),
             diagnostic,
         }
     }
@@ -252,8 +246,8 @@ impl<'a> CapturedOutputReport<'a> {
 }
 
 #[derive(Serialize)]
-struct DiagnosticsEvent<'a> {
-    diagnostics: &'a [RenderedDiagnostic],
+struct RunDiagnosticEvent<'a> {
+    diagnostic: &'a RenderedDiagnostic,
 }
 
 #[derive(Serialize)]
@@ -269,12 +263,4 @@ struct RunFinishedEvent {
 )]
 fn is_false(value: &bool) -> bool {
     !*value
-}
-
-fn captured_outputs_by_test(results: &AggregatedResults) -> HashMap<&str, &CapturedTestOutput> {
-    results
-        .captured_outputs
-        .iter()
-        .map(|output| (output.test_name(), output))
-        .collect()
 }

--- a/crates/karva/tests/it/async.rs
+++ b/crates/karva/tests/it/async.rs
@@ -76,7 +76,9 @@ async def test_async_fails():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_async_fails
 
-    diagnostics:
+    failures:
+
+    test::test_async_fails:
 
     error[test-failure]: Test `test_async_fails` failed
      --> test.py:4:11

--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -724,7 +724,7 @@ fn test_multiple_fixtures_not_found() {
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test_multiple_fixtures_not_found::test_multiple_fixtures_not_found
+           ERROR [TIME] test_multiple_fixtures_not_found::test_multiple_fixtures_not_found
 
     failures:
 
@@ -739,7 +739,7 @@ fn test_multiple_fixtures_not_found() {
     info: Missing fixtures: `a`, `b`, `c`
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");
@@ -1022,7 +1022,7 @@ fn test_invalid_fixture() {
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_fixture_generator
+           ERROR [TIME] test::test_fixture_generator
 
     failures:
 
@@ -1047,7 +1047,7 @@ fn test_invalid_fixture() {
     info: Invalid fixture scope: ssession
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");

--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -702,9 +702,9 @@ fn test_failed_output_is_captured() {
        |     ^^^^^^^^^^^^
        |
 
-    captured stdout for test_failed_output::test_fail_with_output:
+    captured stdout:
     stdout from failure
-    captured stderr for test_failed_output::test_fail_with_output:
+    captured stderr:
     stderr from failure
 
     ────────────

--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -467,7 +467,7 @@ fn test_fail_concise_output() {
     ----- stdout -----
         Starting 3 tests across 1 worker
             FAIL [TIME] test_fail::test_1(fixture_1=1)
-            FAIL [TIME] test_fail::test_2
+           ERROR [TIME] test_fail::test_2
             FAIL [TIME] test_fail::test_3
 
     failures:
@@ -476,20 +476,18 @@ fn test_fail_concise_output() {
 
     test_fail.py:9:5: error[test-failure] Test `test_1` failed
 
+    test_fail.py:5:5: error[invalid-fixture-finalizer] Discovered an invalid fixture finalizer `fixture_1`
+
     test_fail::test_2:
 
-    test_fail.py:16:5: error[missing-fixtures] Test `test_2` has missing fixtures: `fixture_2`
+    test_fail.py:13:5: error[fixture-failure] Fixture `fixture_2` failed
 
     test_fail::test_3:
 
     test_fail.py:19:5: error[test-failure] Test `test_3` failed
 
-    diagnostics:
-
-    test_fail.py:5:5: error[invalid-fixture-finalizer] Discovered an invalid fixture finalizer `fixture_1`
-
     ────────────
-         Summary [TIME] 3 tests run: 0 passed, 3 failed, 0 skipped
+         Summary [TIME] 3 tests run: 0 passed, 2 failed, 1 error, 0 skipped
 
     ----- stderr -----
     ");
@@ -881,9 +879,11 @@ fn test_fixture_generator_two_yields_passing_test() {
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            PASS [TIME] test::test_fixture_generator(fixture_generator=1)
+           ERROR [TIME] test::test_fixture_generator(fixture_generator=1)
 
-    diagnostics:
+    failures:
+
+    test::test_fixture_generator(fixture_generator=1):
 
     error[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `fixture_generator`
      --> test.py:5:5
@@ -894,7 +894,7 @@ fn test_fixture_generator_two_yields_passing_test() {
     info: Fixture had more than one yield statement
 
     ────────────
-         Summary [TIME] 1 test run: 1 passed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");
@@ -943,8 +943,6 @@ fn test_fixture_generator_two_yields_failing_test() {
        |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        |
 
-    diagnostics:
-
     error[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `fixture_generator`
      --> test.py:5:5
       |
@@ -982,9 +980,11 @@ fn test_fixture_generator_fail_in_teardown() {
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            PASS [TIME] test::test_fixture_generator(fixture_generator=1)
+           ERROR [TIME] test::test_fixture_generator(fixture_generator=1)
 
-    diagnostics:
+    failures:
+
+    test::test_fixture_generator(fixture_generator=1):
 
     error[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `fixture_generator`
      --> test.py:5:5
@@ -995,7 +995,7 @@ fn test_fixture_generator_fail_in_teardown() {
     info: Failed to reset fixture: fixture error
 
     ────────────
-         Summary [TIME] 1 test run: 1 passed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");
@@ -1433,21 +1433,20 @@ def test_2(y): pass
     exit_code: 1
     ----- stdout -----
         Starting 2 tests across 1 worker
-            FAIL [TIME] test_file::test_1
+           ERROR [TIME] test_file::test_1
             PASS [TIME] test_file::test_2(y=1)
 
     failures:
 
     test_file::test_1:
 
-    error[missing-fixtures]: Test `test_1` has missing fixtures
-     --> test_file.py:3:5
+    error[fixture-failure]: Fixture `x` failed
+     --> foo.py:5:5
       |
-    3 | def test_1(x): pass
-      |     ^^^^^^
+    5 | def x():
+      |     ^
       |
-    info: Missing fixtures: `x`
-    info: Fixture `x` failed here
+    info: Fixture failed here
      --> foo.py:6:5
       |
     6 |     raise ValueError('Invalid fixture')
@@ -1456,7 +1455,7 @@ def test_2(y): pass
     info: Invalid fixture
 
     ────────────
-         Summary [TIME] 2 tests run: 1 passed, 1 failed, 0 skipped
+         Summary [TIME] 2 tests run: 1 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");

--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -193,7 +193,9 @@ fn test_one_test_fail() {
         Starting 1 test across 1 worker
             FAIL [TIME] test_fail::test_fail
 
-    diagnostics:
+    failures:
+
+    test_fail::test_fail:
 
     error[test-failure]: Test `test_fail` failed
      --> test_fail.py:2:5
@@ -272,31 +274,9 @@ def test_returned_decorated():
             FAIL [TIME] test_return::test_returned_parametrized(value=2)
             FAIL [TIME] test_return::test_returned_decorated
 
-    diagnostics:
+    failures:
 
-    error[test-returned-value]: Test `test_returned_true` returned `True`
-      --> test_return.py:18:5
-       |
-    18 | def test_returned_true():
-       |     ^^^^^^^^^^^^^^^^^^
-       |
-    info: Test functions must return None. Did you mean to use `assert`?
-
-    error[test-returned-value]: Test `test_returned_false` returned `False`
-      --> test_return.py:21:5
-       |
-    21 | def test_returned_false():
-       |     ^^^^^^^^^^^^^^^^^^^
-       |
-    info: Test functions must return None. Did you mean to use `assert`?
-
-    error[test-returned-value]: Test `test_returned_object` returned `value-xxxxxxxxxxxxxxxxxxxxx...`
-      --> test_return.py:24:5
-       |
-    24 | def test_returned_object():
-       |     ^^^^^^^^^^^^^^^^^^^^
-       |
-    info: Test functions must return None. Did you mean to use `assert`?
+    test_return::test_returned_async_value:
 
     error[test-returned-value]: Test `test_returned_async_value` returned `True`
       --> test_return.py:27:11
@@ -306,6 +286,38 @@ def test_returned_decorated():
        |
     info: Test functions must return None. Did you mean to use `assert`?
 
+    test_return::test_returned_decorated:
+
+    error[test-returned-value]: Test `test_returned_decorated` returned `'decorated'`
+      --> test_return.py:35:5
+       |
+    35 | def test_returned_decorated():
+       |     ^^^^^^^^^^^^^^^^^^^^^^^
+       |
+    info: Test functions must return None. Did you mean to use `assert`?
+
+    test_return::test_returned_false:
+
+    error[test-returned-value]: Test `test_returned_false` returned `False`
+      --> test_return.py:21:5
+       |
+    21 | def test_returned_false():
+       |     ^^^^^^^^^^^^^^^^^^^
+       |
+    info: Test functions must return None. Did you mean to use `assert`?
+
+    test_return::test_returned_object:
+
+    error[test-returned-value]: Test `test_returned_object` returned `value-xxxxxxxxxxxxxxxxxxxxx...`
+      --> test_return.py:24:5
+       |
+    24 | def test_returned_object():
+       |     ^^^^^^^^^^^^^^^^^^^^
+       |
+    info: Test functions must return None. Did you mean to use `assert`?
+
+    test_return::test_returned_parametrized(value=1):
+
     error[test-returned-value]: Test `test_returned_parametrized` returned `1`
       --> test_return.py:31:5
        |
@@ -313,6 +325,8 @@ def test_returned_decorated():
        |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
        |
     info: Test functions must return None. Did you mean to use `assert`?
+
+    test_return::test_returned_parametrized(value=2):
 
     error[test-returned-value]: Test `test_returned_parametrized` returned `2`
       --> test_return.py:31:5
@@ -322,11 +336,13 @@ def test_returned_decorated():
        |
     info: Test functions must return None. Did you mean to use `assert`?
 
-    error[test-returned-value]: Test `test_returned_decorated` returned `'decorated'`
-      --> test_return.py:35:5
+    test_return::test_returned_true:
+
+    error[test-returned-value]: Test `test_returned_true` returned `True`
+      --> test_return.py:18:5
        |
-    35 | def test_returned_decorated():
-       |     ^^^^^^^^^^^^^^^^^^^^^^^
+    18 | def test_returned_true():
+       |     ^^^^^^^^^^^^^^^^^^
        |
     info: Test functions must return None. Did you mean to use `assert`?
 
@@ -355,7 +371,9 @@ def test_returned_value():
       TRY 1 FAIL [TIME] test_return::test_returned_value
       TRY 2 FAIL [TIME] test_return::test_returned_value
 
-    diagnostics:
+    failures:
+
+    test_return::test_returned_value:
 
     error[test-returned-value]: Test `test_returned_value` returned `True`
      --> test_return.py:2:5
@@ -392,7 +410,9 @@ fn test_failure_diagnostic_uses_discovered_source_after_file_is_deleted() {
         Starting 1 test across 1 worker
             FAIL [TIME] test_deleted_source::test_failure_after_source_deleted
 
-    diagnostics:
+    failures:
+
+    test_deleted_source::test_failure_after_source_deleted:
 
     error[test-failure]: Test `test_failure_after_source_deleted` failed
      --> test_deleted_source.py:4:5
@@ -450,12 +470,24 @@ fn test_fail_concise_output() {
             FAIL [TIME] test_fail::test_2
             FAIL [TIME] test_fail::test_3
 
+    failures:
+
+    test_fail::test_1(fixture_1=1):
+
+    test_fail.py:9:5: error[test-failure] Test `test_1` failed
+
+    test_fail::test_2:
+
+    test_fail.py:16:5: error[missing-fixtures] Test `test_2` has missing fixtures: `fixture_2`
+
+    test_fail::test_3:
+
+    test_fail.py:19:5: error[test-failure] Test `test_3` failed
+
     diagnostics:
 
     test_fail.py:5:5: error[invalid-fixture-finalizer] Discovered an invalid fixture finalizer `fixture_1`
-    test_fail.py:9:5: error[test-failure] Test `test_1` failed
-    test_fail.py:16:5: error[missing-fixtures] Test `test_2` has missing fixtures: `fixture_2`
-    test_fail.py:19:5: error[test-failure] Test `test_3` failed
+
     ────────────
          Summary [TIME] 3 tests run: 0 passed, 3 failed, 0 skipped
 
@@ -484,7 +516,9 @@ fn test_two_test_fails() {
             FAIL [TIME] tests.test_fail::test_fail
             FAIL [TIME] tests.test_fail::test_fail2
 
-    diagnostics:
+    failures:
+
+    tests.test_fail::test_fail:
 
     error[test-failure]: Test `test_fail` failed
      --> tests/test_fail.py:2:5
@@ -498,6 +532,8 @@ fn test_two_test_fails() {
     3 |     assert False
       |     ^^^^^^^^^^^^
       |
+
+    tests.test_fail::test_fail2:
 
     error[test-failure]: Test `test_fail2` failed
      --> tests/test_fail.py:5:5
@@ -550,7 +586,9 @@ fn test_file_importing_another_file() {
         Starting 1 test across 1 worker
             FAIL [TIME] test_cross_file::test_with_helper
 
-    diagnostics:
+    failures:
+
+    test_cross_file::test_with_helper:
 
     error[test-failure]: Test `test_with_helper` failed
      --> test_cross_file.py:4:5
@@ -647,7 +685,9 @@ fn test_failed_output_is_captured() {
             PASS [TIME] test_failed_output::test_pass_with_output
             FAIL [TIME] test_failed_output::test_fail_with_output
 
-    diagnostics:
+    failures:
+
+    test_failed_output::test_fail_with_output:
 
     error[test-failure]: Test `test_fail_with_output` failed
      --> test_failed_output.py:7:5
@@ -688,7 +728,9 @@ fn test_multiple_fixtures_not_found() {
         Starting 1 test across 1 worker
             FAIL [TIME] test_multiple_fixtures_not_found::test_multiple_fixtures_not_found
 
-    diagnostics:
+    failures:
+
+    test_multiple_fixtures_not_found::test_multiple_fixtures_not_found:
 
     error[missing-fixtures]: Test `test_multiple_fixtures_not_found` has missing fixtures
      --> test_multiple_fixtures_not_found.py:1:5
@@ -778,7 +820,9 @@ fn test_quiet_output_failing() {
     exit_code: 1
     ----- stdout -----
 
-    diagnostics:
+    failures:
+
+    test::test_quiet_output:
 
     error[test-failure]: Test `test_quiet_output` failed
      --> test.py:2:5
@@ -880,15 +924,9 @@ fn test_fixture_generator_two_yields_failing_test() {
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_fixture_generator(fixture_generator=1)
 
-    diagnostics:
+    failures:
 
-    error[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `fixture_generator`
-     --> test.py:5:5
-      |
-    5 | def fixture_generator():
-      |     ^^^^^^^^^^^^^^^^^
-      |
-    info: Fixture had more than one yield statement
+    test::test_fixture_generator(fixture_generator=1):
 
     error[test-failure]: Test `test_fixture_generator` failed
      --> test.py:9:5
@@ -904,6 +942,16 @@ fn test_fixture_generator_two_yields_failing_test() {
     10 |     assert fixture_generator == 2
        |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        |
+
+    diagnostics:
+
+    error[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `fixture_generator`
+     --> test.py:5:5
+      |
+    5 | def fixture_generator():
+      |     ^^^^^^^^^^^^^^^^^
+      |
+    info: Fixture had more than one yield statement
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -976,6 +1024,18 @@ fn test_invalid_fixture() {
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_fixture_generator
 
+    failures:
+
+    test::test_fixture_generator:
+
+    error[missing-fixtures]: Test `test_fixture_generator` has missing fixtures
+     --> test.py:8:5
+      |
+    8 | def test_fixture_generator(fixture_generator):
+      |     ^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: Missing fixtures: `fixture_generator`
+
     diagnostics:
 
     error[invalid-fixture]: Discovered an invalid fixture `fixture_generator`
@@ -985,14 +1045,6 @@ fn test_invalid_fixture() {
       |     ^^^^^^^^^^^^^^^^^
       |
     info: Invalid fixture scope: ssession
-
-    error[missing-fixtures]: Test `test_fixture_generator` has missing fixtures
-     --> test.py:8:5
-      |
-    8 | def test_fixture_generator(fixture_generator):
-      |     ^^^^^^^^^^^^^^^^^^^^^^
-      |
-    info: Missing fixtures: `fixture_generator`
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -1021,7 +1073,9 @@ fn test_failfast() {
         Starting 2 tests across 1 worker
             FAIL [TIME] test_failfast::test_first_fail
 
-    diagnostics:
+    failures:
+
+    test_failfast::test_first_fail:
 
     error[test-failure]: Test `test_first_fail` failed
      --> test_failfast.py:2:5
@@ -1099,7 +1153,9 @@ def test_9():
         Starting 10 tests across 2 workers
             FAIL [TIME] test_a::test_fail
 
-    diagnostics:
+    failures:
+
+    test_a::test_fail:
 
     error[test-failure]: Test `test_fail` failed
      --> test_a.py:4:5
@@ -1227,7 +1283,9 @@ def test_1(fixture_very_very_very_very_very_long_name):
         Starting 1 test across 1 worker
             FAIL [TIME] test_file::test_1(fixture_very_very_very_very...=fixture_very_very_very_very...)
 
-    diagnostics:
+    failures:
+
+    test_file::test_1(fixture_very_very_very_very...=fixture_very_very_very_very...):
 
     error[test-failure]: Test `test_1` failed
      --> test_file.py:8:5
@@ -1378,7 +1436,9 @@ def test_2(y): pass
             FAIL [TIME] test_file::test_1
             PASS [TIME] test_file::test_2(y=1)
 
-    diagnostics:
+    failures:
+
+    test_file::test_1:
 
     error[missing-fixtures]: Test `test_1` has missing fixtures
      --> test_file.py:3:5
@@ -1584,9 +1644,12 @@ def test_fail():
             PASS [TIME] test::test_pass
             FAIL [TIME] test::test_fail
 
-    diagnostics:
+    failures:
+
+    test::test_fail:
 
     test.py:5:5: error[test-failure] Test `test_fail` failed
+
     ────────────
          Summary [TIME] 2 tests run: 1 passed, 1 failed, 0 skipped
 
@@ -1614,6 +1677,7 @@ def test_pass():
     diagnostics:
 
     error[failed-to-import-module] Failed to import python module `test`: No module named 'nonexistent_module_xyz'
+
     ────────────
          Summary [TIME] 0 tests run: 0 passed, 0 skipped
 
@@ -1730,7 +1794,9 @@ def test_fourth_skipped():
             FAIL [TIME] test_max_fail::test_first_fail
             FAIL [TIME] test_max_fail::test_second_fail
 
-    diagnostics:
+    failures:
+
+    test_max_fail::test_first_fail:
 
     error[test-failure]: Test `test_first_fail` failed
      --> test_max_fail.py:2:5
@@ -1745,6 +1811,8 @@ def test_fourth_skipped():
       |     ^^^^^^^^^^^^^^^^^^^^^^
       |
     info: boom 1
+
+    test_max_fail::test_second_fail:
 
     error[test-failure]: Test `test_second_fail` failed
      --> test_max_fail.py:5:5
@@ -1793,7 +1861,9 @@ def test_c():
             FAIL [TIME] test_no_fail_fast::test_b
             PASS [TIME] test_no_fail_fast::test_c
 
-    diagnostics:
+    failures:
+
+    test_no_fail_fast::test_a:
 
     error[test-failure]: Test `test_a` failed
      --> test_no_fail_fast.py:2:5
@@ -1808,6 +1878,8 @@ def test_c():
       |     ^^^^^^^^^^^^^^^^^^^^^^
       |
     info: a boom
+
+    test_no_fail_fast::test_b:
 
     error[test-failure]: Test `test_b` failed
      --> test_no_fail_fast.py:5:5
@@ -1856,7 +1928,9 @@ def test_third():
             PASS [TIME] test_max_fail_one::test_first
             FAIL [TIME] test_max_fail_one::test_second
 
-    diagnostics:
+    failures:
+
+    test_max_fail_one::test_second:
 
     error[test-failure]: Test `test_second` failed
      --> test_max_fail_one.py:5:5
@@ -2194,7 +2268,9 @@ def test_2(): assert False
     exit_code: 1
     ----- stdout -----
 
-    diagnostics:
+    failures:
+
+    test::test_2:
 
     error[test-failure]: Test `test_2` failed
      --> test.py:3:5
@@ -2233,7 +2309,9 @@ def test_fail(): assert False
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_fail
 
-    diagnostics:
+    failures:
+
+    test::test_fail:
 
     error[test-failure]: Test `test_fail` failed
      --> test.py:2:5
@@ -2274,7 +2352,9 @@ def test_always_fails(): assert False
       TRY 2 FAIL [TIME] test::test_always_fails
       TRY 3 FAIL [TIME] test::test_always_fails
 
-    diagnostics:
+    failures:
+
+    test::test_always_fails:
 
     error[test-failure]: Test `test_always_fails` failed
      --> test.py:2:5
@@ -2474,7 +2554,9 @@ def test_always_fails(): assert False
       TRY 2 FAIL [TIME] test::test_always_fails
       TRY 3 FAIL [TIME] test::test_always_fails
 
-    diagnostics:
+    failures:
+
+    test::test_always_fails:
 
     error[test-failure]: Test `test_always_fails` failed
       --> test.py:11:5
@@ -2567,13 +2649,15 @@ def test_always_fails(): assert False
         context
             .command_no_parallel()
             .args(["--retry=1", "--status-level=fail"]),
-        @r"
+        @"
     success: false
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
 
-    diagnostics:
+    failures:
+
+    test::test_always_fails:
 
     error[test-failure]: Test `test_always_fails` failed
      --> test.py:2:5
@@ -2898,7 +2982,9 @@ def test_3(): pass
     exit_code: 1
     ----- stdout -----
 
-    diagnostics:
+    failures:
+
+    test::test_1:
 
     error[test-failure]: Test `test_1` failed
      --> test.py:2:5
@@ -2912,6 +2998,8 @@ def test_3(): pass
     2 | def test_1(): assert False
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
+
+    test::test_2:
 
     error[test-failure]: Test `test_2` failed
      --> test.py:3:5
@@ -2954,7 +3042,9 @@ def test_3(): pass
     exit_code: 1
     ----- stdout -----
 
-    diagnostics:
+    failures:
+
+    test::test_1:
 
     error[test-failure]: Test `test_1` failed
      --> test.py:2:5
@@ -2998,7 +3088,9 @@ def test_3(): assert False
     exit_code: 1
     ----- stdout -----
 
-    diagnostics:
+    failures:
+
+    test::test_1:
 
     error[test-failure]: Test `test_1` failed
      --> test.py:2:5
@@ -3012,6 +3104,8 @@ def test_3(): assert False
     2 | def test_1(): assert False
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
+
+    test::test_2:
 
     error[test-failure]: Test `test_2` failed
      --> test.py:3:5

--- a/crates/karva/tests/it/cancel.rs
+++ b/crates/karva/tests/it/cancel.rs
@@ -57,10 +57,17 @@ def test_slow():
 
     let stdout = String::from_utf8_lossy(&output.stdout);
 
-    assert_snapshot!(stdout, @r"
+    assert_snapshot!(stdout, @"
         Starting 1 test across 1 worker
       Cancelling due to interrupt: 1 test still running
           SIGINT [TIME] test_slow::test_slow
+
+    failures:
+
+    test_slow::test_slow:
+
+    error[interrupted]: Test `test_slow::test_slow` was interrupted
+
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
     ");

--- a/crates/karva/tests/it/configuration/mod.rs
+++ b/crates/karva/tests/it/configuration/mod.rs
@@ -468,7 +468,9 @@ def test_c():
             FAIL [TIME] test::test_a
             FAIL [TIME] test::test_b
 
-    diagnostics:
+    failures:
+
+    test::test_a:
 
     error[test-failure]: Test `test_a` failed
      --> test.py:2:5
@@ -482,6 +484,8 @@ def test_c():
     3 |     assert False
       |     ^^^^^^^^^^^^
       |
+
+    test::test_b:
 
     error[test-failure]: Test `test_b` failed
      --> test.py:5:5
@@ -571,7 +575,9 @@ def test_second():
         Starting 2 tests across 1 worker
             FAIL [TIME] test::test_first
 
-    diagnostics:
+    failures:
+
+    test::test_first:
 
     error[test-failure]: Test `test_first` failed
      --> test.py:2:5
@@ -628,7 +634,9 @@ def test_third():
             PASS [TIME] test::test_second
             FAIL [TIME] test::test_third
 
-    diagnostics:
+    failures:
+
+    test::test_first:
 
     error[test-failure]: Test `test_first` failed
      --> test.py:2:5
@@ -642,6 +650,8 @@ def test_third():
     3 |     assert False
       |     ^^^^^^^^^^^^
       |
+
+    test::test_third:
 
     error[test-failure]: Test `test_third` failed
      --> test.py:8:5
@@ -1199,7 +1209,9 @@ def test_second():
         Starting 2 tests across 1 worker
             FAIL [TIME] test::test_first
 
-    diagnostics:
+    failures:
+
+    test::test_first:
 
     error[test-failure]: Test `test_first` failed
      --> test.py:2:5

--- a/crates/karva/tests/it/configuration/overrides.rs
+++ b/crates/karva/tests/it/configuration/overrides.rs
@@ -76,7 +76,9 @@ def test_flaky():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_flaky
 
-    diagnostics:
+    failures:
+
+    test::test_flaky:
 
     error[test-failure]: Test `test_flaky` failed
      --> test.py:2:5
@@ -133,7 +135,9 @@ def test_unit():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_unit
 
-    diagnostics:
+    failures:
+
+    test::test_unit:
 
     error[test-failure]: Test `test_unit` failed
      --> test.py:5:5
@@ -222,7 +226,9 @@ def test_slow():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_slow
 
-    diagnostics:
+    failures:
+
+    test::test_slow:
 
     error[test-failure]: Test `test_slow` failed
      --> test.py:6:5

--- a/crates/karva/tests/it/durations.rs
+++ b/crates/karva/tests/it/durations.rs
@@ -149,7 +149,9 @@ fn durations_with_failing_tests() {
             PASS [TIME] test_durations::test_pass
             FAIL [TIME] test_durations::test_fail
 
-    diagnostics:
+    failures:
+
+    test_durations::test_fail:
 
     error[test-failure]: Test `test_fail` failed
      --> test_durations.py:6:5

--- a/crates/karva/tests/it/extensions/fixtures/autouse.rs
+++ b/crates/karva/tests/it/extensions/fixtures/autouse.rs
@@ -210,18 +210,38 @@ def test_something_else():
 "#,
     );
 
-    assert_cmd_snapshot!(context.command_no_parallel(), @"
-    success: true
-    exit_code: 0
+    assert_cmd_snapshot!(context.command_no_parallel(), @r#"
+    success: false
+    exit_code: 1
     ----- stdout -----
         Starting 2 tests across 1 worker
-            PASS [TIME] test::test_something
-            PASS [TIME] test::test_something_else
+           ERROR [TIME] test::test_something
+           ERROR [TIME] test::test_something_else
+
+    failures:
+
+    test::test_something:
+    test::test_something_else:
+
+    error[fixture-failure]: Fixture `failing_fixture` failed
+     --> test.py:5:5
+      |
+    5 | def failing_fixture():
+      |     ^^^^^^^^^^^^^^^
+      |
+    info: Fixture failed here
+     --> test.py:6:5
+      |
+    6 |     raise RuntimeError("Setup failed!")
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: Setup failed!
+
     ────────────
-         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+         Summary [TIME] 2 tests run: 0 passed, 2 errors, 0 skipped
 
     ----- stderr -----
-    ");
+    "#);
 }
 
 #[test]
@@ -248,9 +268,11 @@ def test_something():
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            PASS [TIME] test::test_something
+           ERROR [TIME] test::test_something
 
-    diagnostics:
+    failures:
+
+    test::test_something:
 
     error[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `failing_teardown_fixture`
      --> test.py:5:5
@@ -261,7 +283,7 @@ def test_something():
     info: Failed to reset fixture: Teardown failed!
 
     ────────────
-         Summary [TIME] 1 test run: 1 passed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");
@@ -287,17 +309,42 @@ def test_something():
 "#,
     );
 
-    assert_cmd_snapshot!(context.command_no_parallel(), @"
-    success: true
-    exit_code: 0
+    assert_cmd_snapshot!(context.command_no_parallel(), @r#"
+    success: false
+    exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            PASS [TIME] test::test_something
+           ERROR [TIME] test::test_something
+
+    failures:
+
+    test::test_something:
+
+    error[fixture-failure]: Fixture `failing_dep` failed
+     --> test.py:5:5
+      |
+    5 | def failing_dep():
+      |     ^^^^^^^^^^^
+      |
+    info: Fixture `auto_fixture` requires `failing_dep`
+     --> test.py:9:5
+      |
+    9 | def auto_fixture(failing_dep):
+      |     ^^^^^^^^^^^^
+      |
+    info: Fixture failed here
+     --> test.py:6:5
+      |
+    6 |     raise ValueError("Dependency failed!")
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: Dependency failed!
+
     ────────────
-         Summary [TIME] 1 test run: 1 passed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
-    ");
+    "#);
 }
 
 #[test]
@@ -324,10 +371,13 @@ def test_second():
     exit_code: 1
     ----- stdout -----
         Starting 2 tests across 1 worker
-            PASS [TIME] test::test_first
-            PASS [TIME] test::test_second
+           ERROR [TIME] test::test_first
+           ERROR [TIME] test::test_second
 
-    diagnostics:
+    failures:
+
+    test::test_first:
+    test::test_second:
 
     error[fixture-failure]: Fixture `failing_scoped_fixture` failed
      --> test.py:5:5
@@ -344,7 +394,7 @@ def test_second():
     info: Scoped fixture failed!
 
     ────────────
-         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+         Summary [TIME] 2 tests run: 0 passed, 2 errors, 0 skipped
 
     ----- stderr -----
     "#);

--- a/crates/karva/tests/it/extensions/fixtures/autouse.rs
+++ b/crates/karva/tests/it/extensions/fixtures/autouse.rs
@@ -290,6 +290,67 @@ def test_something():
 }
 
 #[test]
+fn test_scoped_auto_use_setup_failure_runs_registered_finalizers() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+
+@karva.fixture(scope="module", auto_use=True)
+def failing_teardown_fixture():
+    yield
+    raise RuntimeError("Teardown failed!")
+
+@karva.fixture(scope="module", auto_use=True)
+def failing_setup_fixture():
+    raise RuntimeError("Setup failed!")
+
+def test_unreachable():
+    raise AssertionError("test body ran")
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+           ERROR [TIME] test::test_unreachable
+
+    failures:
+
+    test::test_unreachable:
+
+    error[fixture-failure]: Fixture `failing_setup_fixture` failed
+      --> test.py:10:5
+       |
+    10 | def failing_setup_fixture():
+       |     ^^^^^^^^^^^^^^^^^^^^^
+       |
+    info: Fixture failed here
+      --> test.py:11:5
+       |
+    11 |     raise RuntimeError("Setup failed!")
+       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       |
+    info: Setup failed!
+
+    error[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `failing_teardown_fixture`
+     --> test.py:5:5
+      |
+    5 | def failing_teardown_fixture():
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: Failed to reset fixture: Teardown failed!
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
+
+    ----- stderr -----
+    "#);
+}
+
+#[test]
 fn test_auto_use_fixture_with_failing_dependency() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva/tests/it/extensions/fixtures/basic.rs
+++ b/crates/karva/tests/it/extensions/fixtures/basic.rs
@@ -814,12 +814,24 @@ Path(__file__).with_name('mypackage').joinpath('fixtures.py').unlink()
         ),
     ]);
 
-    assert_cmd_snapshot!(context.command_no_parallel(), @r"
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
     success: false
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
             FAIL [TIME] test_invoke::test_invoke
+
+    failures:
+
+    test_invoke::test_invoke:
+
+    error[missing-fixtures]: Test `test_invoke` has missing fixtures
+     --> test_invoke.py:1:5
+      |
+    1 | def test_invoke(invoke): assert invoke == 'invoked'
+      |     ^^^^^^^^^^^
+      |
+    info: Missing fixtures: `invoke`
 
     diagnostics:
 
@@ -829,14 +841,6 @@ Path(__file__).with_name('mypackage').joinpath('fixtures.py').unlink()
     1 | from pathlib import Path
       | ^
       |
-
-    error[missing-fixtures]: Test `test_invoke` has missing fixtures
-     --> test_invoke.py:1:5
-      |
-    1 | def test_invoke(invoke): assert invoke == 'invoked'
-      |     ^^^^^^^^^^^
-      |
-    info: Missing fixtures: `invoke`
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped

--- a/crates/karva/tests/it/extensions/fixtures/basic.rs
+++ b/crates/karva/tests/it/extensions/fixtures/basic.rs
@@ -819,7 +819,7 @@ Path(__file__).with_name('mypackage').joinpath('fixtures.py').unlink()
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test_invoke::test_invoke
+           ERROR [TIME] test_invoke::test_invoke
 
     failures:
 
@@ -838,7 +838,7 @@ Path(__file__).with_name('mypackage').joinpath('fixtures.py').unlink()
     error[failed-to-discover-imported-fixture]: Failed to discover imported fixture `invoke` from `<temp_dir>/mypackage/fixtures.py`: failed to open file `<temp_dir>/mypackage/fixtures.py`: No such file or directory (os error 2)
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");

--- a/crates/karva/tests/it/extensions/fixtures/basic.rs
+++ b/crates/karva/tests/it/extensions/fixtures/basic.rs
@@ -836,11 +836,6 @@ Path(__file__).with_name('mypackage').joinpath('fixtures.py').unlink()
     diagnostics:
 
     error[failed-to-discover-imported-fixture]: Failed to discover imported fixture `invoke` from `<temp_dir>/mypackage/fixtures.py`: failed to open file `<temp_dir>/mypackage/fixtures.py`: No such file or directory (os error 2)
-     --> conftest.py:1:1
-      |
-    1 | from pathlib import Path
-      | ^
-      |
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped

--- a/crates/karva/tests/it/extensions/fixtures/cycles.rs
+++ b/crates/karva/tests/it/extensions/fixtures/cycles.rs
@@ -24,7 +24,7 @@ def test_cycle(value):
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_cycle
+           ERROR [TIME] test::test_cycle
 
     failures:
 
@@ -39,7 +39,7 @@ def test_cycle(value):
     info: value -> value
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");
@@ -75,7 +75,7 @@ def test_cycle(database):
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_cycle
+           ERROR [TIME] test::test_cycle
 
     failures:
 
@@ -96,7 +96,7 @@ def test_cycle(database):
     info: database -> client -> database
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");
@@ -142,7 +142,7 @@ def test_cycle(database):
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_cycle
+           ERROR [TIME] test::test_cycle
 
     failures:
 
@@ -163,7 +163,7 @@ def test_cycle(database):
     info: database -> client -> database
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");
@@ -206,7 +206,7 @@ def test_cycle(requested):
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_cycle
+           ERROR [TIME] test::test_cycle
 
     failures:
 
@@ -233,7 +233,7 @@ def test_cycle(requested):
     info: first -> second -> third -> first
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");
@@ -267,7 +267,7 @@ def test_cycle():
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_cycle
+           ERROR [TIME] test::test_cycle
 
     failures:
 
@@ -288,7 +288,7 @@ def test_cycle():
     info: first -> second -> first
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");
@@ -325,27 +325,12 @@ def test_cycle_two():
     exit_code: 1
     ----- stdout -----
         Starting 2 tests across 1 worker
-            FAIL [TIME] test::test_cycle_one
-            FAIL [TIME] test::test_cycle_two
+           ERROR [TIME] test::test_cycle_one
+           ERROR [TIME] test::test_cycle_two
 
     failures:
 
     test::test_cycle_one:
-
-    error[fixture-cycle]: Fixture dependency cycle detected
-     --> test.py:6:5
-      |
-    6 | def first(second):
-      |     ^^^^^
-      |
-    info: Fixture `second` requires `first`
-      --> test.py:10:5
-       |
-    10 | def second(first):
-       |     ^^^^^^
-       |
-    info: first -> second -> first
-
     test::test_cycle_two:
 
     error[fixture-cycle]: Fixture dependency cycle detected
@@ -363,7 +348,7 @@ def test_cycle_two():
     info: first -> second -> first
 
     ────────────
-         Summary [TIME] 2 tests run: 0 passed, 2 failed, 0 skipped
+         Summary [TIME] 2 tests run: 0 passed, 2 errors, 0 skipped
 
     ----- stderr -----
     ");
@@ -416,27 +401,12 @@ def test_nested_cycle():
     exit_code: 1
     ----- stdout -----
         Starting 2 tests across 1 worker
-            FAIL [TIME] test::test_cycle
-            FAIL [TIME] nested.test_nested::test_nested_cycle
+           ERROR [TIME] test::test_cycle
+           ERROR [TIME] nested.test_nested::test_nested_cycle
 
     failures:
 
     nested.test_nested::test_nested_cycle:
-
-    error[fixture-cycle]: Fixture dependency cycle detected
-     --> conftest.py:6:5
-      |
-    6 | def first(second):
-      |     ^^^^^
-      |
-    info: Fixture `second` requires `first`
-      --> conftest.py:10:5
-       |
-    10 | def second(first):
-       |     ^^^^^^
-       |
-    info: first -> second -> first
-
     test::test_cycle:
 
     error[fixture-cycle]: Fixture dependency cycle detected
@@ -454,7 +424,7 @@ def test_nested_cycle():
     info: first -> second -> first
 
     ────────────
-         Summary [TIME] 2 tests run: 0 passed, 2 failed, 0 skipped
+         Summary [TIME] 2 tests run: 0 passed, 2 errors, 0 skipped
 
     ----- stderr -----
     ");
@@ -497,7 +467,7 @@ def test_cycle():
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_cycle
+           ERROR [TIME] test::test_cycle
 
     failures:
 
@@ -518,7 +488,7 @@ def test_cycle():
     info: first -> second -> first
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");
@@ -553,7 +523,7 @@ def test_cycle():
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_cycle
+           ERROR [TIME] test::test_cycle
 
     failures:
 
@@ -574,7 +544,7 @@ def test_cycle():
     info: first -> second -> first
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");

--- a/crates/karva/tests/it/extensions/fixtures/cycles.rs
+++ b/crates/karva/tests/it/extensions/fixtures/cycles.rs
@@ -26,7 +26,9 @@ def test_cycle(value):
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_cycle
 
-    diagnostics:
+    failures:
+
+    test::test_cycle:
 
     error[fixture-cycle]: Fixture dependency cycle detected
      --> test.py:6:5
@@ -75,7 +77,9 @@ def test_cycle(database):
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_cycle
 
-    diagnostics:
+    failures:
+
+    test::test_cycle:
 
     error[fixture-cycle]: Fixture dependency cycle detected
      --> test.py:6:11
@@ -140,7 +144,9 @@ def test_cycle(database):
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_cycle
 
-    diagnostics:
+    failures:
+
+    test::test_cycle:
 
     error[fixture-cycle]: Fixture dependency cycle detected
      --> conftest.py:6:5
@@ -202,7 +208,9 @@ def test_cycle(requested):
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_cycle
 
-    diagnostics:
+    failures:
+
+    test::test_cycle:
 
     error[fixture-cycle]: Fixture dependency cycle detected
       --> test.py:10:5
@@ -261,7 +269,9 @@ def test_cycle():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_cycle
 
-    diagnostics:
+    failures:
+
+    test::test_cycle:
 
     error[fixture-cycle]: Fixture dependency cycle detected
      --> test.py:6:5
@@ -318,7 +328,25 @@ def test_cycle_two():
             FAIL [TIME] test::test_cycle_one
             FAIL [TIME] test::test_cycle_two
 
-    diagnostics:
+    failures:
+
+    test::test_cycle_one:
+
+    error[fixture-cycle]: Fixture dependency cycle detected
+     --> test.py:6:5
+      |
+    6 | def first(second):
+      |     ^^^^^
+      |
+    info: Fixture `second` requires `first`
+      --> test.py:10:5
+       |
+    10 | def second(first):
+       |     ^^^^^^
+       |
+    info: first -> second -> first
+
+    test::test_cycle_two:
 
     error[fixture-cycle]: Fixture dependency cycle detected
      --> test.py:6:5
@@ -391,7 +419,25 @@ def test_nested_cycle():
             FAIL [TIME] test::test_cycle
             FAIL [TIME] nested.test_nested::test_nested_cycle
 
-    diagnostics:
+    failures:
+
+    nested.test_nested::test_nested_cycle:
+
+    error[fixture-cycle]: Fixture dependency cycle detected
+     --> conftest.py:6:5
+      |
+    6 | def first(second):
+      |     ^^^^^
+      |
+    info: Fixture `second` requires `first`
+      --> conftest.py:10:5
+       |
+    10 | def second(first):
+       |     ^^^^^^
+       |
+    info: first -> second -> first
+
+    test::test_cycle:
 
     error[fixture-cycle]: Fixture dependency cycle detected
      --> conftest.py:6:5
@@ -453,7 +499,9 @@ def test_cycle():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_cycle
 
-    diagnostics:
+    failures:
+
+    test::test_cycle:
 
     error[fixture-cycle]: Fixture dependency cycle detected
      --> conftest.py:6:5
@@ -507,7 +555,9 @@ def test_cycle():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_cycle
 
-    diagnostics:
+    failures:
+
+    test::test_cycle:
 
     error[fixture-cycle]: Fixture dependency cycle detected
      --> test.py:6:5

--- a/crates/karva/tests/it/extensions/fixtures/decorators.rs
+++ b/crates/karva/tests/it/extensions/fixtures/decorators.rs
@@ -184,7 +184,7 @@ def test_fixtures_given_by_decorator(a, b):
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_fixtures_given_by_decorator
+           ERROR [TIME] test::test_fixtures_given_by_decorator
 
     failures:
 
@@ -199,7 +199,7 @@ def test_fixtures_given_by_decorator(a, b):
     info: Missing fixtures: `b`
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");

--- a/crates/karva/tests/it/extensions/fixtures/decorators.rs
+++ b/crates/karva/tests/it/extensions/fixtures/decorators.rs
@@ -186,7 +186,9 @@ def test_fixtures_given_by_decorator(a, b):
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_fixtures_given_by_decorator
 
-    diagnostics:
+    failures:
+
+    test::test_fixtures_given_by_decorator:
 
     error[missing-fixtures]: Test `test_fixtures_given_by_decorator` has missing fixtures
       --> test.py:13:5

--- a/crates/karva/tests/it/extensions/fixtures/generators.rs
+++ b/crates/karva/tests/it/extensions/fixtures/generators.rs
@@ -120,9 +120,11 @@ async def test_bad(bad_fixture):
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            PASS [TIME] test::test_bad(bad_fixture=1)
+           ERROR [TIME] test::test_bad(bad_fixture=1)
 
-    diagnostics:
+    failures:
+
+    test::test_bad(bad_fixture=1):
 
     error[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `bad_fixture`
      --> test.py:4:11
@@ -133,7 +135,7 @@ async def test_bad(bad_fixture):
     info: Fixture had more than one yield statement
 
     ────────────
-         Summary [TIME] 1 test run: 1 passed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");
@@ -160,9 +162,11 @@ async def test_error(error_fixture):
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            PASS [TIME] test::test_error(error_fixture=1)
+           ERROR [TIME] test::test_error(error_fixture=1)
 
-    diagnostics:
+    failures:
+
+    test::test_error(error_fixture=1):
 
     error[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `error_fixture`
      --> test.py:4:11
@@ -173,7 +177,7 @@ async def test_error(error_fixture):
     info: Failed to reset fixture: teardown failed
 
     ────────────
-         Summary [TIME] 1 test run: 1 passed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");

--- a/crates/karva/tests/it/extensions/fixtures/invalid.rs
+++ b/crates/karva/tests/it/extensions/fixtures/invalid.rs
@@ -29,6 +29,18 @@ fn test_invalid_pytest_fixture_scope() {
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_all_scopes
 
+    failures:
+
+    test::test_all_scopes:
+
+    error[missing-fixtures]: Test `test_all_scopes` has missing fixtures
+     --> test.py:8:5
+      |
+    8 | def test_all_scopes(
+      |     ^^^^^^^^^^^^^^^
+      |
+    info: Missing fixtures: `some_fixture`
+
     diagnostics:
 
     error[invalid-fixture]: Discovered an invalid fixture `some_fixture`
@@ -38,14 +50,6 @@ fn test_invalid_pytest_fixture_scope() {
       |     ^^^^^^^^^^^^
       |
     info: Invalid fixture scope: sessionss
-
-    error[missing-fixtures]: Test `test_all_scopes` has missing fixtures
-     --> test.py:8:5
-      |
-    8 | def test_all_scopes(
-      |     ^^^^^^^^^^^^^^^
-      |
-    info: Missing fixtures: `some_fixture`
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -76,6 +80,18 @@ def test_all_scopes(some_fixture: int) -> None:
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_all_scopes
 
+    failures:
+
+    test::test_all_scopes:
+
+    error[missing-fixtures]: Test `test_all_scopes` has missing fixtures
+     --> test.py:7:5
+      |
+    7 | def test_all_scopes(some_fixture: int) -> None:
+      |     ^^^^^^^^^^^^^^^
+      |
+    info: Missing fixtures: `some_fixture`
+
     diagnostics:
 
     error[invalid-fixture]: Discovered an invalid fixture `some_fixture`
@@ -85,14 +101,6 @@ def test_all_scopes(some_fixture: int) -> None:
       |     ^^^^^^^^^^^^
       |
     info: Invalid fixture scope: sessionss
-
-    error[missing-fixtures]: Test `test_all_scopes` has missing fixtures
-     --> test.py:7:5
-      |
-    7 | def test_all_scopes(some_fixture: int) -> None:
-      |     ^^^^^^^^^^^^^^^
-      |
-    info: Missing fixtures: `some_fixture`
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -120,7 +128,9 @@ fn test_missing_fixture() {
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_all_scopes
 
-    diagnostics:
+    failures:
+
+    test::test_all_scopes:
 
     error[missing-fixtures]: Test `test_all_scopes` has missing fixtures
      --> test.py:2:5
@@ -160,7 +170,9 @@ fn test_fixture_fails_to_run() {
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_failing_fixture
 
-    diagnostics:
+    failures:
+
+    test::test_failing_fixture:
 
     error[missing-fixtures]: Test `test_failing_fixture` has missing fixtures
      --> test.py:8:5
@@ -207,7 +219,9 @@ fn test_fixture_missing_fixtures() {
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_failing_fixture
 
-    diagnostics:
+    failures:
+
+    test::test_failing_fixture:
 
     error[missing-fixtures]: Test `test_failing_fixture` has missing fixtures
      --> test.py:8:5
@@ -245,7 +259,9 @@ fn missing_arguments_in_nested_function() {
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_failing_fixture
 
-    diagnostics:
+    failures:
+
+    test::test_failing_fixture:
 
     error[test-failure]: Test `test_failing_fixture` failed
      --> test.py:2:5
@@ -293,7 +309,9 @@ fn test_failing_yield_fixture() {
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_failing_fixture
 
-    diagnostics:
+    failures:
+
+    test::test_failing_fixture:
 
     error[missing-fixtures]: Test `test_failing_fixture` has missing fixtures
       --> test.py:10:5
@@ -430,7 +448,9 @@ fn test_fixture_dependency_chain_failure() {
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_with_db
 
-    diagnostics:
+    failures:
+
+    test::test_with_db:
 
     error[missing-fixtures]: Test `test_with_db` has missing fixtures
       --> test.py:16:5
@@ -488,6 +508,18 @@ def test_with_fixture(my_fixture):
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_with_fixture
 
+    failures:
+
+    test::test_with_fixture:
+
+    error[missing-fixtures]: Test `test_with_fixture` has missing fixtures
+     --> test.py:7:5
+      |
+    7 | def test_with_fixture(my_fixture):
+      |     ^^^^^^^^^^^^^^^^^
+      |
+    info: Missing fixtures: `my_fixture`
+
     diagnostics:
 
     error[invalid-fixture]: Discovered an invalid fixture `my_fixture`
@@ -497,14 +529,6 @@ def test_with_fixture(my_fixture):
       |     ^^^^^^^^^^
       |
     info: Scope must be either a string or a callable
-
-    error[missing-fixtures]: Test `test_with_fixture` has missing fixtures
-     --> test.py:7:5
-      |
-    7 | def test_with_fixture(my_fixture):
-      |     ^^^^^^^^^^^^^^^^^
-      |
-    info: Missing fixtures: `my_fixture`
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -544,7 +568,9 @@ def test_database(database):
             Starting 1 test across 1 worker
                 FAIL [TIME] test::test_database
 
-        diagnostics:
+        failures:
+
+        test::test_database:
 
         error[fixture-scope-mismatch]: Fixture `database` with `session` scope cannot depend on fixture `connection` with `function` scope
           --> test.py:10:5
@@ -607,7 +633,9 @@ def test_database():
         Starting 1 test across 1 worker
             FAIL [TIME] nested.test::test_database
 
-    diagnostics:
+    failures:
+
+    nested.test::test_database:
 
     error[fixture-scope-mismatch]: Fixture `database` with `package` scope cannot depend on fixture `connection` with `function` scope
       --> nested/conftest.py:10:11
@@ -667,7 +695,9 @@ def test_database(database):
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_database
 
-    diagnostics:
+    failures:
+
+    test::test_database:
 
     error[fixture-scope-mismatch]: Fixture `repository` with `session` scope cannot depend on fixture `connection` with `function` scope
       --> test.py:13:5
@@ -733,7 +763,9 @@ def test_scopes(package_fixture):
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_scopes
 
-    diagnostics:
+    failures:
+
+    test::test_scopes:
 
     error[fixture-scope-mismatch]: Fixture `session_fixture` with `session` scope cannot depend on fixture `module_fixture` with `module` scope
       --> test.py:14:5

--- a/crates/karva/tests/it/extensions/fixtures/invalid.rs
+++ b/crates/karva/tests/it/extensions/fixtures/invalid.rs
@@ -27,7 +27,7 @@ fn test_invalid_pytest_fixture_scope() {
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_all_scopes
+           ERROR [TIME] test::test_all_scopes
 
     failures:
 
@@ -52,7 +52,7 @@ fn test_invalid_pytest_fixture_scope() {
     info: Invalid fixture scope: sessionss
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");
@@ -78,7 +78,7 @@ def test_all_scopes(some_fixture: int) -> None:
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_all_scopes
+           ERROR [TIME] test::test_all_scopes
 
     failures:
 
@@ -103,7 +103,7 @@ def test_all_scopes(some_fixture: int) -> None:
     info: Invalid fixture scope: sessionss
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");
@@ -126,7 +126,7 @@ fn test_missing_fixture() {
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_all_scopes
+           ERROR [TIME] test::test_all_scopes
 
     failures:
 
@@ -141,7 +141,7 @@ fn test_missing_fixture() {
     info: Missing fixtures: `missing_fixture`
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");
@@ -506,7 +506,7 @@ def test_with_fixture(my_fixture):
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_with_fixture
+           ERROR [TIME] test::test_with_fixture
 
     failures:
 
@@ -531,7 +531,7 @@ def test_with_fixture(my_fixture):
     info: Scope must be either a string or a callable
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");

--- a/crates/karva/tests/it/extensions/fixtures/invalid.rs
+++ b/crates/karva/tests/it/extensions/fixtures/invalid.rs
@@ -168,20 +168,19 @@ fn test_fixture_fails_to_run() {
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_failing_fixture
+           ERROR [TIME] test::test_failing_fixture
 
     failures:
 
     test::test_failing_fixture:
 
-    error[missing-fixtures]: Test `test_failing_fixture` has missing fixtures
-     --> test.py:8:5
+    error[fixture-failure]: Fixture `failing_fixture` failed
+     --> test.py:5:5
       |
-    8 | def test_failing_fixture(failing_fixture):
-      |     ^^^^^^^^^^^^^^^^^^^^
+    5 | def failing_fixture():
+      |     ^^^^^^^^^^^^^^^
       |
-    info: Missing fixtures: `failing_fixture`
-    info: Fixture `failing_fixture` failed here
+    info: Fixture failed here
      --> test.py:6:5
       |
     6 |     raise Exception('Fixture failed')
@@ -190,7 +189,7 @@ fn test_fixture_fails_to_run() {
     info: Fixture failed
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");
@@ -217,23 +216,22 @@ fn test_fixture_missing_fixtures() {
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_failing_fixture
+           ERROR [TIME] test::test_failing_fixture
 
     failures:
 
     test::test_failing_fixture:
 
-    error[missing-fixtures]: Test `test_failing_fixture` has missing fixtures
-     --> test.py:8:5
+    error[fixture-failure]: Fixture `failing_fixture` failed
+     --> test.py:5:5
       |
-    8 | def test_failing_fixture(failing_fixture):
-      |     ^^^^^^^^^^^^^^^^^^^^
+    5 | def failing_fixture(missing_fixture):
+      |     ^^^^^^^^^^^^^^^
       |
-    info: Missing fixtures: `failing_fixture`
     info: failing_fixture() missing 1 required positional argument: 'missing_fixture'
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");
@@ -307,20 +305,19 @@ fn test_failing_yield_fixture() {
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_failing_fixture
+           ERROR [TIME] test::test_failing_fixture
 
     failures:
 
     test::test_failing_fixture:
 
-    error[missing-fixtures]: Test `test_failing_fixture` has missing fixtures
-      --> test.py:10:5
-       |
-    10 | def test_failing_fixture(fixture):
-       |     ^^^^^^^^^^^^^^^^^^^^
-       |
-    info: Missing fixtures: `fixture`
-    info: Fixture `fixture` failed here
+    error[fixture-failure]: Fixture `fixture` failed
+     --> test.py:5:5
+      |
+    5 | def fixture():
+      |     ^^^^^^^
+      |
+    info: Fixture failed here
      --> test.py:7:9
       |
     7 |         raise ValueError('foo')
@@ -329,7 +326,7 @@ fn test_failing_yield_fixture() {
     info: foo
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");
@@ -357,9 +354,11 @@ fn test_fixture_generator_two_yields() {
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            PASS [TIME] test::test_fixture_generator(fixture_generator=1)
+           ERROR [TIME] test::test_fixture_generator(fixture_generator=1)
 
-    diagnostics:
+    failures:
+
+    test::test_fixture_generator(fixture_generator=1):
 
     error[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `fixture_generator`
      --> test.py:5:5
@@ -370,7 +369,7 @@ fn test_fixture_generator_two_yields() {
     info: Fixture had more than one yield statement
 
     ────────────
-         Summary [TIME] 1 test run: 1 passed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");
@@ -398,9 +397,11 @@ fn test_fixture_generator_fail_in_teardown() {
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            PASS [TIME] test::test_fixture_generator(fixture_generator=1)
+           ERROR [TIME] test::test_fixture_generator(fixture_generator=1)
 
-    diagnostics:
+    failures:
+
+    test::test_fixture_generator(fixture_generator=1):
 
     error[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `fixture_generator`
      --> test.py:5:5
@@ -411,7 +412,7 @@ fn test_fixture_generator_fail_in_teardown() {
     info: Failed to reset fixture: fixture-error
 
     ────────────
-         Summary [TIME] 1 test run: 1 passed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");
@@ -446,19 +447,18 @@ fn test_fixture_dependency_chain_failure() {
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_with_db
+           ERROR [TIME] test::test_with_db
 
     failures:
 
     test::test_with_db:
 
-    error[missing-fixtures]: Test `test_with_db` has missing fixtures
-      --> test.py:16:5
-       |
-    16 | def test_with_db(db):
-       |     ^^^^^^^^^^^^
-       |
-    info: Missing fixtures: `db`
+    error[fixture-failure]: Fixture `config` failed
+     --> test.py:5:5
+      |
+    5 | def config():
+      |     ^^^^^^
+      |
     info: Fixture `db` requires `connection`
       --> test.py:13:5
        |
@@ -471,7 +471,7 @@ fn test_fixture_dependency_chain_failure() {
     9 | def connection(config):
       |     ^^^^^^^^^^
       |
-    info: Fixture `config` failed here
+    info: Fixture failed here
      --> test.py:6:5
       |
     6 |     raise Exception('config failed')
@@ -480,7 +480,7 @@ fn test_fixture_dependency_chain_failure() {
     info: config failed
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");
@@ -566,7 +566,7 @@ def test_database(database):
         exit_code: 1
         ----- stdout -----
             Starting 1 test across 1 worker
-                FAIL [TIME] test::test_database
+               ERROR [TIME] test::test_database
 
         failures:
 
@@ -586,7 +586,7 @@ def test_database(database):
           |
 
         ────────────
-             Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+             Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
         ----- stderr -----
         ");
@@ -631,7 +631,7 @@ def test_database():
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] nested.test::test_database
+           ERROR [TIME] nested.test::test_database
 
     failures:
 
@@ -651,7 +651,7 @@ def test_database():
       |
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");
@@ -693,7 +693,7 @@ def test_database(database):
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_database
+           ERROR [TIME] test::test_database
 
     failures:
 
@@ -719,7 +719,7 @@ def test_database(database):
       |
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");
@@ -761,7 +761,7 @@ def test_scopes(package_fixture):
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_scopes
+           ERROR [TIME] test::test_scopes
 
     failures:
 
@@ -787,7 +787,7 @@ def test_scopes(package_fixture):
        |
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");

--- a/crates/karva/tests/it/extensions/fixtures/more_builtins.rs
+++ b/crates/karva/tests/it/extensions/fixtures/more_builtins.rs
@@ -881,7 +881,9 @@ def test_no_such_fixture(not_a_real_fixture):
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_no_such_fixture
 
-    diagnostics:
+    failures:
+
+    test::test_no_such_fixture:
 
     error[missing-fixtures]: Test `test_no_such_fixture` has missing fixtures
      --> test.py:2:5

--- a/crates/karva/tests/it/extensions/fixtures/more_builtins.rs
+++ b/crates/karva/tests/it/extensions/fixtures/more_builtins.rs
@@ -879,7 +879,7 @@ def test_no_such_fixture(not_a_real_fixture):
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_no_such_fixture
+           ERROR [TIME] test::test_no_such_fixture
 
     failures:
 
@@ -894,7 +894,7 @@ def test_no_such_fixture(not_a_real_fixture):
     info: Missing fixtures: `not_a_real_fixture`
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");

--- a/crates/karva/tests/it/extensions/functions.rs
+++ b/crates/karva/tests/it/extensions/functions.rs
@@ -32,21 +32,25 @@ def test_with_fail_with_keyword_reason():
             FAIL [TIME] test::test_with_fail_with_no_reason
             FAIL [TIME] test::test_with_fail_with_keyword_reason
 
-    diagnostics:
+    failures:
 
-    error[test-failure]: Test `test_with_fail_with_reason` failed
-     --> test.py:4:5
-      |
-    4 | def test_with_fail_with_reason():
-      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-      |
+    test::test_with_fail_with_keyword_reason:
+
+    error[test-failure]: Test `test_with_fail_with_keyword_reason` failed
+      --> test.py:10:5
+       |
+    10 | def test_with_fail_with_keyword_reason():
+       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       |
     info: Test failed here
-     --> test.py:5:5
-      |
-    5 |     karva.fail('This is a custom failure message')
-      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      |
+      --> test.py:11:5
+       |
+    11 |     karva.fail(reason='This is a custom failure message')
+       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       |
     info: This is a custom failure message
+
+    test::test_with_fail_with_no_reason:
 
     error[test-failure]: Test `test_with_fail_with_no_reason` failed
      --> test.py:7:5
@@ -61,18 +65,20 @@ def test_with_fail_with_keyword_reason():
       |     ^^^^^^^^^^^^
       |
 
-    error[test-failure]: Test `test_with_fail_with_keyword_reason` failed
-      --> test.py:10:5
-       |
-    10 | def test_with_fail_with_keyword_reason():
-       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-       |
+    test::test_with_fail_with_reason:
+
+    error[test-failure]: Test `test_with_fail_with_reason` failed
+     --> test.py:4:5
+      |
+    4 | def test_with_fail_with_reason():
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
     info: Test failed here
-      --> test.py:11:5
-       |
-    11 |     karva.fail(reason='This is a custom failure message')
-       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-       |
+     --> test.py:5:5
+      |
+    5 |     karva.fail('This is a custom failure message')
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
     info: This is a custom failure message
 
     ────────────
@@ -104,7 +110,9 @@ def test_conditional_fail():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_conditional_fail
 
-    diagnostics:
+    failures:
+
+    test::test_conditional_fail:
 
     error[test-failure]: Test `test_conditional_fail` failed
      --> test.py:4:5
@@ -146,7 +154,9 @@ def test_raise_fail_error():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_raise_fail_error
 
-    diagnostics:
+    failures:
+
+    test::test_raise_fail_error:
 
     error[test-failure]: Test `test_raise_fail_error` failed
      --> test.py:4:5
@@ -370,7 +380,9 @@ def test_raises_no_exception():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_raises_no_exception
 
-    diagnostics:
+    failures:
+
+    test::test_raises_no_exception:
 
     error[test-failure]: Test `test_raises_no_exception` failed
      --> test.py:4:5
@@ -439,7 +451,9 @@ def test_raises_match_fails():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_raises_match_fails
 
-    diagnostics:
+    failures:
+
+    test::test_raises_match_fails:
 
     error[test-failure]: Test `test_raises_match_fails` failed
      --> test.py:4:5
@@ -482,7 +496,9 @@ def test_raises_wrong_type():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_raises_wrong_type
 
-    diagnostics:
+    failures:
+
+    test::test_raises_wrong_type:
 
     error[test-failure]: Test `test_raises_wrong_type` failed
      --> test.py:4:5

--- a/crates/karva/tests/it/extensions/snapshot/basic.rs
+++ b/crates/karva/tests/it/extensions/snapshot/basic.rs
@@ -22,7 +22,9 @@ def test_hello():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_hello
 
-    diagnostics:
+    failures:
+
+    test::test_hello:
 
     error[test-failure]: Test `test_hello` failed
      --> test.py:4:5
@@ -192,7 +194,9 @@ def test_hello():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_hello
 
-    diagnostics:
+    failures:
+
+    test::test_hello:
 
     error[test-failure]: Test `test_hello` failed
      --> test.py:4:5
@@ -411,7 +415,9 @@ def test_hello():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_hello
 
-    diagnostics:
+    failures:
+
+    test::test_hello:
 
     error[test-failure]: Test `test_hello` failed
      --> test.py:4:5
@@ -478,7 +484,9 @@ def test_hello():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_hello
 
-    diagnostics:
+    failures:
+
+    test::test_hello:
 
     error[test-failure]: Test `test_hello` failed
      --> test.py:4:5
@@ -690,7 +698,9 @@ def test_two():
             PASS [TIME] test::test_one
             FAIL [TIME] test::test_two
 
-    diagnostics:
+    failures:
+
+    test::test_two:
 
     error[test-failure]: Test `test_two` failed
      --> test.py:7:5
@@ -832,7 +842,9 @@ def test_multi():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_multi
 
-    diagnostics:
+    failures:
+
+    test::test_multi:
 
     error[test-failure]: Test `test_multi` failed
      --> test.py:4:5

--- a/crates/karva/tests/it/extensions/snapshot/cmd.rs
+++ b/crates/karva/tests/it/extensions/snapshot/cmd.rs
@@ -94,7 +94,9 @@ def test_echo():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_echo
 
-    diagnostics:
+    failures:
+
+    test::test_echo:
 
     error[test-failure]: Test `test_echo` failed
      --> test.py:5:5
@@ -525,7 +527,9 @@ def test_inline_wrong():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_inline_wrong
 
-    diagnostics:
+    failures:
+
+    test::test_inline_wrong:
 
     error[test-failure]: Test `test_inline_wrong` failed
      --> test.py:5:5
@@ -608,7 +612,9 @@ def test_change():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_change
 
-    diagnostics:
+    failures:
+
+    test::test_change:
 
     error[test-failure]: Test `test_change` failed
      --> test.py:5:5
@@ -660,7 +666,9 @@ def test_bad_cmd():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_bad_cmd
 
-    diagnostics:
+    failures:
+
+    test::test_bad_cmd:
 
     error[test-failure]: Test `test_bad_cmd` failed
      --> test.py:4:5
@@ -1035,7 +1043,9 @@ def test_both_args():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_both_args
 
-    diagnostics:
+    failures:
+
+    test::test_both_args:
 
     error[test-failure]: Test `test_both_args` failed
      --> test.py:5:5

--- a/crates/karva/tests/it/extensions/snapshot/content.rs
+++ b/crates/karva/tests/it/extensions/snapshot/content.rs
@@ -226,7 +226,9 @@ def test_poem():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_poem
 
-    diagnostics:
+    failures:
+
+    test::test_poem:
 
     error[test-failure]: Test `test_poem` failed
      --> test.py:4:5

--- a/crates/karva/tests/it/extensions/snapshot/filters.rs
+++ b/crates/karva/tests/it/extensions/snapshot/filters.rs
@@ -200,7 +200,9 @@ def test_bad_regex():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_bad_regex
 
-    diagnostics:
+    failures:
+
+    test::test_bad_regex:
 
     error[test-failure]: Test `test_bad_regex` failed
      --> test.py:4:5

--- a/crates/karva/tests/it/extensions/snapshot/inline.rs
+++ b/crates/karva/tests/it/extensions/snapshot/inline.rs
@@ -82,7 +82,9 @@ def test_hello():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_hello
 
-    diagnostics:
+    failures:
+
+    test::test_hello:
 
     error[test-failure]: Test `test_hello` failed
      --> test.py:4:5

--- a/crates/karva/tests/it/extensions/snapshot/json.rs
+++ b/crates/karva/tests/it/extensions/snapshot/json.rs
@@ -384,7 +384,9 @@ def test_not_json():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_not_json
 
-    diagnostics:
+    failures:
+
+    test::test_not_json:
 
     error[test-failure]: Test `test_not_json` failed
      --> test.py:4:5
@@ -441,7 +443,9 @@ def test_json():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_json
 
-    diagnostics:
+    failures:
+
+    test::test_json:
 
     error[test-failure]: Test `test_json` failed
      --> test.py:4:5

--- a/crates/karva/tests/it/extensions/snapshot/named.rs
+++ b/crates/karva/tests/it/extensions/snapshot/named.rs
@@ -99,7 +99,9 @@ def test_hello():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_hello
 
-    diagnostics:
+    failures:
+
+    test::test_hello:
 
     error[test-failure]: Test `test_hello` failed
      --> test.py:4:5
@@ -230,7 +232,9 @@ def test_both():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_both
 
-    diagnostics:
+    failures:
+
+    test::test_both:
 
     error[test-failure]: Test `test_both` failed
      --> test.py:4:5

--- a/crates/karva/tests/it/extensions/snapshot/update.rs
+++ b/crates/karva/tests/it/extensions/snapshot/update.rs
@@ -62,7 +62,9 @@ def test_hello():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_hello
 
-    diagnostics:
+    failures:
+
+    test::test_hello:
 
     error[test-failure]: Test `test_hello` failed
      --> test.py:4:5
@@ -145,7 +147,9 @@ def test_user_data():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_user_data
 
-    diagnostics:
+    failures:
+
+    test::test_user_data:
 
     error[test-failure]: Test `test_user_data` failed
      --> test.py:7:5
@@ -330,7 +334,9 @@ def test_second():
             PASS [TIME] test::test_first
             FAIL [TIME] test::test_second
 
-    diagnostics:
+    failures:
+
+    test::test_second:
 
     error[test-failure]: Test `test_second` failed
      --> test.py:7:5

--- a/crates/karva/tests/it/extensions/tags/expect_fail.rs
+++ b/crates/karva/tests/it/extensions/tags/expect_fail.rs
@@ -64,7 +64,9 @@ def test_1():
             Starting 1 test across 1 worker
                 FAIL [TIME] test::test_1
 
-        diagnostics:
+        failures:
+
+        test::test_1:
 
         error[test-pass-on-expect-failure]: Test `test_1` passes when expected to fail
          --> test.py:5:5
@@ -103,7 +105,9 @@ def test_1():
             Starting 1 test across 1 worker
                 FAIL [TIME] test::test_1
 
-        diagnostics:
+        failures:
+
+        test::test_1:
 
         error[test-pass-on-expect-failure]: Test `test_1` passes when expected to fail
          --> test.py:5:5
@@ -421,7 +425,9 @@ def test_expected_fail_passes():
                 PASS [TIME] test::test_normal_pass
                 FAIL [TIME] test::test_expected_fail_passes
 
-        diagnostics:
+        failures:
+
+        test::test_expected_fail_passes:
 
         error[test-pass-on-expect-failure]: Test `test_expected_fail_passes` passes when expected to fail
           --> test.py:12:5
@@ -468,7 +474,9 @@ def test_expected_fail_passes():
                 PASS [TIME] test::test_normal_pass
                 FAIL [TIME] test::test_expected_fail_passes
 
-        diagnostics:
+        failures:
+
+        test::test_expected_fail_passes:
 
         error[test-pass-on-expect-failure]: Test `test_expected_fail_passes` passes when expected to fail
           --> test.py:12:5
@@ -636,7 +644,9 @@ def test_should_fail():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_should_fail
 
-    diagnostics:
+    failures:
+
+    test::test_should_fail:
 
     error[test-pass-on-expect-failure]: Test `test_should_fail` passes when expected to fail
      --> test.py:5:5
@@ -767,7 +777,9 @@ def test_1():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_1
 
-    diagnostics:
+    failures:
+
+    test::test_1:
 
     error[test-pass-on-expect-failure]: Test `test_1` passes when expected to fail
      --> test.py:5:5
@@ -834,7 +846,9 @@ def test_1():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_1
 
-    diagnostics:
+    failures:
+
+    test::test_1:
 
     error[test-pass-on-expect-failure]: Test `test_1` passes when expected to fail
      --> test.py:7:5

--- a/crates/karva/tests/it/extensions/tags/parametrize.rs
+++ b/crates/karva/tests/it/extensions/tags/parametrize.rs
@@ -52,8 +52,8 @@ def fixture():
         exit_code: 1
         ----- stdout -----
             Starting 3 tests across 1 worker
-                FAIL [TIME] test::test_too_few
-                FAIL [TIME] test::test_too_many
+               ERROR [TIME] test::test_too_few
+               ERROR [TIME] test::test_too_many
 
         failures:
 
@@ -80,7 +80,7 @@ def fixture():
           |
 
         ────────────
-             Summary [TIME] 2 tests run: 0 passed, 2 failed, 0 skipped
+             Summary [TIME] 2 tests run: 0 passed, 2 errors, 0 skipped
 
         ----- stderr -----
         "#);
@@ -108,7 +108,7 @@ def test_value(left, right):
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_value
+           ERROR [TIME] test::test_value
 
     failures:
 
@@ -124,7 +124,7 @@ def test_value(left, right):
       |
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     "#);
@@ -151,7 +151,7 @@ def test_value(left, right):
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_value
+           ERROR [TIME] test::test_value
 
     failures:
 
@@ -167,7 +167,7 @@ def test_value(left, right):
       |
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     "#);
@@ -194,7 +194,7 @@ def test_value(left, right):
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_value
+           ERROR [TIME] test::test_value
 
     failures:
 
@@ -210,7 +210,7 @@ def test_value(left, right):
       |
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     "#);
@@ -244,8 +244,8 @@ def test_kwargs(left, right):
     exit_code: 1
     ----- stdout -----
         Starting 2 tests across 1 worker
-            FAIL [TIME] test::test_args
-            FAIL [TIME] test::test_kwargs
+           ERROR [TIME] test::test_args
+           ERROR [TIME] test::test_kwargs
 
     failures:
 
@@ -268,7 +268,7 @@ def test_kwargs(left, right):
        |
 
     ────────────
-         Summary [TIME] 2 tests run: 0 passed, 2 failed, 0 skipped
+         Summary [TIME] 2 tests run: 0 passed, 2 errors, 0 skipped
 
     ----- stderr -----
     ");
@@ -303,7 +303,7 @@ def test_value(left, right):
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_value
+           ERROR [TIME] test::test_value
 
     failures:
 
@@ -325,7 +325,7 @@ def test_value(left, right):
        |
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     "#);
@@ -350,7 +350,7 @@ def test_value(left, right):
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_value
+           ERROR [TIME] test::test_value
 
     failures:
 
@@ -366,7 +366,7 @@ def test_value(left, right):
       |
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     "#);
@@ -390,7 +390,7 @@ def test_value(value):
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_value
+           ERROR [TIME] test::test_value
 
     failures:
 
@@ -406,7 +406,7 @@ def test_value(value):
       |
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     "#);
@@ -431,7 +431,7 @@ def test_value(value):
         exit_code: 1
         ----- stdout -----
             Starting 1 test across 1 worker
-                FAIL [TIME] test::test_value
+               ERROR [TIME] test::test_value
 
         failures:
 
@@ -445,7 +445,7 @@ def test_value(value):
           |
 
         ────────────
-             Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+             Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
         ----- stderr -----
         "#);
@@ -476,7 +476,7 @@ def test_value(value):
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_value
+           ERROR [TIME] test::test_value
 
     failures:
 
@@ -492,7 +492,7 @@ def test_value(value):
       |
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     "#);
@@ -522,7 +522,7 @@ def test_value(value):
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_value
+           ERROR [TIME] test::test_value
 
     failures:
 
@@ -538,7 +538,7 @@ def test_value(value):
        |
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     "#);
@@ -567,7 +567,7 @@ def test_value(value):
         exit_code: 1
         ----- stdout -----
             Starting 1 test across 1 worker
-                FAIL [TIME] test::test_value
+               ERROR [TIME] test::test_value
 
         failures:
 
@@ -583,7 +583,7 @@ def test_value(value):
           |
 
         ────────────
-             Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+             Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
         ----- stderr -----
         "#);
@@ -616,7 +616,7 @@ def test_value(value):
         exit_code: 1
         ----- stdout -----
             Starting 1 test across 1 worker
-                FAIL [TIME] test::test_value
+               ERROR [TIME] test::test_value
 
         failures:
 
@@ -632,7 +632,7 @@ def test_value(value):
           |
 
         ────────────
-             Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+             Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
         ----- stderr -----
         "#);
@@ -662,7 +662,7 @@ def test_value(value):
         exit_code: 1
         ----- stdout -----
             Starting 1 test across 1 worker
-                FAIL [TIME] test::test_value
+               ERROR [TIME] test::test_value
 
         failures:
 
@@ -678,7 +678,7 @@ def test_value(value):
           |
 
         ────────────
-             Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+             Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
         ----- stderr -----
         "#);
@@ -705,7 +705,7 @@ def test_value(value):
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_value
+           ERROR [TIME] test::test_value
 
     failures:
 
@@ -721,7 +721,7 @@ def test_value(value):
       |
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     "#);
@@ -750,7 +750,7 @@ def test_value(value):
         exit_code: 1
         ----- stdout -----
             Starting 1 test across 1 worker
-                FAIL [TIME] test::test_value
+               ERROR [TIME] test::test_value
 
         failures:
 
@@ -766,7 +766,7 @@ def test_value(value):
           |
 
         ────────────
-             Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+             Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
         ----- stderr -----
         "#);
@@ -793,7 +793,7 @@ def test_value(value):
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_value
+           ERROR [TIME] test::test_value
 
     failures:
 
@@ -809,7 +809,7 @@ def test_value(value):
       |
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     "#);
@@ -838,7 +838,7 @@ def test_value(value):
         exit_code: 1
         ----- stdout -----
             Starting 1 test across 1 worker
-                FAIL [TIME] test::test_value
+               ERROR [TIME] test::test_value
 
         failures:
 
@@ -854,7 +854,7 @@ def test_value(value):
           |
 
         ────────────
-             Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+             Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
         ----- stderr -----
         "#);
@@ -884,7 +884,7 @@ def test_value(value):
         exit_code: 1
         ----- stdout -----
             Starting 1 test across 1 worker
-                FAIL [TIME] test::test_value
+               ERROR [TIME] test::test_value
 
         failures:
 
@@ -900,7 +900,7 @@ def test_value(value):
           |
 
         ────────────
-             Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+             Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
         ----- stderr -----
         "#);
@@ -941,9 +941,9 @@ def test_invalid(
     exit_code: 1
     ----- stdout -----
         Starting 3 tests across 1 worker
-            FAIL [TIME] test::test_unknown
-            FAIL [TIME] test::test_empty
-            FAIL [TIME] test::test_invalid
+           ERROR [TIME] test::test_unknown
+           ERROR [TIME] test::test_empty
+           ERROR [TIME] test::test_invalid
 
     failures:
 
@@ -992,7 +992,7 @@ def test_invalid(
       |
 
     ────────────
-         Summary [TIME] 3 tests run: 0 passed, 3 failed, 0 skipped
+         Summary [TIME] 3 tests run: 0 passed, 3 errors, 0 skipped
 
     ----- stderr -----
     "#);

--- a/crates/karva/tests/it/extensions/tags/parametrize.rs
+++ b/crates/karva/tests/it/extensions/tags/parametrize.rs
@@ -55,7 +55,9 @@ def fixture():
                 FAIL [TIME] test::test_too_few
                 FAIL [TIME] test::test_too_many
 
-        diagnostics:
+        failures:
+
+        test::test_too_few:
 
         error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 1 value
          --> test.py:5:14
@@ -65,6 +67,8 @@ def fixture():
           |              |
           |              expects 2 values
           |
+
+        test::test_too_many:
 
         error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 3 values
          --> test.py:9:14
@@ -106,7 +110,9 @@ def test_value(left, right):
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_value
 
-    diagnostics:
+    failures:
+
+    test::test_value:
 
     error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 1 value
      --> test.py:5:25
@@ -147,7 +153,9 @@ def test_value(left, right):
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_value
 
-    diagnostics:
+    failures:
+
+    test::test_value:
 
     error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 1 value
      --> test.py:5:24
@@ -188,7 +196,9 @@ def test_value(left, right):
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_value
 
-    diagnostics:
+    failures:
+
+    test::test_value:
 
     error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 1 value
      --> test.py:7:8
@@ -237,7 +247,9 @@ def test_kwargs(left, right):
             FAIL [TIME] test::test_args
             FAIL [TIME] test::test_kwargs
 
-    diagnostics:
+    failures:
+
+    test::test_args:
 
     error[invalid-parametrize]: Expected 2 values for `left,right`, but case 1 contains 1 value
       --> test.py:11:5
@@ -245,6 +257,8 @@ def test_kwargs(left, right):
     11 | def test_args(left, right):
        |     ^^^^^^^^^
        |
+
+    test::test_kwargs:
 
     error[invalid-parametrize]: Expected 2 values for `left,right`, but case 1 contains 1 value
       --> test.py:15:5
@@ -291,7 +305,9 @@ def test_value(left, right):
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_value
 
-    diagnostics:
+    failures:
+
+    test::test_value:
 
     error[invalid-parametrize]: Expected 2 values for `left,right`, but case 2 contains 1 value
       --> test.py:13:9
@@ -336,7 +352,9 @@ def test_value(left, right):
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_value
 
-    diagnostics:
+    failures:
+
+    test::test_value:
 
     error[invalid-parametrize]: Expected 2 values for `left,right`, but case 1 contains 1 value
      --> test.py:5:25
@@ -374,7 +392,9 @@ def test_value(value):
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_value
 
-    diagnostics:
+    failures:
+
+    test::test_value:
 
     error[invalid-parametrize]: Expected 1 value for `value`, but case 1 contains 2 values
      --> test.py:4:25
@@ -413,7 +433,9 @@ def test_value(value):
             Starting 1 test across 1 worker
                 FAIL [TIME] test::test_value
 
-        diagnostics:
+        failures:
+
+        test::test_value:
 
         error[invalid-parametrize]: Parameter `value` is parametrized more than once
          --> test.py:4:25
@@ -456,7 +478,9 @@ def test_value(value):
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_value
 
-    diagnostics:
+    failures:
+
+    test::test_value:
 
     error[invalid-parametrize]: Parameter `value` is parametrized more than once
      --> test.py:6:9
@@ -500,7 +524,9 @@ def test_value(value):
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_value
 
-    diagnostics:
+    failures:
+
+    test::test_value:
 
     error[invalid-parametrize]: Parameter `value` is parametrized more than once
       --> test.py:10:26
@@ -543,7 +569,9 @@ def test_value(value):
             Starting 1 test across 1 worker
                 FAIL [TIME] test::test_value
 
-        diagnostics:
+        failures:
+
+        test::test_value:
 
         error[invalid-parametrize]: Parameter `value` is parametrized more than once
          --> test.py:5:15
@@ -590,7 +618,9 @@ def test_value(value):
             Starting 1 test across 1 worker
                 FAIL [TIME] test::test_value
 
-        diagnostics:
+        failures:
+
+        test::test_value:
 
         error[invalid-parametrize]: Parameter `value` is parametrized more than once
          --> test.py:5:14
@@ -634,7 +664,9 @@ def test_value(value):
             Starting 1 test across 1 worker
                 FAIL [TIME] test::test_value
 
-        diagnostics:
+        failures:
+
+        test::test_value:
 
         error[invalid-parametrize]: Parameter `missing` does not exist in the test function signature
          --> test.py:5:14
@@ -675,7 +707,9 @@ def test_value(value):
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_value
 
-    diagnostics:
+    failures:
+
+    test::test_value:
 
     error[invalid-parametrize]: Parameter `missing` does not exist in the test function signature
      --> test.py:6:18
@@ -718,7 +752,9 @@ def test_value(value):
             Starting 1 test across 1 worker
                 FAIL [TIME] test::test_value
 
-        diagnostics:
+        failures:
+
+        test::test_value:
 
         error[invalid-parametrize]: Parametrization has no cases
          --> test.py:5:14
@@ -759,7 +795,9 @@ def test_value(value):
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_value
 
-    diagnostics:
+    failures:
+
+    test::test_value:
 
     error[invalid-parametrize]: Parametrization has no cases
      --> test.py:6:19
@@ -802,7 +840,9 @@ def test_value(value):
             Starting 1 test across 1 worker
                 FAIL [TIME] test::test_value
 
-        diagnostics:
+        failures:
+
+        test::test_value:
 
         error[invalid-parametrize]: Parameter name cannot be empty
          --> test.py:5:14
@@ -846,7 +886,9 @@ def test_value(value):
             Starting 1 test across 1 worker
                 FAIL [TIME] test::test_value
 
-        diagnostics:
+        failures:
+
+        test::test_value:
 
         error[invalid-parametrize]: `not valid` is not a valid Python identifier
          --> test.py:5:14
@@ -903,7 +945,37 @@ def test_invalid(
             FAIL [TIME] test::test_empty
             FAIL [TIME] test::test_invalid
 
-    diagnostics:
+    failures:
+
+    test::test_empty:
+
+    error[invalid-parametrize]: Parameter name cannot be empty
+      --> test.py:12:25
+       |
+    12 |   @karva.tags.parametrize("", [1])
+       |                           ^^ empty parameter name
+    13 |   def test_empty(
+       |  _______________-
+    14 | |     value,
+    15 | | ):
+       | |_- available parameter
+       |
+
+    test::test_invalid:
+
+    error[invalid-parametrize]: `not valid` is not a valid Python identifier
+      --> test.py:18:25
+       |
+    18 |   @karva.tags.parametrize("not valid", [1])
+       |                           ^^^^^^^^^^^ invalid parameter name
+    19 |   def test_invalid(
+       |  _________________-
+    20 | |     value: int = 1,
+    21 | | ):
+       | |_- available parameter
+       |
+
+    test::test_unknown:
 
     error[invalid-parametrize]: Parameter `missing` does not exist in the test function signature
      --> test.py:4:25
@@ -918,30 +990,6 @@ def test_invalid(
     9 | | ):
       | |_- available parameters
       |
-
-    error[invalid-parametrize]: Parameter name cannot be empty
-      --> test.py:12:25
-       |
-    12 |   @karva.tags.parametrize("", [1])
-       |                           ^^ empty parameter name
-    13 |   def test_empty(
-       |  _______________-
-    14 | |     value,
-    15 | | ):
-       | |_- available parameter
-       |
-
-    error[invalid-parametrize]: `not valid` is not a valid Python identifier
-      --> test.py:18:25
-       |
-    18 |   @karva.tags.parametrize("not valid", [1])
-       |                           ^^^^^^^^^^^ invalid parameter name
-    19 |   def test_invalid(
-       |  _________________-
-    20 | |     value: int = 1,
-    21 | | ):
-       | |_- available parameter
-       |
 
     ────────────
          Summary [TIME] 3 tests run: 0 passed, 3 failed, 0 skipped
@@ -1044,7 +1092,9 @@ def test_order(third, second, first):
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_order(third=3, second=2, first=1)
 
-    diagnostics:
+    failures:
+
+    test::test_order(third=3, second=2, first=1):
 
     error[test-failure]: Test `test_order` failed
       --> test.py:14:5

--- a/crates/karva/tests/it/extensions/tags/timeout.rs
+++ b/crates/karva/tests/it/extensions/tags/timeout.rs
@@ -51,7 +51,9 @@ def test_slow():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_slow
 
-    diagnostics:
+    failures:
+
+    test::test_slow:
 
     error[test-failure]: Test `test_slow` failed
      --> test.py:6:5
@@ -89,7 +91,9 @@ async def test_slow_async():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_slow_async
 
-    diagnostics:
+    failures:
+
+    test::test_slow_async:
 
     error[test-failure]: Test `test_slow_async` failed
      --> test.py:6:11
@@ -233,7 +237,9 @@ def test_1(sleep_for):
             FAIL [TIME] test::test_1(sleep_for=2.0)
             PASS [TIME] test::test_1(sleep_for=0.0)
 
-    diagnostics:
+    failures:
+
+    test::test_1(sleep_for=2.0):
 
     error[test-failure]: Test `test_1` failed
      --> test.py:7:5
@@ -301,7 +307,9 @@ def test_always_slow():
       TRY 1 FAIL [TIME] test::test_always_slow
       TRY 2 FAIL [TIME] test::test_always_slow
 
-    diagnostics:
+    failures:
+
+    test::test_always_slow:
 
     error[test-failure]: Test `test_always_slow` failed
      --> test.py:6:5
@@ -339,7 +347,9 @@ def test_slow():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_slow
 
-    diagnostics:
+    failures:
+
+    test::test_slow:
 
     error[test-failure]: Test `test_slow` failed
      --> test.py:4:5
@@ -472,7 +482,9 @@ def test_slow():
         Starting 1 test across 1 worker
             FAIL [TIME] test::test_slow
 
-    diagnostics:
+    failures:
+
+    test::test_slow:
 
     error[test-failure]: Test `test_slow` failed
      --> test.py:4:5

--- a/crates/karva/tests/it/junit.rs
+++ b/crates/karva/tests/it/junit.rs
@@ -60,7 +60,9 @@ def test_skip():
     exit_code: 1
     ----- stdout -----
 
-    diagnostics:
+    failures:
+
+    test_alpha::test_fail:
 
     error[test-failure]: Test `test_fail` failed
      --> test_alpha.py:8:5
@@ -93,7 +95,20 @@ def test_skip():
     <testsuites name="karva-ci" tests="3" failures="1" skipped="1" errors="0" time="[TIME]">
       <testsuite name="test_alpha" tests="2" failures="1" skipped="0" errors="0" time="[TIME]">
         <testcase classname="test_alpha" name="test_fail" time="[TIME]">
-          <failure message="test failed"/>
+          <failure message="Test `test_fail` failed" type="test-failure">error[test-failure]: Test `test_fail` failed
+     --&gt; test_alpha.py:8:5
+      |
+    8 | def test_fail():
+      |     ^^^^^^^^^
+      |
+    info: Test failed here
+      --&gt; test_alpha.py:11:5
+       |
+    11 |     assert False
+       |     ^^^^^^^^^^^^
+       |
+
+    </failure>
           <system-out>fail stdout
     </system-out>
           <system-err>fail stderr
@@ -150,7 +165,9 @@ def test_flaky():
     exit_code: 1
     ----- stdout -----
 
-    diagnostics:
+    failures:
+
+    test_retry::test_fail:
 
     error[test-failure]: Test `test_fail` failed
      --> test_retry.py:4:5
@@ -179,7 +196,20 @@ def test_flaky():
     <testsuites name="karva-tests" tests="2" failures="1" skipped="0" errors="0" time="[TIME]">
       <testsuite name="test_retry" tests="2" failures="1" skipped="0" errors="0" time="[TIME]">
         <testcase classname="test_retry" name="test_fail" time="[TIME]">
-          <failure message="test failed"/>
+          <failure message="Test `test_fail` failed" type="test-failure">error[test-failure]: Test `test_fail` failed
+     --&gt; test_retry.py:4:5
+      |
+    4 | def test_fail():
+      |     ^^^^^^^^^
+      |
+    info: Test failed here
+     --&gt; test_retry.py:5:5
+      |
+    5 |     assert False
+      |     ^^^^^^^^^^^^
+      |
+
+    </failure>
         </testcase>
         <testcase classname="test_retry" name="test_flaky" time="[TIME]">
           <system-out>attempt 1

--- a/crates/karva/tests/it/junit.rs
+++ b/crates/karva/tests/it/junit.rs
@@ -210,11 +210,180 @@ def test_flaky():
       |
 
     </failure>
+          <rerunFailure message="Test `test_fail` failed" type="test-failure">error[test-failure]: Test `test_fail` failed
+     --&gt; test_retry.py:4:5
+      |
+    4 | def test_fail():
+      |     ^^^^^^^^^
+      |
+    info: Test failed here
+     --&gt; test_retry.py:5:5
+      |
+    5 |     assert False
+      |     ^^^^^^^^^^^^
+      |
+
+    </rerunFailure>
         </testcase>
         <testcase classname="test_retry" name="test_flaky" time="[TIME]">
+          <flakyFailure message="Test `test_flaky` failed" type="test-failure">error[test-failure]: Test `test_flaky` failed
+     --&gt; test_retry.py:7:5
+      |
+    7 | def test_flaky():
+      |     ^^^^^^^^^^
+      |
+    info: Test failed here
+     --&gt; test_retry.py:9:5
+      |
+    9 |     assert os.environ[&quot;KARVA_ATTEMPT&quot;] == &quot;2&quot;
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+
+    </flakyFailure>
           <system-out>attempt 1
     attempt 2
     </system-out>
+        </testcase>
+      </testsuite>
+    </testsuites>
+    "#);
+}
+
+#[test]
+fn junit_reports_run_diagnostics_as_errors() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.ci.junit]
+path = "reports/test-results.xml"
+"#,
+        ),
+        (
+            "test_import.py",
+            r"
+import missing_junit_dependency
+
+def test_unreachable():
+    pass
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .args(["--profile=ci", "--status-level=none"]),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    diagnostics:
+
+    error[failed-to-import-module]: Failed to import python module `test_import`: No module named 'missing_junit_dependency'
+
+    ────────────
+         Summary [TIME] 0 tests run: 0 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+
+    let xml = normalize_junit_xml(&context.read_file("reports/test-results.xml"));
+    assert_snapshot!(xml, @r#"
+    <?xml version="1.0" encoding="UTF-8"?>
+    <testsuites name="karva-tests" tests="1" failures="0" skipped="0" errors="1" time="[TIME]">
+      <testsuite name="karva-tests::run" tests="1" failures="0" skipped="0" errors="1" time="[TIME]">
+        <testcase classname="karva.run" name="failed-to-import-module-1" time="[TIME]">
+          <error message="Failed to import python module `test_import`: No module named &apos;missing_junit_dependency&apos;" type="failed-to-import-module">error[failed-to-import-module]: Failed to import python module `test_import`: No module named &apos;missing_junit_dependency&apos;
+
+    </error>
+        </testcase>
+      </testsuite>
+    </testsuites>
+    "#);
+}
+
+#[test]
+fn junit_distinguishes_fixture_errors_from_test_failures() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.ci.junit]
+path = "reports/test-results.xml"
+"#,
+        ),
+        (
+            "test_fixture.py",
+            r#"
+import karva
+
+@karva.fixture(auto_use=True)
+def broken_fixture():
+    raise RuntimeError("setup failed")
+
+def test_unreachable():
+    raise AssertionError("test body ran")
+"#,
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .args(["--profile=ci", "--status-level=none"]),
+        @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    failures:
+
+    test_fixture::test_unreachable:
+
+    error[fixture-failure]: Fixture `broken_fixture` failed
+     --> test_fixture.py:5:5
+      |
+    5 | def broken_fixture():
+      |     ^^^^^^^^^^^^^^
+      |
+    info: Fixture failed here
+     --> test_fixture.py:6:5
+      |
+    6 |     raise RuntimeError("setup failed")
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: setup failed
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
+
+    ----- stderr -----
+    "#
+    );
+
+    let xml = normalize_junit_xml(&context.read_file("reports/test-results.xml"));
+    assert_snapshot!(xml, @r#"
+    <?xml version="1.0" encoding="UTF-8"?>
+    <testsuites name="karva-tests" tests="1" failures="0" skipped="0" errors="1" time="[TIME]">
+      <testsuite name="test_fixture" tests="1" failures="0" skipped="0" errors="1" time="[TIME]">
+        <testcase classname="test_fixture" name="test_unreachable" time="[TIME]">
+          <error message="Fixture `broken_fixture` failed" type="fixture-failure">error[fixture-failure]: Fixture `broken_fixture` failed
+     --&gt; test_fixture.py:5:5
+      |
+    5 | def broken_fixture():
+      |     ^^^^^^^^^^^^^^
+      |
+    info: Fixture failed here
+     --&gt; test_fixture.py:6:5
+      |
+    6 |     raise RuntimeError(&quot;setup failed&quot;)
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: setup failed
+
+    </error>
         </testcase>
       </testsuite>
     </testsuites>

--- a/crates/karva/tests/it/junit.rs
+++ b/crates/karva/tests/it/junit.rs
@@ -77,9 +77,9 @@ def test_skip():
        |     ^^^^^^^^^^^^
        |
 
-    captured stdout for test_alpha::test_fail:
+    captured stdout:
     fail stdout
-    captured stderr for test_alpha::test_fail:
+    captured stderr:
     fail stderr
 
     ────────────

--- a/crates/karva/tests/it/junit.rs
+++ b/crates/karva/tests/it/junit.rs
@@ -210,7 +210,7 @@ def test_flaky():
       |
 
     </failure>
-          <rerunFailure message="Test `test_fail` failed" type="test-failure">error[test-failure]: Test `test_fail` failed
+          <rerunFailure message="Test `test_fail` failed" type="test-failure" time="[TIME]">error[test-failure]: Test `test_fail` failed
      --&gt; test_retry.py:4:5
       |
     4 | def test_fail():
@@ -226,7 +226,7 @@ def test_flaky():
     </rerunFailure>
         </testcase>
         <testcase classname="test_retry" name="test_flaky" time="[TIME]">
-          <flakyFailure message="Test `test_flaky` failed" type="test-failure">error[test-failure]: Test `test_flaky` failed
+          <flakyFailure message="Test `test_flaky` failed" type="test-failure" time="[TIME]">error[test-failure]: Test `test_flaky` failed
      --&gt; test_retry.py:7:5
       |
     7 | def test_flaky():
@@ -327,6 +327,13 @@ def test_unreachable():
     raise AssertionError("test body ran")
 "#,
         ),
+        (
+            "test_failure.py",
+            r"
+def test_failure():
+    assert False
+",
+        ),
     ]);
 
     assert_cmd_snapshot!(
@@ -339,6 +346,21 @@ def test_unreachable():
     ----- stdout -----
 
     failures:
+
+    test_failure::test_failure:
+
+    error[test-failure]: Test `test_failure` failed
+     --> test_failure.py:2:5
+      |
+    2 | def test_failure():
+      |     ^^^^^^^^^^^^
+      |
+    info: Test failed here
+     --> test_failure.py:3:5
+      |
+    3 |     assert False
+      |     ^^^^^^^^^^^^
+      |
 
     test_fixture::test_unreachable:
 
@@ -357,7 +379,7 @@ def test_unreachable():
     info: setup failed
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
+         Summary [TIME] 2 tests run: 0 passed, 1 failed, 1 error, 0 skipped
 
     ----- stderr -----
     "#
@@ -366,7 +388,25 @@ def test_unreachable():
     let xml = normalize_junit_xml(&context.read_file("reports/test-results.xml"));
     assert_snapshot!(xml, @r#"
     <?xml version="1.0" encoding="UTF-8"?>
-    <testsuites name="karva-tests" tests="1" failures="0" skipped="0" errors="1" time="[TIME]">
+    <testsuites name="karva-tests" tests="2" failures="1" skipped="0" errors="1" time="[TIME]">
+      <testsuite name="test_failure" tests="1" failures="1" skipped="0" errors="0" time="[TIME]">
+        <testcase classname="test_failure" name="test_failure" time="[TIME]">
+          <failure message="Test `test_failure` failed" type="test-failure">error[test-failure]: Test `test_failure` failed
+     --&gt; test_failure.py:2:5
+      |
+    2 | def test_failure():
+      |     ^^^^^^^^^^^^
+      |
+    info: Test failed here
+     --&gt; test_failure.py:3:5
+      |
+    3 |     assert False
+      |     ^^^^^^^^^^^^
+      |
+
+    </failure>
+        </testcase>
+      </testsuite>
       <testsuite name="test_fixture" tests="1" failures="0" skipped="0" errors="1" time="[TIME]">
         <testcase classname="test_fixture" name="test_unreachable" time="[TIME]">
           <error message="Fixture `broken_fixture` failed" type="fixture-failure">error[fixture-failure]: Fixture `broken_fixture` failed

--- a/crates/karva/tests/it/last_failed.rs
+++ b/crates/karva/tests/it/last_failed.rs
@@ -21,7 +21,9 @@ fn last_failed_reruns_only_failures() {
         Starting 1 test across 1 worker
             FAIL [TIME] test_a::test_fail
 
-    diagnostics:
+    failures:
+
+    test_a::test_fail:
 
     error[test-failure]: Test `test_fail` failed
      --> test_a.py:3:5
@@ -62,7 +64,9 @@ fn last_failed_lf_alias() {
         Starting 1 test across 1 worker
             FAIL [TIME] test_a::test_fail
 
-    diagnostics:
+    failures:
+
+    test_a::test_fail:
 
     error[test-failure]: Test `test_fail` failed
      --> test_a.py:3:5
@@ -160,7 +164,9 @@ def test_fail_b(): assert False
     exit_code: 1
     ----- stdout -----
 
-    diagnostics:
+    failures:
+
+    test_a::test_fail_a:
 
     error[test-failure]: Test `test_fail_a` failed
      --> test_a.py:3:5
@@ -174,6 +180,8 @@ def test_fail_b(): assert False
     3 | def test_fail_a(): assert False
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
+
+    test_b::test_fail_b:
 
     error[test-failure]: Test `test_fail_b` failed
      --> test_b.py:3:5
@@ -221,7 +229,9 @@ def test_fail_b(): assert False
         Starting 2 tests across 1 worker
             FAIL [TIME] test_a::test_fail_a
 
-    diagnostics:
+    failures:
+
+    test_a::test_fail_a:
 
     error[test-failure]: Test `test_fail_a` failed
      --> test_a.py:3:5
@@ -268,7 +278,9 @@ def test_fail_b(): assert False
     exit_code: 1
     ----- stdout -----
 
-    diagnostics:
+    failures:
+
+    test_a::test_fail_a:
 
     error[test-failure]: Test `test_fail_a` failed
      --> test_a.py:3:5
@@ -321,7 +333,9 @@ def test_new_fail(): assert False
     exit_code: 1
     ----- stdout -----
 
-    diagnostics:
+    failures:
+
+    test_a::test_fail:
 
     error[test-failure]: Test `test_fail` failed
      --> test_a.py:3:5

--- a/crates/karva/tests/it/result_report.rs
+++ b/crates/karva/tests/it/result_report.rs
@@ -62,7 +62,7 @@ fn writes_json_result_report() {
        |     ^^^^^^^^^^^^
        |
 
-    captured stderr for test_report::test_fail:
+    captured stderr:
     fail stderr
     fail stderr
 
@@ -235,7 +235,8 @@ fn keeps_run_diagnostics_separate_from_tests() {
 
     assert_snapshot!(normalize_result_json(&context.read_file("reports/import.json")), @r#"
     {
-      "diagnostics": [
+      "elapsed_seconds": "[TIME]",
+      "run_diagnostics": [
         {
           "code": "failed-to-import-module",
           "message": "Failed to import python module `test_import`: No module named 'missing_result_report_dependency'",
@@ -243,7 +244,6 @@ fn keeps_run_diagnostics_separate_from_tests() {
           "severity": "error"
         }
       ],
-      "elapsed_seconds": "[TIME]",
       "schema_version": 2,
       "stats": {
         "failed": 0,
@@ -257,6 +257,48 @@ fn keeps_run_diagnostics_separate_from_tests() {
       "tests": []
     }
     "#);
+}
+
+#[test]
+fn writes_jsonl_run_diagnostic_events() {
+    let context = TestContext::with_file(
+        "test_import.py",
+        r"
+        import missing_result_report_dependency
+
+        def test_unreachable():
+            pass
+        ",
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
+            "--status-level=none",
+            "--result-output=reports/import.jsonl",
+            "--result-format=jsonl",
+        ]),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    diagnostics:
+
+    error[failed-to-import-module]: Failed to import python module `test_import`: No module named 'missing_result_report_dependency'
+
+    ────────────
+         Summary [TIME] 0 tests run: 0 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+
+    assert_snapshot!(
+        normalize_result_jsonl(&context.read_file("reports/import.jsonl")),
+        @r#"
+    {"diagnostic":{"code":"failed-to-import-module","message":"Failed to import python module `test_import`: No module named 'missing_result_report_dependency'","rendered":"error[failed-to-import-module]: Failed to import python module `test_import`: No module named 'missing_result_report_dependency'\n\n","severity":"error"},"schema_version":2,"type":"run_diagnostic"}
+    {"elapsed_seconds":"[TIME]","schema_version":2,"stats":{"failed":0,"flaky":0,"passed":0,"skipped":0,"slow":0,"total":0},"status":"failed","type":"run_finished"}
+    "#
+    );
 }
 
 #[test]

--- a/crates/karva/tests/it/result_report.rs
+++ b/crates/karva/tests/it/result_report.rs
@@ -45,7 +45,9 @@ fn writes_json_result_report() {
     exit_code: 1
     ----- stdout -----
 
-    diagnostics:
+    failures:
+
+    test_report::test_fail:
 
     error[test-failure]: Test `test_fail` failed
       --> test_report.py:10:5
@@ -74,9 +76,8 @@ fn writes_json_result_report() {
 
     assert_snapshot!(normalize_result_json(&context.read_file("reports/results.json")), @r#"
     {
-      "diagnostics": "error[test-failure]: Test `test_fail` failed\n  --> test_report.py:10:5\n   |/n10 | def test_fail():\n   |     ^^^^^^^^^\n   |/ninfo: Test failed here\n  --> test_report.py:12:5\n   |/n12 |     assert False\n   |     ^^^^^^^^^^^^\n   |\n\n",
       "elapsed_seconds": "[TIME]",
-      "schema_version": 1,
+      "schema_version": 2,
       "stats": {
         "failed": 1,
         "flaky": 1,
@@ -90,6 +91,12 @@ fn writes_json_result_report() {
         {
           "captured_output": {
             "stderr": "fail stderr/nfail stderr\n"
+          },
+          "diagnostic": {
+            "code": "test-failure",
+            "message": "Test `test_fail` failed",
+            "rendered": "error[test-failure]: Test `test_fail` failed\n  --> test_report.py:10:5\n   |/n10 | def test_fail():\n   |     ^^^^^^^^^\n   |/ninfo: Test failed here\n  --> test_report.py:12:5\n   |/n12 |     assert False\n   |     ^^^^^^^^^^^^\n   |\n\n",
+            "severity": "error"
           },
           "duration_seconds": "[TIME]",
           "full_name": "test_report::test_fail",
@@ -163,7 +170,9 @@ fn writes_jsonl_result_events() {
     exit_code: 1
     ----- stdout -----
 
-    diagnostics:
+    failures:
+
+    test_events::test_fail:
 
     error[test-failure]: Test `test_fail` failed
      --> test_events.py:5:5
@@ -186,10 +195,67 @@ fn writes_jsonl_result_events() {
     );
 
     assert_snapshot!(normalize_result_jsonl(&context.read_file("reports/events.jsonl")), @r#"
-    {"duration_seconds":"[TIME]","full_name":"test_events::test_fail","module":"test_events","name":"test_fail","schema_version":1,"status":"failed","type":"test"}
-    {"duration_seconds":"[TIME]","full_name":"test_events::test_pass","module":"test_events","name":"test_pass","schema_version":1,"status":"passed","type":"test"}
-    {"diagnostics":"error[test-failure]: Test `test_fail` failed\n --> test_events.py:5:5\n  |/n5 | def test_fail():\n  |     ^^^^^^^^^\n  |/ninfo: Test failed here\n --> test_events.py:6:5\n  |/n6 |     assert False\n  |     ^^^^^^^^^^^^\n  |\n\n","schema_version":1,"type":"diagnostics"}
-    {"elapsed_seconds":"[TIME]","schema_version":1,"stats":{"failed":1,"flaky":0,"passed":1,"skipped":0,"slow":0,"total":2},"status":"failed","type":"run_finished"}
+    {"diagnostic":{"code":"test-failure","message":"Test `test_fail` failed","rendered":"error[test-failure]: Test `test_fail` failed\n --> test_events.py:5:5\n  |/n5 | def test_fail():\n  |     ^^^^^^^^^\n  |/ninfo: Test failed here\n --> test_events.py:6:5\n  |/n6 |     assert False\n  |     ^^^^^^^^^^^^\n  |\n\n","severity":"error"},"duration_seconds":"[TIME]","full_name":"test_events::test_fail","module":"test_events","name":"test_fail","schema_version":2,"status":"failed","type":"test"}
+    {"duration_seconds":"[TIME]","full_name":"test_events::test_pass","module":"test_events","name":"test_pass","schema_version":2,"status":"passed","type":"test"}
+    {"elapsed_seconds":"[TIME]","schema_version":2,"stats":{"failed":1,"flaky":0,"passed":1,"skipped":0,"slow":0,"total":2},"status":"failed","type":"run_finished"}
+    "#);
+}
+
+#[test]
+fn keeps_run_diagnostics_separate_from_tests() {
+    let context = TestContext::with_file(
+        "test_import.py",
+        r"
+        import missing_result_report_dependency
+
+        def test_unreachable():
+            pass
+        ",
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
+            "--status-level=none",
+            "--result-output=reports/import.json",
+        ]),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    diagnostics:
+
+    error[failed-to-import-module]: Failed to import python module `test_import`: No module named 'missing_result_report_dependency'
+
+    ────────────
+         Summary [TIME] 0 tests run: 0 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+
+    assert_snapshot!(normalize_result_json(&context.read_file("reports/import.json")), @r#"
+    {
+      "diagnostics": [
+        {
+          "code": "failed-to-import-module",
+          "message": "Failed to import python module `test_import`: No module named 'missing_result_report_dependency'",
+          "rendered": "error[failed-to-import-module]: Failed to import python module `test_import`: No module named 'missing_result_report_dependency'\n\n",
+          "severity": "error"
+        }
+      ],
+      "elapsed_seconds": "[TIME]",
+      "schema_version": 2,
+      "stats": {
+        "failed": 0,
+        "flaky": 0,
+        "passed": 0,
+        "skipped": 0,
+        "slow": 0,
+        "total": 0
+      },
+      "status": "failed",
+      "tests": []
+    }
     "#);
 }
 
@@ -218,7 +284,7 @@ fn result_report_status_matches_no_tests_failure() {
     assert_snapshot!(normalize_result_json(&context.read_file("reports/no-tests.json")), @r#"
     {
       "elapsed_seconds": "[TIME]",
-      "schema_version": 1,
+      "schema_version": 2,
       "stats": {
         "failed": 0,
         "flaky": 0,

--- a/crates/karva/tests/it/result_report.rs
+++ b/crates/karva/tests/it/result_report.rs
@@ -21,6 +21,9 @@ fn writes_json_result_report() {
             print("fail stderr", file=sys.stderr)
             assert False
 
+        def test_error(missing_fixture):
+            pass
+
         @karva.tags.skip("skip reason")
         def test_skip():
             assert False
@@ -48,6 +51,16 @@ fn writes_json_result_report() {
 
     failures:
 
+    test_report::test_error:
+
+    error[missing-fixtures]: Test `test_error` has missing fixtures
+      --> test_report.py:14:5
+       |
+    14 | def test_error(missing_fixture):
+       |     ^^^^^^^^^^
+       |
+    info: Missing fixtures: `missing_fixture`
+
     test_report::test_fail:
 
     error[test-failure]: Test `test_fail` failed
@@ -68,7 +81,7 @@ fn writes_json_result_report() {
     fail stderr
 
     ────────────
-         Summary [TIME] 4 tests run: 2 passed (1 flaky), 1 failed, 1 skipped
+         Summary [TIME] 5 tests run: 2 passed (1 flaky), 1 failed, 1 error, 1 skipped
        FLAKY 2/2 [TIME] test_report::test_flaky
 
     ----- stderr -----
@@ -80,18 +93,31 @@ fn writes_json_result_report() {
     assert_snapshot!(normalize_result_json(&report), @r#"
     {
       "elapsed_seconds": "[TIME]",
-      "schema_version": 3,
+      "schema_version": 2,
       "stats": {
-        "errors": 0,
+        "errors": 1,
         "failed": 1,
         "flaky": 1,
         "passed": 2,
         "skipped": 1,
         "slow": 0,
-        "total": 4
+        "total": 5
       },
       "status": "failed",
       "tests": [
+        {
+          "diagnostic": {
+            "code": "missing-fixtures",
+            "message": "Test `test_error` has missing fixtures",
+            "rendered": "error[missing-fixtures]: Test `test_error` has missing fixtures\n  --> test_report.py:14:5\n   |/n14 | def test_error(missing_fixture):\n   |     ^^^^^^^^^^\n   |/ninfo: Missing fixtures: `missing_fixture`\n\n",
+            "severity": "error"
+          },
+          "duration_seconds": "[TIME]",
+          "full_name": "test_report::test_error",
+          "module": "test_report",
+          "name": "test_error",
+          "status": "error"
+        },
         {
           "attempts": [
             {
@@ -143,7 +169,7 @@ fn writes_json_result_report() {
               "diagnostic": {
                 "code": "test-failure",
                 "message": "Test `test_flaky` failed",
-                "rendered": "error[test-failure]: Test `test_flaky` failed\n  --> test_report.py:18:5\n   |/n18 | def test_flaky():\n   |     ^^^^^^^^^^\n   |/ninfo: Test failed here\n  --> test_report.py:23:5\n   |/n23 |     assert count >= 1\n   |     ^^^^^^^^^^^^^^^^^\n   |\n\n",
+                "rendered": "error[test-failure]: Test `test_flaky` failed\n  --> test_report.py:21:5\n   |/n21 | def test_flaky():\n   |     ^^^^^^^^^^\n   |/ninfo: Test failed here\n  --> test_report.py:26:5\n   |/n26 |     assert count >= 1\n   |     ^^^^^^^^^^^^^^^^^\n   |\n\n",
                 "severity": "error"
               },
               "duration_seconds": "[TIME]",
@@ -241,9 +267,111 @@ fn writes_jsonl_result_records() {
     );
 
     assert_snapshot!(normalize_result_jsonl(&context.read_file("reports/events.jsonl")), @r#"
-    {"diagnostic":{"code":"test-failure","message":"Test `test_fail` failed","rendered":"error[test-failure]: Test `test_fail` failed\n --> test_events.py:5:5\n  |/n5 | def test_fail():\n  |     ^^^^^^^^^\n  |/ninfo: Test failed here\n --> test_events.py:6:5\n  |/n6 |     assert False\n  |     ^^^^^^^^^^^^\n  |\n\n","severity":"error"},"duration_seconds":"[TIME]","full_name":"test_events::test_fail","module":"test_events","name":"test_fail","schema_version":3,"status":"failed","type":"test"}
-    {"duration_seconds":"[TIME]","full_name":"test_events::test_pass","module":"test_events","name":"test_pass","schema_version":3,"status":"passed","type":"test"}
-    {"elapsed_seconds":"[TIME]","schema_version":3,"stats":{"errors":0,"failed":1,"flaky":0,"passed":1,"skipped":0,"slow":0,"total":2},"status":"failed","type":"run_finished"}
+    {"diagnostic":{"code":"test-failure","message":"Test `test_fail` failed","rendered":"error[test-failure]: Test `test_fail` failed\n --> test_events.py:5:5\n  |/n5 | def test_fail():\n  |     ^^^^^^^^^\n  |/ninfo: Test failed here\n --> test_events.py:6:5\n  |/n6 |     assert False\n  |     ^^^^^^^^^^^^\n  |\n\n","severity":"error"},"duration_seconds":"[TIME]","full_name":"test_events::test_fail","module":"test_events","name":"test_fail","schema_version":2,"status":"failed","type":"test"}
+    {"duration_seconds":"[TIME]","full_name":"test_events::test_pass","module":"test_events","name":"test_pass","schema_version":2,"status":"passed","type":"test"}
+    {"elapsed_seconds":"[TIME]","schema_version":2,"stats":{"errors":0,"failed":1,"flaky":0,"passed":1,"skipped":0,"slow":0,"total":2},"status":"failed","type":"run_finished"}
+    "#);
+}
+
+#[test]
+fn writes_related_test_diagnostics() {
+    let context = TestContext::with_file(
+        "test_related.py",
+        r#"
+        import karva
+
+        @karva.fixture
+        def broken_teardown():
+            yield
+            raise RuntimeError("teardown failed")
+
+        def test_failure(broken_teardown):
+            assert False
+        "#,
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
+            "--status-level=none",
+            "--result-output=reports/related.json",
+        ]),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    failures:
+
+    test_related::test_failure(broken_teardown=None):
+
+    error[test-failure]: Test `test_failure` failed
+     --> test_related.py:9:5
+      |
+    9 | def test_failure(broken_teardown):
+      |     ^^^^^^^^^^^^
+      |
+    info: Test ran with arguments:
+    info: `broken_teardown`: `None`
+    info: Test failed here
+      --> test_related.py:10:5
+       |
+    10 |     assert False
+       |     ^^^^^^^^^^^^
+       |
+
+    error[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `broken_teardown`
+     --> test_related.py:5:5
+      |
+    5 | def broken_teardown():
+      |     ^^^^^^^^^^^^^^^
+      |
+    info: Failed to reset fixture: teardown failed
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+
+    assert_snapshot!(normalize_result_json(&context.read_file("reports/related.json")), @r#"
+    {
+      "elapsed_seconds": "[TIME]",
+      "schema_version": 2,
+      "stats": {
+        "errors": 0,
+        "failed": 1,
+        "flaky": 0,
+        "passed": 0,
+        "skipped": 0,
+        "slow": 0,
+        "total": 1
+      },
+      "status": "failed",
+      "tests": [
+        {
+          "diagnostic": {
+            "code": "test-failure",
+            "message": "Test `test_failure` failed",
+            "rendered": "error[test-failure]: Test `test_failure` failed\n --> test_related.py:9:5\n  |/n9 | def test_failure(broken_teardown):\n  |     ^^^^^^^^^^^^\n  |/ninfo: Test ran with arguments:/ninfo: `broken_teardown`: `None`/ninfo: Test failed here\n  --> test_related.py:10:5\n   |/n10 |     assert False\n   |     ^^^^^^^^^^^^\n   |\n\n",
+            "severity": "error"
+          },
+          "duration_seconds": "[TIME]",
+          "full_name": "test_related::test_failure(broken_teardown=None)",
+          "module": "test_related",
+          "name": "test_failure(broken_teardown=None)",
+          "related_diagnostics": [
+            {
+              "code": "invalid-fixture-finalizer",
+              "message": "Discovered an invalid fixture finalizer `broken_teardown`",
+              "rendered": "error[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `broken_teardown`\n --> test_related.py:5:5\n  |/n5 | def broken_teardown():\n  |     ^^^^^^^^^^^^^^^\n  |/ninfo: Failed to reset fixture: teardown failed\n\n",
+              "severity": "error"
+            }
+          ],
+          "status": "failed"
+        }
+      ]
+    }
     "#);
 }
 
@@ -290,7 +418,7 @@ fn keeps_run_diagnostics_separate_from_tests() {
           "severity": "error"
         }
       ],
-      "schema_version": 3,
+      "schema_version": 2,
       "stats": {
         "errors": 0,
         "failed": 0,
@@ -342,8 +470,8 @@ fn writes_jsonl_run_diagnostic_records() {
     assert_snapshot!(
         normalize_result_jsonl(&context.read_file("reports/import.jsonl")),
         @r#"
-    {"diagnostic":{"code":"failed-to-import-module","message":"Failed to import python module `test_import`: No module named 'missing_result_report_dependency'","rendered":"error[failed-to-import-module]: Failed to import python module `test_import`: No module named 'missing_result_report_dependency'\n\n","severity":"error"},"schema_version":3,"type":"run_diagnostic"}
-    {"elapsed_seconds":"[TIME]","schema_version":3,"stats":{"errors":0,"failed":0,"flaky":0,"passed":0,"skipped":0,"slow":0,"total":0},"status":"failed","type":"run_finished"}
+    {"diagnostic":{"code":"failed-to-import-module","message":"Failed to import python module `test_import`: No module named 'missing_result_report_dependency'","rendered":"error[failed-to-import-module]: Failed to import python module `test_import`: No module named 'missing_result_report_dependency'\n\n","severity":"error"},"schema_version":2,"type":"run_diagnostic"}
+    {"elapsed_seconds":"[TIME]","schema_version":2,"stats":{"errors":0,"failed":0,"flaky":0,"passed":0,"skipped":0,"slow":0,"total":0},"status":"failed","type":"run_finished"}
     "#
     );
 }
@@ -373,7 +501,7 @@ fn result_report_status_matches_no_tests_failure() {
     assert_snapshot!(normalize_result_json(&context.read_file("reports/no-tests.json")), @r#"
     {
       "elapsed_seconds": "[TIME]",
-      "schema_version": 3,
+      "schema_version": 2,
       "stats": {
         "errors": 0,
         "failed": 0,

--- a/crates/karva/tests/it/result_report.rs
+++ b/crates/karva/tests/it/result_report.rs
@@ -37,6 +37,7 @@ fn writes_json_result_report() {
     assert_cmd_snapshot!(
         context.command_no_parallel().args([
             "--retry=1",
+            "--color=always",
             "--status-level=none",
             "--result-output=reports/results.json",
         ]),
@@ -74,11 +75,14 @@ fn writes_json_result_report() {
     "
     );
 
-    assert_snapshot!(normalize_result_json(&context.read_file("reports/results.json")), @r#"
+    let report = context.read_file("reports/results.json");
+    assert!(!report.contains('\u{1b}'));
+    assert_snapshot!(normalize_result_json(&report), @r#"
     {
       "elapsed_seconds": "[TIME]",
-      "schema_version": 2,
+      "schema_version": 3,
       "stats": {
+        "errors": 0,
         "failed": 1,
         "flaky": 1,
         "passed": 2,
@@ -89,6 +93,30 @@ fn writes_json_result_report() {
       "status": "failed",
       "tests": [
         {
+          "attempts": [
+            {
+              "attempt": 1,
+              "diagnostic": {
+                "code": "test-failure",
+                "message": "Test `test_fail` failed",
+                "rendered": "error[test-failure]: Test `test_fail` failed\n  --> test_report.py:10:5\n   |/n10 | def test_fail():\n   |     ^^^^^^^^^\n   |/ninfo: Test failed here\n  --> test_report.py:12:5\n   |/n12 |     assert False\n   |     ^^^^^^^^^^^^\n   |\n\n",
+                "severity": "error"
+              },
+              "duration_seconds": "[TIME]",
+              "status": "failed"
+            },
+            {
+              "attempt": 2,
+              "diagnostic": {
+                "code": "test-failure",
+                "message": "Test `test_fail` failed",
+                "rendered": "error[test-failure]: Test `test_fail` failed\n  --> test_report.py:10:5\n   |/n10 | def test_fail():\n   |     ^^^^^^^^^\n   |/ninfo: Test failed here\n  --> test_report.py:12:5\n   |/n12 |     assert False\n   |     ^^^^^^^^^^^^\n   |\n\n",
+                "severity": "error"
+              },
+              "duration_seconds": "[TIME]",
+              "status": "failed"
+            }
+          ],
           "captured_output": {
             "stderr": "fail stderr/nfail stderr\n"
           },
@@ -109,6 +137,24 @@ fn writes_json_result_report() {
           "status": "failed"
         },
         {
+          "attempts": [
+            {
+              "attempt": 1,
+              "diagnostic": {
+                "code": "test-failure",
+                "message": "Test `test_flaky` failed",
+                "rendered": "error[test-failure]: Test `test_flaky` failed\n  --> test_report.py:18:5\n   |/n18 | def test_flaky():\n   |     ^^^^^^^^^^\n   |/ninfo: Test failed here\n  --> test_report.py:23:5\n   |/n23 |     assert count >= 1\n   |     ^^^^^^^^^^^^^^^^^\n   |\n\n",
+                "severity": "error"
+              },
+              "duration_seconds": "[TIME]",
+              "status": "failed"
+            },
+            {
+              "attempt": 2,
+              "duration_seconds": "[TIME]",
+              "status": "passed"
+            }
+          ],
           "captured_output": {
             "stdout": "flaky attempt 1/nflaky attempt 2\n"
           },
@@ -147,7 +193,7 @@ fn writes_json_result_report() {
 }
 
 #[test]
-fn writes_jsonl_result_events() {
+fn writes_jsonl_result_records() {
     let context = TestContext::with_file(
         "test_events.py",
         r"
@@ -195,9 +241,9 @@ fn writes_jsonl_result_events() {
     );
 
     assert_snapshot!(normalize_result_jsonl(&context.read_file("reports/events.jsonl")), @r#"
-    {"diagnostic":{"code":"test-failure","message":"Test `test_fail` failed","rendered":"error[test-failure]: Test `test_fail` failed\n --> test_events.py:5:5\n  |/n5 | def test_fail():\n  |     ^^^^^^^^^\n  |/ninfo: Test failed here\n --> test_events.py:6:5\n  |/n6 |     assert False\n  |     ^^^^^^^^^^^^\n  |\n\n","severity":"error"},"duration_seconds":"[TIME]","full_name":"test_events::test_fail","module":"test_events","name":"test_fail","schema_version":2,"status":"failed","type":"test"}
-    {"duration_seconds":"[TIME]","full_name":"test_events::test_pass","module":"test_events","name":"test_pass","schema_version":2,"status":"passed","type":"test"}
-    {"elapsed_seconds":"[TIME]","schema_version":2,"stats":{"failed":1,"flaky":0,"passed":1,"skipped":0,"slow":0,"total":2},"status":"failed","type":"run_finished"}
+    {"diagnostic":{"code":"test-failure","message":"Test `test_fail` failed","rendered":"error[test-failure]: Test `test_fail` failed\n --> test_events.py:5:5\n  |/n5 | def test_fail():\n  |     ^^^^^^^^^\n  |/ninfo: Test failed here\n --> test_events.py:6:5\n  |/n6 |     assert False\n  |     ^^^^^^^^^^^^\n  |\n\n","severity":"error"},"duration_seconds":"[TIME]","full_name":"test_events::test_fail","module":"test_events","name":"test_fail","schema_version":3,"status":"failed","type":"test"}
+    {"duration_seconds":"[TIME]","full_name":"test_events::test_pass","module":"test_events","name":"test_pass","schema_version":3,"status":"passed","type":"test"}
+    {"elapsed_seconds":"[TIME]","schema_version":3,"stats":{"errors":0,"failed":1,"flaky":0,"passed":1,"skipped":0,"slow":0,"total":2},"status":"failed","type":"run_finished"}
     "#);
 }
 
@@ -244,8 +290,9 @@ fn keeps_run_diagnostics_separate_from_tests() {
           "severity": "error"
         }
       ],
-      "schema_version": 2,
+      "schema_version": 3,
       "stats": {
+        "errors": 0,
         "failed": 0,
         "flaky": 0,
         "passed": 0,
@@ -260,7 +307,7 @@ fn keeps_run_diagnostics_separate_from_tests() {
 }
 
 #[test]
-fn writes_jsonl_run_diagnostic_events() {
+fn writes_jsonl_run_diagnostic_records() {
     let context = TestContext::with_file(
         "test_import.py",
         r"
@@ -295,8 +342,8 @@ fn writes_jsonl_run_diagnostic_events() {
     assert_snapshot!(
         normalize_result_jsonl(&context.read_file("reports/import.jsonl")),
         @r#"
-    {"diagnostic":{"code":"failed-to-import-module","message":"Failed to import python module `test_import`: No module named 'missing_result_report_dependency'","rendered":"error[failed-to-import-module]: Failed to import python module `test_import`: No module named 'missing_result_report_dependency'\n\n","severity":"error"},"schema_version":2,"type":"run_diagnostic"}
-    {"elapsed_seconds":"[TIME]","schema_version":2,"stats":{"failed":0,"flaky":0,"passed":0,"skipped":0,"slow":0,"total":0},"status":"failed","type":"run_finished"}
+    {"diagnostic":{"code":"failed-to-import-module","message":"Failed to import python module `test_import`: No module named 'missing_result_report_dependency'","rendered":"error[failed-to-import-module]: Failed to import python module `test_import`: No module named 'missing_result_report_dependency'\n\n","severity":"error"},"schema_version":3,"type":"run_diagnostic"}
+    {"elapsed_seconds":"[TIME]","schema_version":3,"stats":{"errors":0,"failed":0,"flaky":0,"passed":0,"skipped":0,"slow":0,"total":0},"status":"failed","type":"run_finished"}
     "#
     );
 }
@@ -326,8 +373,9 @@ fn result_report_status_matches_no_tests_failure() {
     assert_snapshot!(normalize_result_json(&context.read_file("reports/no-tests.json")), @r#"
     {
       "elapsed_seconds": "[TIME]",
-      "schema_version": 2,
+      "schema_version": 3,
       "stats": {
+        "errors": 0,
         "failed": 0,
         "flaky": 0,
         "passed": 0,

--- a/crates/karva/tests/it/run_ignored.rs
+++ b/crates/karva/tests/it/run_ignored.rs
@@ -28,7 +28,9 @@ fn runignored_runs_only_skipped_tests() {
             FAIL [TIME] test::test_skipped
             FAIL [TIME] test::test_skipped_with_reason
 
-    diagnostics:
+    failures:
+
+    test::test_skipped:
 
     error[test-failure]: Test `test_skipped` failed
      --> test.py:5:5
@@ -42,6 +44,8 @@ fn runignored_runs_only_skipped_tests() {
     6 |     assert False
       |     ^^^^^^^^^^^^
       |
+
+    test::test_skipped_with_reason:
 
     error[test-failure]: Test `test_skipped_with_reason` failed
      --> test.py:9:5
@@ -75,7 +79,9 @@ fn runignored_all_runs_skipped_alongside_normal() {
             FAIL [TIME] test::test_skipped_with_reason
             PASS [TIME] test::test_normal
 
-    diagnostics:
+    failures:
+
+    test::test_skipped:
 
     error[test-failure]: Test `test_skipped` failed
      --> test.py:5:5
@@ -89,6 +95,8 @@ fn runignored_all_runs_skipped_alongside_normal() {
     6 |     assert False
       |     ^^^^^^^^^^^^
       |
+
+    test::test_skipped_with_reason:
 
     error[test-failure]: Test `test_skipped_with_reason` failed
      --> test.py:9:5

--- a/crates/karva_cache/src/artifact.rs
+++ b/crates/karva_cache/src/artifact.rs
@@ -18,18 +18,10 @@ use tempfile::NamedTempFile;
 /// One of the well-known files in the cache directory hierarchy.
 #[derive(Clone, Copy)]
 pub enum CacheFile {
-    /// Per-worker JSON: aggregated `TestResultStats`.
-    Stats,
-    /// Per-worker JSON: structured run-level diagnostics.
-    RunDiagnostics,
+    /// Per-worker JSON: completed test results.
+    Results,
     /// Per-worker JSON: map of test id to wall-clock duration.
     Durations,
-    /// Per-worker JSON: list of failed test names.
-    FailedTests,
-    /// Per-worker JSON: list of `FlakyTest` records.
-    FlakyTests,
-    /// Per-worker JSON: final result records for executed test variants.
-    TestCases,
     /// Per-worker JSON: line-coverage data for sources tracked during the run.
     Coverage,
     /// Per-run empty sentinel marking that fail-fast was triggered.
@@ -46,12 +38,8 @@ impl CacheFile {
     /// Returns the on-disk filename for this artifact.
     pub const fn filename(self) -> &'static str {
         match self {
-            Self::Stats => "stats.json",
-            Self::RunDiagnostics => "run_diagnostics.json",
+            Self::Results => "results.json",
             Self::Durations => "durations.json",
-            Self::FailedTests => "failed_tests.json",
-            Self::FlakyTests => "flaky_tests.json",
-            Self::TestCases => "test_cases.json",
             Self::Coverage => "coverage.json",
             Self::FailFastSignal => "fail-fast",
             Self::LastFailed => "last-failed.json",
@@ -92,21 +80,6 @@ fn write_bytes(dir: &Utf8Path, file: CacheFile, content: &[u8]) -> Result<()> {
         .map_err(|err| err.error)
         .with_context(|| format!("failed to replace `{path}`"))?;
     Ok(())
-}
-
-/// Like [`write_json`], but skips writing entirely when `items` is empty.
-///
-/// Used for artifacts where an empty list carries no information and the file
-/// is treated as absent by readers.
-pub fn write_json_if_nonempty<T: Serialize>(
-    dir: &Utf8Path,
-    file: CacheFile,
-    items: &[T],
-) -> Result<()> {
-    if items.is_empty() {
-        return Ok(());
-    }
-    write_json(dir, file, &items)
 }
 
 /// Reads `dir/<file>` as JSON, or returns `Ok(None)` when the file does not exist.

--- a/crates/karva_cache/src/artifact.rs
+++ b/crates/karva_cache/src/artifact.rs
@@ -21,7 +21,7 @@ pub enum CacheFile {
     /// Per-worker JSON: aggregated `TestResultStats`.
     Stats,
     /// Per-worker JSON: structured run-level diagnostics.
-    Diagnostics,
+    RunDiagnostics,
     /// Per-worker JSON: map of test id to wall-clock duration.
     Durations,
     /// Per-worker JSON: list of failed test names.
@@ -30,8 +30,6 @@ pub enum CacheFile {
     FlakyTests,
     /// Per-worker JSON: final result records for executed test variants.
     TestCases,
-    /// Per-worker JSON: captured Python stdout/stderr records by exact test name.
-    CapturedOutput,
     /// Per-worker JSON: line-coverage data for sources tracked during the run.
     Coverage,
     /// Per-run empty sentinel marking that fail-fast was triggered.
@@ -49,12 +47,11 @@ impl CacheFile {
     pub const fn filename(self) -> &'static str {
         match self {
             Self::Stats => "stats.json",
-            Self::Diagnostics => "diagnostics.json",
+            Self::RunDiagnostics => "run_diagnostics.json",
             Self::Durations => "durations.json",
             Self::FailedTests => "failed_tests.json",
             Self::FlakyTests => "flaky_tests.json",
             Self::TestCases => "test_cases.json",
-            Self::CapturedOutput => "captured_output.json",
             Self::Coverage => "coverage.json",
             Self::FailFastSignal => "fail-fast",
             Self::LastFailed => "last-failed.json",

--- a/crates/karva_cache/src/artifact.rs
+++ b/crates/karva_cache/src/artifact.rs
@@ -20,7 +20,7 @@ use tempfile::NamedTempFile;
 pub enum CacheFile {
     /// Per-worker JSON: aggregated `TestResultStats`.
     Stats,
-    /// Per-worker text: rendered diagnostics from discovery, collection, and execution.
+    /// Per-worker JSON: structured run-level diagnostics.
     Diagnostics,
     /// Per-worker JSON: map of test id to wall-clock duration.
     Durations,
@@ -49,7 +49,7 @@ impl CacheFile {
     pub const fn filename(self) -> &'static str {
         match self {
             Self::Stats => "stats.json",
-            Self::Diagnostics => "diagnostics.txt",
+            Self::Diagnostics => "diagnostics.json",
             Self::Durations => "durations.json",
             Self::FailedTests => "failed_tests.json",
             Self::FlakyTests => "flaky_tests.json",

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -42,7 +42,7 @@ pub struct AggregatedResults {
 
 #[derive(Default, Serialize, Deserialize)]
 struct WorkerResults {
-    slow: usize,
+    stats: TestResultStats,
     run_diagnostics: Vec<RenderedDiagnostic>,
     test_cases: Vec<TestCaseResult>,
 }
@@ -81,28 +81,26 @@ impl AggregatedResults {
                 self.run_diagnostics.push(diagnostic);
             }
         }
-        for _ in 0..worker.slow {
-            self.stats.add(TestResultKind::Slow);
-        }
-        for case in worker.test_cases {
-            self.stats.add(case.outcome().result_kind().into());
-            if case.outcome().is_non_success() {
-                self.failed_tests.push(base_test_name(case.full_name()));
+        self.stats.merge(&worker.stats);
+        if !worker.stats.is_success() || worker.stats.flaky() > 0 {
+            for case in &worker.test_cases {
+                if case.outcome().is_non_success() {
+                    self.failed_tests.push(base_test_name(case.full_name()));
+                }
+                if let Some(retry) = case.retry()
+                    && matches!(case.outcome(), TestCaseOutcome::Passed)
+                {
+                    self.flaky_tests.push(FlakyTest::from_display_name(
+                        case.module_name(),
+                        case.name(),
+                        retry.attempts(),
+                        retry.max_attempts(),
+                        case.duration(),
+                    ));
+                }
             }
-            if let Some(retry) = case.retry()
-                && matches!(case.outcome(), TestCaseOutcome::Passed)
-            {
-                self.stats.add(TestResultKind::Flaky);
-                self.flaky_tests.push(FlakyTest::from_display_name(
-                    case.module_name(),
-                    case.name(),
-                    retry.attempts(),
-                    retry.max_attempts(),
-                    case.duration(),
-                ));
-            }
-            self.test_cases.push(case);
         }
+        self.test_cases.extend(worker.test_cases);
     }
 }
 
@@ -228,7 +226,7 @@ impl RunCache {
             .collect::<Result<Vec<TestCaseResult>>>()?;
 
         let worker_results = WorkerResults {
-            slow: stats.slow(),
+            stats,
             run_diagnostics,
             test_cases,
         };
@@ -442,7 +440,7 @@ mod tests {
         write_worker_results(
             &worker_dir,
             &WorkerResults {
-                slow: stats.slow(),
+                stats,
                 run_diagnostics: Vec::new(),
                 test_cases,
             },
@@ -787,10 +785,15 @@ mod tests {
         let worker1 = run_dir.join("worker-1");
         fs::create_dir_all(&worker0).unwrap();
         fs::create_dir_all(&worker1).unwrap();
+        let mut worker0_stats = TestResultStats::default();
+        worker0_stats.add(TestResultKind::Failed);
+        let mut worker1_stats = TestResultStats::default();
+        worker1_stats.add(TestResultKind::Failed);
 
         write_worker_results(
             &worker0,
             &WorkerResults {
+                stats: worker0_stats,
                 test_cases: vec![failed_case("mod::test_a")],
                 ..WorkerResults::default()
             },
@@ -798,6 +801,7 @@ mod tests {
         write_worker_results(
             &worker1,
             &WorkerResults {
+                stats: worker1_stats,
                 test_cases: vec![failed_case("mod::test_b")],
                 ..WorkerResults::default()
             },
@@ -857,6 +861,10 @@ mod tests {
         let worker1 = run_dir.join("worker-1");
         fs::create_dir_all(&worker0).unwrap();
         fs::create_dir_all(&worker1).unwrap();
+        let mut worker0_stats = TestResultStats::default();
+        worker0_stats.add(TestResultKind::Passed);
+        let mut worker1_stats = TestResultStats::default();
+        worker1_stats.add(TestResultKind::Passed);
 
         let case0: TestCaseResult = TestCaseResult::from_display_name(
             "mod::test_a",
@@ -880,6 +888,7 @@ mod tests {
         write_worker_results(
             &worker0,
             &WorkerResults {
+                stats: worker0_stats,
                 test_cases: vec![case0],
                 ..WorkerResults::default()
             },
@@ -887,6 +896,7 @@ mod tests {
         write_worker_results(
             &worker1,
             &WorkerResults {
+                stats: worker1_stats,
                 test_cases: vec![case1],
                 ..WorkerResults::default()
             },

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -12,9 +12,7 @@ use karva_diagnostic::{
 use ruff_db::diagnostic::DisplayDiagnosticConfig;
 use serde::{Deserialize, Serialize};
 
-use crate::artifact::{
-    CacheFile, read_json, read_text, write_json, write_json_if_nonempty, write_text,
-};
+use crate::artifact::{CacheFile, read_json, read_text, write_json, write_text};
 use crate::diagnostics::render_diagnostic;
 use crate::{RUN_PREFIX, RunHash, WORKER_PREFIX, worker_folder};
 
@@ -42,6 +40,16 @@ pub struct AggregatedResults {
     pub durations: HashMap<String, Duration>,
 }
 
+#[derive(Default, Serialize, Deserialize)]
+#[serde(default)]
+struct WorkerResults {
+    stats: TestResultStats,
+    run_diagnostics: Vec<RenderedDiagnostic>,
+    failed_tests: Vec<String>,
+    flaky_tests: Vec<FlakyTest>,
+    test_cases: Vec<TestCaseResult>,
+}
+
 impl AggregatedResults {
     pub fn register_interrupted_test(&mut self, name: &str, duration: Duration) {
         let function_name = base_test_name(name);
@@ -56,6 +64,14 @@ impl AggregatedResults {
             None,
         ));
         self.durations.insert(function_name, duration);
+    }
+
+    fn merge_worker(&mut self, worker: WorkerResults) {
+        self.stats.merge(&worker.stats);
+        self.run_diagnostics.extend(worker.run_diagnostics);
+        self.failed_tests.extend(worker.failed_tests);
+        self.flaky_tests.extend(worker.flaky_tests);
+        self.test_cases.extend(worker.test_cases);
     }
 }
 
@@ -173,17 +189,11 @@ impl RunCache {
             .iter()
             .map(|diagnostic| render_diagnostic(diagnostic, cwd, config))
             .collect::<Result<Vec<_>>>()?;
-        write_json_if_nonempty(&worker_dir, CacheFile::RunDiagnostics, &run_diagnostics)?;
-        write_json(&worker_dir, CacheFile::Stats, result.stats())?;
-        write_json(&worker_dir, CacheFile::Durations, result.durations())?;
-
         let failed_names: Vec<String> = result
             .failed_tests()
             .iter()
             .map(ToString::to_string)
             .collect();
-        write_json_if_nonempty(&worker_dir, CacheFile::FailedTests, &failed_names)?;
-        write_json_if_nonempty(&worker_dir, CacheFile::FlakyTests, result.flaky_tests())?;
         let test_cases = result
             .test_cases()
             .iter()
@@ -191,34 +201,27 @@ impl RunCache {
                 case.try_map_diagnostic(|diagnostic| render_diagnostic(diagnostic, cwd, config))
             })
             .collect::<Result<Vec<TestCaseResult>>>()?;
-        write_json_if_nonempty(&worker_dir, CacheFile::TestCases, &test_cases)?;
+
+        let worker_results = WorkerResults {
+            stats: result.stats().clone(),
+            run_diagnostics,
+            failed_tests: failed_names,
+            flaky_tests: result.flaky_tests().to_vec(),
+            test_cases,
+        };
+
+        write_json(&worker_dir, CacheFile::Durations, result.durations())?;
+        write_json(&worker_dir, CacheFile::Results, &worker_results)?;
         Ok(())
     }
 }
 
 /// Reads results from a single worker directory into the accumulator.
 fn read_worker_results(worker_dir: &Utf8Path, results: &mut AggregatedResults) -> Result<()> {
-    if let Some(stats) = read_json::<TestResultStats>(worker_dir, CacheFile::Stats)? {
-        results.stats.merge(&stats);
-    }
-
-    if let Some(diagnostics) =
-        read_json::<Vec<RenderedDiagnostic>>(worker_dir, CacheFile::RunDiagnostics)?
-    {
-        results.run_diagnostics.extend(diagnostics);
-    }
-
-    if let Some(failed) = read_json::<Vec<String>>(worker_dir, CacheFile::FailedTests)? {
-        results.failed_tests.extend(failed);
-    }
-
-    if let Some(flaky) = read_json::<Vec<FlakyTest>>(worker_dir, CacheFile::FlakyTests)? {
-        results.flaky_tests.extend(flaky);
-    }
-
-    if let Some(cases) = read_json::<Vec<TestCaseResult>>(worker_dir, CacheFile::TestCases)? {
-        results.test_cases.extend(cases);
-    }
+    let Some(worker_results) = read_json::<WorkerResults>(worker_dir, CacheFile::Results)? else {
+        return Ok(());
+    };
+    results.merge_worker(worker_results);
 
     if let Some(durations) =
         read_json::<HashMap<String, Duration>>(worker_dir, CacheFile::Durations)?
@@ -390,7 +393,21 @@ mod tests {
     ) {
         let worker_dir = dir.join(run_name).join(format!("worker-{worker_id}"));
         fs::create_dir_all(&worker_dir).unwrap();
-        fs::write(worker_dir.join(CacheFile::Stats.filename()), stats_json).unwrap();
+        write_worker_results(
+            &worker_dir,
+            &WorkerResults {
+                stats: serde_json::from_str(stats_json).unwrap(),
+                ..WorkerResults::default()
+            },
+        );
+    }
+
+    fn write_worker_results(worker_dir: &std::path::Path, results: &WorkerResults) {
+        fs::write(
+            worker_dir.join(CacheFile::Results.filename()),
+            serde_json::to_string(results).unwrap(),
+        )
+        .unwrap();
     }
 
     #[test]
@@ -453,6 +470,31 @@ mod tests {
 
         assert_eq!(results.stats.total(), 0);
         assert!(results.run_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn aggregate_results_ignores_incomplete_worker() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let run_hash = RunHash::from_existing("run-610");
+        let worker_dir = tmp.path().join(run_hash.dir_name()).join("worker-0");
+        fs::create_dir_all(&worker_dir).unwrap();
+
+        let durations = HashMap::from([(
+            "mod::test_uncommitted".to_string(),
+            Duration::from_millis(10),
+        )]);
+        fs::write(
+            worker_dir.join(CacheFile::Durations.filename()),
+            serde_json::to_string(&durations).unwrap(),
+        )
+        .unwrap();
+
+        let results = RunCache::new(&cache_dir, &run_hash)
+            .aggregate_results()
+            .unwrap();
+
+        assert!(results.durations.is_empty());
     }
 
     #[test]
@@ -679,16 +721,20 @@ mod tests {
         fs::create_dir_all(&worker0).unwrap();
         fs::create_dir_all(&worker1).unwrap();
 
-        fs::write(
-            worker0.join(CacheFile::FailedTests.filename()),
-            r#"["mod::test_a"]"#,
-        )
-        .unwrap();
-        fs::write(
-            worker1.join(CacheFile::FailedTests.filename()),
-            r#"["mod::test_b"]"#,
-        )
-        .unwrap();
+        write_worker_results(
+            &worker0,
+            &WorkerResults {
+                failed_tests: vec!["mod::test_a".to_string()],
+                ..WorkerResults::default()
+            },
+        );
+        write_worker_results(
+            &worker1,
+            &WorkerResults {
+                failed_tests: vec!["mod::test_b".to_string()],
+                ..WorkerResults::default()
+            },
+        );
 
         let mut d0 = HashMap::new();
         d0.insert("mod::test_a".to_string(), Duration::from_millis(10));
@@ -764,16 +810,20 @@ mod tests {
             )),
         );
 
-        fs::write(
-            worker0.join(CacheFile::TestCases.filename()),
-            serde_json::to_string(&[case0]).unwrap(),
-        )
-        .unwrap();
-        fs::write(
-            worker1.join(CacheFile::TestCases.filename()),
-            serde_json::to_string(&[case1]).unwrap(),
-        )
-        .unwrap();
+        write_worker_results(
+            &worker0,
+            &WorkerResults {
+                test_cases: vec![case0],
+                ..WorkerResults::default()
+            },
+        );
+        write_worker_results(
+            &worker1,
+            &WorkerResults {
+                test_cases: vec![case1],
+                ..WorkerResults::default()
+            },
+        );
 
         let cache = RunCache::new(&cache_dir, &run_hash);
         let mut cases = cache.aggregate_results().unwrap().test_cases;

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -232,7 +232,11 @@ impl RunCache {
         };
 
         write_json(&worker_dir, CacheFile::Durations, &durations)?;
-        write_json(&worker_dir, CacheFile::Results, &worker_results)?;
+        write_text(
+            &worker_dir,
+            CacheFile::Results,
+            serde_json::to_vec(&worker_results)?,
+        )?;
         Ok(())
     }
 }

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -41,25 +41,34 @@ pub struct AggregatedResults {
 }
 
 #[derive(Default, Serialize, Deserialize)]
-#[serde(default)]
 struct WorkerResults {
-    stats: TestResultStats,
+    slow: usize,
     run_diagnostics: Vec<RenderedDiagnostic>,
-    failed_tests: Vec<String>,
-    flaky_tests: Vec<FlakyTest>,
     test_cases: Vec<TestCaseResult>,
 }
 
 impl AggregatedResults {
+    pub fn is_success(&self) -> bool {
+        self.stats.is_success()
+            && !self
+                .run_diagnostics
+                .iter()
+                .any(RenderedDiagnostic::is_error)
+    }
+
+    pub fn has_run_errors(&self) -> bool {
+        self.run_diagnostics
+            .iter()
+            .any(RenderedDiagnostic::is_error)
+    }
+
     pub fn register_interrupted_test(&mut self, name: &str, duration: Duration) {
         let function_name = base_test_name(name);
         self.stats.add(TestResultKind::Failed);
         self.failed_tests.push(function_name.clone());
         self.test_cases.push(TestCaseResult::from_display_name(
             name,
-            TestCaseOutcome::Failed {
-                diagnostic: RenderedDiagnostic::interrupted(name),
-            },
+            TestCaseOutcome::failed(RenderedDiagnostic::interrupted(name)),
             duration,
             None,
         ));
@@ -67,11 +76,33 @@ impl AggregatedResults {
     }
 
     fn merge_worker(&mut self, worker: WorkerResults) {
-        self.stats.merge(&worker.stats);
-        self.run_diagnostics.extend(worker.run_diagnostics);
-        self.failed_tests.extend(worker.failed_tests);
-        self.flaky_tests.extend(worker.flaky_tests);
-        self.test_cases.extend(worker.test_cases);
+        for diagnostic in worker.run_diagnostics {
+            if !self.run_diagnostics.contains(&diagnostic) {
+                self.run_diagnostics.push(diagnostic);
+            }
+        }
+        for _ in 0..worker.slow {
+            self.stats.add(TestResultKind::Slow);
+        }
+        for case in worker.test_cases {
+            self.stats.add(case.outcome().result_kind().into());
+            if case.outcome().is_non_success() {
+                self.failed_tests.push(base_test_name(case.full_name()));
+            }
+            if let Some(retry) = case.retry()
+                && matches!(case.outcome(), TestCaseOutcome::Passed)
+            {
+                self.stats.add(TestResultKind::Flaky);
+                self.flaky_tests.push(FlakyTest::from_display_name(
+                    case.module_name(),
+                    case.name(),
+                    retry.attempts(),
+                    retry.max_attempts(),
+                    case.duration(),
+                ));
+            }
+            self.test_cases.push(case);
+        }
     }
 }
 
@@ -189,11 +220,6 @@ impl RunCache {
             .iter()
             .map(|diagnostic| render_diagnostic(diagnostic, cwd, config))
             .collect::<Result<Vec<_>>>()?;
-        let failed_names: Vec<String> = result
-            .failed_tests()
-            .iter()
-            .map(ToString::to_string)
-            .collect();
         let test_cases = result
             .test_cases()
             .iter()
@@ -203,10 +229,8 @@ impl RunCache {
             .collect::<Result<Vec<TestCaseResult>>>()?;
 
         let worker_results = WorkerResults {
-            stats: result.stats().clone(),
+            slow: result.stats().slow(),
             run_diagnostics,
-            failed_tests: failed_names,
-            flaky_tests: result.flaky_tests().to_vec(),
             test_cases,
         };
 
@@ -370,6 +394,7 @@ mod tests {
     use camino::Utf8PathBuf;
     use insta::assert_debug_snapshot;
     use karva_diagnostic::CapturedTestOutput;
+    use ruff_db::diagnostic::Severity;
 
     use super::*;
 
@@ -393,13 +418,49 @@ mod tests {
     ) {
         let worker_dir = dir.join(run_name).join(format!("worker-{worker_id}"));
         fs::create_dir_all(&worker_dir).unwrap();
+        let stats: TestResultStats = serde_json::from_str(stats_json).unwrap();
+        let mut test_cases = Vec::new();
+        for index in 0..stats.passed() {
+            test_cases.push(TestCaseResult::from_display_name(
+                &format!("mod::test_passed_{index}"),
+                TestCaseOutcome::Passed,
+                Duration::ZERO,
+                None,
+            ));
+        }
+        for index in 0..stats.failed() {
+            test_cases.push(failed_case(&format!("mod::test_failed_{index}")));
+        }
+        for index in 0..stats.skipped() {
+            test_cases.push(TestCaseResult::from_display_name(
+                &format!("mod::test_skipped_{index}"),
+                TestCaseOutcome::Skipped { reason: None },
+                Duration::ZERO,
+                None,
+            ));
+        }
         write_worker_results(
             &worker_dir,
             &WorkerResults {
-                stats: serde_json::from_str(stats_json).unwrap(),
-                ..WorkerResults::default()
+                slow: stats.slow(),
+                run_diagnostics: Vec::new(),
+                test_cases,
             },
         );
+    }
+
+    fn failed_case(name: &str) -> TestCaseResult {
+        TestCaseResult::from_display_name(
+            name,
+            TestCaseOutcome::failed(RenderedDiagnostic::new(
+                "test-failure",
+                Severity::Error,
+                "failed",
+                "error[test-failure]: failed\n",
+            )),
+            Duration::ZERO,
+            None,
+        )
     }
 
     fn write_worker_results(worker_dir: &std::path::Path, results: &WorkerResults) {
@@ -495,6 +556,11 @@ mod tests {
             .unwrap();
 
         assert!(results.durations.is_empty());
+    }
+
+    #[test]
+    fn worker_results_reject_missing_fields() {
+        assert!(serde_json::from_str::<WorkerResults>("{}").is_err());
     }
 
     #[test]
@@ -724,14 +790,14 @@ mod tests {
         write_worker_results(
             &worker0,
             &WorkerResults {
-                failed_tests: vec!["mod::test_a".to_string()],
+                test_cases: vec![failed_case("mod::test_a")],
                 ..WorkerResults::default()
             },
         );
         write_worker_results(
             &worker1,
             &WorkerResults {
-                failed_tests: vec!["mod::test_b".to_string()],
+                test_cases: vec![failed_case("mod::test_b")],
                 ..WorkerResults::default()
             },
         );
@@ -844,6 +910,7 @@ mod tests {
                         stderr: "",
                     },
                 ),
+                attempts: [],
             },
             TestCaseResult {
                 module_name: "mod",
@@ -858,6 +925,7 @@ mod tests {
                         stderr: "worker 1 stderr\n",
                     },
                 ),
+                attempts: [],
             },
         ]
         "#);
@@ -921,11 +989,14 @@ mod tests {
                         severity: Error,
                         message: "Test `mod::test_slow(value=1)` was interrupted",
                         rendered: "error[interrupted]: Test `mod::test_slow(value=1)` was interrupted\n",
+                        colored_rendered: None,
                     },
+                    related: [],
                 },
                 duration: 42ms,
                 retry: None,
                 captured_output: None,
+                attempts: [],
             },
             TestCaseResult {
                 module_name: "mod",
@@ -937,11 +1008,14 @@ mod tests {
                         severity: Error,
                         message: "Test `mod::test_legacy[value]` was interrupted",
                         rendered: "error[interrupted]: Test `mod::test_legacy[value]` was interrupted\n",
+                        colored_rendered: None,
                     },
+                    related: [],
                 },
                 duration: 24ms,
                 retry: None,
                 captured_output: None,
+                attempts: [],
             },
         ]
         "#);

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -6,8 +6,8 @@ use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use fs_err as fs;
 use karva_diagnostic::{
-    CapturedTestOutput, FlakyTest, RenderedDiagnostic, TestCaseOutcome, TestCaseResult,
-    TestResultKind, TestResultStats, TestRunResult,
+    FlakyTest, RenderedDiagnostic, TestCaseOutcome, TestCaseResult, TestResultKind,
+    TestResultStats, TestRunResult,
 };
 use ruff_db::diagnostic::DisplayDiagnosticConfig;
 use serde::{Deserialize, Serialize};
@@ -35,11 +35,10 @@ pub struct CurrentTest {
 #[derive(Default)]
 pub struct AggregatedResults {
     pub stats: TestResultStats,
-    pub diagnostics: Vec<RenderedDiagnostic>,
+    pub run_diagnostics: Vec<RenderedDiagnostic>,
     pub failed_tests: Vec<String>,
     pub flaky_tests: Vec<FlakyTest>,
     pub test_cases: Vec<TestCaseResult>,
-    pub captured_outputs: Vec<CapturedTestOutput>,
     pub durations: HashMap<String, Duration>,
 }
 
@@ -54,6 +53,7 @@ impl AggregatedResults {
                 diagnostic: RenderedDiagnostic::interrupted(name),
             },
             duration,
+            None,
         ));
         self.durations.insert(function_name, duration);
     }
@@ -173,7 +173,7 @@ impl RunCache {
             .iter()
             .map(|diagnostic| render_diagnostic(diagnostic, cwd, config))
             .collect::<Result<Vec<_>>>()?;
-        write_json_if_nonempty(&worker_dir, CacheFile::Diagnostics, &run_diagnostics)?;
+        write_json_if_nonempty(&worker_dir, CacheFile::RunDiagnostics, &run_diagnostics)?;
         write_json(&worker_dir, CacheFile::Stats, result.stats())?;
         write_json(&worker_dir, CacheFile::Durations, result.durations())?;
 
@@ -192,12 +192,6 @@ impl RunCache {
             })
             .collect::<Result<Vec<TestCaseResult>>>()?;
         write_json_if_nonempty(&worker_dir, CacheFile::TestCases, &test_cases)?;
-        write_json_if_nonempty(
-            &worker_dir,
-            CacheFile::CapturedOutput,
-            result.captured_outputs(),
-        )?;
-
         Ok(())
     }
 }
@@ -209,9 +203,9 @@ fn read_worker_results(worker_dir: &Utf8Path, results: &mut AggregatedResults) -
     }
 
     if let Some(diagnostics) =
-        read_json::<Vec<RenderedDiagnostic>>(worker_dir, CacheFile::Diagnostics)?
+        read_json::<Vec<RenderedDiagnostic>>(worker_dir, CacheFile::RunDiagnostics)?
     {
-        results.diagnostics.extend(diagnostics);
+        results.run_diagnostics.extend(diagnostics);
     }
 
     if let Some(failed) = read_json::<Vec<String>>(worker_dir, CacheFile::FailedTests)? {
@@ -224,12 +218,6 @@ fn read_worker_results(worker_dir: &Utf8Path, results: &mut AggregatedResults) -
 
     if let Some(cases) = read_json::<Vec<TestCaseResult>>(worker_dir, CacheFile::TestCases)? {
         results.test_cases.extend(cases);
-    }
-
-    if let Some(outputs) =
-        read_json::<Vec<CapturedTestOutput>>(worker_dir, CacheFile::CapturedOutput)?
-    {
-        results.captured_outputs.extend(outputs);
     }
 
     if let Some(durations) =
@@ -378,6 +366,7 @@ mod tests {
 
     use camino::Utf8PathBuf;
     use insta::assert_debug_snapshot;
+    use karva_diagnostic::CapturedTestOutput;
 
     use super::*;
 
@@ -463,7 +452,7 @@ mod tests {
         let results = cache.aggregate_results().unwrap();
 
         assert_eq!(results.stats.total(), 0);
-        assert!(results.diagnostics.is_empty());
+        assert!(results.run_diagnostics.is_empty());
     }
 
     #[test]
@@ -745,7 +734,7 @@ mod tests {
     }
 
     #[test]
-    fn aggregate_results_merges_captured_output_across_workers() {
+    fn aggregate_results_merges_test_output_across_workers() {
         let tmp = tempfile::tempdir().unwrap();
         let cache_dir = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
         let run_hash = RunHash::from_existing("run-710");
@@ -756,47 +745,69 @@ mod tests {
         fs::create_dir_all(&worker0).unwrap();
         fs::create_dir_all(&worker1).unwrap();
 
-        let output0 = CapturedTestOutput::new(
-            "mod::test_a".to_string(),
-            karva_diagnostic::CapturedTestOutcome::Failed,
-            "worker 0 stdout\n".to_string(),
-            String::new(),
+        let case0: TestCaseResult = TestCaseResult::from_display_name(
+            "mod::test_a",
+            TestCaseOutcome::Passed,
+            Duration::ZERO,
+            Some(CapturedTestOutput::new(
+                "worker 0 stdout\n".to_string(),
+                String::new(),
+            )),
         );
-        let output1 = CapturedTestOutput::new(
-            "mod::test_b".to_string(),
-            karva_diagnostic::CapturedTestOutcome::Passed,
-            String::new(),
-            "worker 1 stderr\n".to_string(),
+        let case1: TestCaseResult = TestCaseResult::from_display_name(
+            "mod::test_b",
+            TestCaseOutcome::Passed,
+            Duration::ZERO,
+            Some(CapturedTestOutput::new(
+                String::new(),
+                "worker 1 stderr\n".to_string(),
+            )),
         );
 
         fs::write(
-            worker0.join(CacheFile::CapturedOutput.filename()),
-            serde_json::to_string(&[output0]).unwrap(),
+            worker0.join(CacheFile::TestCases.filename()),
+            serde_json::to_string(&[case0]).unwrap(),
         )
         .unwrap();
         fs::write(
-            worker1.join(CacheFile::CapturedOutput.filename()),
-            serde_json::to_string(&[output1]).unwrap(),
+            worker1.join(CacheFile::TestCases.filename()),
+            serde_json::to_string(&[case1]).unwrap(),
         )
         .unwrap();
 
         let cache = RunCache::new(&cache_dir, &run_hash);
-        let mut outputs = cache.aggregate_results().unwrap().captured_outputs;
-        outputs.sort_by(|a, b| a.test_name().cmp(b.test_name()));
+        let mut cases = cache.aggregate_results().unwrap().test_cases;
+        cases.sort_by(|a, b| a.full_name().cmp(b.full_name()));
 
-        assert_debug_snapshot!(outputs, @r#"
+        assert_debug_snapshot!(cases, @r#"
         [
-            CapturedTestOutput {
-                test_name: "mod::test_a",
-                outcome: Failed,
-                stdout: "worker 0 stdout\n",
-                stderr: "",
-            },
-            CapturedTestOutput {
-                test_name: "mod::test_b",
+            TestCaseResult {
+                module_name: "mod",
+                name: "test_a",
+                full_name: "mod::test_a",
                 outcome: Passed,
-                stdout: "",
-                stderr: "worker 1 stderr\n",
+                duration: 0ns,
+                retry: None,
+                captured_output: Some(
+                    CapturedTestOutput {
+                        stdout: "worker 0 stdout\n",
+                        stderr: "",
+                    },
+                ),
+            },
+            TestCaseResult {
+                module_name: "mod",
+                name: "test_b",
+                full_name: "mod::test_b",
+                outcome: Passed,
+                duration: 0ns,
+                retry: None,
+                captured_output: Some(
+                    CapturedTestOutput {
+                        stdout: "",
+                        stderr: "worker 1 stderr\n",
+                    },
+                ),
             },
         ]
         "#);
@@ -864,6 +875,7 @@ mod tests {
                 },
                 duration: 42ms,
                 retry: None,
+                captured_output: None,
             },
             TestCaseResult {
                 module_name: "mod",
@@ -879,6 +891,7 @@ mod tests {
                 },
                 duration: 24ms,
                 retry: None,
+                captured_output: None,
             },
         ]
         "#);

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -6,8 +6,8 @@ use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use fs_err as fs;
 use karva_diagnostic::{
-    CapturedTestOutput, FlakyTest, TestCaseOutcome, TestCaseResult, TestResultKind,
-    TestResultStats, TestRunResult,
+    CapturedTestOutput, FlakyTest, RenderedDiagnostic, TestCaseOutcome, TestCaseResult,
+    TestResultKind, TestResultStats, TestRunResult,
 };
 use ruff_db::diagnostic::DisplayDiagnosticConfig;
 use serde::{Deserialize, Serialize};
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use crate::artifact::{
     CacheFile, read_json, read_text, write_json, write_json_if_nonempty, write_text,
 };
-use crate::diagnostics::write_diagnostics;
+use crate::diagnostics::render_diagnostic;
 use crate::{RUN_PREFIX, RunHash, WORKER_PREFIX, worker_folder};
 
 /// Snapshot of the test a worker is currently executing.
@@ -35,7 +35,7 @@ pub struct CurrentTest {
 #[derive(Default)]
 pub struct AggregatedResults {
     pub stats: TestResultStats,
-    pub diagnostics: String,
+    pub diagnostics: Vec<RenderedDiagnostic>,
     pub failed_tests: Vec<String>,
     pub flaky_tests: Vec<FlakyTest>,
     pub test_cases: Vec<TestCaseResult>,
@@ -50,7 +50,9 @@ impl AggregatedResults {
         self.failed_tests.push(function_name.clone());
         self.test_cases.push(TestCaseResult::from_display_name(
             name,
-            TestCaseOutcome::Failed,
+            TestCaseOutcome::Failed {
+                diagnostic: RenderedDiagnostic::interrupted(name),
+            },
             duration,
         ));
         self.durations.insert(function_name, duration);
@@ -166,7 +168,12 @@ impl RunCache {
         let worker_dir = self.worker_dir(worker_id);
         fs::create_dir_all(&worker_dir)?;
 
-        write_diagnostics(&worker_dir, result, cwd, config)?;
+        let run_diagnostics = result
+            .run_diagnostics()
+            .iter()
+            .map(|diagnostic| render_diagnostic(diagnostic, cwd, config))
+            .collect::<Result<Vec<_>>>()?;
+        write_json_if_nonempty(&worker_dir, CacheFile::Diagnostics, &run_diagnostics)?;
         write_json(&worker_dir, CacheFile::Stats, result.stats())?;
         write_json(&worker_dir, CacheFile::Durations, result.durations())?;
 
@@ -177,7 +184,14 @@ impl RunCache {
             .collect();
         write_json_if_nonempty(&worker_dir, CacheFile::FailedTests, &failed_names)?;
         write_json_if_nonempty(&worker_dir, CacheFile::FlakyTests, result.flaky_tests())?;
-        write_json_if_nonempty(&worker_dir, CacheFile::TestCases, result.test_cases())?;
+        let test_cases = result
+            .test_cases()
+            .iter()
+            .map(|case| {
+                case.try_map_diagnostic(|diagnostic| render_diagnostic(diagnostic, cwd, config))
+            })
+            .collect::<Result<Vec<TestCaseResult>>>()?;
+        write_json_if_nonempty(&worker_dir, CacheFile::TestCases, &test_cases)?;
         write_json_if_nonempty(
             &worker_dir,
             CacheFile::CapturedOutput,
@@ -194,8 +208,10 @@ fn read_worker_results(worker_dir: &Utf8Path, results: &mut AggregatedResults) -
         results.stats.merge(&stats);
     }
 
-    if let Some(content) = read_text(worker_dir, CacheFile::Diagnostics)? {
-        results.diagnostics.push_str(&content);
+    if let Some(diagnostics) =
+        read_json::<Vec<RenderedDiagnostic>>(worker_dir, CacheFile::Diagnostics)?
+    {
+        results.diagnostics.extend(diagnostics);
     }
 
     if let Some(failed) = read_json::<Vec<String>>(worker_dir, CacheFile::FailedTests)? {
@@ -838,7 +854,14 @@ mod tests {
                 module_name: "mod",
                 name: "test_slow(value=1)",
                 full_name: "mod::test_slow(value=1)",
-                outcome: Failed,
+                outcome: Failed {
+                    diagnostic: RenderedDiagnostic {
+                        code: "interrupted",
+                        severity: Error,
+                        message: "Test `mod::test_slow(value=1)` was interrupted",
+                        rendered: "error[interrupted]: Test `mod::test_slow(value=1)` was interrupted\n",
+                    },
+                },
                 duration: 42ms,
                 retry: None,
             },
@@ -846,7 +869,14 @@ mod tests {
                 module_name: "mod",
                 name: "test_legacy[value]",
                 full_name: "mod::test_legacy[value]",
-                outcome: Failed,
+                outcome: Failed {
+                    diagnostic: RenderedDiagnostic {
+                        code: "interrupted",
+                        severity: Error,
+                        message: "Test `mod::test_legacy[value]` was interrupted",
+                        rendered: "error[interrupted]: Test `mod::test_legacy[value]` was interrupted\n",
+                    },
+                },
                 duration: 24ms,
                 retry: None,
             },

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -208,33 +208,32 @@ impl RunCache {
     pub fn write_result(
         &self,
         worker_id: usize,
-        result: &TestRunResult,
+        result: TestRunResult,
         cwd: &Utf8Path,
         config: &DisplayDiagnosticConfig,
     ) -> Result<()> {
         let worker_dir = self.worker_dir(worker_id);
         fs::create_dir_all(&worker_dir)?;
 
-        let run_diagnostics = result
-            .run_diagnostics()
+        let (run_diagnostics, stats, durations, test_cases) = result.into_parts();
+        let run_diagnostics = run_diagnostics
             .iter()
             .map(|diagnostic| render_diagnostic(diagnostic, cwd, config))
             .collect::<Result<Vec<_>>>()?;
-        let test_cases = result
-            .test_cases()
-            .iter()
+        let test_cases = test_cases
+            .into_iter()
             .map(|case| {
                 case.try_map_diagnostic(|diagnostic| render_diagnostic(diagnostic, cwd, config))
             })
             .collect::<Result<Vec<TestCaseResult>>>()?;
 
         let worker_results = WorkerResults {
-            slow: result.stats().slow(),
+            slow: stats.slow(),
             run_diagnostics,
             test_cases,
         };
 
-        write_json(&worker_dir, CacheFile::Durations, result.durations())?;
+        write_json(&worker_dir, CacheFile::Durations, &durations)?;
         write_json(&worker_dir, CacheFile::Results, &worker_results)?;
         Ok(())
     }
@@ -418,7 +417,8 @@ mod tests {
     ) {
         let worker_dir = dir.join(run_name).join(format!("worker-{worker_id}"));
         fs::create_dir_all(&worker_dir).unwrap();
-        let stats: TestResultStats = serde_json::from_str(stats_json).unwrap();
+        let stats: TestResultStats =
+            serde_json::from_str(stats_json).expect("deserialize test stats");
         let mut test_cases = Vec::new();
         for index in 0..stats.passed() {
             test_cases.push(TestCaseResult::from_display_name(
@@ -466,9 +466,9 @@ mod tests {
     fn write_worker_results(worker_dir: &std::path::Path, results: &WorkerResults) {
         fs::write(
             worker_dir.join(CacheFile::Results.filename()),
-            serde_json::to_string(results).unwrap(),
+            serde_json::to_string(results).expect("serialize worker results"),
         )
-        .unwrap();
+        .expect("write worker results");
     }
 
     #[test]
@@ -535,11 +535,12 @@ mod tests {
 
     #[test]
     fn aggregate_results_ignores_incomplete_worker() {
-        let tmp = tempfile::tempdir().unwrap();
-        let cache_dir = Utf8PathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        let tmp = tempfile::tempdir().expect("create temporary directory");
+        let cache_dir =
+            Utf8PathBuf::try_from(tmp.path().to_path_buf()).expect("temporary path is UTF-8");
         let run_hash = RunHash::from_existing("run-610");
         let worker_dir = tmp.path().join(run_hash.dir_name()).join("worker-0");
-        fs::create_dir_all(&worker_dir).unwrap();
+        fs::create_dir_all(&worker_dir).expect("create worker directory");
 
         let durations = HashMap::from([(
             "mod::test_uncommitted".to_string(),
@@ -547,13 +548,13 @@ mod tests {
         )]);
         fs::write(
             worker_dir.join(CacheFile::Durations.filename()),
-            serde_json::to_string(&durations).unwrap(),
+            serde_json::to_string(&durations).expect("serialize durations"),
         )
-        .unwrap();
+        .expect("write durations");
 
         let results = RunCache::new(&cache_dir, &run_hash)
             .aggregate_results()
-            .unwrap();
+            .expect("aggregate results");
 
         assert!(results.durations.is_empty());
     }
@@ -892,7 +893,10 @@ mod tests {
         );
 
         let cache = RunCache::new(&cache_dir, &run_hash);
-        let mut cases = cache.aggregate_results().unwrap().test_cases;
+        let mut cases = cache
+            .aggregate_results()
+            .expect("aggregate results")
+            .test_cases;
         cases.sort_by(|a, b| a.full_name().cmp(b.full_name()));
 
         assert_debug_snapshot!(cases, @r#"

--- a/crates/karva_cache/src/diagnostics.rs
+++ b/crates/karva_cache/src/diagnostics.rs
@@ -120,7 +120,7 @@ mod tests {
         ));
 
         let config = DisplayDiagnosticConfig::new("karva").context(0);
-        let rendered = render_diagnostic(&diagnostic, &cwd, &config).unwrap();
+        let rendered = render_diagnostic(&diagnostic, &cwd, &config).expect("render diagnostic");
 
         assert_eq!(rendered.code(), "test-failure");
         assert_eq!(rendered.message(), "Test `test_example` failed");
@@ -131,8 +131,9 @@ mod tests {
 
     #[test]
     fn keeps_machine_rendering_plain_when_terminal_uses_color() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let cwd = Utf8PathBuf::try_from(temp_dir.path().to_path_buf()).unwrap();
+        let temp_dir = tempfile::tempdir().expect("create temporary directory");
+        let cwd =
+            Utf8PathBuf::try_from(temp_dir.path().to_path_buf()).expect("temporary path is UTF-8");
         let diagnostic = Diagnostic::new(
             DiagnosticId::Lint(LintName::of("test-failure")),
             Severity::Error,
@@ -144,7 +145,7 @@ mod tests {
             &cwd,
             &DisplayDiagnosticConfig::new("karva").color(true),
         )
-        .unwrap();
+        .expect("render diagnostic");
 
         assert!(!rendered.rendered().contains('\u{1b}'));
         assert!(rendered.rendered_for_terminal().contains('\u{1b}'));

--- a/crates/karva_cache/src/diagnostics.rs
+++ b/crates/karva_cache/src/diagnostics.rs
@@ -2,53 +2,45 @@ use std::path::Path;
 
 use anyhow::{Result, bail};
 use camino::Utf8Path;
-use karva_diagnostic::TestRunResult;
+use karva_diagnostic::RenderedDiagnostic;
 use ruff_db::diagnostic::{
-    DisplayDiagnosticConfig, DisplayDiagnostics, DummyFileResolver, FileResolver, Input,
-    UnifiedFile,
+    Diagnostic, DisplayDiagnosticConfig, DummyFileResolver, FileResolver, Input, UnifiedFile,
 };
 use ruff_db::files::File;
 use ruff_notebook::NotebookIndex;
 
-use crate::artifact::{CacheFile, write_text};
-
-/// Renders diagnostics into the worker directory.
-///
 /// Karva creates diagnostics from `ruff_source_file::SourceFile` values, not
 /// from Ruff's ty/Salsa database. Validate that contract before entering
 /// Ruff's renderer so an unsupported span is reported as a cache write error
 /// instead of becoming a renderer panic.
-pub fn write_diagnostics(
-    worker_dir: &Utf8Path,
-    result: &TestRunResult,
+pub fn render_diagnostic(
+    diagnostic: &Diagnostic,
     cwd: &Utf8Path,
     config: &DisplayDiagnosticConfig,
-) -> Result<()> {
-    if result.diagnostics().is_empty() {
-        return Ok(());
-    }
-
-    ensure_source_file_spans(result)?;
+) -> Result<RenderedDiagnostic> {
+    ensure_source_file_spans(diagnostic)?;
 
     let resolver = DiagnosticFileResolver::new(cwd);
-    let output = DisplayDiagnostics::new(&resolver, config, result.diagnostics());
-    write_text(worker_dir, CacheFile::Diagnostics, output.to_string())
+    Ok(RenderedDiagnostic::new(
+        diagnostic.id().as_str(),
+        diagnostic.severity().into(),
+        diagnostic.primary_message(),
+        diagnostic.display(&resolver, config).to_string(),
+    ))
 }
 
-fn ensure_source_file_spans(result: &TestRunResult) -> Result<()> {
-    for diagnostic in result.diagnostics() {
-        for annotation in diagnostic
-            .primary_annotation()
-            .into_iter()
-            .chain(diagnostic.secondary_annotations())
-        {
-            ensure_source_file_span(annotation.get_span().file())?;
-        }
+fn ensure_source_file_spans(diagnostic: &Diagnostic) -> Result<()> {
+    for annotation in diagnostic
+        .primary_annotation()
+        .into_iter()
+        .chain(diagnostic.secondary_annotations())
+    {
+        ensure_source_file_span(annotation.get_span().file())?;
+    }
 
-        for sub_diagnostic in diagnostic.sub_diagnostics() {
-            for annotation in sub_diagnostic.annotations() {
-                ensure_source_file_span(annotation.get_span().file())?;
-            }
+    for sub_diagnostic in diagnostic.sub_diagnostics() {
+        for annotation in sub_diagnostic.annotations() {
+            ensure_source_file_span(annotation.get_span().file())?;
         }
     }
 
@@ -97,7 +89,6 @@ impl FileResolver for DiagnosticFileResolver<'_> {
 #[cfg(test)]
 mod tests {
     use camino::Utf8PathBuf;
-    use karva_diagnostic::TestRunResult;
     use ruff_db::diagnostic::{
         Annotation, Diagnostic, DiagnosticId, DisplayDiagnosticConfig, LintName, Severity, Span,
     };
@@ -107,11 +98,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn writes_source_file_diagnostics() {
+    fn renders_source_file_diagnostics() {
         let temp_dir = tempfile::tempdir().unwrap();
         let cwd = Utf8PathBuf::try_from(temp_dir.path().to_path_buf()).unwrap();
-        let worker_dir = cwd.join("worker-0");
-        std::fs::create_dir_all(&worker_dir).unwrap();
 
         let source = "def test_example():\n    assert False\n";
         let source_file =
@@ -125,16 +114,13 @@ mod tests {
             Span::from(source_file).with_range(TextRange::new(TextSize::new(4), TextSize::new(16))),
         ));
 
-        let mut result = TestRunResult::default();
-        result.add_diagnostic(diagnostic);
-
         let config = DisplayDiagnosticConfig::new("karva").context(0);
-        write_diagnostics(&worker_dir, &result, &cwd, &config).unwrap();
+        let rendered = render_diagnostic(&diagnostic, &cwd, &config).unwrap();
 
-        let rendered =
-            std::fs::read_to_string(CacheFile::Diagnostics.path_in(&worker_dir)).unwrap();
-        assert!(rendered.contains("test_sample.py"));
-        assert!(rendered.contains("Test `test_example` failed"));
-        assert!(rendered.contains("def test_example():"));
+        assert_eq!(rendered.code(), "test-failure");
+        assert_eq!(rendered.message(), "Test `test_example` failed");
+        assert!(rendered.rendered().contains("test_sample.py"));
+        assert!(rendered.rendered().contains("Test `test_example` failed"));
+        assert!(rendered.rendered().contains("def test_example():"));
     }
 }

--- a/crates/karva_cache/src/diagnostics.rs
+++ b/crates/karva_cache/src/diagnostics.rs
@@ -23,7 +23,7 @@ pub fn render_diagnostic(
     let resolver = DiagnosticFileResolver::new(cwd);
     Ok(RenderedDiagnostic::new(
         diagnostic.id().as_str(),
-        diagnostic.severity().into(),
+        diagnostic.severity(),
         diagnostic.primary_message(),
         diagnostic.display(&resolver, config).to_string(),
     ))

--- a/crates/karva_cache/src/diagnostics.rs
+++ b/crates/karva_cache/src/diagnostics.rs
@@ -21,12 +21,17 @@ pub fn render_diagnostic(
     ensure_source_file_spans(diagnostic)?;
 
     let resolver = DiagnosticFileResolver::new(cwd);
+    let rendered = diagnostic
+        .display(&resolver, &config.clone().color(false))
+        .to_string();
+    let colored_rendered = diagnostic.display(&resolver, config).to_string();
     Ok(RenderedDiagnostic::new(
         diagnostic.id().as_str(),
         diagnostic.severity(),
         diagnostic.primary_message(),
-        diagnostic.display(&resolver, config).to_string(),
-    ))
+        rendered,
+    )
+    .with_colored_rendered(colored_rendered))
 }
 
 fn ensure_source_file_spans(diagnostic: &Diagnostic) -> Result<()> {
@@ -122,5 +127,26 @@ mod tests {
         assert!(rendered.rendered().contains("test_sample.py"));
         assert!(rendered.rendered().contains("Test `test_example` failed"));
         assert!(rendered.rendered().contains("def test_example():"));
+    }
+
+    #[test]
+    fn keeps_machine_rendering_plain_when_terminal_uses_color() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let cwd = Utf8PathBuf::try_from(temp_dir.path().to_path_buf()).unwrap();
+        let diagnostic = Diagnostic::new(
+            DiagnosticId::Lint(LintName::of("test-failure")),
+            Severity::Error,
+            "failed",
+        );
+
+        let rendered = render_diagnostic(
+            &diagnostic,
+            &cwd,
+            &DisplayDiagnosticConfig::new("karva").color(true),
+        )
+        .unwrap();
+
+        assert!(!rendered.rendered().contains('\u{1b}'));
+        assert!(rendered.rendered_for_terminal().contains('\u{1b}'));
     }
 }

--- a/crates/karva_cli/src/enums.rs
+++ b/crates/karva_cli/src/enums.rs
@@ -80,7 +80,7 @@ pub enum ResultFormat {
     #[value(name = "json")]
     Json,
 
-    /// Write newline-delimited JSON events.
+    /// Write newline-delimited JSON records.
     #[value(name = "jsonl")]
     Jsonl,
 }

--- a/crates/karva_diagnostic/src/lib.rs
+++ b/crates/karva_diagnostic/src/lib.rs
@@ -5,8 +5,9 @@ mod traceback;
 
 pub use reporter::{DummyReporter, Reporter, TestCaseReporter};
 pub use result::{
-    CapturedTestOutcome, CapturedTestOutput, DisplayFlakyTest, DisplayFlakyTests, FlakyTest,
-    IndividualTestResultKind, TestCaseOutcome, TestCaseResult, TestCaseRetry, TestResultKind,
+    CapturedTestOutcome, CapturedTestOutput, DiagnosticSeverity, DisplayFlakyTest,
+    DisplayFlakyTests, FlakyTest, IndividualTestResultKind, RenderedDiagnostic, TestCaseOutcome,
+    TestCaseResult, TestCaseRetry, TestExecutionOutcome, TestExecutionResult, TestResultKind,
     TestResultStats, TestRunResult,
 };
 

--- a/crates/karva_diagnostic/src/lib.rs
+++ b/crates/karva_diagnostic/src/lib.rs
@@ -5,10 +5,9 @@ mod traceback;
 
 pub use reporter::{DummyReporter, Reporter, TestCaseReporter};
 pub use result::{
-    CapturedTestOutcome, CapturedTestOutput, DiagnosticSeverity, DisplayFlakyTest,
-    DisplayFlakyTests, FlakyTest, IndividualTestResultKind, RenderedDiagnostic, TestCaseOutcome,
-    TestCaseResult, TestCaseRetry, TestExecutionOutcome, TestExecutionResult, TestResultKind,
-    TestResultStats, TestRunResult,
+    CapturedTestOutput, DisplayFlakyTest, DisplayFlakyTests, FlakyTest, IndividualTestResultKind,
+    RenderedDiagnostic, TestCaseOutcome, TestCaseResult, TestCaseRetry, TestExecutionOutcome,
+    TestExecutionResult, TestResultKind, TestResultStats, TestRunResult,
 };
 
 #[cfg(feature = "traceback")]

--- a/crates/karva_diagnostic/src/lib.rs
+++ b/crates/karva_diagnostic/src/lib.rs
@@ -6,8 +6,9 @@ mod traceback;
 pub use reporter::{DummyReporter, Reporter, TestCaseReporter};
 pub use result::{
     CapturedTestOutput, DisplayFlakyTest, DisplayFlakyTests, FlakyTest, IndividualTestResultKind,
-    RenderedDiagnostic, TestCaseOutcome, TestCaseResult, TestCaseRetry, TestExecutionOutcome,
-    TestExecutionResult, TestResultKind, TestResultStats, TestRunResult,
+    RenderedDiagnostic, TestCaseAttempt, TestCaseOutcome, TestCaseResult, TestCaseRetry,
+    TestExecutionAttempt, TestExecutionOutcome, TestExecutionResult, TestResultKind,
+    TestResultStats, TestRunResult,
 };
 
 #[cfg(feature = "traceback")]

--- a/crates/karva_diagnostic/src/reporter.rs
+++ b/crates/karva_diagnostic/src/reporter.rs
@@ -71,11 +71,16 @@ fn show_for_status_level(level: StatusLevel, kind: &IndividualTestResultKind) ->
     match level {
         StatusLevel::None => false,
         StatusLevel::Fail | StatusLevel::Retry | StatusLevel::Slow => {
-            matches!(kind, IndividualTestResultKind::Failed)
+            matches!(
+                kind,
+                IndividualTestResultKind::Failed | IndividualTestResultKind::Error
+            )
         }
         StatusLevel::Pass => matches!(
             kind,
-            IndividualTestResultKind::Failed | IndividualTestResultKind::Passed
+            IndividualTestResultKind::Failed
+                | IndividualTestResultKind::Error
+                | IndividualTestResultKind::Passed
         ),
         StatusLevel::Skip | StatusLevel::All => true,
     }
@@ -389,6 +394,7 @@ fn count_digits(n: u32) -> usize {
 enum ResultLabel {
     Pass,
     Fail,
+    Error,
     Skip,
     Slow,
 }
@@ -398,6 +404,7 @@ impl ResultLabel {
         match self {
             Self::Pass => "PASS",
             Self::Fail => "FAIL",
+            Self::Error => "ERROR",
             Self::Skip => "SKIP",
             Self::Slow => "SLOW",
         }
@@ -407,7 +414,7 @@ impl ResultLabel {
         let text = self.text();
         match self {
             Self::Pass => text.green().bold().to_string(),
-            Self::Fail => text.red().bold().to_string(),
+            Self::Fail | Self::Error => text.red().bold().to_string(),
             Self::Skip | Self::Slow => text.yellow().bold().to_string(),
         }
     }
@@ -418,6 +425,7 @@ impl From<&IndividualTestResultKind> for ResultLabel {
         match kind {
             IndividualTestResultKind::Passed => Self::Pass,
             IndividualTestResultKind::Failed => Self::Fail,
+            IndividualTestResultKind::Error => Self::Error,
             IndividualTestResultKind::Skipped { .. } => Self::Skip,
         }
     }

--- a/crates/karva_diagnostic/src/result/case.rs
+++ b/crates/karva_diagnostic/src/result/case.rs
@@ -122,20 +122,20 @@ impl<D> TestCaseResult<D> {
     }
 
     pub fn try_map_diagnostic<T, E>(
-        &self,
+        self,
         mut map: impl FnMut(&D) -> Result<T, E>,
     ) -> Result<TestCaseResult<T>, E> {
         Ok(TestCaseResult {
-            module_name: self.module_name.clone(),
-            name: self.name.clone(),
-            full_name: self.full_name.clone(),
+            module_name: self.module_name,
+            name: self.name,
+            full_name: self.full_name,
             outcome: self.outcome.try_map_diagnostic(&mut map)?,
             duration: self.duration,
-            retry: self.retry.clone(),
-            captured_output: self.captured_output.clone(),
+            retry: self.retry,
+            captured_output: self.captured_output,
             attempts: self
                 .attempts
-                .iter()
+                .into_iter()
                 .map(|attempt| attempt.try_map_diagnostic(&mut map))
                 .collect::<Result<Vec<_>, _>>()?,
         })
@@ -171,7 +171,7 @@ impl<D> TestCaseAttempt<D> {
     }
 
     fn try_map_diagnostic<T, E>(
-        &self,
+        self,
         mut map: impl FnMut(&D) -> Result<T, E>,
     ) -> Result<TestCaseAttempt<T>, E> {
         Ok(TestCaseAttempt {
@@ -233,24 +233,14 @@ impl<D> TestCaseOutcome<D> {
     }
 
     pub fn error(diagnostic: D) -> Self {
-        Self::Error {
-            diagnostic,
-            related: Vec::new(),
-        }
+        Self::error_with_related(diagnostic, Vec::new())
     }
 
-    #[must_use]
-    pub fn with_related(mut self, related: Vec<D>) -> Self {
-        match &mut self {
-            Self::Failed {
-                related: existing, ..
-            }
-            | Self::Error {
-                related: existing, ..
-            } => *existing = related,
-            Self::Passed | Self::Skipped { .. } => {}
+    pub fn error_with_related(diagnostic: D, related: Vec<D>) -> Self {
+        Self::Error {
+            diagnostic,
+            related,
         }
-        self
     }
 
     pub fn is_failed(&self) -> bool {
@@ -295,7 +285,7 @@ impl<D> TestCaseOutcome<D> {
     }
 
     fn try_map_diagnostic<T, E>(
-        &self,
+        self,
         mut map: impl FnMut(&D) -> Result<T, E>,
     ) -> Result<TestCaseOutcome<T>, E> {
         Ok(match self {
@@ -304,19 +294,23 @@ impl<D> TestCaseOutcome<D> {
                 diagnostic,
                 related,
             } => TestCaseOutcome::Failed {
-                diagnostic: map(diagnostic)?,
-                related: related.iter().map(map).collect::<Result<Vec<_>, _>>()?,
+                diagnostic: map(&diagnostic)?,
+                related: related
+                    .into_iter()
+                    .map(|diagnostic| map(&diagnostic))
+                    .collect::<Result<Vec<_>, _>>()?,
             },
             Self::Error {
                 diagnostic,
                 related,
             } => TestCaseOutcome::Error {
-                diagnostic: map(diagnostic)?,
-                related: related.iter().map(map).collect::<Result<Vec<_>, _>>()?,
+                diagnostic: map(&diagnostic)?,
+                related: related
+                    .into_iter()
+                    .map(|diagnostic| map(&diagnostic))
+                    .collect::<Result<Vec<_>, _>>()?,
             },
-            Self::Skipped { reason } => TestCaseOutcome::Skipped {
-                reason: reason.clone(),
-            },
+            Self::Skipped { reason } => TestCaseOutcome::Skipped { reason },
         })
     }
 }

--- a/crates/karva_diagnostic/src/result/case.rs
+++ b/crates/karva_diagnostic/src/result/case.rs
@@ -1,10 +1,12 @@
 use std::time::Duration;
 
 use karva_python_semantic::QualifiedTestName;
-use ruff_db::diagnostic::{Diagnostic, Severity};
+use ruff_db::diagnostic::Diagnostic;
 use serde::{Deserialize, Serialize};
 
+use super::diagnostic::RenderedDiagnostic;
 use super::kind::IndividualTestResultKind;
+use super::output::CapturedTestOutput;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TestCaseResult<D = RenderedDiagnostic> {
@@ -15,6 +17,8 @@ pub struct TestCaseResult<D = RenderedDiagnostic> {
     duration: Duration,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     retry: Option<TestCaseRetry>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    captured_output: Option<CapturedTestOutput>,
 }
 
 impl<D> TestCaseResult<D> {
@@ -22,6 +26,7 @@ impl<D> TestCaseResult<D> {
         test_case_name: &QualifiedTestName,
         outcome: TestCaseOutcome<D>,
         duration: Duration,
+        captured_output: Option<CapturedTestOutput>,
     ) -> Self {
         let function_name = test_case_name.function_name();
         let module_name = function_name.module_path().module_name().to_string();
@@ -39,6 +44,7 @@ impl<D> TestCaseResult<D> {
             outcome,
             duration,
             retry: None,
+            captured_output,
         }
     }
 
@@ -47,8 +53,9 @@ impl<D> TestCaseResult<D> {
         outcome: TestCaseOutcome<D>,
         duration: Duration,
         retry: TestCaseRetry,
+        captured_output: Option<CapturedTestOutput>,
     ) -> Self {
-        let mut result = Self::new(test_case_name, outcome, duration);
+        let mut result = Self::new(test_case_name, outcome, duration, captured_output);
         result.retry = Some(retry);
         result
     }
@@ -57,6 +64,7 @@ impl<D> TestCaseResult<D> {
         full_name: &str,
         outcome: TestCaseOutcome<D>,
         duration: Duration,
+        captured_output: Option<CapturedTestOutput>,
     ) -> Self {
         let (module_name, name) = full_name
             .split_once("::")
@@ -71,6 +79,7 @@ impl<D> TestCaseResult<D> {
             outcome,
             duration,
             retry: None,
+            captured_output,
         }
     }
 
@@ -98,6 +107,10 @@ impl<D> TestCaseResult<D> {
         self.retry.as_ref()
     }
 
+    pub fn captured_output(&self) -> Option<&CapturedTestOutput> {
+        self.captured_output.as_ref()
+    }
+
     pub fn try_map_diagnostic<T, E>(
         &self,
         map: impl FnOnce(&D) -> Result<T, E>,
@@ -109,6 +122,7 @@ impl<D> TestCaseResult<D> {
             outcome: self.outcome.try_map_diagnostic(map)?,
             duration: self.duration,
             retry: self.retry.clone(),
+            captured_output: self.captured_output.clone(),
         })
     }
 }
@@ -188,73 +202,3 @@ impl<D> TestCaseOutcome<D> {
 
 pub type TestExecutionResult = TestCaseResult<Diagnostic>;
 pub type TestExecutionOutcome = TestCaseOutcome<Diagnostic>;
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct RenderedDiagnostic {
-    code: String,
-    severity: DiagnosticSeverity,
-    message: String,
-    rendered: String,
-}
-
-impl RenderedDiagnostic {
-    pub fn new(
-        code: impl Into<String>,
-        severity: DiagnosticSeverity,
-        message: impl Into<String>,
-        rendered: impl Into<String>,
-    ) -> Self {
-        Self {
-            code: code.into(),
-            severity,
-            message: message.into(),
-            rendered: rendered.into(),
-        }
-    }
-
-    pub fn interrupted(test_name: &str) -> Self {
-        let message = format!("Test `{test_name}` was interrupted");
-        Self::new(
-            "interrupted",
-            DiagnosticSeverity::Error,
-            &message,
-            format!("error[interrupted]: {message}\n"),
-        )
-    }
-
-    pub fn code(&self) -> &str {
-        &self.code
-    }
-
-    pub fn severity(&self) -> DiagnosticSeverity {
-        self.severity
-    }
-
-    pub fn message(&self) -> &str {
-        &self.message
-    }
-
-    pub fn rendered(&self) -> &str {
-        &self.rendered
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum DiagnosticSeverity {
-    Info,
-    Warning,
-    Error,
-    Fatal,
-}
-
-impl From<Severity> for DiagnosticSeverity {
-    fn from(value: Severity) -> Self {
-        match value {
-            Severity::Info => Self::Info,
-            Severity::Warning => Self::Warning,
-            Severity::Error => Self::Error,
-            Severity::Fatal => Self::Fatal,
-        }
-    }
-}

--- a/crates/karva_diagnostic/src/result/case.rs
+++ b/crates/karva_diagnostic/src/result/case.rs
@@ -1,25 +1,26 @@
 use std::time::Duration;
 
 use karva_python_semantic::QualifiedTestName;
+use ruff_db::diagnostic::{Diagnostic, Severity};
 use serde::{Deserialize, Serialize};
 
 use super::kind::IndividualTestResultKind;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct TestCaseResult {
+pub struct TestCaseResult<D = RenderedDiagnostic> {
     module_name: String,
     name: String,
     full_name: String,
-    outcome: TestCaseOutcome,
+    outcome: TestCaseOutcome<D>,
     duration: Duration,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     retry: Option<TestCaseRetry>,
 }
 
-impl TestCaseResult {
+impl<D> TestCaseResult<D> {
     pub fn new(
         test_case_name: &QualifiedTestName,
-        outcome: TestCaseOutcome,
+        outcome: TestCaseOutcome<D>,
         duration: Duration,
     ) -> Self {
         let function_name = test_case_name.function_name();
@@ -43,7 +44,7 @@ impl TestCaseResult {
 
     pub fn retried(
         test_case_name: &QualifiedTestName,
-        outcome: TestCaseOutcome,
+        outcome: TestCaseOutcome<D>,
         duration: Duration,
         retry: TestCaseRetry,
     ) -> Self {
@@ -54,7 +55,7 @@ impl TestCaseResult {
 
     pub fn from_display_name(
         full_name: &str,
-        outcome: TestCaseOutcome,
+        outcome: TestCaseOutcome<D>,
         duration: Duration,
     ) -> Self {
         let (module_name, name) = full_name
@@ -85,7 +86,7 @@ impl TestCaseResult {
         &self.full_name
     }
 
-    pub fn outcome(&self) -> &TestCaseOutcome {
+    pub fn outcome(&self) -> &TestCaseOutcome<D> {
         &self.outcome
     }
 
@@ -95,6 +96,20 @@ impl TestCaseResult {
 
     pub fn retry(&self) -> Option<&TestCaseRetry> {
         self.retry.as_ref()
+    }
+
+    pub fn try_map_diagnostic<T, E>(
+        &self,
+        map: impl FnOnce(&D) -> Result<T, E>,
+    ) -> Result<TestCaseResult<T>, E> {
+        Ok(TestCaseResult {
+            module_name: self.module_name.clone(),
+            name: self.name.clone(),
+            full_name: self.full_name.clone(),
+            outcome: self.outcome.try_map_diagnostic(map)?,
+            duration: self.duration,
+            retry: self.retry.clone(),
+        })
     }
 }
 
@@ -123,30 +138,123 @@ impl TestCaseRetry {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum TestCaseOutcome {
+pub enum TestCaseOutcome<D = RenderedDiagnostic> {
     Passed,
-    Failed,
+    Failed { diagnostic: D },
     Skipped { reason: Option<String> },
 }
 
-impl TestCaseOutcome {
+impl<D> TestCaseOutcome<D> {
     pub fn is_failed(&self) -> bool {
-        matches!(self, Self::Failed)
+        matches!(self, Self::Failed { .. })
     }
 
     pub fn is_skipped(&self) -> bool {
         matches!(self, Self::Skipped { .. })
     }
-}
 
-impl From<&IndividualTestResultKind> for TestCaseOutcome {
-    fn from(value: &IndividualTestResultKind) -> Self {
-        match value {
-            IndividualTestResultKind::Passed => Self::Passed,
-            IndividualTestResultKind::Failed => Self::Failed,
-            IndividualTestResultKind::Skipped { reason } => Self::Skipped {
+    pub fn diagnostic(&self) -> Option<&D> {
+        match self {
+            Self::Failed { diagnostic } => Some(diagnostic),
+            Self::Passed | Self::Skipped { .. } => None,
+        }
+    }
+
+    pub fn result_kind(&self) -> IndividualTestResultKind {
+        match self {
+            Self::Passed => IndividualTestResultKind::Passed,
+            Self::Failed { .. } => IndividualTestResultKind::Failed,
+            Self::Skipped { reason } => IndividualTestResultKind::Skipped {
                 reason: reason.clone(),
             },
+        }
+    }
+
+    fn try_map_diagnostic<T, E>(
+        &self,
+        map: impl FnOnce(&D) -> Result<T, E>,
+    ) -> Result<TestCaseOutcome<T>, E> {
+        Ok(match self {
+            Self::Passed => TestCaseOutcome::Passed,
+            Self::Failed { diagnostic } => TestCaseOutcome::Failed {
+                diagnostic: map(diagnostic)?,
+            },
+            Self::Skipped { reason } => TestCaseOutcome::Skipped {
+                reason: reason.clone(),
+            },
+        })
+    }
+}
+
+pub type TestExecutionResult = TestCaseResult<Diagnostic>;
+pub type TestExecutionOutcome = TestCaseOutcome<Diagnostic>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RenderedDiagnostic {
+    code: String,
+    severity: DiagnosticSeverity,
+    message: String,
+    rendered: String,
+}
+
+impl RenderedDiagnostic {
+    pub fn new(
+        code: impl Into<String>,
+        severity: DiagnosticSeverity,
+        message: impl Into<String>,
+        rendered: impl Into<String>,
+    ) -> Self {
+        Self {
+            code: code.into(),
+            severity,
+            message: message.into(),
+            rendered: rendered.into(),
+        }
+    }
+
+    pub fn interrupted(test_name: &str) -> Self {
+        let message = format!("Test `{test_name}` was interrupted");
+        Self::new(
+            "interrupted",
+            DiagnosticSeverity::Error,
+            &message,
+            format!("error[interrupted]: {message}\n"),
+        )
+    }
+
+    pub fn code(&self) -> &str {
+        &self.code
+    }
+
+    pub fn severity(&self) -> DiagnosticSeverity {
+        self.severity
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    pub fn rendered(&self) -> &str {
+        &self.rendered
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiagnosticSeverity {
+    Info,
+    Warning,
+    Error,
+    Fatal,
+}
+
+impl From<Severity> for DiagnosticSeverity {
+    fn from(value: Severity) -> Self {
+        match value {
+            Severity::Info => Self::Info,
+            Severity::Warning => Self::Warning,
+            Severity::Error => Self::Error,
+            Severity::Fatal => Self::Fatal,
         }
     }
 }

--- a/crates/karva_diagnostic/src/result/case.rs
+++ b/crates/karva_diagnostic/src/result/case.rs
@@ -19,6 +19,8 @@ pub struct TestCaseResult<D = RenderedDiagnostic> {
     retry: Option<TestCaseRetry>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     captured_output: Option<CapturedTestOutput>,
+    #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
+    attempts: Vec<TestCaseAttempt<D>>,
 }
 
 impl<D> TestCaseResult<D> {
@@ -45,6 +47,7 @@ impl<D> TestCaseResult<D> {
             duration,
             retry: None,
             captured_output,
+            attempts: Vec::new(),
         }
     }
 
@@ -54,9 +57,11 @@ impl<D> TestCaseResult<D> {
         duration: Duration,
         retry: TestCaseRetry,
         captured_output: Option<CapturedTestOutput>,
+        attempts: Vec<TestCaseAttempt<D>>,
     ) -> Self {
         let mut result = Self::new(test_case_name, outcome, duration, captured_output);
         result.retry = Some(retry);
+        result.attempts = attempts;
         result
     }
 
@@ -80,6 +85,7 @@ impl<D> TestCaseResult<D> {
             duration,
             retry: None,
             captured_output,
+            attempts: Vec::new(),
         }
     }
 
@@ -111,18 +117,67 @@ impl<D> TestCaseResult<D> {
         self.captured_output.as_ref()
     }
 
+    pub fn attempts(&self) -> &[TestCaseAttempt<D>] {
+        &self.attempts
+    }
+
     pub fn try_map_diagnostic<T, E>(
         &self,
-        map: impl FnOnce(&D) -> Result<T, E>,
+        mut map: impl FnMut(&D) -> Result<T, E>,
     ) -> Result<TestCaseResult<T>, E> {
         Ok(TestCaseResult {
             module_name: self.module_name.clone(),
             name: self.name.clone(),
             full_name: self.full_name.clone(),
-            outcome: self.outcome.try_map_diagnostic(map)?,
+            outcome: self.outcome.try_map_diagnostic(&mut map)?,
             duration: self.duration,
             retry: self.retry.clone(),
             captured_output: self.captured_output.clone(),
+            attempts: self
+                .attempts
+                .iter()
+                .map(|attempt| attempt.try_map_diagnostic(&mut map))
+                .collect::<Result<Vec<_>, _>>()?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TestCaseAttempt<D = RenderedDiagnostic> {
+    attempt: u32,
+    outcome: TestCaseOutcome<D>,
+    duration: Duration,
+}
+
+impl<D> TestCaseAttempt<D> {
+    pub fn new(attempt: u32, outcome: TestCaseOutcome<D>, duration: Duration) -> Self {
+        Self {
+            attempt,
+            outcome,
+            duration,
+        }
+    }
+
+    pub fn attempt(&self) -> u32 {
+        self.attempt
+    }
+
+    pub fn outcome(&self) -> &TestCaseOutcome<D> {
+        &self.outcome
+    }
+
+    pub fn duration(&self) -> Duration {
+        self.duration
+    }
+
+    fn try_map_diagnostic<T, E>(
+        &self,
+        mut map: impl FnMut(&D) -> Result<T, E>,
+    ) -> Result<TestCaseAttempt<T>, E> {
+        Ok(TestCaseAttempt {
+            attempt: self.attempt,
+            outcome: self.outcome.try_map_diagnostic(&mut map)?,
+            duration: self.duration,
         })
     }
 }
@@ -154,13 +209,60 @@ impl TestCaseRetry {
 #[serde(rename_all = "snake_case")]
 pub enum TestCaseOutcome<D = RenderedDiagnostic> {
     Passed,
-    Failed { diagnostic: D },
-    Skipped { reason: Option<String> },
+    Failed {
+        diagnostic: D,
+        #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
+        related: Vec<D>,
+    },
+    Error {
+        diagnostic: D,
+        #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
+        related: Vec<D>,
+    },
+    Skipped {
+        reason: Option<String>,
+    },
 }
 
 impl<D> TestCaseOutcome<D> {
+    pub fn failed(diagnostic: D) -> Self {
+        Self::Failed {
+            diagnostic,
+            related: Vec::new(),
+        }
+    }
+
+    pub fn error(diagnostic: D) -> Self {
+        Self::Error {
+            diagnostic,
+            related: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_related(mut self, related: Vec<D>) -> Self {
+        match &mut self {
+            Self::Failed {
+                related: existing, ..
+            }
+            | Self::Error {
+                related: existing, ..
+            } => *existing = related,
+            Self::Passed | Self::Skipped { .. } => {}
+        }
+        self
+    }
+
     pub fn is_failed(&self) -> bool {
         matches!(self, Self::Failed { .. })
+    }
+
+    pub fn is_error(&self) -> bool {
+        matches!(self, Self::Error { .. })
+    }
+
+    pub fn is_non_success(&self) -> bool {
+        matches!(self, Self::Failed { .. } | Self::Error { .. })
     }
 
     pub fn is_skipped(&self) -> bool {
@@ -169,8 +271,15 @@ impl<D> TestCaseOutcome<D> {
 
     pub fn diagnostic(&self) -> Option<&D> {
         match self {
-            Self::Failed { diagnostic } => Some(diagnostic),
+            Self::Failed { diagnostic, .. } | Self::Error { diagnostic, .. } => Some(diagnostic),
             Self::Passed | Self::Skipped { .. } => None,
+        }
+    }
+
+    pub fn related_diagnostics(&self) -> &[D] {
+        match self {
+            Self::Failed { related, .. } | Self::Error { related, .. } => related,
+            Self::Passed | Self::Skipped { .. } => &[],
         }
     }
 
@@ -178,6 +287,7 @@ impl<D> TestCaseOutcome<D> {
         match self {
             Self::Passed => IndividualTestResultKind::Passed,
             Self::Failed { .. } => IndividualTestResultKind::Failed,
+            Self::Error { .. } => IndividualTestResultKind::Error,
             Self::Skipped { reason } => IndividualTestResultKind::Skipped {
                 reason: reason.clone(),
             },
@@ -186,12 +296,23 @@ impl<D> TestCaseOutcome<D> {
 
     fn try_map_diagnostic<T, E>(
         &self,
-        map: impl FnOnce(&D) -> Result<T, E>,
+        mut map: impl FnMut(&D) -> Result<T, E>,
     ) -> Result<TestCaseOutcome<T>, E> {
         Ok(match self {
             Self::Passed => TestCaseOutcome::Passed,
-            Self::Failed { diagnostic } => TestCaseOutcome::Failed {
+            Self::Failed {
+                diagnostic,
+                related,
+            } => TestCaseOutcome::Failed {
                 diagnostic: map(diagnostic)?,
+                related: related.iter().map(map).collect::<Result<Vec<_>, _>>()?,
+            },
+            Self::Error {
+                diagnostic,
+                related,
+            } => TestCaseOutcome::Error {
+                diagnostic: map(diagnostic)?,
+                related: related.iter().map(map).collect::<Result<Vec<_>, _>>()?,
             },
             Self::Skipped { reason } => TestCaseOutcome::Skipped {
                 reason: reason.clone(),
@@ -202,3 +323,4 @@ impl<D> TestCaseOutcome<D> {
 
 pub type TestExecutionResult = TestCaseResult<Diagnostic>;
 pub type TestExecutionOutcome = TestCaseOutcome<Diagnostic>;
+pub type TestExecutionAttempt = TestCaseAttempt<Diagnostic>;

--- a/crates/karva_diagnostic/src/result/diagnostic.rs
+++ b/crates/karva_diagnostic/src/result/diagnostic.rs
@@ -8,6 +8,8 @@ pub struct RenderedDiagnostic {
     severity: Severity,
     message: String,
     rendered: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    colored_rendered: Option<String>,
 }
 
 impl RenderedDiagnostic {
@@ -22,7 +24,16 @@ impl RenderedDiagnostic {
             severity,
             message: message.into(),
             rendered: rendered.into(),
+            colored_rendered: None,
         }
+    }
+
+    #[must_use]
+    pub fn with_colored_rendered(mut self, rendered: String) -> Self {
+        if rendered != self.rendered {
+            self.colored_rendered = Some(rendered);
+        }
+        self
     }
 
     pub fn interrupted(test_name: &str) -> Self {
@@ -43,12 +54,29 @@ impl RenderedDiagnostic {
         self.severity
     }
 
+    pub fn severity_name(&self) -> &'static str {
+        match self.severity {
+            Severity::Info => "info",
+            Severity::Warning => "warning",
+            Severity::Error => "error",
+            Severity::Fatal => "fatal",
+        }
+    }
+
+    pub fn is_error(&self) -> bool {
+        matches!(self.severity, Severity::Error | Severity::Fatal)
+    }
+
     pub fn message(&self) -> &str {
         &self.message
     }
 
     pub fn rendered(&self) -> &str {
         &self.rendered
+    }
+
+    pub fn rendered_for_terminal(&self) -> &str {
+        self.colored_rendered.as_deref().unwrap_or(&self.rendered)
     }
 }
 
@@ -67,13 +95,19 @@ mod tests {
 
     #[test]
     fn serializes_ruff_severity() {
-        let diagnostic =
-            RenderedDiagnostic::new("test-failure", Severity::Error, "failed", "rendered");
+        for (severity, name) in [
+            (Severity::Info, "info"),
+            (Severity::Warning, "warning"),
+            (Severity::Error, "error"),
+            (Severity::Fatal, "fatal"),
+        ] {
+            let diagnostic =
+                RenderedDiagnostic::new("test-failure", severity, "failed", "rendered");
+            let json = serde_json::to_string(&diagnostic).unwrap();
+            let roundtrip: RenderedDiagnostic = serde_json::from_str(&json).unwrap();
 
-        let json = serde_json::to_string(&diagnostic).unwrap();
-        let roundtrip: RenderedDiagnostic = serde_json::from_str(&json).unwrap();
-
-        assert_eq!(roundtrip, diagnostic);
-        assert!(json.contains(r#""severity":"error""#));
+            assert_eq!(roundtrip, diagnostic);
+            assert!(json.contains(&format!(r#""severity":"{name}""#)));
+        }
     }
 }

--- a/crates/karva_diagnostic/src/result/diagnostic.rs
+++ b/crates/karva_diagnostic/src/result/diagnostic.rs
@@ -103,8 +103,9 @@ mod tests {
         ] {
             let diagnostic =
                 RenderedDiagnostic::new("test-failure", severity, "failed", "rendered");
-            let json = serde_json::to_string(&diagnostic).unwrap();
-            let roundtrip: RenderedDiagnostic = serde_json::from_str(&json).unwrap();
+            let json = serde_json::to_string(&diagnostic).expect("serialize diagnostic");
+            let roundtrip: RenderedDiagnostic =
+                serde_json::from_str(&json).expect("deserialize diagnostic");
 
             assert_eq!(roundtrip, diagnostic);
             assert!(json.contains(&format!(r#""severity":"{name}""#)));

--- a/crates/karva_diagnostic/src/result/diagnostic.rs
+++ b/crates/karva_diagnostic/src/result/diagnostic.rs
@@ -1,0 +1,79 @@
+use ruff_db::diagnostic::Severity;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RenderedDiagnostic {
+    code: String,
+    #[serde(with = "SerializableSeverity")]
+    severity: Severity,
+    message: String,
+    rendered: String,
+}
+
+impl RenderedDiagnostic {
+    pub fn new(
+        code: impl Into<String>,
+        severity: Severity,
+        message: impl Into<String>,
+        rendered: impl Into<String>,
+    ) -> Self {
+        Self {
+            code: code.into(),
+            severity,
+            message: message.into(),
+            rendered: rendered.into(),
+        }
+    }
+
+    pub fn interrupted(test_name: &str) -> Self {
+        let message = format!("Test `{test_name}` was interrupted");
+        Self::new(
+            "interrupted",
+            Severity::Error,
+            &message,
+            format!("error[interrupted]: {message}\n"),
+        )
+    }
+
+    pub fn code(&self) -> &str {
+        &self.code
+    }
+
+    pub fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    pub fn rendered(&self) -> &str {
+        &self.rendered
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "Severity", rename_all = "lowercase")]
+enum SerializableSeverity {
+    Info,
+    Warning,
+    Error,
+    Fatal,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serializes_ruff_severity() {
+        let diagnostic =
+            RenderedDiagnostic::new("test-failure", Severity::Error, "failed", "rendered");
+
+        let json = serde_json::to_string(&diagnostic).unwrap();
+        let roundtrip: RenderedDiagnostic = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(roundtrip, diagnostic);
+        assert!(json.contains(r#""severity":"error""#));
+    }
+}

--- a/crates/karva_diagnostic/src/result/flaky.rs
+++ b/crates/karva_diagnostic/src/result/flaky.rs
@@ -38,6 +38,27 @@ impl FlakyTest {
         }
     }
 
+    pub fn from_display_name(
+        module_name: &str,
+        name: &str,
+        passed_on: u32,
+        total_attempts: u32,
+        duration: Duration,
+    ) -> Self {
+        let parameter_start = name.find(['(', '[']);
+        let (function_name, params) = parameter_start.map_or((name, None), |index| {
+            (&name[..index], Some(name[index..].to_string()))
+        });
+        Self {
+            module_name: module_name.to_string(),
+            function_name: function_name.to_string(),
+            params,
+            passed_on,
+            total_attempts,
+            duration,
+        }
+    }
+
     pub fn display(&self) -> DisplayFlakyTest<'_> {
         DisplayFlakyTest(self)
     }

--- a/crates/karva_diagnostic/src/result/flaky.rs
+++ b/crates/karva_diagnostic/src/result/flaky.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 
 use colored::Colorize;
 use karva_logging::time::format_duration_bracketed;
-use karva_python_semantic::QualifiedTestName;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -18,26 +17,6 @@ pub struct FlakyTest {
 }
 
 impl FlakyTest {
-    pub fn from_qualified_name(
-        test_name: &QualifiedTestName,
-        passed_on: u32,
-        total_attempts: u32,
-        duration: Duration,
-    ) -> Self {
-        Self {
-            module_name: test_name
-                .function_name()
-                .module_path()
-                .module_name()
-                .to_string(),
-            function_name: test_name.function_name().function_name().to_string(),
-            params: test_name.params().map(str::to_string),
-            passed_on,
-            total_attempts,
-            duration,
-        }
-    }
-
     pub fn from_display_name(
         module_name: &str,
         name: &str,

--- a/crates/karva_diagnostic/src/result/kind.rs
+++ b/crates/karva_diagnostic/src/result/kind.rs
@@ -6,6 +6,7 @@
 pub enum IndividualTestResultKind {
     Passed,
     Failed,
+    Error,
     Skipped { reason: Option<String> },
 }
 
@@ -18,6 +19,7 @@ pub enum IndividualTestResultKind {
 pub enum TestResultKind {
     Passed,
     Failed,
+    Error,
     Skipped,
     /// A test that passed only after at least one retry. Tracked alongside
     /// (not instead of) `Passed` so the summary can show how many of the
@@ -34,6 +36,7 @@ impl TestResultKind {
         match self {
             Self::Passed => "passed",
             Self::Failed => "failed",
+            Self::Error => "error",
             Self::Skipped => "skipped",
             Self::Flaky => "flaky",
             Self::Slow => "slow",
@@ -44,6 +47,7 @@ impl TestResultKind {
         match s {
             "passed" => Ok(Self::Passed),
             "failed" => Ok(Self::Failed),
+            "error" => Ok(Self::Error),
             "skipped" => Ok(Self::Skipped),
             "flaky" => Ok(Self::Flaky),
             "slow" => Ok(Self::Slow),
@@ -57,6 +61,7 @@ impl From<IndividualTestResultKind> for TestResultKind {
         match val {
             IndividualTestResultKind::Passed => Self::Passed,
             IndividualTestResultKind::Failed => Self::Failed,
+            IndividualTestResultKind::Error => Self::Error,
             IndividualTestResultKind::Skipped { .. } => Self::Skipped,
         }
     }

--- a/crates/karva_diagnostic/src/result/mod.rs
+++ b/crates/karva_diagnostic/src/result/mod.rs
@@ -190,4 +190,20 @@ impl TestRunResult {
     pub fn test_cases(&self) -> &[TestExecutionResult] {
         &self.test_cases
     }
+
+    pub fn into_parts(
+        self,
+    ) -> (
+        Vec<Diagnostic>,
+        TestResultStats,
+        HashMap<QualifiedFunctionName, std::time::Duration>,
+        Vec<TestExecutionResult>,
+    ) {
+        (
+            self.run_diagnostics,
+            self.stats,
+            self.durations,
+            self.test_cases,
+        )
+    }
 }

--- a/crates/karva_diagnostic/src/result/mod.rs
+++ b/crates/karva_diagnostic/src/result/mod.rs
@@ -1,4 +1,5 @@
 mod case;
+mod diagnostic;
 mod flaky;
 mod kind;
 mod output;
@@ -12,12 +13,12 @@ use ruff_db::diagnostic::Diagnostic;
 use crate::reporter::Reporter;
 
 pub use case::{
-    DiagnosticSeverity, RenderedDiagnostic, TestCaseOutcome, TestCaseResult, TestCaseRetry,
-    TestExecutionOutcome, TestExecutionResult,
+    TestCaseOutcome, TestCaseResult, TestCaseRetry, TestExecutionOutcome, TestExecutionResult,
 };
+pub use diagnostic::RenderedDiagnostic;
 pub use flaky::{DisplayFlakyTest, DisplayFlakyTests, FlakyTest};
 pub use kind::{IndividualTestResultKind, TestResultKind};
-pub use output::{CapturedTestOutcome, CapturedTestOutput};
+pub use output::CapturedTestOutput;
 pub use stats::TestResultStats;
 
 /// Represents the result of a test run.
@@ -25,8 +26,7 @@ pub use stats::TestResultStats;
 /// This is held in the test context and updated throughout the test run.
 #[derive(Debug, Clone, Default)]
 pub struct TestRunResult {
-    /// Diagnostics generated during test discovery and collection,
-    /// in the order they were emitted.
+    /// Diagnostics that describe the run rather than one test case.
     run_diagnostics: Vec<Diagnostic>,
 
     /// Stats generated during test execution.
@@ -43,9 +43,6 @@ pub struct TestRunResult {
 
     /// Final outcome for each executed test variant.
     test_cases: Vec<TestExecutionResult>,
-
-    /// Captured Python stdout/stderr for individual test variants.
-    captured_outputs: Vec<CapturedTestOutput>,
 }
 
 /// Orders diagnostics for display.
@@ -82,37 +79,24 @@ impl TestRunResult {
         &self.stats
     }
 
-    pub fn register_captured_output(
-        &mut self,
-        test_case_name: &QualifiedTestName,
-        result: &IndividualTestResultKind,
-        stdout: String,
-        stderr: String,
-    ) {
-        let output = CapturedTestOutput::new(
-            test_case_name.to_string(),
-            CapturedTestOutcome::from(result),
-            stdout,
-            stderr,
-        );
-        if !output.is_empty() {
-            self.captured_outputs.push(output);
-        }
-    }
-
     pub fn register_test_case_result(
         &mut self,
         test_case_name: &QualifiedTestName,
         outcome: TestExecutionOutcome,
         duration: std::time::Duration,
+        captured_output: Option<CapturedTestOutput>,
         reporter: Option<&dyn Reporter>,
     ) {
         let result = outcome.result_kind();
         self.stats.add(result.clone().into());
 
         let function_name = test_case_name.function_name().clone();
-        self.test_cases
-            .push(TestCaseResult::new(test_case_name, outcome, duration));
+        self.test_cases.push(TestCaseResult::new(
+            test_case_name,
+            outcome,
+            duration,
+            captured_output,
+        ));
 
         if matches!(&result, IndividualTestResultKind::Failed) {
             self.failed_tests.push(function_name.clone());
@@ -145,7 +129,7 @@ impl TestRunResult {
         duration: std::time::Duration,
         passed_on: u32,
         total_attempts: u32,
-        _reporter: Option<&dyn Reporter>,
+        captured_output: Option<CapturedTestOutput>,
     ) {
         let result = outcome.result_kind();
         self.stats.add(result.clone().into());
@@ -156,6 +140,7 @@ impl TestRunResult {
             outcome,
             duration,
             TestCaseRetry::new(passed_on, total_attempts),
+            captured_output,
         ));
 
         if matches!(&result, IndividualTestResultKind::Failed) {
@@ -215,8 +200,6 @@ impl TestRunResult {
                 .cmp(b.module_name())
                 .then_with(|| a.name().cmp(b.name()))
         });
-        self.captured_outputs
-            .sort_by(|a, b| a.test_name().cmp(b.test_name()));
         self
     }
 
@@ -234,9 +217,5 @@ impl TestRunResult {
 
     pub fn test_cases(&self) -> &[TestExecutionResult] {
         &self.test_cases
-    }
-
-    pub fn captured_outputs(&self) -> &[CapturedTestOutput] {
-        &self.captured_outputs
     }
 }

--- a/crates/karva_diagnostic/src/result/mod.rs
+++ b/crates/karva_diagnostic/src/result/mod.rs
@@ -11,7 +11,10 @@ use ruff_db::diagnostic::Diagnostic;
 
 use crate::reporter::Reporter;
 
-pub use case::{TestCaseOutcome, TestCaseResult, TestCaseRetry};
+pub use case::{
+    DiagnosticSeverity, RenderedDiagnostic, TestCaseOutcome, TestCaseResult, TestCaseRetry,
+    TestExecutionOutcome, TestExecutionResult,
+};
 pub use flaky::{DisplayFlakyTest, DisplayFlakyTests, FlakyTest};
 pub use kind::{IndividualTestResultKind, TestResultKind};
 pub use output::{CapturedTestOutcome, CapturedTestOutput};
@@ -22,9 +25,9 @@ pub use stats::TestResultStats;
 /// This is held in the test context and updated throughout the test run.
 #[derive(Debug, Clone, Default)]
 pub struct TestRunResult {
-    /// Diagnostics generated during test discovery, collection, and execution,
+    /// Diagnostics generated during test discovery and collection,
     /// in the order they were emitted.
-    diagnostics: Vec<Diagnostic>,
+    run_diagnostics: Vec<Diagnostic>,
 
     /// Stats generated during test execution.
     stats: TestResultStats,
@@ -39,7 +42,7 @@ pub struct TestRunResult {
     flaky_tests: Vec<FlakyTest>,
 
     /// Final outcome for each executed test variant.
-    test_cases: Vec<TestCaseResult>,
+    test_cases: Vec<TestExecutionResult>,
 
     /// Captured Python stdout/stderr for individual test variants.
     captured_outputs: Vec<CapturedTestOutput>,
@@ -67,12 +70,12 @@ fn diagnostic_display_ordering(a: &Diagnostic, b: &Diagnostic) -> std::cmp::Orde
 }
 
 impl TestRunResult {
-    pub fn diagnostics(&self) -> &[Diagnostic] {
-        &self.diagnostics
+    pub fn run_diagnostics(&self) -> &[Diagnostic] {
+        &self.run_diagnostics
     }
 
-    pub fn add_diagnostic(&mut self, diagnostic: Diagnostic) {
-        self.diagnostics.push(diagnostic);
+    pub fn add_run_diagnostic(&mut self, diagnostic: Diagnostic) {
+        self.run_diagnostics.push(diagnostic);
     }
 
     pub fn stats(&self) -> &TestResultStats {
@@ -100,20 +103,18 @@ impl TestRunResult {
     pub fn register_test_case_result(
         &mut self,
         test_case_name: &QualifiedTestName,
-        result: IndividualTestResultKind,
+        outcome: TestExecutionOutcome,
         duration: std::time::Duration,
         reporter: Option<&dyn Reporter>,
     ) {
+        let result = outcome.result_kind();
         self.stats.add(result.clone().into());
 
         let function_name = test_case_name.function_name().clone();
-        self.test_cases.push(TestCaseResult::new(
-            test_case_name,
-            TestCaseOutcome::from(&result),
-            duration,
-        ));
+        self.test_cases
+            .push(TestCaseResult::new(test_case_name, outcome, duration));
 
-        if matches!(result, IndividualTestResultKind::Failed) {
+        if matches!(&result, IndividualTestResultKind::Failed) {
             self.failed_tests.push(function_name.clone());
         }
 
@@ -140,25 +141,26 @@ impl TestRunResult {
     pub fn register_retried_result(
         &mut self,
         test_case_name: &QualifiedTestName,
-        result: &IndividualTestResultKind,
+        outcome: TestExecutionOutcome,
         duration: std::time::Duration,
         passed_on: u32,
         total_attempts: u32,
         _reporter: Option<&dyn Reporter>,
     ) {
+        let result = outcome.result_kind();
         self.stats.add(result.clone().into());
 
         let function_name = test_case_name.function_name().clone();
         self.test_cases.push(TestCaseResult::retried(
             test_case_name,
-            TestCaseOutcome::from(result),
+            outcome,
             duration,
             TestCaseRetry::new(passed_on, total_attempts),
         ));
 
-        if matches!(result, IndividualTestResultKind::Failed) {
+        if matches!(&result, IndividualTestResultKind::Failed) {
             self.failed_tests.push(function_name.clone());
-        } else if matches!(result, IndividualTestResultKind::Passed) {
+        } else if matches!(&result, IndividualTestResultKind::Passed) {
             self.stats.add(TestResultKind::Flaky);
             self.flaky_tests.push(FlakyTest::from_qualified_name(
                 test_case_name,
@@ -207,7 +209,7 @@ impl TestRunResult {
 
     #[must_use]
     pub fn into_sorted(mut self) -> Self {
-        self.diagnostics.sort_by(diagnostic_display_ordering);
+        self.run_diagnostics.sort_by(diagnostic_display_ordering);
         self.test_cases.sort_by(|a, b| {
             a.module_name()
                 .cmp(b.module_name())
@@ -230,7 +232,7 @@ impl TestRunResult {
         &self.flaky_tests
     }
 
-    pub fn test_cases(&self) -> &[TestCaseResult] {
+    pub fn test_cases(&self) -> &[TestExecutionResult] {
         &self.test_cases
     }
 

--- a/crates/karva_diagnostic/src/result/mod.rs
+++ b/crates/karva_diagnostic/src/result/mod.rs
@@ -13,7 +13,8 @@ use ruff_db::diagnostic::Diagnostic;
 use crate::reporter::Reporter;
 
 pub use case::{
-    TestCaseOutcome, TestCaseResult, TestCaseRetry, TestExecutionOutcome, TestExecutionResult,
+    TestCaseAttempt, TestCaseOutcome, TestCaseResult, TestCaseRetry, TestExecutionAttempt,
+    TestExecutionOutcome, TestExecutionResult,
 };
 pub use diagnostic::RenderedDiagnostic;
 pub use flaky::{DisplayFlakyTest, DisplayFlakyTests, FlakyTest};
@@ -34,12 +35,6 @@ pub struct TestRunResult {
 
     /// The duration of each test function.
     durations: HashMap<QualifiedFunctionName, std::time::Duration>,
-
-    /// Names of tests that failed during this run.
-    failed_tests: Vec<QualifiedFunctionName>,
-
-    /// Tests that passed only after at least one retry.
-    flaky_tests: Vec<FlakyTest>,
 
     /// Final outcome for each executed test variant.
     test_cases: Vec<TestExecutionResult>,
@@ -98,10 +93,6 @@ impl TestRunResult {
             captured_output,
         ));
 
-        if matches!(&result, IndividualTestResultKind::Failed) {
-            self.failed_tests.push(function_name.clone());
-        }
-
         if let Some(reporter) = reporter {
             reporter.report_test_case_result(test_case_name, result, duration);
         }
@@ -117,19 +108,15 @@ impl TestRunResult {
     /// `report_test_case_result` line — the per-attempt `TRY N STATUS`
     /// lines are the user-visible output for a retried test.
     ///
-    /// `passed_on` is the 1-indexed attempt number that ultimately succeeded
-    /// (only meaningful when `result` is `Passed`). `total_attempts` mirrors
-    /// nextest's `FLAKY M/T` denominator: the maximum number of attempts the
-    /// test was allowed (`retries + 1`), not just the count that ran.
     /// When the final outcome is `Passed`, the test is counted as flaky.
     pub fn register_retried_result(
         &mut self,
         test_case_name: &QualifiedTestName,
         outcome: TestExecutionOutcome,
         duration: std::time::Duration,
-        passed_on: u32,
-        total_attempts: u32,
+        retry: TestCaseRetry,
         captured_output: Option<CapturedTestOutput>,
+        attempts: Vec<TestExecutionAttempt>,
     ) {
         let result = outcome.result_kind();
         self.stats.add(result.clone().into());
@@ -139,20 +126,13 @@ impl TestRunResult {
             test_case_name,
             outcome,
             duration,
-            TestCaseRetry::new(passed_on, total_attempts),
+            retry,
             captured_output,
+            attempts,
         ));
 
-        if matches!(&result, IndividualTestResultKind::Failed) {
-            self.failed_tests.push(function_name.clone());
-        } else if matches!(&result, IndividualTestResultKind::Passed) {
+        if matches!(&result, IndividualTestResultKind::Passed) {
             self.stats.add(TestResultKind::Flaky);
-            self.flaky_tests.push(FlakyTest::from_qualified_name(
-                test_case_name,
-                passed_on,
-                total_attempts,
-                duration,
-            ));
         }
 
         self.durations
@@ -205,14 +185,6 @@ impl TestRunResult {
 
     pub fn durations(&self) -> &HashMap<QualifiedFunctionName, std::time::Duration> {
         &self.durations
-    }
-
-    pub fn failed_tests(&self) -> &[QualifiedFunctionName] {
-        &self.failed_tests
-    }
-
-    pub fn flaky_tests(&self) -> &[FlakyTest] {
-        &self.flaky_tests
     }
 
     pub fn test_cases(&self) -> &[TestExecutionResult] {

--- a/crates/karva_diagnostic/src/result/output.rs
+++ b/crates/karva_diagnostic/src/result/output.rs
@@ -1,36 +1,14 @@
 use serde::{Deserialize, Serialize};
 
-use super::kind::IndividualTestResultKind;
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CapturedTestOutput {
-    test_name: String,
-    outcome: CapturedTestOutcome,
     stdout: String,
     stderr: String,
 }
 
 impl CapturedTestOutput {
-    pub fn new(
-        test_name: String,
-        outcome: CapturedTestOutcome,
-        stdout: String,
-        stderr: String,
-    ) -> Self {
-        Self {
-            test_name,
-            outcome,
-            stdout,
-            stderr,
-        }
-    }
-
-    pub fn test_name(&self) -> &str {
-        &self.test_name
-    }
-
-    pub fn outcome(&self) -> CapturedTestOutcome {
-        self.outcome
+    pub fn new(stdout: String, stderr: String) -> Self {
+        Self { stdout, stderr }
     }
 
     pub fn stdout(&self) -> &str {
@@ -43,29 +21,5 @@ impl CapturedTestOutput {
 
     pub fn is_empty(&self) -> bool {
         self.stdout.is_empty() && self.stderr.is_empty()
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum CapturedTestOutcome {
-    Passed,
-    Failed,
-    Skipped,
-}
-
-impl CapturedTestOutcome {
-    pub fn is_failed(self) -> bool {
-        matches!(self, Self::Failed)
-    }
-}
-
-impl From<&IndividualTestResultKind> for CapturedTestOutcome {
-    fn from(value: &IndividualTestResultKind) -> Self {
-        match value {
-            IndividualTestResultKind::Passed => Self::Passed,
-            IndividualTestResultKind::Failed => Self::Failed,
-            IndividualTestResultKind::Skipped { .. } => Self::Skipped,
-        }
     }
 }

--- a/crates/karva_diagnostic/src/result/stats.rs
+++ b/crates/karva_diagnostic/src/result/stats.rs
@@ -12,6 +12,7 @@ use super::kind::TestResultKind;
 pub struct TestResultStats {
     passed: usize,
     failed: usize,
+    errors: usize,
     skipped: usize,
     flaky: usize,
     slow: usize,
@@ -21,16 +22,17 @@ impl TestResultStats {
     /// Total number of tests run. `Flaky` is a marker on a passing test and
     /// is not counted as a separate test.
     pub fn total(&self) -> usize {
-        self.passed() + self.failed() + self.skipped()
+        self.passed() + self.failed() + self.errors() + self.skipped()
     }
 
     pub fn is_success(&self) -> bool {
-        self.failed() == 0
+        self.failed() == 0 && self.errors() == 0
     }
 
     pub fn merge(&mut self, other: &Self) {
         self.passed += other.passed;
         self.failed += other.failed;
+        self.errors += other.errors;
         self.skipped += other.skipped;
         self.flaky += other.flaky;
         self.slow += other.slow;
@@ -42,6 +44,10 @@ impl TestResultStats {
 
     pub fn failed(&self) -> usize {
         self.failed
+    }
+
+    pub fn errors(&self) -> usize {
+        self.errors
     }
 
     pub fn skipped(&self) -> usize {
@@ -60,14 +66,15 @@ impl TestResultStats {
         match kind {
             TestResultKind::Passed => self.passed += 1,
             TestResultKind::Failed => self.failed += 1,
+            TestResultKind::Error => self.errors += 1,
             TestResultKind::Skipped => self.skipped += 1,
             TestResultKind::Flaky => self.flaky += 1,
             TestResultKind::Slow => self.slow += 1,
         }
     }
 
-    pub fn display(&self, start_time: Instant) -> DisplayTestResultStats<'_> {
-        DisplayTestResultStats::new(self, start_time)
+    pub fn display(&self, start_time: Instant, success: bool) -> DisplayTestResultStats<'_> {
+        DisplayTestResultStats::new(self, start_time, success)
     }
 }
 
@@ -81,6 +88,7 @@ impl Serialize for TestResultStats {
         let counts = [
             (TestResultKind::Passed, self.passed),
             (TestResultKind::Failed, self.failed),
+            (TestResultKind::Error, self.errors),
             (TestResultKind::Skipped, self.skipped),
             (TestResultKind::Flaky, self.flaky),
             (TestResultKind::Slow, self.slow),
@@ -120,12 +128,13 @@ impl<'de> Deserialize<'de> for TestResultStats {
                     let kind = TestResultKind::from_str(&key).map_err(|_| {
                         de::Error::unknown_field(
                             &key,
-                            &["passed", "failed", "skipped", "flaky", "slow"],
+                            &["passed", "failed", "error", "skipped", "flaky", "slow"],
                         )
                     })?;
                     match kind {
                         TestResultKind::Passed => stats.passed = value,
                         TestResultKind::Failed => stats.failed = value,
+                        TestResultKind::Error => stats.errors = value,
                         TestResultKind::Skipped => stats.skipped = value,
                         TestResultKind::Flaky => stats.flaky = value,
                         TestResultKind::Slow => stats.slow = value,
@@ -143,23 +152,27 @@ impl<'de> Deserialize<'de> for TestResultStats {
 pub struct DisplayTestResultStats<'a> {
     stats: &'a TestResultStats,
     start_time: Instant,
+    success: bool,
 }
 
 impl<'a> DisplayTestResultStats<'a> {
-    fn new(stats: &'a TestResultStats, start_time: Instant) -> Self {
-        Self { stats, start_time }
+    fn new(stats: &'a TestResultStats, start_time: Instant, success: bool) -> Self {
+        Self {
+            stats,
+            start_time,
+            success,
+        }
     }
 }
 
 impl fmt::Display for DisplayTestResultStats<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let success = self.stats.is_success();
         let elapsed = self.start_time.elapsed();
 
         writeln!(f, "{}", "─".repeat(12))?;
 
         let label = format!("{:>12}", "Summary");
-        if success {
+        if self.success {
             write!(f, "{}", label.green().bold())?;
         } else {
             write!(f, "{}", label.red().bold())?;
@@ -181,6 +194,22 @@ impl fmt::Display for DisplayTestResultStats<'_> {
                     .red()
                     .bold()
                     .to_string(),
+            );
+        }
+        if self.stats.errors() > 0 {
+            parts.push(
+                format!(
+                    "{} {}",
+                    self.stats.errors(),
+                    if self.stats.errors() == 1 {
+                        "error"
+                    } else {
+                        "errors"
+                    }
+                )
+                .red()
+                .bold()
+                .to_string(),
             );
         }
         parts.push(

--- a/crates/karva_test_semantic/src/context.rs
+++ b/crates/karva_test_semantic/src/context.rs
@@ -2,12 +2,11 @@ use std::cell::RefCell;
 
 use camino::Utf8Path;
 use karva_collector::CollectionSettings;
-use karva_diagnostic::{IndividualTestResultKind, Reporter, TestRunResult};
+use karva_diagnostic::{IndividualTestResultKind, Reporter, TestExecutionOutcome, TestRunResult};
 use karva_metadata::ProjectSettings;
 use karva_python_semantic::QualifiedTestName;
+use ruff_db::diagnostic::Diagnostic;
 use ruff_python_ast::PythonVersion;
-
-use crate::diagnostic::{DiagnosticGuardBuilder, DiagnosticType};
 
 /// Central context object that holds shared state for a test run.
 ///
@@ -87,22 +86,19 @@ impl<'a> Context<'a> {
     pub fn register_test_case_result(
         &self,
         test_case_name: &QualifiedTestName,
-        test_result: IndividualTestResultKind,
+        outcome: TestExecutionOutcome,
         duration: std::time::Duration,
     ) -> bool {
-        let result = matches!(
-            &test_result,
-            IndividualTestResultKind::Passed | IndividualTestResultKind::Skipped { .. }
-        );
+        let passed = !outcome.is_failed();
 
         self.result().register_test_case_result(
             test_case_name,
-            test_result,
+            outcome,
             duration,
             Some(self.reporter),
         );
 
-        result
+        passed
     }
 
     /// Forward a per-attempt outcome to the reporter. Does not touch
@@ -143,18 +139,15 @@ impl<'a> Context<'a> {
     pub fn register_retried_result(
         &self,
         test_case_name: &QualifiedTestName,
-        result: &IndividualTestResultKind,
+        outcome: TestExecutionOutcome,
         duration: std::time::Duration,
         passed_on: u32,
         total_attempts: u32,
     ) -> bool {
-        let passed = matches!(
-            result,
-            IndividualTestResultKind::Passed | IndividualTestResultKind::Skipped { .. }
-        );
+        let passed = !outcome.is_failed();
         self.result().register_retried_result(
             test_case_name,
-            result,
+            outcome,
             duration,
             passed_on,
             total_attempts,
@@ -174,11 +167,8 @@ impl<'a> Context<'a> {
             .register_captured_output(test_case_name, result, stdout, stderr);
     }
 
-    pub(crate) fn report_diagnostic<'ctx>(
-        &'ctx self,
-        rule: &'static DiagnosticType,
-    ) -> DiagnosticGuardBuilder<'ctx, 'a> {
-        DiagnosticGuardBuilder::new(self, rule)
+    pub(crate) fn add_run_diagnostic(&self, diagnostic: Diagnostic) {
+        self.result().add_run_diagnostic(diagnostic);
     }
 
     pub fn python_version(&self) -> PythonVersion {

--- a/crates/karva_test_semantic/src/context.rs
+++ b/crates/karva_test_semantic/src/context.rs
@@ -2,7 +2,9 @@ use std::cell::RefCell;
 
 use camino::Utf8Path;
 use karva_collector::CollectionSettings;
-use karva_diagnostic::{IndividualTestResultKind, Reporter, TestExecutionOutcome, TestRunResult};
+use karva_diagnostic::{
+    CapturedTestOutput, IndividualTestResultKind, Reporter, TestExecutionOutcome, TestRunResult,
+};
 use karva_metadata::ProjectSettings;
 use karva_python_semantic::QualifiedTestName;
 use ruff_db::diagnostic::Diagnostic;
@@ -88,6 +90,7 @@ impl<'a> Context<'a> {
         test_case_name: &QualifiedTestName,
         outcome: TestExecutionOutcome,
         duration: std::time::Duration,
+        captured_output: Option<CapturedTestOutput>,
     ) -> bool {
         let passed = !outcome.is_failed();
 
@@ -95,6 +98,7 @@ impl<'a> Context<'a> {
             test_case_name,
             outcome,
             duration,
+            captured_output,
             Some(self.reporter),
         );
 
@@ -143,6 +147,7 @@ impl<'a> Context<'a> {
         duration: std::time::Duration,
         passed_on: u32,
         total_attempts: u32,
+        captured_output: Option<CapturedTestOutput>,
     ) -> bool {
         let passed = !outcome.is_failed();
         self.result().register_retried_result(
@@ -151,20 +156,9 @@ impl<'a> Context<'a> {
             duration,
             passed_on,
             total_attempts,
-            Some(self.reporter),
+            captured_output,
         );
         passed
-    }
-
-    pub fn register_captured_output(
-        &self,
-        test_case_name: &QualifiedTestName,
-        result: &IndividualTestResultKind,
-        stdout: String,
-        stderr: String,
-    ) {
-        self.result()
-            .register_captured_output(test_case_name, result, stdout, stderr);
     }
 
     pub(crate) fn add_run_diagnostic(&self, diagnostic: Diagnostic) {

--- a/crates/karva_test_semantic/src/context.rs
+++ b/crates/karva_test_semantic/src/context.rs
@@ -3,7 +3,8 @@ use std::cell::RefCell;
 use camino::Utf8Path;
 use karva_collector::CollectionSettings;
 use karva_diagnostic::{
-    CapturedTestOutput, IndividualTestResultKind, Reporter, TestExecutionOutcome, TestRunResult,
+    CapturedTestOutput, IndividualTestResultKind, Reporter, TestCaseRetry, TestExecutionAttempt,
+    TestExecutionOutcome, TestRunResult,
 };
 use karva_metadata::ProjectSettings;
 use karva_python_semantic::QualifiedTestName;
@@ -92,7 +93,7 @@ impl<'a> Context<'a> {
         duration: std::time::Duration,
         captured_output: Option<CapturedTestOutput>,
     ) -> bool {
-        let passed = !outcome.is_failed();
+        let passed = !outcome.is_non_success();
 
         self.result().register_test_case_result(
             test_case_name,
@@ -145,18 +146,18 @@ impl<'a> Context<'a> {
         test_case_name: &QualifiedTestName,
         outcome: TestExecutionOutcome,
         duration: std::time::Duration,
-        passed_on: u32,
-        total_attempts: u32,
+        retry: TestCaseRetry,
         captured_output: Option<CapturedTestOutput>,
+        attempts: Vec<TestExecutionAttempt>,
     ) -> bool {
-        let passed = !outcome.is_failed();
+        let passed = !outcome.is_non_success();
         self.result().register_retried_result(
             test_case_name,
             outcome,
             duration,
-            passed_on,
-            total_attempts,
+            retry,
             captured_output,
+            attempts,
         );
         passed
     }

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -263,12 +263,11 @@ pub fn report_invalid_fixture(
     context.add_run_diagnostic(diagnostic);
 }
 
-pub fn report_invalid_fixture_finalizer(
-    context: &Context,
+pub fn invalid_fixture_finalizer_diagnostic(
     source_file: SourceFile,
     stmt_function_def: &StmtFunctionDef,
     reason: &str,
-) {
+) -> Diagnostic {
     let mut diagnostic = INVALID_FIXTURE_FINALIZER.diagnostic(format!(
         "Discovered an invalid fixture finalizer `{}`",
         stmt_function_def.name
@@ -277,10 +276,10 @@ pub fn report_invalid_fixture_finalizer(
     annotate_function_name(&mut diagnostic, source_file, stmt_function_def);
 
     diagnostic.info(reason);
-    context.add_run_diagnostic(diagnostic);
+    diagnostic
 }
 
-pub fn report_fixture_failure(context: &Context, py: Python, error: FixtureCallError) {
+pub fn fixture_failure_diagnostic(py: Python, error: FixtureCallError) -> Diagnostic {
     let FixtureCallError {
         fixture_name,
         error,
@@ -303,7 +302,7 @@ pub fn report_fixture_failure(context: &Context, py: Python, error: FixtureCallE
         FunctionKind::Fixture,
         &error,
     );
-    context.add_run_diagnostic(diagnostic);
+    diagnostic
 }
 
 pub fn fixture_resolution_diagnostic(error: FixtureResolutionError) -> Diagnostic {
@@ -402,12 +401,10 @@ fn fixture_scope_mismatch_diagnostic(
 }
 
 pub fn missing_fixtures_diagnostic(
-    py: Python,
     source_file: SourceFile,
     stmt_function_def: &StmtFunctionDef,
     missing_fixtures: &[String],
     function_kind: FunctionKind,
-    fixture_call_errors: Vec<FixtureCallError>,
 ) -> Diagnostic {
     let mut diagnostic = MISSING_FIXTURES.diagnostic(format!(
         "{} `{}` has missing fixtures",
@@ -431,40 +428,6 @@ pub fn missing_fixtures_diagnostic(
         stmt_function_def.name,
     ));
 
-    for FixtureCallError {
-        error,
-        fixture_name,
-        source_file,
-        dependency_chain,
-        ..
-    } in fixture_call_errors
-    {
-        report_dependency_chain(&mut diagnostic, &dependency_chain, &fixture_name);
-
-        if let Some(Traceback {
-            lines: _,
-            error_source_file,
-            location,
-        }) = Traceback::from_error_with_source(py, &error, &source_file)
-        {
-            let mut sub = SubDiagnostic::new(
-                SubDiagnosticSeverity::Info,
-                format!("Fixture `{fixture_name}` failed here"),
-            );
-
-            let secondary_span = Span::from(error_source_file).with_range(location);
-
-            sub.annotate(Annotation::primary(secondary_span));
-
-            diagnostic.sub(sub);
-        }
-
-        let error_string = error.value(py).to_string();
-
-        if !error_string.is_empty() {
-            diagnostic.info(indent_continuation_lines(&error_string));
-        }
-    }
     diagnostic
 }
 

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -229,15 +229,13 @@ pub fn report_failed_to_import_module(context: &Context, module_name: &str, erro
 pub fn report_failed_to_discover_imported_fixture(
     context: &Context,
     fixture_name: &str,
-    importing_source_file: SourceFile,
     source_path: &Utf8Path,
     error: &std::io::Error,
 ) {
-    let mut diagnostic = FAILED_TO_DISCOVER_IMPORTED_FIXTURE.diagnostic(format!(
+    let diagnostic = FAILED_TO_DISCOVER_IMPORTED_FIXTURE.diagnostic(format!(
         "Failed to discover imported fixture `{fixture_name}` from `{source_path}`: {error}"
     ));
 
-    diagnostic.annotate(Annotation::primary(Span::from(importing_source_file)));
     context.add_run_diagnostic(diagnostic);
 }
 

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -17,8 +17,6 @@ use ruff_source_file::SourceFile;
 
 mod metadata;
 
-pub use metadata::{DiagnosticGuardBuilder, DiagnosticType};
-
 use crate::extensions::tags::parametrize::InvalidParametrizeError;
 use crate::runner::{
     FixtureArguments, FixtureCallError, FixtureChainEntry, FixtureResolutionEntry,
@@ -217,17 +215,15 @@ fn report_dependency_chain(
 }
 
 pub fn report_collection_error(context: &Context, error: &CollectionError) {
-    let builder = context.report_diagnostic(&FAILED_TO_COLLECT_MODULE);
-
-    builder.into_diagnostic(format!("Failed to collect python module: {error}"));
+    context.add_run_diagnostic(
+        FAILED_TO_COLLECT_MODULE.diagnostic(format!("Failed to collect python module: {error}")),
+    );
 }
 
 pub fn report_failed_to_import_module(context: &Context, module_name: &str, error: &str) {
-    let builder = context.report_diagnostic(&FAILED_TO_IMPORT_MODULE);
-
-    builder.into_diagnostic(format!(
+    context.add_run_diagnostic(FAILED_TO_IMPORT_MODULE.diagnostic(format!(
         "Failed to import python module `{module_name}`: {error}"
-    ));
+    )));
 }
 
 pub fn report_failed_to_discover_imported_fixture(
@@ -237,13 +233,12 @@ pub fn report_failed_to_discover_imported_fixture(
     source_path: &Utf8Path,
     error: &std::io::Error,
 ) {
-    let builder = context.report_diagnostic(&FAILED_TO_DISCOVER_IMPORTED_FIXTURE);
-
-    let mut diagnostic = builder.into_diagnostic(format!(
+    let mut diagnostic = FAILED_TO_DISCOVER_IMPORTED_FIXTURE.diagnostic(format!(
         "Failed to discover imported fixture `{fixture_name}` from `{source_path}`: {error}"
     ));
 
     diagnostic.annotate(Annotation::primary(Span::from(importing_source_file)));
+    context.add_run_diagnostic(diagnostic);
 }
 
 pub fn report_invalid_fixture(
@@ -253,9 +248,7 @@ pub fn report_invalid_fixture(
     stmt_function_def: &StmtFunctionDef,
     error: &PyErr,
 ) {
-    let builder = context.report_diagnostic(&INVALID_FIXTURE);
-
-    let mut diagnostic = builder.into_diagnostic(format!(
+    let mut diagnostic = INVALID_FIXTURE.diagnostic(format!(
         "Discovered an invalid fixture `{}`",
         stmt_function_def.name
     ));
@@ -267,6 +260,7 @@ pub fn report_invalid_fixture(
     if !error_string.is_empty() {
         diagnostic.info(indent_continuation_lines(&error_string));
     }
+    context.add_run_diagnostic(diagnostic);
 }
 
 pub fn report_invalid_fixture_finalizer(
@@ -275,9 +269,7 @@ pub fn report_invalid_fixture_finalizer(
     stmt_function_def: &StmtFunctionDef,
     reason: &str,
 ) {
-    let builder = context.report_diagnostic(&INVALID_FIXTURE_FINALIZER);
-
-    let mut diagnostic = builder.into_diagnostic(format!(
+    let mut diagnostic = INVALID_FIXTURE_FINALIZER.diagnostic(format!(
         "Discovered an invalid fixture finalizer `{}`",
         stmt_function_def.name
     ));
@@ -285,6 +277,7 @@ pub fn report_invalid_fixture_finalizer(
     annotate_function_name(&mut diagnostic, source_file, stmt_function_def);
 
     diagnostic.info(reason);
+    context.add_run_diagnostic(diagnostic);
 }
 
 pub fn report_fixture_failure(context: &Context, py: Python, error: FixtureCallError) {
@@ -297,9 +290,7 @@ pub fn report_fixture_failure(context: &Context, py: Python, error: FixtureCallE
         dependency_chain,
     } = error;
 
-    let builder = context.report_diagnostic(&FIXTURE_FAILURE);
-
-    let mut diagnostic = builder.into_diagnostic(format!("Fixture `{fixture_name}` failed"));
+    let mut diagnostic = FIXTURE_FAILURE.diagnostic(format!("Fixture `{fixture_name}` failed"));
 
     report_dependency_chain(&mut diagnostic, &dependency_chain, &fixture_name);
 
@@ -312,32 +303,30 @@ pub fn report_fixture_failure(context: &Context, py: Python, error: FixtureCallE
         FunctionKind::Fixture,
         &error,
     );
+    context.add_run_diagnostic(diagnostic);
 }
 
-pub fn report_fixture_resolution_error(context: &Context, error: FixtureResolutionError) {
+pub fn fixture_resolution_diagnostic(error: FixtureResolutionError) -> Diagnostic {
     match error {
-        FixtureResolutionError::Cycle { cycle } => report_fixture_cycle(context, &cycle),
+        FixtureResolutionError::Cycle { cycle } => fixture_cycle_diagnostic(&cycle),
         FixtureResolutionError::ScopeMismatch {
             dependency_path,
             fixture,
             dependency,
-        } => report_fixture_scope_mismatch(context, &dependency_path, &fixture, &dependency),
+        } => fixture_scope_mismatch_diagnostic(&dependency_path, &fixture, &dependency),
     }
 }
 
-fn report_fixture_cycle(context: &Context, cycle: &[FixtureResolutionEntry]) {
-    let Some(first_fixture) = cycle.first() else {
-        return;
-    };
+fn fixture_cycle_diagnostic(cycle: &[FixtureResolutionEntry]) -> Diagnostic {
+    let mut diagnostic = FIXTURE_CYCLE.diagnostic("Fixture dependency cycle detected");
 
-    let builder = context.report_diagnostic(&FIXTURE_CYCLE);
-    let mut diagnostic = builder.into_diagnostic("Fixture dependency cycle detected");
-
-    annotate_function_name(
-        &mut diagnostic,
-        first_fixture.source_file.clone(),
-        &first_fixture.stmt_function_def,
-    );
+    if let Some(first_fixture) = cycle.first() {
+        annotate_function_name(
+            &mut diagnostic,
+            first_fixture.source_file.clone(),
+            &first_fixture.stmt_function_def,
+        );
+    }
 
     for dependency_edge in cycle.windows(2).skip(1) {
         let [fixture, dependency] = dependency_edge else {
@@ -360,16 +349,15 @@ fn report_fixture_cycle(context: &Context, cycle: &[FixtureResolutionEntry]) {
             .collect::<Vec<_>>()
             .join(" -> "),
     );
+    diagnostic
 }
 
-fn report_fixture_scope_mismatch(
-    context: &Context,
+fn fixture_scope_mismatch_diagnostic(
     dependency_path: &[FixtureResolutionEntry],
     fixture: &FixtureResolutionEntry,
     dependency: &FixtureResolutionEntry,
-) {
-    let builder = context.report_diagnostic(&FIXTURE_SCOPE_MISMATCH);
-    let mut diagnostic = builder.into_diagnostic(format!(
+) -> Diagnostic {
+    let mut diagnostic = FIXTURE_SCOPE_MISMATCH.diagnostic(format!(
         "Fixture `{}` with `{}` scope cannot depend on fixture `{}` with `{}` scope",
         fixture.name,
         fixture.scope.name(),
@@ -410,20 +398,18 @@ fn report_fixture_scope_mismatch(
         .with_range(dependency.stmt_function_def.name.range);
     dependency_sub.annotate(Annotation::primary(span));
     diagnostic.sub(dependency_sub);
+    diagnostic
 }
 
-pub fn report_missing_fixtures(
-    context: &Context,
+pub fn missing_fixtures_diagnostic(
     py: Python,
     source_file: SourceFile,
     stmt_function_def: &StmtFunctionDef,
     missing_fixtures: &[String],
     function_kind: FunctionKind,
     fixture_call_errors: Vec<FixtureCallError>,
-) {
-    let builder = context.report_diagnostic(&MISSING_FIXTURES);
-
-    let mut diagnostic = builder.into_diagnostic(format!(
+) -> Diagnostic {
+    let mut diagnostic = MISSING_FIXTURES.diagnostic(format!(
         "{} `{}` has missing fixtures",
         function_kind.capitalised(),
         stmt_function_def.name
@@ -479,17 +465,15 @@ pub fn report_missing_fixtures(
             diagnostic.info(indent_continuation_lines(&error_string));
         }
     }
+    diagnostic
 }
 
-pub fn report_test_pass_on_expect_failure(
-    context: &Context,
+pub fn test_pass_on_expect_failure_diagnostic(
     source_file: SourceFile,
     stmt_function_def: &StmtFunctionDef,
     reason: Option<String>,
-) {
-    let builder = context.report_diagnostic(&TEST_PASS_ON_EXPECT_FAILURE);
-
-    let mut diagnostic = builder.into_diagnostic(format!(
+) -> Diagnostic {
+    let mut diagnostic = TEST_PASS_ON_EXPECT_FAILURE.diagnostic(format!(
         "Test `{}` passes when expected to fail",
         stmt_function_def.name
     ));
@@ -499,20 +483,18 @@ pub fn report_test_pass_on_expect_failure(
     if let Some(reason) = reason {
         diagnostic.info(format!("Reason: {reason}"));
     }
+    diagnostic
 }
 
-pub fn report_test_failure(
-    context: &Context,
+pub fn test_failure_diagnostic(
     py: Python,
     source_file: &SourceFile,
     stmt_function_def: &StmtFunctionDef,
     arguments: &FixtureArguments,
     error: &PyErr,
-) {
-    let builder = context.report_diagnostic(&TEST_FAILURE);
-
+) -> Diagnostic {
     let mut diagnostic =
-        builder.into_diagnostic(format!("Test `{}` failed", stmt_function_def.name));
+        TEST_FAILURE.diagnostic(format!("Test `{}` failed", stmt_function_def.name));
 
     handle_failed_function_call(
         &mut diagnostic,
@@ -523,6 +505,7 @@ pub fn report_test_failure(
         FunctionKind::Test,
         error,
     );
+    diagnostic
 }
 
 pub fn report_generator_test(
@@ -530,28 +513,25 @@ pub fn report_generator_test(
     source_file: SourceFile,
     stmt_function_def: &StmtFunctionDef,
 ) {
-    let builder = context.report_diagnostic(&INVALID_TEST);
-
-    let mut diagnostic = builder.into_diagnostic(format!(
+    let mut diagnostic = INVALID_TEST.diagnostic(format!(
         "Generator test `{}` is not supported",
         stmt_function_def.name
     ));
 
     annotate_function_name(&mut diagnostic, source_file, stmt_function_def);
     diagnostic.info("Use `@karva.tags.parametrize` to define multiple test cases.");
+    context.add_run_diagnostic(diagnostic);
 }
 
-pub fn report_invalid_parametrize(
-    context: &Context,
+pub fn invalid_parametrize_diagnostic(
     source_file: SourceFile,
     stmt_function_def: &StmtFunctionDef,
     error: &InvalidParametrizeError,
-) {
-    let builder = context.report_diagnostic(&INVALID_PARAMETRIZE);
-    let mut diagnostic = builder.into_diagnostic(error.to_string());
+) -> Diagnostic {
+    let mut diagnostic = INVALID_PARAMETRIZE.diagnostic(error.to_string());
     let Some(location) = error.diagnostic_location(stmt_function_def) else {
         annotate_function_name(&mut diagnostic, source_file, stmt_function_def);
-        return;
+        return diagnostic;
     };
 
     diagnostic.annotate(
@@ -564,23 +544,22 @@ pub fn report_invalid_parametrize(
                 .message(secondary.message),
         );
     }
+    diagnostic
 }
 
-pub fn report_test_returned_value(
-    context: &Context,
+pub fn test_returned_value_diagnostic(
     source_file: SourceFile,
     stmt_function_def: &StmtFunctionDef,
     returned_value: &str,
-) {
-    let builder = context.report_diagnostic(&TEST_RETURNED_VALUE);
-
-    let mut diagnostic = builder.into_diagnostic(format!(
+) -> Diagnostic {
+    let mut diagnostic = TEST_RETURNED_VALUE.diagnostic(format!(
         "Test `{}` returned `{returned_value}`",
         stmt_function_def.name
     ));
 
     annotate_function_name(&mut diagnostic, source_file, stmt_function_def);
     diagnostic.info("Test functions must return None. Did you mean to use `assert`?");
+    diagnostic
 }
 
 fn handle_failed_function_call(

--- a/crates/karva_test_semantic/src/diagnostic/metadata.rs
+++ b/crates/karva_test_semantic/src/diagnostic/metadata.rs
@@ -1,7 +1,5 @@
 use ruff_db::diagnostic::{Diagnostic, DiagnosticId, LintName, Severity};
 
-use crate::Context;
-
 /// Defines a type of diagnostic that can be reported during test execution.
 ///
 /// Each diagnostic type has a unique name, summary description, and severity level
@@ -37,76 +35,8 @@ macro_rules! declare_diagnostic_type {
     };
 }
 
-/// Builder for creating diagnostic guards with the appropriate context.
-///
-/// Used to construct diagnostics with the correct ID, severity, and context
-/// before they are finalized and reported.
-pub struct DiagnosticGuardBuilder<'ctx, 'a> {
-    /// Reference to the test execution context.
-    context: &'ctx Context<'a>,
-
-    /// Unique identifier for this diagnostic.
-    id: DiagnosticId,
-
-    /// Severity level for this diagnostic.
-    severity: Severity,
-}
-
-impl<'ctx, 'a> DiagnosticGuardBuilder<'ctx, 'a> {
-    pub(crate) fn new(
-        context: &'ctx Context<'a>,
-        diagnostic_type: &'static DiagnosticType,
-    ) -> Self {
-        DiagnosticGuardBuilder {
-            context,
-            id: DiagnosticId::Lint(diagnostic_type.name),
-            severity: diagnostic_type.severity,
-        }
-    }
-
-    /// Build a diagnostic guard with the given message.
-    pub(crate) fn into_diagnostic(
-        self,
-        message: impl std::fmt::Display,
-    ) -> DiagnosticGuard<'ctx, 'a> {
-        DiagnosticGuard {
-            context: self.context,
-            diag: Some(Diagnostic::new(self.id, self.severity, message)),
-        }
-    }
-}
-
-/// A guard that holds a diagnostic and reports it when dropped.
-///
-/// Allows mutation of the diagnostic before it is automatically
-/// reported to the test results when the guard goes out of scope.
-pub struct DiagnosticGuard<'ctx, 'a> {
-    /// Reference to the test execution context.
-    context: &'ctx Context<'a>,
-
-    /// The diagnostic being built, wrapped in Option for take-on-drop.
-    diag: Option<Diagnostic>,
-}
-
-/// Return a immutable borrow of the diagnostic in this guard.
-impl std::ops::Deref for DiagnosticGuard<'_, '_> {
-    type Target = Diagnostic;
-
-    fn deref(&self) -> &Diagnostic {
-        self.diag.as_ref().unwrap()
-    }
-}
-
-/// Return a mutable borrow of the diagnostic in this guard.
-impl std::ops::DerefMut for DiagnosticGuard<'_, '_> {
-    fn deref_mut(&mut self) -> &mut Diagnostic {
-        self.diag.as_mut().unwrap()
-    }
-}
-
-impl Drop for DiagnosticGuard<'_, '_> {
-    fn drop(&mut self) {
-        let diag = self.diag.take().unwrap();
-        self.context.result().add_diagnostic(diag);
+impl DiagnosticType {
+    pub(crate) fn diagnostic(&self, message: impl std::fmt::Display) -> Diagnostic {
+        Diagnostic::new(DiagnosticId::Lint(self.name), self.severity, message)
     }
 }

--- a/crates/karva_test_semantic/src/discovery/visitor.rs
+++ b/crates/karva_test_semantic/src/discovery/visitor.rs
@@ -226,7 +226,6 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
                 report_failed_to_discover_imported_fixture(
                     self.context,
                     name,
-                    self.module.source_file(),
                     utf8_file_name,
                     &err,
                 );

--- a/crates/karva_test_semantic/src/extensions/fixtures/finalizer.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/finalizer.rs
@@ -5,8 +5,9 @@ use pyo3::types::PyIterator;
 use ruff_python_ast::StmtFunctionDef;
 use ruff_source_file::SourceFile;
 
-use crate::Context;
-use crate::diagnostic::report_invalid_fixture_finalizer;
+use ruff_db::diagnostic::Diagnostic;
+
+use crate::diagnostic::invalid_fixture_finalizer_diagnostic;
 use crate::extensions::fixtures::FixtureScope;
 use crate::utils::run_coroutine;
 
@@ -41,7 +42,7 @@ pub struct Finalizer {
 }
 
 impl Finalizer {
-    pub(crate) fn run(self, context: &Context, py: Python<'_>) {
+    pub(crate) fn run(self, py: Python<'_>) -> Option<Diagnostic> {
         let invalid_finalizer_reason = if self.is_async {
             self.run_async_teardown(py)
         } else {
@@ -52,8 +53,13 @@ impl Finalizer {
             && let Some(stmt_function_def) = self.stmt_function_def
             && let Some(source_file) = self.source_file
         {
-            report_invalid_fixture_finalizer(context, source_file, &stmt_function_def, &reason);
+            return Some(invalid_fixture_finalizer_diagnostic(
+                source_file,
+                &stmt_function_def,
+                &reason,
+            ));
         }
+        None
     }
 
     /// Runs teardown for a sync generator fixture.

--- a/crates/karva_test_semantic/src/runner/finalizer_cache.rs
+++ b/crates/karva_test_semantic/src/runner/finalizer_cache.rs
@@ -1,6 +1,6 @@
 use pyo3::prelude::*;
+use ruff_db::diagnostic::Diagnostic;
 
-use crate::Context;
 use crate::extensions::fixtures::{Finalizer, FixtureScope};
 use crate::runner::scoped_storage::ScopedStorage;
 
@@ -23,16 +23,16 @@ impl FinalizerCache {
 
     pub(crate) fn run_and_clear_scope(
         &self,
-        context: &Context,
         py: Python<'_>,
         scope: FixtureScope,
-    ) {
+    ) -> Vec<Diagnostic> {
         // Run finalizers in reverse order (LIFO)
         self.storage
             .get(scope)
             .borrow_mut()
             .drain(..)
             .rev()
-            .for_each(|finalizer| finalizer.run(context, py));
+            .filter_map(|finalizer| finalizer.run(py))
+            .collect()
     }
 }

--- a/crates/karva_test_semantic/src/runner/mod.rs
+++ b/crates/karva_test_semantic/src/runner/mod.rs
@@ -9,7 +9,5 @@ mod test_iterator;
 use finalizer_cache::FinalizerCache;
 pub use fixture_arguments::FixtureArguments;
 use fixture_cache::FixtureCache;
-pub use fixture_resolver::{
-    FixtureResolutionEntry, FixtureResolutionError, FixtureResolutionResult,
-};
+pub use fixture_resolver::{FixtureResolutionEntry, FixtureResolutionError};
 pub use package_runner::{FixtureCallError, FixtureChainEntry, PackageRunner};

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -118,7 +118,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
     ) {
         self.context.register_test_case_result(
             &QualifiedTestName::new(test.name.clone(), None),
-            TestExecutionOutcome::error(diagnostic).with_related(related),
+            TestExecutionOutcome::error_with_related(diagnostic, related),
             std::time::Duration::ZERO,
             None,
         );
@@ -250,10 +250,11 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         self.report_scope_cleanup(py, FixtureScope::Session);
     }
 
-    /// Resolve and run auto-use fixtures for `scope`. Resolution cycles are
-    /// returned to the caller; execution failures are reported here. The
-    /// `current` source is whichever `HasFixtures` provider applies for this
-    /// scope (the session package, a module, or a package configuration module).
+    /// Resolve and run auto-use fixtures for `scope`.
+    ///
+    /// The `current` source is whichever `HasFixtures` provider applies for
+    /// this scope (the session package, a module, or a package configuration
+    /// module).
     fn run_auto_use_fixtures<'b>(
         &self,
         py: Python<'_>,
@@ -262,17 +263,24 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         scope: FixtureScope,
     ) -> Result<(), Vec<Diagnostic>> {
         let mut resolver = RuntimeFixtureResolver::new(parents, current);
-        let auto_use_fixtures = resolver
-            .get_normalized_auto_use_fixtures(py, scope)
-            .map_err(|error| vec![fixture_resolution_diagnostic(error)])?;
+        let auto_use_fixtures = match resolver.get_normalized_auto_use_fixtures(py, scope) {
+            Ok(fixtures) => fixtures,
+            Err(error) => {
+                let mut diagnostics = vec![fixture_resolution_diagnostic(error)];
+                diagnostics.extend(self.clean_up_scope(py, scope));
+                return Err(diagnostics);
+            }
+        };
         let auto_use_errors = self.run_fixtures(py, &auto_use_fixtures);
         if auto_use_errors.is_empty() {
             Ok(())
         } else {
-            Err(auto_use_errors
+            let mut diagnostics = auto_use_errors
                 .into_iter()
                 .map(|error| fixture_failure_diagnostic(py, error))
-                .collect())
+                .collect::<Vec<_>>();
+            diagnostics.extend(self.clean_up_scope(py, scope));
+            Err(diagnostics)
         }
     }
 
@@ -540,24 +548,24 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
 
         let missing_args = missing_arguments_from_error(ctx.name.function_name(), &err.to_string());
 
-        let diagnostic = if missing_args.is_empty() {
-            test_failure_diagnostic(
+        if missing_args.is_empty() {
+            let diagnostic = test_failure_diagnostic(
                 py,
                 ctx.source_file,
                 ctx.stmt_function_def,
                 ctx.function_arguments,
                 &err,
-            )
+            );
+            TestExecutionOutcome::failed(diagnostic)
         } else {
-            missing_fixtures_diagnostic(
+            let diagnostic = missing_fixtures_diagnostic(
                 ctx.source_file.clone(),
                 ctx.stmt_function_def,
                 &missing_args,
                 FunctionKind::Test,
-            )
-        };
-
-        TestExecutionOutcome::failed(diagnostic)
+            );
+            TestExecutionOutcome::error(diagnostic)
+        }
     }
 
     /// Drive the test closure with the configured retry budget.
@@ -586,11 +594,15 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         let mut attempt: u32 = 1;
         let mut current_attempt = run_attempt(attempt);
         let mut retry_count = configured_retries;
-        let mut was_retried = false;
-        let mut attempts = Vec::new();
+        let mut prior_attempts = Vec::new();
 
         while retry_count > 0 {
-            if !should_retry_result(py, &current_attempt.result, expect_fail) {
+            if !should_retry_result(
+                py,
+                &current_attempt.result,
+                expect_fail,
+                qualified_test_name.function_name().function_name(),
+            ) {
                 break;
             }
             self.context.report_test_attempt(
@@ -599,8 +611,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                 IndividualTestResultKind::Failed,
                 current_attempt.duration,
             );
-            attempts.push(current_attempt);
-            was_retried = true;
+            prior_attempts.push(current_attempt);
 
             tracing::debug!("Retrying test `{}`", qualified_test_name);
             retry_count -= 1;
@@ -608,7 +619,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             current_attempt = run_attempt(attempt);
         }
 
-        if was_retried {
+        if !prior_attempts.is_empty() {
             // Emit the per-attempt line for the final attempt so output
             // ordering matches nextest:
             //   TRY 1 FAIL ...
@@ -623,13 +634,11 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                 current_attempt.duration,
             );
         }
-        attempts.push(current_attempt);
 
         RetryOutcome {
-            attempt,
             max_attempts,
-            was_retried,
-            attempts,
+            prior_attempts,
+            final_attempt: current_attempt,
         }
     }
 
@@ -718,7 +727,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             let diagnostic = diagnostics.remove(0);
             return self.context.register_test_case_result(
                 &qualified_test_name,
-                TestExecutionOutcome::error(diagnostic).with_related(diagnostics),
+                TestExecutionOutcome::error_with_related(diagnostic, diagnostics),
                 duration,
                 captured_output,
             );
@@ -795,10 +804,9 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             coverage.set_current_context(py, Some(&qualified_name_str));
         }
         let RetryOutcome {
-            attempt,
             max_attempts,
-            was_retried,
-            attempts,
+            prior_attempts,
+            final_attempt,
         } = self.run_with_retries(
             py,
             &qualified_test_name,
@@ -823,20 +831,10 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             self.context.settings().slow_timeout_for(&eval_ctx),
         );
 
-        let execution_attempts = attempts
-            .into_iter()
-            .map(|attempt| {
-                TestExecutionAttempt::new(
-                    attempt.attempt,
-                    Self::classify_test_result(py, attempt.result, &report_ctx),
-                    attempt.duration,
-                )
-            })
-            .collect::<Vec<_>>();
-        let Some(final_attempt) = execution_attempts.last() else {
-            return false;
-        };
-        let outcome = final_attempt.outcome().clone();
+        let final_attempt_number = final_attempt.attempt;
+        let final_attempt_duration = final_attempt.duration;
+        let final_attempt_outcome =
+            Self::classify_test_result(py, final_attempt.result, &report_ctx);
 
         let mut finalizer_diagnostics = test_finalizers
             .into_iter()
@@ -844,27 +842,45 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             .filter_map(|finalizer| finalizer.run(py))
             .collect::<Vec<_>>();
         finalizer_diagnostics.extend(self.clean_up_scope(py, FixtureScope::Function));
-        let outcome = attach_finalizer_diagnostics(outcome, finalizer_diagnostics);
         let captured_output = Self::finish_output_capture(py, output_capture);
         if let Some(coverage) = self.coverage {
             coverage.set_current_context(py, None);
         }
 
-        if was_retried {
-            self.context.register_retried_result(
-                &qualified_test_name,
-                outcome,
-                total_duration,
-                TestCaseRetry::new(attempt, max_attempts),
-                captured_output,
-                execution_attempts,
-            )
-        } else {
+        if prior_attempts.is_empty() {
+            let outcome =
+                attach_finalizer_diagnostics(final_attempt_outcome, finalizer_diagnostics);
             self.context.register_test_case_result(
                 &qualified_test_name,
                 outcome,
                 total_duration,
                 captured_output,
+            )
+        } else {
+            let mut execution_attempts = prior_attempts
+                .into_iter()
+                .map(|attempt| {
+                    TestExecutionAttempt::new(
+                        attempt.attempt,
+                        Self::classify_test_result(py, attempt.result, &report_ctx),
+                        attempt.duration,
+                    )
+                })
+                .collect::<Vec<_>>();
+            execution_attempts.push(TestExecutionAttempt::new(
+                final_attempt_number,
+                final_attempt_outcome.clone(),
+                final_attempt_duration,
+            ));
+            let outcome =
+                attach_finalizer_diagnostics(final_attempt_outcome, finalizer_diagnostics);
+            self.context.register_retried_result(
+                &qualified_test_name,
+                outcome,
+                total_duration,
+                TestCaseRetry::new(final_attempt_number, max_attempts),
+                captured_output,
+                execution_attempts,
             )
         }
     }
@@ -960,10 +976,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         }
     }
 
-    /// Runs the fixtures for a given scope.
-    ///
-    /// Helper function used at the beginning of a scope to execute auto use fixture.
-    /// Here, we do nothing with the result.
+    /// Runs auto-use fixtures at the beginning of a scope.
     fn run_fixtures<P: std::ops::Deref<Target = NormalizedFixture>>(
         &self,
         py: Python,
@@ -1060,6 +1073,7 @@ fn should_retry_result(
     py: Python<'_>,
     test_result: &PyResult<TestCallOutcome>,
     expect_fail: bool,
+    test_name: &str,
 ) -> bool {
     if expect_fail {
         return false;
@@ -1068,7 +1082,10 @@ fn should_retry_result(
     match test_result {
         Ok(TestCallOutcome::ReturnedNone) => false,
         Ok(TestCallOutcome::ReturnedValue(_)) => true,
-        Err(err) => !is_skip_exception(py, err),
+        Err(err) => {
+            !is_skip_exception(py, err)
+                && missing_arguments_from_error(test_name, &err.to_string()).is_empty()
+        }
     }
 }
 
@@ -1113,7 +1130,7 @@ fn attach_finalizer_diagnostics(
         }
         TestExecutionOutcome::Passed | TestExecutionOutcome::Skipped { .. } => {
             let diagnostic = diagnostics.remove(0);
-            TestExecutionOutcome::error(diagnostic).with_related(diagnostics)
+            TestExecutionOutcome::error_with_related(diagnostic, diagnostics)
         }
     }
 }
@@ -1125,13 +1142,10 @@ enum TestCallOutcome {
 
 /// Outcome of driving a test through the configured retry budget.
 struct RetryOutcome {
-    /// The attempt number on which the test produced its final result.
-    attempt: u32,
     /// The maximum number of attempts the test was allowed (`retries + 1`).
     max_attempts: u32,
-    /// `true` if at least one retry occurred.
-    was_retried: bool,
-    attempts: Vec<TestCallAttempt>,
+    prior_attempts: Vec<TestCallAttempt>,
+    final_attempt: TestCallAttempt,
 }
 
 struct TestCallAttempt {

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -4,20 +4,21 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use karva_coverage::CoverageSession;
-use karva_diagnostic::IndividualTestResultKind;
+use karva_diagnostic::{IndividualTestResultKind, TestExecutionOutcome};
 use karva_metadata::RunIgnoredMode;
 use karva_metadata::filter::EvalContext;
 use karva_python_semantic::{FunctionKind, QualifiedFunctionName, QualifiedTestName};
 use pyo3::prelude::*;
 use pyo3::types::PyIterator;
+use ruff_db::diagnostic::Diagnostic;
 use ruff_python_ast::StmtFunctionDef;
 use ruff_source_file::SourceFile;
 
 use crate::Context;
 use crate::diagnostic::{
-    report_fixture_failure, report_fixture_resolution_error, report_invalid_parametrize,
-    report_missing_fixtures, report_test_failure, report_test_pass_on_expect_failure,
-    report_test_returned_value,
+    fixture_resolution_diagnostic, invalid_parametrize_diagnostic, missing_fixtures_diagnostic,
+    report_fixture_failure, test_failure_diagnostic, test_pass_on_expect_failure_diagnostic,
+    test_returned_value_diagnostic,
 };
 use crate::discovery::{DiscoveredModule, DiscoveredPackage, DiscoveredTestFunction};
 use crate::extensions::fixtures::{
@@ -106,34 +107,34 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         }
     }
 
-    fn register_failed_test(&self, test: &DiscoveredTestFunction) {
+    fn register_failed_test(&self, test: &DiscoveredTestFunction, diagnostic: Diagnostic) {
         self.context.register_test_case_result(
             &QualifiedTestName::new(test.name.clone(), None),
-            IndividualTestResultKind::Failed,
+            TestExecutionOutcome::Failed { diagnostic },
             std::time::Duration::ZERO,
         );
         self.record_outcome(false);
     }
 
-    fn register_failed_module_tests(&self, module: &DiscoveredModule) {
+    fn register_failed_module_tests(&self, module: &DiscoveredModule, diagnostic: &Diagnostic) {
         for test in module.test_functions() {
-            self.register_failed_test(test);
+            self.register_failed_test(test, diagnostic.clone());
             if self.max_fail_reached() {
                 return;
             }
         }
     }
 
-    fn register_failed_package_tests(&self, package: &DiscoveredPackage) {
+    fn register_failed_package_tests(&self, package: &DiscoveredPackage, diagnostic: &Diagnostic) {
         for module in package.modules().values() {
-            self.register_failed_module_tests(module);
+            self.register_failed_module_tests(module, diagnostic);
             if self.max_fail_reached() {
                 return;
             }
         }
 
         for child_package in package.packages().values() {
-            self.register_failed_package_tests(child_package);
+            self.register_failed_package_tests(child_package, diagnostic);
             if self.max_fail_reached() {
                 return;
             }
@@ -149,13 +150,12 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                     .tags
                     .validate_parametrize(&test_function.stmt_function_def)
                 {
-                    report_invalid_parametrize(
-                        self.context,
+                    let diagnostic = invalid_parametrize_diagnostic(
                         test_function.source_file.clone(),
                         &test_function.stmt_function_def,
                         &error,
                     );
-                    self.register_failed_test(test_function);
+                    self.register_failed_test(test_function, diagnostic);
                     valid = false;
                     if self.max_fail_reached() {
                         return false;
@@ -224,8 +224,8 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         // `if let Some(...)` gate: the session always exists, and if neither
         // slot contributes any autouse fixtures the walk returns an empty vec.
         if let Err(error) = self.run_auto_use_fixtures(py, &[], session, FixtureScope::Session) {
-            report_fixture_resolution_error(self.context, error);
-            self.register_failed_package_tests(session);
+            let diagnostic = fixture_resolution_diagnostic(error);
+            self.register_failed_package_tests(session, &diagnostic);
             return;
         }
 
@@ -267,8 +267,8 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         parents: &[&DiscoveredPackage],
     ) -> bool {
         if let Err(error) = self.run_auto_use_fixtures(py, parents, module, FixtureScope::Module) {
-            report_fixture_resolution_error(self.context, error);
-            self.register_failed_module_tests(module);
+            let diagnostic = fixture_resolution_diagnostic(error);
+            self.register_failed_module_tests(module, &diagnostic);
             return false;
         }
 
@@ -281,8 +281,8 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             let variants = match TestVariantIterator::new(py, test_function, &mut test_resolver) {
                 Ok(variants) => variants,
                 Err(error) => {
-                    report_fixture_resolution_error(self.context, error);
-                    self.register_failed_test(test_function);
+                    let diagnostic = fixture_resolution_diagnostic(error);
+                    self.register_failed_test(test_function, diagnostic);
                     passed = false;
                     if self.max_fail_reached() {
                         break;
@@ -330,8 +330,8 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             if let Err(error) =
                 self.run_auto_use_fixtures(py, parents, config_module, FixtureScope::Package)
             {
-                report_fixture_resolution_error(self.context, error);
-                self.register_failed_package_tests(package);
+                let diagnostic = fixture_resolution_diagnostic(error);
+                self.register_failed_package_tests(package, &diagnostic);
                 return false;
             }
         }
@@ -384,7 +384,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             if !filter.matches(&ctx) {
                 return Some(self.context.register_test_case_result(
                     &qualified,
-                    IndividualTestResultKind::Skipped { reason: None },
+                    TestExecutionOutcome::Skipped { reason: None },
                     std::time::Duration::ZERO,
                 ));
             }
@@ -395,7 +395,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                 if let (true, reason) = tags.should_skip() {
                     return Some(self.context.register_test_case_result(
                         &QualifiedTestName::new(name.clone(), None),
-                        IndividualTestResultKind::Skipped { reason },
+                        TestExecutionOutcome::Skipped { reason },
                         std::time::Duration::ZERO,
                     ));
                 }
@@ -406,7 +406,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                 if let (false, _) = tags.should_skip() {
                     return Some(self.context.register_test_case_result(
                         &QualifiedTestName::new(name.clone(), None),
-                        IndividualTestResultKind::Skipped { reason: None },
+                        TestExecutionOutcome::Skipped { reason: None },
                         std::time::Duration::ZERO,
                     ));
                 }
@@ -468,16 +468,15 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
 
     /// Classify a test result, handling `expect_fail` logic and error
     /// reporting. The provided `register` closure is invoked exactly once
-    /// with the final [`IndividualTestResultKind`] so the caller can choose
+    /// with the final [`TestExecutionOutcome`] so the caller can choose
     /// between `register_test_case_result` (for non-retried tests) and
     /// `register_retried_result` (for retried tests).
     fn classify_test_result(
-        &self,
         py: Python<'_>,
         test_result: PyResult<TestCallOutcome>,
         fixture_call_errors: Vec<FixtureCallError>,
         ctx: &VariantReportCtx<'_>,
-        register: impl FnOnce(IndividualTestResultKind) -> bool,
+        register: impl FnOnce(TestExecutionOutcome) -> bool,
     ) -> bool {
         let expect_fail = ctx
             .expect_fail_tag
@@ -486,65 +485,61 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
 
         let err = match test_result {
             Ok(TestCallOutcome::ReturnedValue(_)) if expect_fail => {
-                return register(IndividualTestResultKind::Passed);
+                return register(TestExecutionOutcome::Passed);
             }
             Ok(TestCallOutcome::ReturnedValue(value)) => {
-                report_test_returned_value(
-                    self.context,
+                let diagnostic = test_returned_value_diagnostic(
                     ctx.source_file.clone(),
                     ctx.stmt_function_def,
                     &value,
                 );
-                return register(IndividualTestResultKind::Failed);
+                return register(TestExecutionOutcome::Failed { diagnostic });
             }
             Ok(TestCallOutcome::ReturnedNone) if expect_fail => {
                 let reason = ctx.expect_fail_tag.as_ref().and_then(ExpectFailTag::reason);
-                report_test_pass_on_expect_failure(
-                    self.context,
+                let diagnostic = test_pass_on_expect_failure_diagnostic(
                     ctx.source_file.clone(),
                     ctx.stmt_function_def,
                     reason,
                 );
-                return register(IndividualTestResultKind::Failed);
+                return register(TestExecutionOutcome::Failed { diagnostic });
             }
-            Ok(TestCallOutcome::ReturnedNone) => return register(IndividualTestResultKind::Passed),
+            Ok(TestCallOutcome::ReturnedNone) => return register(TestExecutionOutcome::Passed),
             Err(err) => err,
         };
 
         if is_skip_exception(py, &err) {
-            return register(IndividualTestResultKind::Skipped {
+            return register(TestExecutionOutcome::Skipped {
                 reason: extract_skip_reason(py, &err),
             });
         }
 
         if expect_fail {
-            return register(IndividualTestResultKind::Passed);
+            return register(TestExecutionOutcome::Passed);
         }
 
         let missing_args = missing_arguments_from_error(ctx.name.function_name(), &err.to_string());
 
-        if missing_args.is_empty() {
-            report_test_failure(
-                self.context,
+        let diagnostic = if missing_args.is_empty() {
+            test_failure_diagnostic(
                 py,
                 ctx.source_file,
                 ctx.stmt_function_def,
                 ctx.function_arguments,
                 &err,
-            );
+            )
         } else {
-            report_missing_fixtures(
-                self.context,
+            missing_fixtures_diagnostic(
                 py,
                 ctx.source_file.clone(),
                 ctx.stmt_function_def,
                 &missing_args,
                 FunctionKind::Test,
                 fixture_call_errors,
-            );
-        }
+            )
+        };
 
-        register(IndividualTestResultKind::Failed)
+        register(TestExecutionOutcome::Failed { diagnostic })
     }
 
     /// Drive the test closure with the configured retry budget.
@@ -788,22 +783,37 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             // ran. This keeps `FLAKY M/T` readable as "passed on attempt M
             // out of an allowed T."
             let total_attempts = max_attempts;
-            self.classify_test_result(py, test_result, fixture_call_errors, &report_ctx, |kind| {
-                final_kind = Some(kind.clone());
-                self.context.register_retried_result(
-                    &qualified_test_name,
-                    &kind,
-                    total_duration,
-                    passed_on,
-                    total_attempts,
-                )
-            })
+            Self::classify_test_result(
+                py,
+                test_result,
+                fixture_call_errors,
+                &report_ctx,
+                |outcome| {
+                    final_kind = Some(outcome.result_kind());
+                    self.context.register_retried_result(
+                        &qualified_test_name,
+                        outcome,
+                        total_duration,
+                        passed_on,
+                        total_attempts,
+                    )
+                },
+            )
         } else {
-            self.classify_test_result(py, test_result, fixture_call_errors, &report_ctx, |kind| {
-                final_kind = Some(kind.clone());
-                self.context
-                    .register_test_case_result(&qualified_test_name, kind, total_duration)
-            })
+            Self::classify_test_result(
+                py,
+                test_result,
+                fixture_call_errors,
+                &report_ctx,
+                |outcome| {
+                    final_kind = Some(outcome.result_kind());
+                    self.context.register_test_case_result(
+                        &qualified_test_name,
+                        outcome,
+                        total_duration,
+                    )
+                },
+            )
         };
 
         for finalizer in test_finalizers.into_iter().rev() {

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use karva_coverage::CoverageSession;
-use karva_diagnostic::{IndividualTestResultKind, TestExecutionOutcome};
+use karva_diagnostic::{CapturedTestOutput, IndividualTestResultKind, TestExecutionOutcome};
 use karva_metadata::RunIgnoredMode;
 use karva_metadata::filter::EvalContext;
 use karva_python_semantic::{FunctionKind, QualifiedFunctionName, QualifiedTestName};
@@ -112,6 +112,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             &QualifiedTestName::new(test.name.clone(), None),
             TestExecutionOutcome::Failed { diagnostic },
             std::time::Duration::ZERO,
+            None,
         );
         self.record_outcome(false);
     }
@@ -188,25 +189,21 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         }
     }
 
-    fn register_captured_output(
-        &self,
+    fn finish_output_capture(
         py: Python<'_>,
         capture: Option<PythonOutputCapture>,
-        test_name: &QualifiedTestName,
-        result: &IndividualTestResultKind,
-    ) {
-        let Some(capture) = capture else {
-            return;
-        };
+    ) -> Option<CapturedTestOutput> {
+        let capture = capture?;
 
         match capture.finish(py) {
-            Ok(output) => self.context.register_captured_output(
-                test_name,
-                result,
-                output.stdout,
-                output.stderr,
-            ),
-            Err(err) => tracing::warn!("failed to finish Python output capture: {err}"),
+            Ok(output) => {
+                let output = CapturedTestOutput::new(output.stdout, output.stderr);
+                (!output.is_empty()).then_some(output)
+            }
+            Err(err) => {
+                tracing::warn!("failed to finish Python output capture: {err}");
+                None
+            }
         }
     }
 
@@ -386,6 +383,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                     &qualified,
                     TestExecutionOutcome::Skipped { reason: None },
                     std::time::Duration::ZERO,
+                    None,
                 ));
             }
         }
@@ -397,6 +395,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                         &QualifiedTestName::new(name.clone(), None),
                         TestExecutionOutcome::Skipped { reason },
                         std::time::Duration::ZERO,
+                        None,
                     ));
                 }
             }
@@ -408,6 +407,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                         &QualifiedTestName::new(name.clone(), None),
                         TestExecutionOutcome::Skipped { reason: None },
                         std::time::Duration::ZERO,
+                        None,
                     ));
                 }
             }
@@ -466,18 +466,13 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         (function_arguments, fixture_call_errors, test_finalizers)
     }
 
-    /// Classify a test result, handling `expect_fail` logic and error
-    /// reporting. The provided `register` closure is invoked exactly once
-    /// with the final [`TestExecutionOutcome`] so the caller can choose
-    /// between `register_test_case_result` (for non-retried tests) and
-    /// `register_retried_result` (for retried tests).
+    /// Classify a test result, handling `expect_fail` logic and diagnostics.
     fn classify_test_result(
         py: Python<'_>,
         test_result: PyResult<TestCallOutcome>,
         fixture_call_errors: Vec<FixtureCallError>,
         ctx: &VariantReportCtx<'_>,
-        register: impl FnOnce(TestExecutionOutcome) -> bool,
-    ) -> bool {
+    ) -> TestExecutionOutcome {
         let expect_fail = ctx
             .expect_fail_tag
             .as_ref()
@@ -485,7 +480,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
 
         let err = match test_result {
             Ok(TestCallOutcome::ReturnedValue(_)) if expect_fail => {
-                return register(TestExecutionOutcome::Passed);
+                return TestExecutionOutcome::Passed;
             }
             Ok(TestCallOutcome::ReturnedValue(value)) => {
                 let diagnostic = test_returned_value_diagnostic(
@@ -493,7 +488,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                     ctx.stmt_function_def,
                     &value,
                 );
-                return register(TestExecutionOutcome::Failed { diagnostic });
+                return TestExecutionOutcome::Failed { diagnostic };
             }
             Ok(TestCallOutcome::ReturnedNone) if expect_fail => {
                 let reason = ctx.expect_fail_tag.as_ref().and_then(ExpectFailTag::reason);
@@ -502,20 +497,20 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                     ctx.stmt_function_def,
                     reason,
                 );
-                return register(TestExecutionOutcome::Failed { diagnostic });
+                return TestExecutionOutcome::Failed { diagnostic };
             }
-            Ok(TestCallOutcome::ReturnedNone) => return register(TestExecutionOutcome::Passed),
+            Ok(TestCallOutcome::ReturnedNone) => return TestExecutionOutcome::Passed,
             Err(err) => err,
         };
 
         if is_skip_exception(py, &err) {
-            return register(TestExecutionOutcome::Skipped {
+            return TestExecutionOutcome::Skipped {
                 reason: extract_skip_reason(py, &err),
-            });
+            };
         }
 
         if expect_fail {
-            return register(TestExecutionOutcome::Passed);
+            return TestExecutionOutcome::Passed;
         }
 
         let missing_args = missing_arguments_from_error(ctx.name.function_name(), &err.to_string());
@@ -539,7 +534,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             )
         };
 
-        register(TestExecutionOutcome::Failed { diagnostic })
+        TestExecutionOutcome::Failed { diagnostic }
     }
 
     /// Drive the test closure with the configured retry budget.
@@ -775,71 +770,35 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             self.context.settings().slow_timeout_for(&eval_ctx),
         );
 
-        let mut final_kind = None;
-        let passed = if was_retried {
-            let passed_on = attempt;
-            // `total_attempts` mirrors nextest: the maximum number of attempts
-            // the test was allowed (`retries + 1`), not just the count that
-            // ran. This keeps `FLAKY M/T` readable as "passed on attempt M
-            // out of an allowed T."
-            let total_attempts = max_attempts;
-            Self::classify_test_result(
-                py,
-                test_result,
-                fixture_call_errors,
-                &report_ctx,
-                |outcome| {
-                    final_kind = Some(outcome.result_kind());
-                    self.context.register_retried_result(
-                        &qualified_test_name,
-                        outcome,
-                        total_duration,
-                        passed_on,
-                        total_attempts,
-                    )
-                },
-            )
-        } else {
-            Self::classify_test_result(
-                py,
-                test_result,
-                fixture_call_errors,
-                &report_ctx,
-                |outcome| {
-                    final_kind = Some(outcome.result_kind());
-                    self.context.register_test_case_result(
-                        &qualified_test_name,
-                        outcome,
-                        total_duration,
-                    )
-                },
-            )
-        };
+        let outcome = Self::classify_test_result(py, test_result, fixture_call_errors, &report_ctx);
 
         for finalizer in test_finalizers.into_iter().rev() {
             finalizer.run(self.context, py);
         }
 
         self.clean_up_scope(py, FixtureScope::Function);
-        match final_kind.as_ref() {
-            Some(kind) => {
-                self.register_captured_output(py, output_capture, &qualified_test_name, kind);
-            }
-            None => {
-                if let Some(capture) = output_capture
-                    && let Err(err) = capture.finish(py)
-                {
-                    tracing::warn!(
-                        "discarded Python output capture for `{qualified_test_name}` after missing result kind: {err}"
-                    );
-                }
-            }
-        }
+        let captured_output = Self::finish_output_capture(py, output_capture);
         if let Some(coverage) = self.coverage {
             coverage.set_current_context(py, None);
         }
 
-        passed
+        if was_retried {
+            self.context.register_retried_result(
+                &qualified_test_name,
+                outcome,
+                total_duration,
+                attempt,
+                max_attempts,
+                captured_output,
+            )
+        } else {
+            self.context.register_test_case_result(
+                &qualified_test_name,
+                outcome,
+                total_duration,
+                captured_output,
+            )
+        }
     }
 
     /// Run a fixture

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -4,7 +4,10 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use karva_coverage::CoverageSession;
-use karva_diagnostic::{CapturedTestOutput, IndividualTestResultKind, TestExecutionOutcome};
+use karva_diagnostic::{
+    CapturedTestOutput, IndividualTestResultKind, TestCaseRetry, TestExecutionAttempt,
+    TestExecutionOutcome,
+};
 use karva_metadata::RunIgnoredMode;
 use karva_metadata::filter::EvalContext;
 use karva_python_semantic::{FunctionKind, QualifiedFunctionName, QualifiedTestName};
@@ -16,8 +19,8 @@ use ruff_source_file::SourceFile;
 
 use crate::Context;
 use crate::diagnostic::{
-    fixture_resolution_diagnostic, invalid_parametrize_diagnostic, missing_fixtures_diagnostic,
-    report_fixture_failure, test_failure_diagnostic, test_pass_on_expect_failure_diagnostic,
+    fixture_failure_diagnostic, fixture_resolution_diagnostic, invalid_parametrize_diagnostic,
+    missing_fixtures_diagnostic, test_failure_diagnostic, test_pass_on_expect_failure_diagnostic,
     test_returned_value_diagnostic,
 };
 use crate::discovery::{DiscoveredModule, DiscoveredPackage, DiscoveredTestFunction};
@@ -31,7 +34,7 @@ use crate::extensions::tags::timeout::TimeoutTag;
 use crate::output_capture::PythonOutputCapture;
 use crate::runner::fixture_resolver::RuntimeFixtureResolver;
 use crate::runner::test_iterator::{TestVariant, TestVariantIterator};
-use crate::runner::{FinalizerCache, FixtureArguments, FixtureCache, FixtureResolutionResult};
+use crate::runner::{FinalizerCache, FixtureArguments, FixtureCache};
 use crate::utils::{
     full_test_name, run_coroutine, run_test_with_timeout, set_attempt_env, set_test_name_env,
     truncate_string,
@@ -107,35 +110,49 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         }
     }
 
-    fn register_failed_test(&self, test: &DiscoveredTestFunction, diagnostic: Diagnostic) {
+    fn register_error_test(
+        &self,
+        test: &DiscoveredTestFunction,
+        diagnostic: Diagnostic,
+        related: Vec<Diagnostic>,
+    ) {
         self.context.register_test_case_result(
             &QualifiedTestName::new(test.name.clone(), None),
-            TestExecutionOutcome::Failed { diagnostic },
+            TestExecutionOutcome::error(diagnostic).with_related(related),
             std::time::Duration::ZERO,
             None,
         );
         self.record_outcome(false);
     }
 
-    fn register_failed_module_tests(&self, module: &DiscoveredModule, diagnostic: &Diagnostic) {
+    fn register_error_module_tests(
+        &self,
+        module: &DiscoveredModule,
+        diagnostic: &Diagnostic,
+        related: &[Diagnostic],
+    ) {
         for test in module.test_functions() {
-            self.register_failed_test(test, diagnostic.clone());
+            self.register_error_test(test, diagnostic.clone(), related.to_vec());
             if self.max_fail_reached() {
                 return;
             }
         }
     }
 
-    fn register_failed_package_tests(&self, package: &DiscoveredPackage, diagnostic: &Diagnostic) {
+    fn register_error_package_tests(
+        &self,
+        package: &DiscoveredPackage,
+        diagnostic: &Diagnostic,
+        related: &[Diagnostic],
+    ) {
         for module in package.modules().values() {
-            self.register_failed_module_tests(module, diagnostic);
+            self.register_error_module_tests(module, diagnostic, related);
             if self.max_fail_reached() {
                 return;
             }
         }
-
         for child_package in package.packages().values() {
-            self.register_failed_package_tests(child_package, diagnostic);
+            self.register_error_package_tests(child_package, diagnostic, related);
             if self.max_fail_reached() {
                 return;
             }
@@ -156,7 +173,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                         &test_function.stmt_function_def,
                         &error,
                     );
-                    self.register_failed_test(test_function, diagnostic);
+                    self.register_error_test(test_function, diagnostic, Vec::new());
                     valid = false;
                     if self.max_fail_reached() {
                         return false;
@@ -220,15 +237,17 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         // the user conftest at the session root and the framework module. No
         // `if let Some(...)` gate: the session always exists, and if neither
         // slot contributes any autouse fixtures the walk returns an empty vec.
-        if let Err(error) = self.run_auto_use_fixtures(py, &[], session, FixtureScope::Session) {
-            let diagnostic = fixture_resolution_diagnostic(error);
-            self.register_failed_package_tests(session, &diagnostic);
+        if let Err(mut diagnostics) =
+            self.run_auto_use_fixtures(py, &[], session, FixtureScope::Session)
+        {
+            let diagnostic = diagnostics.remove(0);
+            self.register_error_package_tests(session, &diagnostic, &diagnostics);
             return;
         }
 
         self.execute_package(py, session, &[]);
 
-        self.clean_up_scope(py, FixtureScope::Session);
+        self.report_scope_cleanup(py, FixtureScope::Session);
     }
 
     /// Resolve and run auto-use fixtures for `scope`. Resolution cycles are
@@ -241,15 +260,20 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         parents: &'b [&'b DiscoveredPackage],
         current: &'b (dyn HasFixtures<'b> + 'b),
         scope: FixtureScope,
-    ) -> FixtureResolutionResult<()> {
+    ) -> Result<(), Vec<Diagnostic>> {
         let mut resolver = RuntimeFixtureResolver::new(parents, current);
-        let auto_use_fixtures = resolver.get_normalized_auto_use_fixtures(py, scope)?;
+        let auto_use_fixtures = resolver
+            .get_normalized_auto_use_fixtures(py, scope)
+            .map_err(|error| vec![fixture_resolution_diagnostic(error)])?;
         let auto_use_errors = self.run_fixtures(py, &auto_use_fixtures);
-        for error in auto_use_errors {
-            report_fixture_failure(self.context, py, error);
+        if auto_use_errors.is_empty() {
+            Ok(())
+        } else {
+            Err(auto_use_errors
+                .into_iter()
+                .map(|error| fixture_failure_diagnostic(py, error))
+                .collect())
         }
-
-        Ok(())
     }
 
     /// Execute a module.
@@ -263,9 +287,11 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         module: &DiscoveredModule,
         parents: &[&DiscoveredPackage],
     ) -> bool {
-        if let Err(error) = self.run_auto_use_fixtures(py, parents, module, FixtureScope::Module) {
-            let diagnostic = fixture_resolution_diagnostic(error);
-            self.register_failed_module_tests(module, &diagnostic);
+        if let Err(mut diagnostics) =
+            self.run_auto_use_fixtures(py, parents, module, FixtureScope::Module)
+        {
+            let diagnostic = diagnostics.remove(0);
+            self.register_error_module_tests(module, &diagnostic, &diagnostics);
             return false;
         }
 
@@ -279,7 +305,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                 Ok(variants) => variants,
                 Err(error) => {
                     let diagnostic = fixture_resolution_diagnostic(error);
-                    self.register_failed_test(test_function, diagnostic);
+                    self.register_error_test(test_function, diagnostic, Vec::new());
                     passed = false;
                     if self.max_fail_reached() {
                         break;
@@ -304,7 +330,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             }
         }
 
-        self.clean_up_scope(py, FixtureScope::Module);
+        self.report_scope_cleanup(py, FixtureScope::Module);
 
         passed
     }
@@ -324,11 +350,11 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         new_parents.push(package);
 
         if let Some(config_module) = package.configuration_module_impl() {
-            if let Err(error) =
+            if let Err(mut diagnostics) =
                 self.run_auto_use_fixtures(py, parents, config_module, FixtureScope::Package)
             {
-                let diagnostic = fixture_resolution_diagnostic(error);
-                self.register_failed_package_tests(package, &diagnostic);
+                let diagnostic = diagnostics.remove(0);
+                self.register_error_package_tests(package, &diagnostic, &diagnostics);
                 return false;
             }
         }
@@ -353,7 +379,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             }
         }
 
-        self.clean_up_scope(py, FixtureScope::Package);
+        self.report_scope_cleanup(py, FixtureScope::Package);
 
         passed
     }
@@ -470,7 +496,6 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
     fn classify_test_result(
         py: Python<'_>,
         test_result: PyResult<TestCallOutcome>,
-        fixture_call_errors: Vec<FixtureCallError>,
         ctx: &VariantReportCtx<'_>,
     ) -> TestExecutionOutcome {
         let expect_fail = ctx
@@ -488,7 +513,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                     ctx.stmt_function_def,
                     &value,
                 );
-                return TestExecutionOutcome::Failed { diagnostic };
+                return TestExecutionOutcome::failed(diagnostic);
             }
             Ok(TestCallOutcome::ReturnedNone) if expect_fail => {
                 let reason = ctx.expect_fail_tag.as_ref().and_then(ExpectFailTag::reason);
@@ -497,7 +522,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                     ctx.stmt_function_def,
                     reason,
                 );
-                return TestExecutionOutcome::Failed { diagnostic };
+                return TestExecutionOutcome::failed(diagnostic);
             }
             Ok(TestCallOutcome::ReturnedNone) => return TestExecutionOutcome::Passed,
             Err(err) => err,
@@ -525,16 +550,14 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             )
         } else {
             missing_fixtures_diagnostic(
-                py,
                 ctx.source_file.clone(),
                 ctx.stmt_function_def,
                 &missing_args,
                 FunctionKind::Test,
-                fixture_call_errors,
             )
         };
 
-        TestExecutionOutcome::Failed { diagnostic }
+        TestExecutionOutcome::failed(diagnostic)
     }
 
     /// Drive the test closure with the configured retry budget.
@@ -551,36 +574,38 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         mut run_test: impl FnMut() -> PyResult<TestCallOutcome>,
     ) -> RetryOutcome {
         let max_attempts = configured_retries.saturating_add(1);
-        let mut run_attempt =
-            |attempt| set_attempt_env(py, attempt, max_attempts).and_then(|()| run_test());
-
+        let mut run_attempt = |attempt| {
+            let start = std::time::Instant::now();
+            let result = set_attempt_env(py, attempt, max_attempts).and_then(|()| run_test());
+            TestCallAttempt {
+                attempt,
+                result,
+                duration: start.elapsed(),
+            }
+        };
         let mut attempt: u32 = 1;
-        let mut attempt_start = std::time::Instant::now();
-        let mut test_result = run_attempt(attempt);
-
+        let mut current_attempt = run_attempt(attempt);
         let mut retry_count = configured_retries;
         let mut was_retried = false;
-        let mut final_attempt_duration = attempt_start.elapsed();
+        let mut attempts = Vec::new();
 
         while retry_count > 0 {
-            if !should_retry_result(py, &test_result, expect_fail) {
+            if !should_retry_result(py, &current_attempt.result, expect_fail) {
                 break;
             }
-            let attempt_duration = attempt_start.elapsed();
             self.context.report_test_attempt(
                 qualified_test_name,
                 attempt,
                 IndividualTestResultKind::Failed,
-                attempt_duration,
+                current_attempt.duration,
             );
+            attempts.push(current_attempt);
             was_retried = true;
 
             tracing::debug!("Retrying test `{}`", qualified_test_name);
             retry_count -= 1;
             attempt += 1;
-            attempt_start = std::time::Instant::now();
-            test_result = run_attempt(attempt);
-            final_attempt_duration = attempt_start.elapsed();
+            current_attempt = run_attempt(attempt);
         }
 
         if was_retried {
@@ -590,20 +615,21 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             //   TRY 2 PASS ...   (or TRY 2 FAIL for an exhausted retry)
             // The diagnostic for the final attempt (if any) is collected by
             // `classify_test_result` and shown in the end-of-run block.
-            let final_kind = attempt_result_kind(py, &test_result);
+            let final_kind = attempt_result_kind(py, &current_attempt.result);
             self.context.report_test_attempt(
                 qualified_test_name,
                 attempt,
                 final_kind,
-                final_attempt_duration,
+                current_attempt.duration,
             );
         }
+        attempts.push(current_attempt);
 
         RetryOutcome {
-            test_result,
             attempt,
             max_attempts,
             was_retried,
+            attempts,
         }
     }
 
@@ -661,8 +687,42 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
 
         let qualified_test_name =
             QualifiedTestName::new(name.clone(), Some(computed_full_test_name));
+        let custom_tag_names = tags.custom_tag_names();
+        let qualified_name_str = qualified_test_name.to_string();
+        let eval_ctx = karva_metadata::filter::EvalContext {
+            test_name: &qualified_name_str,
+            tags: &custom_tag_names,
+        };
 
         tracing::debug!("Running test `{}`", qualified_test_name);
+
+        if !fixture_call_errors.is_empty() {
+            let mut diagnostics = fixture_call_errors
+                .into_iter()
+                .map(|error| fixture_failure_diagnostic(py, error))
+                .collect::<Vec<_>>();
+            diagnostics.extend(
+                test_finalizers
+                    .into_iter()
+                    .rev()
+                    .filter_map(|finalizer| finalizer.run(py)),
+            );
+            diagnostics.extend(self.clean_up_scope(py, FixtureScope::Function));
+            let captured_output = Self::finish_output_capture(py, output_capture);
+            let duration = start_time.elapsed();
+            self.maybe_register_slow(
+                &qualified_test_name,
+                duration,
+                self.context.settings().slow_timeout_for(&eval_ctx),
+            );
+            let diagnostic = diagnostics.remove(0);
+            return self.context.register_test_case_result(
+                &qualified_test_name,
+                TestExecutionOutcome::error(diagnostic).with_related(diagnostics),
+                duration,
+                captured_output,
+            );
+        }
 
         let test_name_env_result = set_test_name_env(py, &qualified_test_name.to_string());
 
@@ -679,13 +739,6 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                 &fixture_names,
             ),
         );
-
-        let custom_tag_names = tags.custom_tag_names();
-        let qualified_name_str = qualified_test_name.to_string();
-        let eval_ctx = karva_metadata::filter::EvalContext {
-            test_name: &qualified_name_str,
-            tags: &custom_tag_names,
-        };
 
         let async_patch_result = if stmt_function_def.is_async {
             crate::utils::patch_async_test_function(py, &function)
@@ -742,10 +795,10 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             coverage.set_current_context(py, Some(&qualified_name_str));
         }
         let RetryOutcome {
-            test_result,
             attempt,
             max_attempts,
             was_retried,
+            attempts,
         } = self.run_with_retries(
             py,
             &qualified_test_name,
@@ -770,13 +823,28 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             self.context.settings().slow_timeout_for(&eval_ctx),
         );
 
-        let outcome = Self::classify_test_result(py, test_result, fixture_call_errors, &report_ctx);
+        let execution_attempts = attempts
+            .into_iter()
+            .map(|attempt| {
+                TestExecutionAttempt::new(
+                    attempt.attempt,
+                    Self::classify_test_result(py, attempt.result, &report_ctx),
+                    attempt.duration,
+                )
+            })
+            .collect::<Vec<_>>();
+        let Some(final_attempt) = execution_attempts.last() else {
+            return false;
+        };
+        let outcome = final_attempt.outcome().clone();
 
-        for finalizer in test_finalizers.into_iter().rev() {
-            finalizer.run(self.context, py);
-        }
-
-        self.clean_up_scope(py, FixtureScope::Function);
+        let mut finalizer_diagnostics = test_finalizers
+            .into_iter()
+            .rev()
+            .filter_map(|finalizer| finalizer.run(py))
+            .collect::<Vec<_>>();
+        finalizer_diagnostics.extend(self.clean_up_scope(py, FixtureScope::Function));
+        let outcome = attach_finalizer_diagnostics(outcome, finalizer_diagnostics);
         let captured_output = Self::finish_output_capture(py, output_capture);
         if let Some(coverage) = self.coverage {
             coverage.set_current_context(py, None);
@@ -787,9 +855,9 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                 &qualified_test_name,
                 outcome,
                 total_duration,
-                attempt,
-                max_attempts,
+                TestCaseRetry::new(attempt, max_attempts),
                 captured_output,
+                execution_attempts,
             )
         } else {
             self.context.register_test_case_result(
@@ -880,11 +948,16 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
     /// Cleans up the fixtures and finalizers for a given scope.
     ///
     /// This should be run after the given scope has finished execution.
-    fn clean_up_scope(&self, py: Python, scope: FixtureScope) {
-        self.finalizer_cache
-            .run_and_clear_scope(self.context, py, scope);
-
+    fn clean_up_scope(&self, py: Python, scope: FixtureScope) -> Vec<Diagnostic> {
+        let diagnostics = self.finalizer_cache.run_and_clear_scope(py, scope);
         self.fixture_cache.clear_fixtures(scope);
+        diagnostics
+    }
+
+    fn report_scope_cleanup(&self, py: Python, scope: FixtureScope) {
+        for diagnostic in self.clean_up_scope(py, scope) {
+            self.context.add_run_diagnostic(diagnostic);
+        }
     }
 
     /// Runs the fixtures for a given scope.
@@ -1009,6 +1082,42 @@ fn returned_value_repr(py: Python<'_>, value: &Py<PyAny>) -> String {
     }
 }
 
+fn attach_finalizer_diagnostics(
+    outcome: TestExecutionOutcome,
+    mut diagnostics: Vec<Diagnostic>,
+) -> TestExecutionOutcome {
+    if diagnostics.is_empty() {
+        return outcome;
+    }
+
+    match outcome {
+        TestExecutionOutcome::Failed {
+            diagnostic,
+            mut related,
+        } => {
+            related.append(&mut diagnostics);
+            TestExecutionOutcome::Failed {
+                diagnostic,
+                related,
+            }
+        }
+        TestExecutionOutcome::Error {
+            diagnostic,
+            mut related,
+        } => {
+            related.append(&mut diagnostics);
+            TestExecutionOutcome::Error {
+                diagnostic,
+                related,
+            }
+        }
+        TestExecutionOutcome::Passed | TestExecutionOutcome::Skipped { .. } => {
+            let diagnostic = diagnostics.remove(0);
+            TestExecutionOutcome::error(diagnostic).with_related(diagnostics)
+        }
+    }
+}
+
 enum TestCallOutcome {
     ReturnedNone,
     ReturnedValue(String),
@@ -1016,13 +1125,19 @@ enum TestCallOutcome {
 
 /// Outcome of driving a test through the configured retry budget.
 struct RetryOutcome {
-    test_result: PyResult<TestCallOutcome>,
     /// The attempt number on which the test produced its final result.
     attempt: u32,
     /// The maximum number of attempts the test was allowed (`retries + 1`).
     max_attempts: u32,
     /// `true` if at least one retry occurred.
     was_retried: bool,
+    attempts: Vec<TestCallAttempt>,
+}
+
+struct TestCallAttempt {
+    attempt: u32,
+    result: PyResult<TestCallOutcome>,
+    duration: std::time::Duration,
 }
 
 /// Immutable per-variant state threaded into [`PackageRunner::classify_test_result`].

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -153,14 +153,14 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
         .color(colored::control::SHOULD_COLORIZE.should_colorize())
         .context(0);
 
-    cache.write_result(args.worker_id, &result, &cwd, &config)?;
-
     // Propagate the stop signal to sibling workers whenever this worker has
     // reached (or exceeded) its configured max-fail budget. The budget is
     // enforced locally per worker inside `PackageRunner`, so hitting any
     // failure here while `max_fail` is set means we ran out of budget.
     let failed_count =
         u32::try_from(result.stats().failed() + result.stats().errors()).unwrap_or(u32::MAX);
+    cache.write_result(args.worker_id, result, &cwd, &config)?;
+
     if settings.max_fail().is_exceeded_by(failed_count) {
         cache.write_fail_fast_signal()?;
     }

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -159,7 +159,8 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
     // reached (or exceeded) its configured max-fail budget. The budget is
     // enforced locally per worker inside `PackageRunner`, so hitting any
     // failure here while `max_fail` is set means we ran out of budget.
-    let failed_count = u32::try_from(result.stats().failed()).unwrap_or(u32::MAX);
+    let failed_count =
+        u32::try_from(result.stats().failed() + result.stats().errors()).unwrap_or(u32::MAX);
     if settings.max_fail().is_exceeded_by(failed_count) {
         cache.write_fail_fast_signal()?;
     }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -134,7 +134,7 @@ karva test [OPTIONS] [PATH]...
 <p>Possible values:</p>
 <ul>
 <li><code>json</code>:  Write one JSON document with the full run result</li>
-<li><code>jsonl</code>:  Write newline-delimited JSON events</li>
+<li><code>jsonl</code>:  Write newline-delimited JSON records</li>
 </ul></dd><dt id="karva-test--result-output"><a href="#karva-test--result-output"><code>--result-output</code></a> <i>path</i></dt><dd><p>Write machine-readable test results to this path</p>
 </dd><dt id="karva-test--retry"><a href="#karva-test--retry"><code>--retry</code></a> <i>retry</i></dt><dd><p>When set, the test will retry failed tests up to this number of times</p>
 </dd><dt id="karva-test--run-ignored"><a href="#karva-test--run-ignored"><code>--run-ignored</code></a> <i>run-ignored</i></dt><dd><p>Run ignored tests</p>


### PR DESCRIPTION
## Summary

Model test outcomes as passed, failed, errored, or skipped; attach fixture setup and teardown diagnostics to the affected test; and preserve every retry attempt while keeping collection diagnostics run-scoped. Terminal, JSON/JSONL, JUnit, and cache reporting now consume the same canonical records, with nextest-style error and rerun output and plain machine-readable diagnostics.

## Test Plan

`just test`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `uvx prek run -a`.