### PR TITLE
Restore release version input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,15 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g., 1.0.0)"
+        required: true
+        default: dry-run
+        type: string
 
 env:
   PYTHON_VERSION: "3.14"
-  VERSION: "0.0.1-alpha.8"
 
 permissions: {}
 
@@ -17,7 +22,7 @@ jobs:
       contents: read
     outputs:
       release-metadata: ${{ steps.seal-generate.outputs.metadata }}
-      tag: ${{ env.VERSION }}
+      tag: ${{ github.event.inputs.tag }}
 
     steps:
       - name: Checkout repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,8 +183,7 @@ seal bump <version>
 ```
 
 Seal creates the release branch, commits and pushes the changes, and opens a pull request. The
-release workflow handles the remaining publication steps after merge. Its release version is
-updated by `seal bump`, so running the workflow requires no version input.
+release workflow handles the remaining publication steps after merge.
 
 ## GitHub Actions
 

--- a/seal.toml
+++ b/seal.toml
@@ -2,7 +2,6 @@
 current-version = "0.0.1-alpha.8"
 
 version-files = [
-    { path = ".github/workflows/release.yml", search = "VERSION: \"{version}\"" },
     "crates/karva/Cargo.toml",
     "crates/karva_version/Cargo.toml",
     "crates/karva_python/Cargo.toml",


### PR DESCRIPTION
## Summary

Restore the required release tag input so each workflow dispatch selects the version to publish. Remove the obsolete Seal version-file entry and update release documentation to match.

## Test Plan

`pinact run` and `uvx prek run -a`