### PR TITLE
Support explicit parametrize IDs

### DIFF
--- a/crates/karva/tests/it/extensions/tags/parametrize.rs
+++ b/crates/karva/tests/it/extensions/tags/parametrize.rs
@@ -1261,6 +1261,13 @@ import {framework}
 @{parametrize}("value", [1, 2], ids=["one", "two"])
 def test_value(value):
     assert value > 0
+
+def parameter_id(value):
+    return value.upper() if isinstance(value, str) else None
+
+@{parametrize}("number,label", [(1, "one"), (2, "two")], ids=parameter_id)
+def test_pair(number, label):
+    assert number == {{"one": 1, "two": 2}}[label]
 "#,
             parametrize = get_parametrize_function(framework),
         ),
@@ -1271,11 +1278,13 @@ def test_value(value):
         success: true
         exit_code: 0
         ----- stdout -----
-            Starting 1 test across 1 worker
+            Starting 2 tests across 1 worker
                 PASS [TIME] test::test_value(one)
                 PASS [TIME] test::test_value(two)
+                PASS [TIME] test::test_pair(1-ONE)
+                PASS [TIME] test::test_pair(2-TWO)
         ────────────
-             Summary [TIME] 2 tests run: 2 passed, 0 skipped
+             Summary [TIME] 4 tests run: 4 passed, 0 skipped
 
         ----- stderr -----
         ");

--- a/crates/karva/tests/it/extensions/tags/parametrize.rs
+++ b/crates/karva/tests/it/extensions/tags/parametrize.rs
@@ -1250,6 +1250,143 @@ fn test_parametrize_multiple_args_single_string(#[values("pytest", "karva")] fra
     }
 }
 
+#[rstest]
+fn test_parametrize_with_ids(#[values("pytest", "karva")] framework: &str) {
+    let test_context = TestContext::with_file(
+        "test.py",
+        &format!(
+            r#"
+import {framework}
+
+@{parametrize}("value", [1, 2], ids=["one", "two"])
+def test_value(value):
+    assert value > 0
+"#,
+            parametrize = get_parametrize_function(framework),
+        ),
+    );
+
+    allow_duplicates! {
+        assert_cmd_snapshot!(test_context.command(), @"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+            Starting 1 test across 1 worker
+                PASS [TIME] test::test_value(one)
+                PASS [TIME] test::test_value(two)
+        ────────────
+             Summary [TIME] 2 tests run: 2 passed, 0 skipped
+
+        ----- stderr -----
+        ");
+    }
+}
+
+#[test]
+fn test_pytest_parametrize_ids_use_pytest_positional_index() {
+    let test_context = TestContext::with_file(
+        "test.py",
+        r#"
+import pytest
+
+@pytest.mark.parametrize("value", [1, 2], False, ["one", "two"])
+def test_value(value):
+    assert value > 0
+"#,
+    );
+
+    assert_cmd_snapshot!(test_context.command(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_value(one)
+            PASS [TIME] test::test_value(two)
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[rstest]
+fn test_stacked_parametrize_combines_ids(#[values("pytest", "karva")] framework: &str) {
+    let test_context = TestContext::with_file(
+        "test.py",
+        &format!(
+            r#"
+import {framework}
+
+@{parametrize}("left", [1, 2], ids=["one", "two"])
+@{parametrize}("right", [3, 4], ids=["three", "four"])
+def test_values(left, right):
+    assert left < right
+"#,
+            parametrize = get_parametrize_function(framework),
+        ),
+    );
+
+    allow_duplicates! {
+        assert_cmd_snapshot!(test_context.command(), @"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+            Starting 1 test across 1 worker
+                PASS [TIME] test::test_values(three-one)
+                PASS [TIME] test::test_values(three-two)
+                PASS [TIME] test::test_values(four-one)
+                PASS [TIME] test::test_values(four-two)
+        ────────────
+             Summary [TIME] 4 tests run: 4 passed, 0 skipped
+
+        ----- stderr -----
+        ");
+    }
+}
+
+#[rstest]
+fn test_parametrize_rejects_duplicate_ids(#[values("pytest", "karva")] framework: &str) {
+    let test_context = TestContext::with_file(
+        "test.py",
+        &format!(
+            r#"
+import {framework}
+
+@{parametrize}("value", [1, 2], ids=["same", "same"])
+def test_value(value):
+    pass
+"#,
+            parametrize = get_parametrize_function(framework),
+        ),
+    );
+
+    allow_duplicates! {
+        assert_cmd_snapshot!(test_context.command(), @"
+        success: false
+        exit_code: 1
+        ----- stdout -----
+            Starting 1 test across 1 worker
+               ERROR [TIME] test::test_value
+
+        failures:
+
+        test::test_value:
+
+        error[invalid-parametrize]: Parameter ID `same` is used more than once
+         --> test.py:5:5
+          |
+        5 | def test_value(value):
+          |     ^^^^^^^^^^
+          |
+
+        ────────────
+             Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
+
+        ----- stderr -----
+        ");
+    }
+}
+
 #[test]
 fn test_parametrize_with_pytest_param_single_arg() {
     let test_context = TestContext::with_file(
@@ -1259,7 +1396,7 @@ import pytest
 
 @pytest.mark.parametrize("a", [
     pytest.param(1),
-    pytest.param(2),
+    pytest.param(2, id="two"),
     pytest.param(3),
 ])
 def test_single_arg(a):
@@ -1273,7 +1410,7 @@ def test_single_arg(a):
     ----- stdout -----
         Starting 1 test across 1 worker
             PASS [TIME] test::test_single_arg(a=1)
-            PASS [TIME] test::test_single_arg(a=2)
+            PASS [TIME] test::test_single_arg(two)
             PASS [TIME] test::test_single_arg(a=3)
     ────────────
          Summary [TIME] 3 tests run: 3 passed, 0 skipped

--- a/crates/karva_test_semantic/src/extensions/functions/python.rs
+++ b/crates/karva_test_semantic/src/extensions/functions/python.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 
-use crate::extensions::tags::parametrize::Parametrization;
+use crate::extensions::tags::parametrize::{Parametrization, default_param_id};
 use crate::extensions::tags::{Tag, Tags};
 
 // SkipError exception that can be raised to skip tests at runtime with an optional reason
@@ -20,6 +20,12 @@ pub struct Param {
 
     /// Tags associated with this parametrization
     pub(crate) tags: Tags,
+
+    /// Explicit display ID.
+    pub(crate) id: Option<String>,
+
+    /// Value-derived display ID for partially explicit stacked parametrization.
+    pub(crate) default_id: String,
 }
 
 impl Param {
@@ -32,14 +38,29 @@ impl Param {
             );
         }
 
+        let values = values.into_iter().map(Arc::new).collect::<Vec<_>>();
         Ok(Self {
-            values: values.into_iter().map(Arc::new).collect(),
+            default_id: default_param_id(py, &values),
+            values,
             tags: Tags::new(new_tags),
+            id: None,
         })
     }
 
-    pub(crate) fn from_parametrization(Parametrization { values, tags }: Parametrization) -> Self {
-        Self { values, tags }
+    pub(crate) fn from_parametrization(
+        Parametrization {
+            values,
+            tags,
+            id,
+            default_id,
+        }: Parametrization,
+    ) -> Self {
+        Self {
+            values,
+            tags,
+            id,
+            default_id,
+        }
     }
 }
 

--- a/crates/karva_test_semantic/src/extensions/tags/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/mod.rs
@@ -339,6 +339,19 @@ impl Tags {
             }
         }
 
+        let mut seen_ids = HashSet::new();
+        for params in self.parametrize_args() {
+            let Some(id) = params.id() else {
+                continue;
+            };
+            if id.is_empty() {
+                return Err(InvalidParametrizeError::EmptyId);
+            }
+            if !seen_ids.insert(id.to_string()) {
+                return Err(InvalidParametrizeError::DuplicateId { id: id.to_string() });
+            }
+        }
+
         Ok(())
     }
 

--- a/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
@@ -484,9 +484,23 @@ pub(super) fn apply_parametrize_ids(
         return Ok(());
     }
     if ids.is_callable() {
-        return Err(PyValueError::new_err(
-            "callable parametrize IDs are not supported",
-        ));
+        let py = ids.py();
+        for parametrization in parametrizations {
+            if parametrization.id.is_some() {
+                continue;
+            }
+            let mut parts = Vec::with_capacity(parametrization.values.len());
+            for value in &parametrization.values {
+                let generated = ids.call1((value.bind(py),))?;
+                if generated.is_none() {
+                    parts.push(value.bind(py).to_string());
+                } else {
+                    parts.push(generated.to_string());
+                }
+            }
+            parametrization.id = Some(parts.join("-"));
+        }
+        return Ok(());
     }
     let ids = ids.extract::<Vec<Option<String>>>().map_err(|_| {
         PyValueError::new_err("parametrize ids must be a sequence of strings or None")

--- a/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
@@ -61,6 +61,10 @@ pub enum InvalidParametrizeError {
     },
     #[error("Parameter `{name}` does not exist in the test function signature")]
     UnknownName { name: String },
+    #[error("Parameter ID cannot be empty")]
+    EmptyId,
+    #[error("Parameter ID `{id}` is used more than once")]
+    DuplicateId { id: String },
 }
 
 struct ParametrizeSyntax<'a> {
@@ -162,6 +166,7 @@ impl InvalidParametrizeError {
             Self::UnknownName { name } => {
                 name_diagnostic_location(&syntaxes, name, "not accepted by test", function)
             }
+            Self::EmptyId | Self::DuplicateId { .. } => None,
         }
     }
 }
@@ -355,6 +360,12 @@ pub struct Parametrization {
 
     /// Tags specific to this parameter set (e.g., marks on pytest.param).
     pub(crate) tags: Tags,
+
+    /// Explicit display ID.
+    pub(crate) id: Option<String>,
+
+    /// Value-derived display ID for partially explicit stacked parametrization.
+    pub(crate) default_id: String,
 }
 
 impl Parametrization {
@@ -368,6 +379,8 @@ impl From<PyRef<'_, Param>> for Parametrization {
         Self {
             values: param.values.clone(),
             tags: param.tags.clone(),
+            id: param.id.clone(),
+            default_id: param.default_id.clone(),
         }
     }
 }
@@ -383,6 +396,9 @@ pub struct ParametrizationArgs {
 
     /// Combined tags from all parameter sets.
     pub(crate) tags: Tags,
+
+    id: String,
+    has_explicit_id: bool,
 }
 
 impl ParametrizationArgs {
@@ -393,7 +409,25 @@ impl ParametrizationArgs {
     pub(crate) fn extend(&mut self, other: Self) {
         self.values.extend(other.values);
         self.tags.extend(&other.tags);
+        if !self.id.is_empty() && !other.id.is_empty() {
+            self.id.push('-');
+        }
+        self.id.push_str(&other.id);
+        self.has_explicit_id |= other.has_explicit_id;
     }
+
+    pub(crate) fn id(&self) -> Option<&str> {
+        self.has_explicit_id.then_some(self.id.as_str())
+    }
+}
+
+pub fn default_param_id(py: Python<'_>, values: &[Arc<Py<PyAny>>]) -> String {
+    values
+        .iter()
+        .filter_map(|value| value.cast_bound::<PyAny>(py).ok())
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("-")
 }
 
 /// Normalize argument names from Python into a `Vec<String>`.
@@ -439,6 +473,42 @@ pub(super) fn parse_parametrize_args(
     Ok((names, parametrizations))
 }
 
+pub(super) fn apply_parametrize_ids(
+    ids: Option<&Bound<'_, PyAny>>,
+    parametrizations: &mut [Parametrization],
+) -> PyResult<()> {
+    let Some(ids) = ids else {
+        return Ok(());
+    };
+    if ids.is_none() {
+        return Ok(());
+    }
+    if ids.is_callable() {
+        return Err(PyValueError::new_err(
+            "callable parametrize IDs are not supported",
+        ));
+    }
+    let ids = ids.extract::<Vec<Option<String>>>().map_err(|_| {
+        PyValueError::new_err("parametrize ids must be a sequence of strings or None")
+    })?;
+    if ids.is_empty() {
+        return Ok(());
+    }
+    if ids.len() != parametrizations.len() {
+        return Err(PyValueError::new_err(format!(
+            "{} parameter sets specified, with different number of ids: {}",
+            parametrizations.len(),
+            ids.len()
+        )));
+    }
+    for (parametrization, id) in parametrizations.iter_mut().zip(ids) {
+        if parametrization.id.is_none() {
+            parametrization.id = id;
+        }
+    }
+    Ok(())
+}
+
 /// Represents different argument names and values that can be given to a test.
 ///
 /// This is most useful to repeat a test multiple times with different arguments instead of duplicating the test.
@@ -458,9 +528,15 @@ pub struct ParametrizeTag {
 /// - `@pytest.mark.parametrize(argnames="x", argvalues=[1, 2])` - both kwargs
 /// - `@pytest.mark.parametrize("x", argvalues=[1, 2])` - mixed
 /// - `@pytest.mark.parametrize(argnames="x", [1, 2])` - mixed
+struct ExtractedParametrizeArgs<'py> {
+    names: Bound<'py, PyAny>,
+    values: Bound<'py, PyAny>,
+    ids: Option<Bound<'py, PyAny>>,
+}
+
 fn extract_parametrize_args<'py>(
     py_mark: &Bound<'py, PyAny>,
-) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)> {
+) -> PyResult<ExtractedParametrizeArgs<'py>> {
     // Try to get argnames from positional args first, then kwargs
     let arg_names = py_mark
         .getattr("args")
@@ -483,7 +559,21 @@ fn extract_parametrize_args<'py>(
         })
         .map_err(|_| PyValueError::new_err("pytest parametrize mark requires argvalues"))?;
 
-    Ok((arg_names, arg_values))
+    let ids = py_mark
+        .getattr("args")
+        .and_then(|args| args.get_item(3))
+        .or_else(|_| {
+            py_mark
+                .getattr("kwargs")
+                .and_then(|kwargs| kwargs.get_item("ids"))
+        })
+        .ok();
+
+    Ok(ExtractedParametrizeArgs {
+        names: arg_names,
+        values: arg_values,
+        ids,
+    })
 }
 
 impl ParametrizeTag {
@@ -503,9 +593,13 @@ impl ParametrizeTag {
                     |Param {
                          values: param_values,
                          tags,
+                         id,
+                         default_id,
                      }| Parametrization {
                         values: param_values,
                         tags,
+                        id,
+                        default_id,
                     },
                 )
                 .collect(),
@@ -516,10 +610,10 @@ impl ParametrizeTag {
         py_mark: &Bound<'_, PyAny>,
         globals: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<Option<Self>> {
-        let (arg_names, arg_values) = extract_parametrize_args(py_mark)?;
+        let ExtractedParametrizeArgs { names, values, ids } = extract_parametrize_args(py_mark)?;
 
-        let (arg_names, parametrizations) =
-            parse_parametrize_args(&arg_names, &arg_values, globals)?;
+        let (arg_names, mut parametrizations) = parse_parametrize_args(&names, &values, globals)?;
+        apply_parametrize_ids(ids.as_ref(), &mut parametrizations)?;
 
         Ok(Some(Self::new(arg_names, parametrizations)))
     }
@@ -585,6 +679,11 @@ impl ParametrizeTag {
             let current_param_args = ParametrizationArgs {
                 values: current_parameratisation,
                 tags: parametrization.tags().clone(),
+                id: parametrization
+                    .id
+                    .clone()
+                    .unwrap_or_else(|| parametrization.default_id.clone()),
+                has_explicit_id: parametrization.id.is_some(),
             };
             param_args.push(current_param_args);
         }
@@ -604,6 +703,8 @@ pub(super) fn handle_custom_parametrize_param(
     let default_parametrization = || Parametrization {
         values: vec![Arc::clone(&param_arc)],
         tags: Tags::default(),
+        id: None,
+        default_id: default_param_id(py, &[Arc::clone(&param_arc)]),
     };
 
     if let Ok(param_bound) = param_arc.cast_bound::<Param>(py) {
@@ -647,11 +748,27 @@ pub(super) fn handle_custom_parametrize_param(
             }
         };
 
-        Ok(Parametrization { values, tags })
-    } else if expect_multiple && let Ok(params) = bound_param.extract::<Vec<Py<PyAny>>>() {
+        let parameter_id = bound_param.getattr("id")?;
+        let id = if parameter_id.is_none() {
+            None
+        } else {
+            Some(parameter_id.extract::<String>()?)
+        };
+        let default_id = default_param_id(py, &values);
+
         Ok(Parametrization {
-            values: params.into_iter().map(Arc::new).collect(),
+            values,
+            tags,
+            id,
+            default_id,
+        })
+    } else if expect_multiple && let Ok(params) = bound_param.extract::<Vec<Py<PyAny>>>() {
+        let values = params.into_iter().map(Arc::new).collect::<Vec<_>>();
+        Ok(Parametrization {
+            default_id: default_param_id(py, &values),
+            values,
             tags: Tags::default(),
+            id: None,
         })
     } else {
         Ok(default_parametrization())

--- a/crates/karva_test_semantic/src/extensions/tags/python.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/python.rs
@@ -128,7 +128,7 @@ pub mod tags {
 
     use super::{CustomTagBuilder, PyTag, PyTags};
     use crate::extensions::functions::python::Param;
-    use crate::extensions::tags::parametrize::parse_parametrize_args;
+    use crate::extensions::tags::parametrize::{apply_parametrize_ids, parse_parametrize_args};
     use crate::extensions::tags::python::PyTestFunction;
 
     /// Handle dynamic attribute access for custom tags.
@@ -140,14 +140,18 @@ pub mod tags {
     }
 
     #[pyfunction]
+    #[pyo3(signature = (arg_names, arg_values, ids = None))]
     fn parametrize(
         arg_names: &Bound<'_, PyAny>,
         arg_values: &Bound<'_, PyAny>,
+        ids: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<PyTags> {
         const PARAMETRIZE_TYPE_ERROR: &str = "Expected a string or a list of strings for the arg_names, and a list of lists of objects for the arg_values";
 
-        let (names, parametrization) = parse_parametrize_args(arg_names, arg_values, None)
+        let (names, mut parametrization) = parse_parametrize_args(arg_names, arg_values, None)
             .map_err(|_| PyErr::new::<PyTypeError, _>(PARAMETRIZE_TYPE_ERROR))?;
+        apply_parametrize_ids(ids, &mut parametrization)
+            .map_err(|error| PyErr::new::<PyTypeError, _>(error.to_string()))?;
 
         Ok(PyTags {
             inner: vec![PyTag::Parametrize {

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
@@ -49,6 +49,8 @@ struct VariantRunner<'runner, 'context, 'settings, 'test, 'py> {
     test: &'test crate::discovery::DiscoveredTestFunction,
     /// Parameter values reused when a retry prepares fresh fixtures.
     params: HashMap<String, Arc<Py<PyAny>>>,
+    /// User-defined parameter ID used in the displayed test name.
+    id: Option<String>,
     /// Fixtures passed as Python keyword arguments.
     fixture_dependencies: Rc<[Rc<NormalizedFixture>]>,
     /// Fixtures run for side effects but omitted from test arguments.
@@ -75,6 +77,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
         let TestVariant {
             test,
             params,
+            id,
             fixture_dependencies,
             use_fixture_dependencies,
             auto_use_fixtures,
@@ -86,6 +89,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             py,
             test,
             params,
+            id,
             fixture_dependencies,
             use_fixture_dependencies,
             auto_use_fixtures,
@@ -194,13 +198,17 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             .filter(|fixture| fixture.name.module_path().module_name() == "karva._builtins")
             .map(|fixture| fixture.function_name())
             .collect::<Vec<_>>();
-        let full_name = full_test_name(
-            self.py,
-            name.to_string(),
-            function_arguments,
-            &self.test.stmt_function_def.parameters,
-            &framework_fixture_names,
-        );
+        let full_name = if let Some(id) = &self.id {
+            format!("{name}({id})")
+        } else {
+            full_test_name(
+                self.py,
+                name.to_string(),
+                function_arguments,
+                &self.test.stmt_function_def.parameters,
+                &framework_fixture_names,
+            )
+        };
         let qualified_test_name = QualifiedTestName::new(name.clone(), Some(full_name));
         let qualified_name = qualified_test_name.to_string();
         let custom_tag_names = self.tags.custom_tag_names();

--- a/crates/karva_test_semantic/src/runner/test_iterator.rs
+++ b/crates/karva_test_semantic/src/runner/test_iterator.rs
@@ -32,6 +32,8 @@ pub(super) struct TestVariant<'a> {
     /// caller can unwrap without a Python refcount bump.
     pub(super) params: HashMap<String, Arc<Py<PyAny>>>,
 
+    pub id: Option<String>,
+
     /// Fixtures to be passed as arguments to the test function.
     pub(super) fixture_dependencies: Rc<[Rc<NormalizedFixture>]>,
 
@@ -149,6 +151,7 @@ impl<'a> Iterator for TestVariantIterator<'a> {
 
         Some(TestVariant {
             test: self.test,
+            id: param_args.id().map(str::to_string),
             params: param_args.values,
             fixture_dependencies: Rc::clone(&self.fixture_dependencies),
             use_fixture_dependencies: Rc::clone(&self.use_fixture_dependencies),

--- a/docs/usage/tags/parametrize.md
+++ b/docs/usage/tags/parametrize.md
@@ -72,6 +72,24 @@ def test_function(a: int, b: int):
 
 This runs `test_function` four times with all combinations of `a` and `b`.
 
+## IDs
+
+Use `ids` to give parameter sets stable, readable names:
+
+```python title="test.py"
+import karva
+
+@karva.tags.parametrize(
+    "card,expected",
+    [(valid_card, "paid"), (expired_card, "declined")],
+    ids=["valid-card", "expired-card"],
+)
+def test_checkout(card, expected):
+    assert checkout(card) == expected
+```
+
+IDs combine with `-` when multiple parametrize tags are stacked.
+
 ## Params
 
 You can use `karva.param` (similar to `pytest.param`) to attach tags to individual parameter sets:

--- a/docs/usage/tags/parametrize.md
+++ b/docs/usage/tags/parametrize.md
@@ -88,6 +88,21 @@ def test_checkout(card, expected):
     assert checkout(card) == expected
 ```
 
+`ids` can also be a function. It is called for each parameter value, and returned
+parts are joined with `-`:
+
+```python title="test.py"
+import karva
+
+@karva.tags.parametrize(
+    "status,expected",
+    [("paid", True), ("declined", False)],
+    ids=lambda value: value.upper() if isinstance(value, str) else None,
+)
+def test_status(status, expected):
+    assert is_successful(status) is expected
+```
+
 IDs combine with `-` when multiple parametrize tags are stacked.
 
 ## Params

--- a/python/karva/_karva/tags.pyi
+++ b/python/karva/_karva/tags.pyi
@@ -9,7 +9,7 @@ _P = ParamSpec("_P")
 def parametrize(
     arg_names: Sequence[str] | str,
     arg_values: Sequence[Sequence[object]] | Sequence[object],
-    ids: Sequence[str | None] | None = ...,
+    ids: Sequence[str | None] | Callable[[object], object | None] | None = ...,
 ) -> Tags:
     """Parametrize the current test with the given arguments."""
 

--- a/python/karva/_karva/tags.pyi
+++ b/python/karva/_karva/tags.pyi
@@ -9,6 +9,7 @@ _P = ParamSpec("_P")
 def parametrize(
     arg_names: Sequence[str] | str,
     arg_values: Sequence[Sequence[object]] | Sequence[object],
+    ids: Sequence[str | None] | None = ...,
 ) -> Tags:
     """Parametrize the current test with the given arguments."""
 


### PR DESCRIPTION
## Summary

Add sequence and callable `ids` support to `karva.tags.parametrize` and retain explicit IDs from pytest decorators and `pytest.param`. Callable generators run once per parameter value and fall back to the value-derived segment when returning `None`, matching pytest. IDs produce stable variant names throughout Karva, combine deterministically when decorators are stacked, and reject empty or duplicate resolved values. This addresses top-level parametrize IDs from #961.

## Test Plan

Ran `cargo nextest run -p karva extensions::tags::parametrize` and `uvx prek run -a`.