### PR TITLE
Add fail-slow duration budget for tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,6 +1377,7 @@ dependencies = [
  "karva_collector",
  "karva_coverage",
  "karva_diagnostic",
+ "karva_logging",
  "karva_metadata",
  "karva_project",
  "karva_python_semantic",

--- a/crates/karva/tests/it/configuration/overrides.rs
+++ b/crates/karva/tests/it/configuration/overrides.rs
@@ -331,3 +331,96 @@ def test_unit():
     "
     );
 }
+
+/// A matching override's `fail-slow` overrides the profile-level value.
+#[test]
+fn override_fail_slow_fails_matching_test() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[[profile.default.overrides]]
+filter = "tag(slow)"
+fail-slow = 0.1
+"#,
+        ),
+        (
+            "test.py",
+            r"
+import time
+import karva
+
+@karva.tags.slow
+def test_slow():
+    time.sleep(0.3)
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_slow
+
+    failures:
+
+    test::test_slow:
+
+    error[fail-slow-exceeded]: Test `test_slow` exceeded its fail-slow budget
+     --> test.py:6:5
+      |
+    6 | def test_slow():
+      |     ^^^^^^^^^
+      |
+    info: Configured budget: [TIME], actual duration: [TIME] (slowest phase: call)
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+/// `fail-slow = 0` on a matching override disables the budget even when
+/// the profile sets one.
+#[test]
+fn override_fail_slow_zero_disables_profile_budget() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.default.test]
+fail-slow = 0.1
+
+[[profile.default.overrides]]
+filter = "tag(integration)"
+fail-slow = 0
+"#,
+        ),
+        (
+            "test.py",
+            r"
+import time
+import karva
+
+@karva.tags.integration
+def test_long_lived():
+    time.sleep(0.3)
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_long_lived
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}

--- a/crates/karva/tests/it/extensions/tags/fail_slow.rs
+++ b/crates/karva/tests/it/extensions/tags/fail_slow.rs
@@ -221,11 +221,9 @@ def test_slow_and_wrong():
     ");
 }
 
-/// The budget is only known after the full lifecycle (including teardown)
-/// completes, so a slow-but-passing attempt is never retried purely for
-/// slowness — it runs once and is reported as an ordinary failure.
+/// A fail-slow failure consumes the retry budget like any other failure.
 #[test]
-fn test_fail_slow_is_not_retried_even_with_retry_configured() {
+fn test_fail_slow_retries_to_a_fast_attempt() {
     let context = TestContext::with_file(
         "test.py",
         r"
@@ -237,31 +235,21 @@ attempts = [0]
 @karva.tags.fail_slow(0.1)
 def test_slow():
     attempts[0] += 1
-    time.sleep(0.3)
+    if attempts[0] == 1:
+        time.sleep(0.3)
         ",
     );
 
-    assert_cmd_snapshot!(context.command_no_parallel().arg("--retry=2"), @"
-    success: false
-    exit_code: 1
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--retry=1"), @"
+    success: true
+    exit_code: 0
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test::test_slow
-
-    failures:
-
-    test::test_slow:
-
-    error[fail-slow-exceeded]: Test `test_slow` exceeded its fail-slow budget
-     --> test.py:8:5
-      |
-    8 | def test_slow():
-      |     ^^^^^^^^^
-      |
-    info: Configured budget: [TIME], actual duration: [TIME] (slowest phase: call)
-
+      TRY 1 FAIL [TIME] test::test_slow
+      TRY 2 PASS [TIME] test::test_slow
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test::test_slow
 
     ----- stderr -----
     ");
@@ -269,7 +257,7 @@ def test_slow():
 
 #[rstest]
 fn test_fail_slow_invalid_seconds_rejected(
-    #[values("0", "-1", "float('nan')", "float('inf')")] arg: &str,
+    #[values("0", "-1", "float('nan')", "float('inf')", "1e-300", "1e300")] arg: &str,
 ) {
     let context = TestContext::with_file(
         "test.py",
@@ -292,7 +280,7 @@ def test_1():
             Starting 1 test across 1 worker
         diagnostics:
 
-        error[failed-to-import-module]: Failed to import python module `test`: fail_slow seconds must be a finite, positive number
+        error[failed-to-import-module]: Failed to import python module `test`: fail_slow seconds must be a finite, positive duration supported by this platform
 
         ────────────
              Summary [TIME] 0 tests run: 0 passed, 0 skipped
@@ -300,6 +288,178 @@ def test_1():
         ----- stderr -----
         ");
     }
+}
+
+#[test]
+fn test_fail_slow_does_not_sum_retry_attempts() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import os
+import time
+import karva
+
+@karva.tags.fail_slow(0.2)
+def test_retry():
+    time.sleep(0.15)
+    assert os.environ["KARVA_ATTEMPT"] == "2"
+        "#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--retry=1"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+      TRY 1 FAIL [TIME] test::test_retry
+      TRY 2 PASS [TIME] test::test_retry
+    ────────────
+         Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test::test_retry
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_fail_slow_sets_attempt_environment_before_retry_fixture_setup() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import os
+import time
+import karva
+
+fixture_attempts = []
+
+@karva.fixture
+def resource():
+    fixture_attempts.append(os.environ.get("KARVA_ATTEMPT"))
+    yield
+    if len(fixture_attempts) == 1:
+        time.sleep(0.3)
+
+@karva.tags.fail_slow(0.2)
+def test_retry(resource):
+    if os.environ["KARVA_ATTEMPT"] == "2":
+        assert fixture_attempts[-1] == "2"
+        "#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--retry=1"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+      TRY 1 FAIL [TIME] test::test_retry(resource=None)
+      TRY 2 PASS [TIME] test::test_retry(resource=None)
+    ────────────
+         Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test::test_retry(resource=None)
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_fail_slow_setup_error_reports_slow_teardown() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import time
+import karva
+
+@karva.fixture
+def established():
+    yield
+    time.sleep(0.4)
+
+@karva.fixture
+def broken(established):
+    raise RuntimeError("setup failed")
+
+@karva.tags.fail_slow(0.2)
+def test_example(broken):
+    pass
+        "#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+           ERROR [TIME] test::test_example
+
+    failures:
+
+    test::test_example:
+
+    error[fixture-failure]: Fixture `broken` failed
+      --> test.py:11:5
+       |
+    11 | def broken(established):
+       |     ^^^^^^
+       |
+    info: Fixture ran with arguments:
+    info: `established`: `None`
+    info: Fixture failed here
+      --> test.py:12:5
+       |
+    12 |     raise RuntimeError("setup failed")
+       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       |
+    info: setup failed
+
+    error[fail-slow-exceeded]: Test `test_example` exceeded its fail-slow budget
+      --> test.py:15:5
+       |
+    15 | def test_example(broken):
+       |     ^^^^^^^^^^^^
+       |
+    info: Configured budget: [TIME], actual duration: [TIME] (slowest phase: teardown)
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
+
+    ----- stderr -----
+    "#);
+}
+
+#[test]
+fn test_fail_slow_excludes_test_name_rendering() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import time
+import karva
+
+class SlowString:
+    def __str__(self):
+        time.sleep(0.3)
+        return "value"
+
+@karva.fixture
+def value():
+    return SlowString()
+
+@karva.tags.fail_slow(0.2)
+def test_example(value):
+    pass
+        "#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_example(value=value)
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
 }
 
 #[test]

--- a/crates/karva/tests/it/extensions/tags/fail_slow.rs
+++ b/crates/karva/tests/it/extensions/tags/fail_slow.rs
@@ -1,0 +1,527 @@
+use insta::allow_duplicates;
+use insta_cmd::assert_cmd_snapshot;
+use rstest::rstest;
+
+use crate::common::TestContext;
+
+#[test]
+fn test_fail_slow_passes_when_under_budget() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import karva
+
+@karva.tags.fail_slow(5.0)
+def test_fast():
+    assert True
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_fast
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_fail_slow_fails_when_exceeded() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import time
+import karva
+
+@karva.tags.fail_slow(0.1)
+def test_slow():
+    time.sleep(0.3)
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_slow
+
+    failures:
+
+    test::test_slow:
+
+    error[fail-slow-exceeded]: Test `test_slow` exceeded its fail-slow budget
+     --> test.py:6:5
+      |
+    6 | def test_slow():
+      |     ^^^^^^^^^
+      |
+    info: Configured budget: [TIME], actual duration: [TIME] (slowest phase: call)
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_fail_slow_async_test() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import asyncio
+import karva
+
+@karva.tags.fail_slow(0.1)
+async def test_slow_async():
+    await asyncio.sleep(0.3)
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_slow_async
+
+    failures:
+
+    test::test_slow_async:
+
+    error[fail-slow-exceeded]: Test `test_slow_async` exceeded its fail-slow budget
+     --> test.py:6:11
+      |
+    6 | async def test_slow_async():
+      |           ^^^^^^^^^^^^^^^
+      |
+    info: Configured budget: [TIME], actual duration: [TIME] (slowest phase: call)
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+/// A test's teardown always runs before the budget is checked — a
+/// budget-exceeded failure never skips cleanup.
+#[test]
+fn test_fail_slow_runs_teardown_before_failing() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import time
+import karva
+
+events = []
+
+@karva.fixture
+def resource():
+    events.append('setup')
+    yield 'resource'
+    events.append('teardown')
+
+@karva.tags.fail_slow(0.1)
+def test_slow(resource):
+    time.sleep(0.3)
+
+def test_after():
+    assert events == ['setup', 'teardown']
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            FAIL [TIME] test::test_slow(resource=resource)
+            PASS [TIME] test::test_after
+
+    failures:
+
+    test::test_slow(resource=resource):
+
+    error[fail-slow-exceeded]: Test `test_slow` exceeded its fail-slow budget
+      --> test.py:14:5
+       |
+    14 | def test_slow(resource):
+       |     ^^^^^^^^^
+       |
+    info: Configured budget: [TIME], actual duration: [TIME] (slowest phase: call)
+
+    ────────────
+         Summary [TIME] 2 tests run: 1 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+/// A test that already fails for another reason and also exceeds its
+/// budget shows both: the original failure stays primary, the exceeded
+/// budget is noted alongside it.
+#[test]
+fn test_fail_slow_combined_with_assertion_failure_shows_both() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import time
+import karva
+
+@karva.tags.fail_slow(0.1)
+def test_slow_and_wrong():
+    time.sleep(0.3)
+    assert False
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_slow_and_wrong
+
+    failures:
+
+    test::test_slow_and_wrong:
+
+    error[test-failure]: Test `test_slow_and_wrong` failed
+     --> test.py:6:5
+      |
+    6 | def test_slow_and_wrong():
+      |     ^^^^^^^^^^^^^^^^^^^
+      |
+    info: Test failed here
+     --> test.py:8:5
+      |
+    8 |     assert False
+      |     ^^^^^^^^^^^^
+      |
+
+    error[fail-slow-exceeded]: Test `test_slow_and_wrong` exceeded its fail-slow budget
+     --> test.py:6:5
+      |
+    6 | def test_slow_and_wrong():
+      |     ^^^^^^^^^^^^^^^^^^^
+      |
+    info: Configured budget: [TIME], actual duration: [TIME] (slowest phase: call)
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+/// The budget is only known after the full lifecycle (including teardown)
+/// completes, so a slow-but-passing attempt is never retried purely for
+/// slowness — it runs once and is reported as an ordinary failure.
+#[test]
+fn test_fail_slow_is_not_retried_even_with_retry_configured() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import time
+import karva
+
+attempts = [0]
+
+@karva.tags.fail_slow(0.1)
+def test_slow():
+    attempts[0] += 1
+    time.sleep(0.3)
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--retry=2"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_slow
+
+    failures:
+
+    test::test_slow:
+
+    error[fail-slow-exceeded]: Test `test_slow` exceeded its fail-slow budget
+     --> test.py:8:5
+      |
+    8 | def test_slow():
+      |     ^^^^^^^^^
+      |
+    info: Configured budget: [TIME], actual duration: [TIME] (slowest phase: call)
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[rstest]
+fn test_fail_slow_invalid_seconds_rejected(
+    #[values("0", "-1", "float('nan')", "float('inf')")] arg: &str,
+) {
+    let context = TestContext::with_file(
+        "test.py",
+        &format!(
+            r"
+import karva
+
+@karva.tags.fail_slow({arg})
+def test_1():
+    assert True
+        "
+        ),
+    );
+
+    allow_duplicates! {
+        assert_cmd_snapshot!(context.command(), @"
+        success: false
+        exit_code: 1
+        ----- stdout -----
+            Starting 1 test across 1 worker
+        diagnostics:
+
+        error[failed-to-import-module]: Failed to import python module `test`: fail_slow seconds must be a finite, positive number
+
+        ────────────
+             Summary [TIME] 0 tests run: 0 passed, 0 skipped
+
+        ----- stderr -----
+        ");
+    }
+}
+
+#[test]
+fn test_fail_slow_with_parametrize_only_slow_case_fails() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import time
+import karva
+
+@karva.tags.fail_slow(0.1)
+@karva.tags.parametrize('sleep_for', [0.0, 0.3, 0.0])
+def test_1(sleep_for):
+    time.sleep(sleep_for)
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_1(sleep_for=0.0)
+            FAIL [TIME] test::test_1(sleep_for=0.3)
+            PASS [TIME] test::test_1(sleep_for=0.0)
+
+    failures:
+
+    test::test_1(sleep_for=0.3):
+
+    error[fail-slow-exceeded]: Test `test_1` exceeded its fail-slow budget
+     --> test.py:7:5
+      |
+    7 | def test_1(sleep_for):
+      |     ^^^^^^
+      |
+    info: Configured budget: [TIME], actual duration: [TIME] (slowest phase: call)
+
+    ────────────
+         Summary [TIME] 3 tests run: 2 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+/// `--fail-slow` applies to every test that does not already carry an
+/// `@karva.tags.fail_slow` decorator.
+#[test]
+fn test_cli_fail_slow_fails_slow_test() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import time
+
+def test_slow():
+    time.sleep(0.3)
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command().arg("--fail-slow=0.1"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_slow
+
+    failures:
+
+    test::test_slow:
+
+    error[fail-slow-exceeded]: Test `test_slow` exceeded its fail-slow budget
+     --> test.py:4:5
+      |
+    4 | def test_slow():
+      |     ^^^^^^^^^
+      |
+    info: Configured budget: [TIME], actual duration: [TIME] (slowest phase: call)
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_cli_fail_slow_does_not_flag_fast_tests() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+def test_fast():
+    assert True
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command().arg("--fail-slow=60"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_fast
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+/// A test-level `@karva.tags.fail_slow` overrides the configured default.
+#[test]
+fn test_cli_fail_slow_tag_overrides_default() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import time
+import karva
+
+@karva.tags.fail_slow(2.0)
+def test_under_tag_budget():
+    time.sleep(0.1)
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command().arg("--fail-slow=0.05"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_under_tag_budget
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_config_fail_slow_fails_slow_test() {
+    let context = TestContext::with_files([
+        (
+            "pyproject.toml",
+            r"
+[tool.karva.profile.default.test]
+fail-slow = 0.1
+            ",
+        ),
+        (
+            "test.py",
+            r"
+import time
+
+def test_slow():
+    time.sleep(0.3)
+            ",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_slow
+
+    failures:
+
+    test::test_slow:
+
+    error[fail-slow-exceeded]: Test `test_slow` exceeded its fail-slow budget
+     --> test.py:4:5
+      |
+    4 | def test_slow():
+      |     ^^^^^^^^^
+      |
+    info: Configured budget: [TIME], actual duration: [TIME] (slowest phase: call)
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+/// A hard `timeout` shorter than the `fail-slow` budget kills the test
+/// well within that budget, so no fail-slow diagnostic is produced.
+#[test]
+fn test_timeout_shorter_than_fail_slow_budget_only_reports_timeout() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import time
+
+def test_slow():
+    time.sleep(2)
+        ",
+    );
+
+    assert_cmd_snapshot!(
+        context.command().arg("--timeout=0.1").arg("--fail-slow=10.0"),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_slow
+
+    failures:
+
+    test::test_slow:
+
+    error[test-failure]: Test `test_slow` failed
+     --> test.py:4:5
+      |
+    4 | def test_slow():
+      |     ^^^^^^^^^
+      |
+    info: Test exceeded timeout of 0.1 seconds
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+}

--- a/crates/karva/tests/it/extensions/tags/mod.rs
+++ b/crates/karva/tests/it/extensions/tags/mod.rs
@@ -1,5 +1,6 @@
 pub mod custom;
 pub mod expect_fail;
+pub mod fail_slow;
 pub mod parametrize;
 pub mod skip;
 pub mod timeout;

--- a/crates/karva/tests/it/junit.rs
+++ b/crates/karva/tests/it/junit.rs
@@ -11,6 +11,19 @@ fn normalize_junit_xml(xml: &str) -> String {
         .to_string()
 }
 
+fn normalize_junit_xml_with_min_duration(xml: &str, minimum: f64) -> String {
+    let test_case_time =
+        Regex::new(r#"(<testcase [^>]*time=")([0-9.]+)(")"#).expect("valid testcase time regex");
+    let xml = test_case_time.replace_all(xml, |captures: &regex::Captures<'_>| {
+        let duration = captures[2]
+            .parse::<f64>()
+            .expect("testcase duration should be numeric");
+        let comparison = if duration >= minimum { ">=" } else { "<" };
+        format!(r"{}[{comparison}{minimum}s]{}", &captures[1], &captures[3])
+    });
+    normalize_junit_xml(&xml)
+}
+
 #[test]
 fn writes_junit_xml_report() {
     let context = TestContext::with_files([
@@ -247,6 +260,88 @@ def test_flaky():
       </testsuite>
     </testsuites>
     "#);
+}
+
+#[test]
+fn junit_reports_fail_slow_teardown_duration() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.ci.junit]
+path = "reports/test-results.xml"
+"#,
+        ),
+        (
+            "test_fail_slow.py",
+            r"
+import time
+import karva
+
+@karva.fixture
+def resource():
+    yield
+    time.sleep(0.4)
+
+@karva.tags.fail_slow(0.2)
+def test_resource(resource):
+    pass
+            ",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .args(["--profile=ci", "--status-level=none"]),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    failures:
+
+    test_fail_slow::test_resource(resource=None):
+
+    error[fail-slow-exceeded]: Test `test_resource` exceeded its fail-slow budget
+      --> test_fail_slow.py:11:5
+       |
+    11 | def test_resource(resource):
+       |     ^^^^^^^^^^^^^
+       |
+    info: Configured budget: [TIME], actual duration: [TIME] (slowest phase: teardown)
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+
+    assert_snapshot!(
+        normalize_junit_xml_with_min_duration(
+            &context.read_file("reports/test-results.xml"),
+            0.4,
+        ),
+        @r#"
+    <?xml version="1.0" encoding="UTF-8"?>
+    <testsuites name="karva-tests" tests="1" failures="1" skipped="0" errors="0" time="[TIME]">
+      <testsuite name="test_fail_slow" tests="1" failures="1" skipped="0" errors="0" time="[TIME]">
+        <testcase classname="test_fail_slow" name="test_resource(resource=None)" time="[>=0.4s]">
+          <failure message="Test `test_resource` exceeded its fail-slow budget" type="fail-slow-exceeded">error[fail-slow-exceeded]: Test `test_resource` exceeded its fail-slow budget
+      --&gt; test_fail_slow.py:11:5
+       |
+    11 | def test_resource(resource):
+       |     ^^^^^^^^^^^^^
+       |
+    info: Configured budget: [TIME], actual duration: [TIME] (slowest phase: teardown)
+
+    </failure>
+        </testcase>
+      </testsuite>
+    </testsuites>
+    "#
+    );
 }
 
 #[test]

--- a/crates/karva/tests/it/result_report.rs
+++ b/crates/karva/tests/it/result_report.rs
@@ -274,6 +274,134 @@ fn writes_jsonl_result_records() {
 }
 
 #[test]
+fn fail_slow_reports_teardown_duration_in_json_and_jsonl() {
+    let context = TestContext::with_file(
+        "test_fail_slow.py",
+        r"
+import time
+import karva
+
+@karva.fixture
+def resource():
+    yield
+    time.sleep(0.4)
+
+@karva.tags.fail_slow(0.2)
+def test_resource(resource):
+    pass
+        ",
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
+            "--status-level=none",
+            "--result-output=reports/results.json",
+        ]),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    failures:
+
+    test_fail_slow::test_resource(resource=None):
+
+    error[fail-slow-exceeded]: Test `test_resource` exceeded its fail-slow budget
+      --> test_fail_slow.py:11:5
+       |
+    11 | def test_resource(resource):
+       |     ^^^^^^^^^^^^^
+       |
+    info: Configured budget: [TIME], actual duration: [TIME] (slowest phase: teardown)
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+
+    assert_snapshot!(
+        normalize_result_json_with_min_duration(
+            &context.read_file("reports/results.json"),
+            0.4,
+        ),
+        @r#"
+    {
+      "elapsed_seconds": "[TIME]",
+      "schema_version": 2,
+      "stats": {
+        "errors": 0,
+        "failed": 1,
+        "flaky": 0,
+        "passed": 0,
+        "skipped": 0,
+        "slow": 0,
+        "total": 1
+      },
+      "status": "failed",
+      "tests": [
+        {
+          "diagnostic": {
+            "code": "fail-slow-exceeded",
+            "message": "Test `test_resource` exceeded its fail-slow budget",
+            "rendered": "error[fail-slow-exceeded]: Test `test_resource` exceeded its fail-slow budget\n  --> test_fail_slow.py:11:5\n   |/n11 | def test_resource(resource):\n   |     ^^^^^^^^^^^^^\n   |/ninfo: Configured budget: [TIME], actual duration: [TIME] (slowest phase: teardown)\n\n",
+            "severity": "error"
+          },
+          "duration_seconds": "[>=0.4s]",
+          "full_name": "test_fail_slow::test_resource(resource=None)",
+          "module": "test_fail_slow",
+          "name": "test_resource(resource=None)",
+          "status": "failed"
+        }
+      ]
+    }
+    "#
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
+            "--status-level=none",
+            "--result-output=reports/results.jsonl",
+            "--result-format=jsonl",
+        ]),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    failures:
+
+    test_fail_slow::test_resource(resource=None):
+
+    error[fail-slow-exceeded]: Test `test_resource` exceeded its fail-slow budget
+      --> test_fail_slow.py:11:5
+       |
+    11 | def test_resource(resource):
+       |     ^^^^^^^^^^^^^
+       |
+    info: Configured budget: [TIME], actual duration: [TIME] (slowest phase: teardown)
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+
+    assert_snapshot!(
+        normalize_result_jsonl_with_min_duration(
+            &context.read_file("reports/results.jsonl"),
+            0.4,
+        ),
+        @r#"
+    {"diagnostic":{"code":"fail-slow-exceeded","message":"Test `test_resource` exceeded its fail-slow budget","rendered":"error[fail-slow-exceeded]: Test `test_resource` exceeded its fail-slow budget\n  --> test_fail_slow.py:11:5\n   |/n11 | def test_resource(resource):\n   |     ^^^^^^^^^^^^^\n   |/ninfo: Configured budget: [TIME], actual duration: [TIME] (slowest phase: teardown)\n\n","severity":"error"},"duration_seconds":"[>=0.4s]","full_name":"test_fail_slow::test_resource(resource=None)","module":"test_fail_slow","name":"test_resource(resource=None)","schema_version":2,"status":"failed","type":"test"}
+    {"elapsed_seconds":"[TIME]","schema_version":2,"stats":{"errors":0,"failed":1,"flaky":0,"passed":0,"skipped":0,"slow":0,"total":1},"status":"failed","type":"run_finished"}
+    "#
+    );
+}
+
+#[test]
 fn writes_related_test_diagnostics() {
     let context = TestContext::with_file(
         "test_related.py",
@@ -518,7 +646,18 @@ fn result_report_status_matches_no_tests_failure() {
 }
 
 fn normalize_result_json(raw: &str) -> String {
+    normalize_result_json_with_optional_min_duration(raw, None)
+}
+
+fn normalize_result_json_with_min_duration(raw: &str, minimum: f64) -> String {
+    normalize_result_json_with_optional_min_duration(raw, Some(minimum))
+}
+
+fn normalize_result_json_with_optional_min_duration(raw: &str, minimum: Option<f64>) -> String {
     let mut value: Value = serde_json::from_str(raw).expect("parse result report");
+    if let Some(minimum) = minimum {
+        classify_test_durations(&mut value, minimum);
+    }
     redact_times(&mut value);
     let mut output = serde_json::to_string_pretty(&value).expect("serialize result report");
     output.push('\n');
@@ -526,10 +665,21 @@ fn normalize_result_json(raw: &str) -> String {
 }
 
 fn normalize_result_jsonl(raw: &str) -> String {
+    normalize_result_jsonl_with_optional_min_duration(raw, None)
+}
+
+fn normalize_result_jsonl_with_min_duration(raw: &str, minimum: f64) -> String {
+    normalize_result_jsonl_with_optional_min_duration(raw, Some(minimum))
+}
+
+fn normalize_result_jsonl_with_optional_min_duration(raw: &str, minimum: Option<f64>) -> String {
     let mut output = raw
         .lines()
         .map(|line| {
             let mut value: Value = serde_json::from_str(line).expect("parse result event");
+            if let Some(minimum) = minimum {
+                classify_test_durations(&mut value, minimum);
+            }
             redact_times(&mut value);
             serde_json::to_string(&value).expect("serialize result event")
         })
@@ -537,6 +687,28 @@ fn normalize_result_jsonl(raw: &str) -> String {
         .join("\n");
     output.push('\n');
     output
+}
+
+fn classify_test_durations(value: &mut Value, minimum: f64) {
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                classify_test_durations(value, minimum);
+            }
+        }
+        Value::Object(map) => {
+            for (key, value) in map {
+                if key == "duration_seconds" {
+                    let duration = value.as_f64().expect("test duration should be numeric");
+                    let comparison = if duration >= minimum { ">=" } else { "<" };
+                    *value = Value::String(format!("[{comparison}{minimum}s]"));
+                } else {
+                    classify_test_durations(value, minimum);
+                }
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
 }
 
 fn redact_times(value: &mut Value) {
@@ -548,7 +720,7 @@ fn redact_times(value: &mut Value) {
         }
         Value::Object(map) => {
             for (key, value) in map {
-                if key == "duration_seconds" || key == "elapsed_seconds" {
+                if (key == "duration_seconds" || key == "elapsed_seconds") && value.is_number() {
                     *value = Value::String("[TIME]".to_string());
                 } else {
                     redact_times(value);

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -136,7 +136,12 @@ pub struct SubTestCommand {
     /// specific test.
     ///
     /// Accepts fractional seconds such as `--fail-slow=1` or `--fail-slow=0.25`.
-    #[clap(long, value_name = "SECONDS", help_heading = "Runner options")]
+    #[clap(
+        long,
+        value_name = "SECONDS",
+        value_parser = parse_fail_slow,
+        help_heading = "Runner options"
+    )]
     pub fail_slow: Option<f64>,
 
     /// Update snapshots directly instead of creating pending `.snap.new` files.
@@ -509,6 +514,18 @@ fn parse_override_json(raw: &str) -> Result<OverrideOptions, String> {
     serde_json::from_str(raw).map_err(|err| err.to_string())
 }
 
+fn parse_fail_slow(raw: &str) -> Result<f64, String> {
+    let value: f64 = raw
+        .parse()
+        .map_err(|err| format!("`{raw}` is not a valid number: {err}"))?;
+    if FailSlowSecs(value).as_duration().is_none() {
+        return Err(format!(
+            "must be a finite, positive duration supported by this platform, got `{raw}`"
+        ));
+    }
+    Ok(value)
+}
+
 /// Parse and validate a `--cov-fail-under=N` argument.
 ///
 /// Accepts any finite percentage in `0..=100`.
@@ -626,5 +643,11 @@ mod tests {
     fn fail_slow_flag_parses_into_sub_command() {
         let command = TestCommand::parse_from(["karva-test", "--fail-slow=0.25"]);
         assert_eq!(command.sub_command.fail_slow, Some(0.25));
+    }
+
+    #[test]
+    fn fail_slow_flag_rejects_unrepresentable_duration() {
+        assert!(TestCommand::try_parse_from(["karva-test", "--fail-slow=1e-300"]).is_err());
+        assert!(TestCommand::try_parse_from(["karva-test", "--fail-slow=1e300"]).is_err());
     }
 }

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -4,9 +4,9 @@ use camino::Utf8PathBuf;
 use clap::Parser;
 use karva_logging::{FinalStatusLevel, StatusLevel, TerminalColor};
 use karva_metadata::{
-    CovFailUnder, CoverageOptions, MaxFail, Options, OverrideOptions, RunTimeoutSecs,
-    SlowTimeoutSecs, SrcOptions, TerminalOptions, TerminationGracePeriodSecs, TestOptions,
-    TestTimeoutSecs,
+    CovFailUnder, CoverageOptions, FailSlowSecs, MaxFail, Options, OverrideOptions,
+    RunTimeoutSecs, SlowTimeoutSecs, SrcOptions, TerminalOptions, TerminationGracePeriodSecs,
+    TestOptions, TestTimeoutSecs,
 };
 use karva_static::EnvVars;
 
@@ -126,6 +126,18 @@ pub struct SubTestCommand {
     /// Accepts fractional seconds such as `--timeout=120` or `--timeout=0.5`.
     #[clap(long, value_name = "SECONDS", help_heading = "Runner options")]
     pub timeout: Option<f64>,
+
+    /// Duration budget, in seconds, for a test's full lifecycle.
+    ///
+    /// Unlike `--timeout`, a test is always allowed to finish — including
+    /// fixture teardown — before being reported as a failure if the total
+    /// duration exceeded this budget. A test-level
+    /// [`@karva.tags.fail_slow`] decorator overrides the default for that
+    /// specific test.
+    ///
+    /// Accepts fractional seconds such as `--fail-slow=1` or `--fail-slow=0.25`.
+    #[clap(long, value_name = "SECONDS", help_heading = "Runner options")]
+    pub fail_slow: Option<f64>,
 
     /// Update snapshots directly instead of creating pending `.snap.new` files.
     ///
@@ -445,6 +457,7 @@ impl SubTestCommand {
                 retry: self.retry,
                 no_tests: self.no_tests.map(Into::into),
                 slow_timeout: self.slow_timeout.map(SlowTimeoutSecs),
+                fail_slow: self.fail_slow.map(FailSlowSecs),
                 timeout: self.timeout.map(TestTimeoutSecs),
                 // `run-timeout` is a main-process-only option and is never
                 // forwarded to workers, so it lives on `TestCommand` rather
@@ -607,5 +620,11 @@ mod tests {
                 path: Some(Utf8PathBuf::from("build/htmlcov")),
             })
         );
+    }
+
+    #[test]
+    fn fail_slow_flag_parses_into_sub_command() {
+        let command = TestCommand::parse_from(["karva-test", "--fail-slow=0.25"]);
+        assert_eq!(command.sub_command.fail_slow, Some(0.25));
     }
 }

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -4,9 +4,9 @@ use camino::Utf8PathBuf;
 use clap::Parser;
 use karva_logging::{FinalStatusLevel, StatusLevel, TerminalColor};
 use karva_metadata::{
-    CovFailUnder, CoverageOptions, FailSlowSecs, MaxFail, Options, OverrideOptions,
-    RunTimeoutSecs, SlowTimeoutSecs, SrcOptions, TerminalOptions, TerminationGracePeriodSecs,
-    TestOptions, TestTimeoutSecs,
+    CovFailUnder, CoverageOptions, FailSlowSecs, MaxFail, Options, OverrideOptions, RunTimeoutSecs,
+    SlowTimeoutSecs, SrcOptions, TerminalOptions, TerminationGracePeriodSecs, TestOptions,
+    TestTimeoutSecs,
 };
 use karva_static::EnvVars;
 

--- a/crates/karva_metadata/src/lib.rs
+++ b/crates/karva_metadata/src/lib.rs
@@ -18,8 +18,9 @@ pub use options::{
 };
 pub use pyproject::{PyProject, PyProjectError};
 pub use settings::{
-    CovFailUnder, CoverageSettings, JunitSettings, NoTestsMode, OverrideSettings, ProjectSettings,
-    RunIgnoredMode, RunTimeoutSecs, SlowTimeoutSecs, TerminationGracePeriodSecs, TestTimeoutSecs,
+    CovFailUnder, CoverageSettings, FailSlowSecs, JunitSettings, NoTestsMode, OverrideSettings,
+    ProjectSettings, RunIgnoredMode, RunTimeoutSecs, SlowTimeoutSecs, TerminationGracePeriodSecs,
+    TestTimeoutSecs,
 };
 
 use crate::options::KarvaTomlError;

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -1720,4 +1720,26 @@ fail-slow = 0
             Some(std::time::Duration::from_secs(1))
         );
     }
+
+    #[test]
+    fn fail_slow_rejects_unrepresentable_config_duration() {
+        for value in ["1e-300", "1e300"] {
+            let profile = format!(
+                r"
+[profile.default.test]
+fail-slow = {value}
+"
+            );
+            assert!(Config::from_toml_str(&profile).is_err());
+
+            let override_value = format!(
+                r#"
+[[profile.default.overrides]]
+filter = "tag(slow)"
+fail-slow = {value}
+"#
+            );
+            assert!(Config::from_toml_str(&override_value).is_err());
+        }
+    }
 }

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -15,9 +15,9 @@ pub use overrides::ProjectOptionsOverrides;
 use crate::filter::{FiltersetSet, ValidatedFilter};
 use crate::max_fail::MaxFail;
 use crate::settings::{
-    CovFailUnder, CoverageSettings, JunitSettings, NoTestsMode, OverrideSettings, ProjectSettings,
-    RunIgnoredMode, RunTimeoutSecs, SlowTimeoutSecs, SrcSettings, TerminalSettings,
-    TerminationGracePeriodSecs, TestSettings, TestTimeoutSecs,
+    CovFailUnder, CoverageSettings, FailSlowSecs, JunitSettings, NoTestsMode, OverrideSettings,
+    ProjectSettings, RunIgnoredMode, RunTimeoutSecs, SlowTimeoutSecs, SrcSettings,
+    TerminalSettings, TerminationGracePeriodSecs, TestSettings, TestTimeoutSecs,
 };
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, OptionsMetadata)]
@@ -111,6 +111,12 @@ pub struct OverrideOptions {
     /// disables slow tracking for the matching test.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub slow_timeout: Option<SlowTimeoutSecs>,
+
+    /// Duration budget (in seconds) for a matching test's full lifecycle.
+    /// Mirrors the profile-level [`fail-slow`](#fail-slow) field. A
+    /// non-positive value disables the budget for the matching test.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fail_slow: Option<FailSlowSecs>,
 }
 
 impl OverrideOptions {
@@ -120,6 +126,7 @@ impl OverrideOptions {
             retries: self.retries,
             timeout: self.timeout,
             slow_timeout: self.slow_timeout,
+            fail_slow: self.fail_slow,
         }
     }
 }
@@ -374,6 +381,32 @@ pub struct TestOptions {
     )]
     pub timeout: Option<TestTimeoutSecs>,
 
+    /// Duration budget (in seconds) for a test's full lifecycle (fixture
+    /// setup, the test call, and fixture teardown).
+    ///
+    /// When set, a test is allowed to run to completion — including
+    /// teardown, so cleanup is never skipped — and is then reported as a
+    /// failure if the full lifecycle took longer than this budget. Tests
+    /// can override the limit individually with
+    /// [`@karva.tags.fail_slow`](https://docs.karva.dev/usage/failure-handling/fail-slow/),
+    /// which takes precedence over the configured default.
+    ///
+    /// This is distinct from [`timeout`](#timeout), which kills a test
+    /// mid-execution, and [`slow_timeout`](#slow-timeout), which is purely
+    /// informational and never fails a test.
+    ///
+    /// Defaults to unset, which disables budget checking unless a tag is
+    /// applied to the test.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"null"#,
+        value_type = "float (seconds)",
+        example = r#"
+            fail-slow = 0.25
+        "#
+    )]
+    pub fail_slow: Option<FailSlowSecs>,
+
     /// Wall-clock limit (in seconds) for the entire run.
     ///
     /// When the run takes longer than this duration, karva stops the
@@ -430,6 +463,7 @@ impl TestOptions {
             run_ignored: RunIgnoredMode::default(),
             no_tests: self.no_tests.unwrap_or_default(),
             slow_timeout: self.slow_timeout.and_then(SlowTimeoutSecs::as_duration),
+            fail_slow: self.fail_slow.and_then(FailSlowSecs::as_duration),
             timeout: self.timeout.and_then(TestTimeoutSecs::as_duration),
             run_timeout: self.run_timeout.and_then(RunTimeoutSecs::as_duration),
             termination_grace_period: self
@@ -815,7 +849,7 @@ nonsense = 42
           |
         4 | nonsense = 42
           | ^^^^^^^^
-        unknown field `nonsense`, expected one of `test-function-prefix`, `fail-fast`, `max-fail`, `try-import-fixtures`, `retry`, `no-tests`, `slow-timeout`, `timeout`, `run-timeout`, `termination-grace-period`
+        unknown field `nonsense`, expected one of `test-function-prefix`, `fail-fast`, `max-fail`, `try-import-fixtures`, `retry`, `no-tests`, `slow-timeout`, `timeout`, `fail-slow`, `run-timeout`, `termination-grace-period`
         "
         );
     }
@@ -915,6 +949,7 @@ max-fail = 0
             no_tests: None,
             slow_timeout: None,
             timeout: None,
+            fail_slow: None,
             run_timeout: None,
             termination_grace_period: None,
         }
@@ -946,6 +981,7 @@ max-fail = 0
             no_tests: None,
             slow_timeout: None,
             timeout: None,
+            fail_slow: None,
             run_timeout: None,
             termination_grace_period: None,
         }
@@ -1010,6 +1046,7 @@ retry = 2
                 no_tests: None,
                 slow_timeout: None,
                 timeout: None,
+                fail_slow: None,
                 run_timeout: None,
                 termination_grace_period: None,
             },
@@ -1068,6 +1105,7 @@ retry = 5
                 no_tests: None,
                 slow_timeout: None,
                 timeout: None,
+                fail_slow: None,
                 run_timeout: None,
                 termination_grace_period: None,
             },
@@ -1636,6 +1674,49 @@ slow-timeout = 30.0
         );
         assert_eq!(
             settings.slow_timeout_for(&other),
+            Some(std::time::Duration::from_secs(1))
+        );
+    }
+
+    #[test]
+    fn fail_slow_for_picks_first_matching_override() {
+        let toml = r#"
+[profile.default.test]
+fail-slow = 1.0
+
+[[profile.default.overrides]]
+filter = "tag(slow)"
+fail-slow = 30.0
+
+[[profile.default.overrides]]
+filter = "tag(unit)"
+fail-slow = 0
+"#;
+        let resolved = Config::from_toml_str(toml)
+            .expect("parse")
+            .resolve_profile(None)
+            .expect("resolves");
+        let settings = resolved.to_settings();
+        let slow = crate::filter::EvalContext {
+            test_name: "test::a",
+            tags: &["slow"],
+        };
+        let unit = crate::filter::EvalContext {
+            test_name: "test::b",
+            tags: &["unit"],
+        };
+        let other = crate::filter::EvalContext {
+            test_name: "test::c",
+            tags: &[],
+        };
+        assert_eq!(
+            settings.fail_slow_for(&slow),
+            Some(std::time::Duration::from_secs(30))
+        );
+        // `fail-slow = 0` on a matching override disables the budget.
+        assert_eq!(settings.fail_slow_for(&unit), None);
+        assert_eq!(
+            settings.fail_slow_for(&other),
             Some(std::time::Duration::from_secs(1))
         );
     }

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -99,6 +99,39 @@ impl Combine for TestTimeoutSecs {
     }
 }
 
+/// A per-test duration budget expressed in seconds.
+///
+/// Wraps `f64` for the same reason as [`SlowTimeoutSecs`]. Unlike
+/// [`SlowTimeoutSecs`] (informational) or [`TestTimeoutSecs`] (kills the
+/// test mid-flight), a test exceeding this budget is allowed to finish its
+/// full lifecycle — including fixture teardown — and is then reported as a
+/// failure (see [`crate::settings::TestSettings::fail_slow`]).
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct FailSlowSecs(pub f64);
+
+impl Eq for FailSlowSecs {}
+
+impl FailSlowSecs {
+    pub fn as_duration(self) -> Option<Duration> {
+        if self.0.is_finite() && self.0 > 0.0 {
+            Some(Duration::from_secs_f64(self.0))
+        } else {
+            None
+        }
+    }
+}
+
+impl Combine for FailSlowSecs {
+    #[inline(always)]
+    fn combine_with(&mut self, _other: Self) {}
+
+    #[inline]
+    fn combine(self, _other: Self) -> Self {
+        self
+    }
+}
+
 /// A global run timeout expressed in seconds.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -199,6 +232,8 @@ pub struct OverrideSettings {
     pub timeout: Option<TestTimeoutSecs>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub slow_timeout: Option<SlowTimeoutSecs>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fail_slow: Option<FailSlowSecs>,
 }
 
 impl OverrideSettings {
@@ -279,6 +314,20 @@ impl ProjectSettings {
             return secs.as_duration();
         }
         self.test.slow_timeout
+    }
+
+    /// Resolve the fail-slow duration budget for a single test.
+    ///
+    /// First match wins. A matching override with a non-positive value
+    /// disables the budget for that test even when the profile sets one.
+    /// Unlike [`Self::timeout_for`], this never kills a running test — it
+    /// only determines, after the fact, whether the full lifecycle
+    /// (setup + call + teardown) took too long.
+    pub fn fail_slow_for(&self, ctx: &EvalContext<'_>) -> Option<Duration> {
+        if let Some(secs) = self.first_matching_override(ctx, |ovr| ovr.fail_slow) {
+            return secs.as_duration();
+        }
+        self.test.fail_slow
     }
 
     pub fn set_filter(&mut self, filter: FiltersetSet) {
@@ -394,6 +443,15 @@ pub struct TestSettings {
         serialize_with = "serialize_duration_secs"
     )]
     pub slow_timeout: Option<Duration>,
+    /// Duration budget for a test's full lifecycle (setup + call +
+    /// teardown). `None` disables budget checking. Unlike `timeout`, a test
+    /// exceeding this budget is allowed to finish (including teardown)
+    /// before being reported as a failure.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_duration_secs"
+    )]
+    pub fail_slow: Option<Duration>,
     /// Hard per-test timeout. Tests that run longer than this duration are
     /// killed and reported as failures. `None` disables the hard timeout
     /// (tests may still set their own limit via `@karva.tags.timeout`).

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use karva_combine::Combine;
 use karva_logging::{FinalStatusLevel, StatusLevel};
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::filter::{EvalContext, FiltersetSet, ValidatedFilter};
 use crate::max_fail::MaxFail;
@@ -106,7 +106,7 @@ impl Combine for TestTimeoutSecs {
 /// test mid-flight), a test exceeding this budget is allowed to finish its
 /// full lifecycle — including fixture teardown — and is then reported as a
 /// failure (see [`crate::settings::TestSettings::fail_slow`]).
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
 #[serde(transparent)]
 pub struct FailSlowSecs(pub f64);
 
@@ -115,10 +115,27 @@ impl Eq for FailSlowSecs {}
 impl FailSlowSecs {
     pub fn as_duration(self) -> Option<Duration> {
         if self.0.is_finite() && self.0 > 0.0 {
-            Some(Duration::from_secs_f64(self.0))
+            Duration::try_from_secs_f64(self.0)
+                .ok()
+                .filter(|duration| !duration.is_zero())
         } else {
             None
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for FailSlowSecs {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let seconds = f64::deserialize(deserializer)?;
+        if !seconds.is_finite() || (seconds > 0.0 && Self(seconds).as_duration().is_none()) {
+            return Err(serde::de::Error::custom(
+                "fail-slow must be a finite duration supported by this platform",
+            ));
+        }
+        Ok(Self(seconds))
     }
 }
 

--- a/crates/karva_runner/src/worker_args.rs
+++ b/crates/karva_runner/src/worker_args.rs
@@ -135,6 +135,10 @@ fn inner_cli_args(settings: &ProjectSettings, args: &SubTestCommand) -> Vec<Stri
         push_value_arg(&mut cli_args, "--slow-timeout", threshold.as_secs_f64());
     }
 
+    if let Some(budget) = settings.test().fail_slow {
+        push_value_arg(&mut cli_args, "--fail-slow", budget.as_secs_f64());
+    }
+
     if let Some(timeout) = settings.test().timeout {
         push_value_arg(&mut cli_args, "--timeout", timeout.as_secs_f64());
     }
@@ -165,6 +169,7 @@ fn inner_cli_args(settings: &ProjectSettings, args: &SubTestCommand) -> Vec<Stri
             "retries": ovr.retries,
             "timeout": ovr.timeout.map(|t| t.0),
             "slow-timeout": ovr.slow_timeout.map(|t| t.0),
+            "fail-slow": ovr.fail_slow.map(|t| t.0),
         });
         push_value_arg(&mut cli_args, "--override-json", json);
     }

--- a/crates/karva_test_semantic/Cargo.toml
+++ b/crates/karva_test_semantic/Cargo.toml
@@ -17,6 +17,7 @@ fs-err = { workspace = true }
 karva_collector = { workspace = true }
 karva_coverage = { workspace = true }
 karva_diagnostic = { workspace = true, features = ["traceback"] }
+karva_logging = { workspace = true }
 karva_metadata = { workspace = true }
 karva_project = { workspace = true }
 karva_python_semantic = { workspace = true }

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -540,11 +540,8 @@ pub fn test_returned_value_diagnostic(
 /// Build the diagnostic for a test whose full lifecycle exceeded its
 /// configured `fail-slow` budget.
 ///
-/// `actual` and `slowest_phase` describe the lifecycle that was actually
-/// measured (setup, call, and — except for the fixture-setup-failure path —
-/// teardown), which is distinct from the test's officially reported
-/// duration (captured before teardown, used for `slow-timeout` and
-/// reporting).
+/// `actual` and `slowest_phase` describe the measured setup, call, and
+/// teardown phases for one attempt.
 pub fn fail_slow_exceeded_diagnostic(
     source_file: SourceFile,
     stmt_function_def: &StmtFunctionDef,

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -7,6 +7,7 @@
 use camino::Utf8Path;
 use karva_collector::CollectionError;
 use karva_diagnostic::Traceback;
+use karva_logging::time::format_duration;
 use karva_python_semantic::FunctionKind;
 use pyo3::{PyErr, Python};
 use ruff_db::diagnostic::{
@@ -172,6 +173,19 @@ declare_diagnostic_type! {
     /// If a test returns anything other than `None`, we will raise this error.
     pub static TEST_RETURNED_VALUE = {
         summary: "Test returned a non-None value",
+        severity: Severity::Error,
+    }
+}
+
+declare_diagnostic_type! {
+    /// ## Fail-slow budget exceeded
+    ///
+    /// Raised when a test's full lifecycle (fixture setup, the test call,
+    /// and fixture teardown) takes longer than its configured `fail-slow`
+    /// budget. Unlike a hard `timeout`, the test always runs to completion
+    /// before this diagnostic is produced.
+    pub static FAIL_SLOW_EXCEEDED = {
+        summary: "Test exceeded its fail-slow duration budget",
         severity: Severity::Error,
     }
 }
@@ -520,6 +534,37 @@ pub fn test_returned_value_diagnostic(
 
     annotate_function_name(&mut diagnostic, source_file, stmt_function_def);
     diagnostic.info("Test functions must return None. Did you mean to use `assert`?");
+    diagnostic
+}
+
+/// Build the diagnostic for a test whose full lifecycle exceeded its
+/// configured `fail-slow` budget.
+///
+/// `actual` and `slowest_phase` describe the lifecycle that was actually
+/// measured (setup, call, and — except for the fixture-setup-failure path —
+/// teardown), which is distinct from the test's officially reported
+/// duration (captured before teardown, used for `slow-timeout` and
+/// reporting).
+pub fn fail_slow_exceeded_diagnostic(
+    source_file: SourceFile,
+    stmt_function_def: &StmtFunctionDef,
+    budget: std::time::Duration,
+    actual: std::time::Duration,
+    slowest_phase: &str,
+) -> Diagnostic {
+    let mut diagnostic = FAIL_SLOW_EXCEEDED.diagnostic(format!(
+        "Test `{}` exceeded its fail-slow budget",
+        stmt_function_def.name
+    ));
+
+    annotate_function_name(&mut diagnostic, source_file, stmt_function_def);
+
+    diagnostic.info(format!(
+        "Configured budget: {}, actual duration: {} (slowest phase: {slowest_phase})",
+        format_duration(budget),
+        format_duration(actual),
+    ));
+
     diagnostic
 }
 

--- a/crates/karva_test_semantic/src/extensions/tags/fail_slow.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/fail_slow.rs
@@ -1,0 +1,19 @@
+/// Represents a per-test duration budget, in seconds.
+///
+/// Unlike [`super::timeout::TimeoutTag`], this never kills a running test.
+/// The budget is checked after the test's full lifecycle (setup, call, and
+/// teardown) completes; see `PackageRunner::execute_test_variant`.
+#[derive(Debug, Clone, Copy)]
+pub struct FailSlowTag {
+    seconds: f64,
+}
+
+impl FailSlowTag {
+    pub(crate) fn new(seconds: f64) -> Self {
+        Self { seconds }
+    }
+
+    pub(crate) fn seconds(self) -> f64 {
+        self.seconds
+    }
+}

--- a/crates/karva_test_semantic/src/extensions/tags/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/mod.rs
@@ -9,6 +9,7 @@ use crate::extensions::tags::python::{PyTag, PyTags, PyTestFunction};
 
 pub mod custom;
 pub mod expect_fail;
+pub mod fail_slow;
 pub mod parametrize;
 pub mod python;
 pub mod skip;
@@ -17,6 +18,7 @@ mod use_fixtures;
 
 use custom::CustomTag;
 use expect_fail::ExpectFailTag;
+use fail_slow::FailSlowTag;
 use parametrize::{InvalidParametrizeError, ParametrizationArgs, ParametrizeTag};
 use skip::SkipTag;
 use timeout::TimeoutTag;
@@ -106,6 +108,7 @@ pub enum Tag {
     Skip(SkipTag),
     ExpectFail(ExpectFailTag),
     Timeout(TimeoutTag),
+    FailSlow(FailSlowTag),
     Custom(CustomTag),
 }
 
@@ -192,6 +195,7 @@ impl Tag {
                 Self::ExpectFail(ExpectFailTag::new(conditions.clone(), reason.clone()))
             }
             PyTag::Timeout { seconds } => Self::Timeout(TimeoutTag::new(*seconds)),
+            PyTag::FailSlow { seconds } => Self::FailSlow(FailSlowTag::new(*seconds)),
             PyTag::Custom {
                 tag_name,
                 tag_args,
@@ -391,6 +395,16 @@ impl Tags {
         for tag in &self.inner {
             if let Tag::Timeout(timeout_tag) = tag {
                 return Some(*timeout_tag);
+            }
+        }
+        None
+    }
+
+    /// Return the `FailSlowTag` if it exists.
+    pub(crate) fn fail_slow_tag(&self) -> Option<FailSlowTag> {
+        for tag in &self.inner {
+            if let Tag::FailSlow(fail_slow_tag) = tag {
+                return Some(*fail_slow_tag);
             }
         }
         None

--- a/crates/karva_test_semantic/src/extensions/tags/python.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/python.rs
@@ -32,6 +32,9 @@ pub enum PyTag {
     #[pyo3(name = "timeout")]
     Timeout { seconds: f64 },
 
+    #[pyo3(name = "fail_slow")]
+    FailSlow { seconds: f64 },
+
     #[pyo3(name = "custom")]
     Custom {
         tag_name: String,
@@ -62,6 +65,7 @@ impl PyTag {
                 reason: reason.clone(),
             },
             Self::Timeout { seconds } => Self::Timeout { seconds: *seconds },
+            Self::FailSlow { seconds } => Self::FailSlow { seconds: *seconds },
             Self::Custom {
                 tag_name,
                 tag_args,
@@ -255,6 +259,18 @@ pub mod tags {
         }
         Ok(PyTags {
             inner: vec![PyTag::Timeout { seconds }],
+        })
+    }
+
+    #[pyfunction]
+    fn fail_slow(seconds: f64) -> PyResult<PyTags> {
+        if !(seconds.is_finite() && seconds > 0.0) {
+            return Err(PyErr::new::<PyTypeError, _>(
+                "fail_slow seconds must be a finite, positive number",
+            ));
+        }
+        Ok(PyTags {
+            inner: vec![PyTag::FailSlow { seconds }],
         })
     }
 }

--- a/crates/karva_test_semantic/src/extensions/tags/python.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/python.rs
@@ -120,6 +120,7 @@ impl PyTags {
 
 #[pymodule]
 pub mod tags {
+    use karva_metadata::FailSlowSecs;
     use pyo3::IntoPyObjectExt;
     use pyo3::exceptions::PyTypeError;
     use pyo3::prelude::*;
@@ -264,9 +265,9 @@ pub mod tags {
 
     #[pyfunction]
     fn fail_slow(seconds: f64) -> PyResult<PyTags> {
-        if !(seconds.is_finite() && seconds > 0.0) {
+        if FailSlowSecs(seconds).as_duration().is_none() {
             return Err(PyErr::new::<PyTypeError, _>(
-                "fail_slow seconds must be a finite, positive number",
+                "fail_slow seconds must be a finite, positive duration supported by this platform",
             ));
         }
         Ok(PyTags {

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -5,8 +5,7 @@ use std::sync::Arc;
 
 use karva_coverage::CoverageSession;
 use karva_diagnostic::{
-    CapturedTestOutput, IndividualTestResultKind, TestCaseRetry, TestExecutionAttempt,
-    TestExecutionOutcome,
+    CapturedTestOutput, TestCaseRetry, TestExecutionAttempt, TestExecutionOutcome,
 };
 use karva_metadata::RunIgnoredMode;
 use karva_metadata::filter::EvalContext;
@@ -569,80 +568,6 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         }
     }
 
-    /// Drive the test closure with the configured retry budget.
-    ///
-    /// Emits a per-attempt report after every failed retry and, when at
-    /// least one retry occurred, after the final attempt as well, so the
-    /// reporter sees the same `TRY N PASS|FAIL` ordering as nextest.
-    fn run_with_retries(
-        &self,
-        py: Python<'_>,
-        qualified_test_name: &QualifiedTestName,
-        configured_retries: u32,
-        expect_fail: bool,
-        mut run_test: impl FnMut() -> PyResult<TestCallOutcome>,
-    ) -> RetryOutcome {
-        let max_attempts = configured_retries.saturating_add(1);
-        let mut run_attempt = |attempt| {
-            let start = std::time::Instant::now();
-            let result = set_attempt_env(py, attempt, max_attempts).and_then(|()| run_test());
-            TestCallAttempt {
-                attempt,
-                result,
-                duration: start.elapsed(),
-            }
-        };
-        let mut attempt: u32 = 1;
-        let mut current_attempt = run_attempt(attempt);
-        let mut retry_count = configured_retries;
-        let mut prior_attempts = Vec::new();
-
-        while retry_count > 0 {
-            if !should_retry_result(
-                py,
-                &current_attempt.result,
-                expect_fail,
-                qualified_test_name.function_name().function_name(),
-            ) {
-                break;
-            }
-            self.context.report_test_attempt(
-                qualified_test_name,
-                attempt,
-                IndividualTestResultKind::Failed,
-                current_attempt.duration,
-            );
-            prior_attempts.push(current_attempt);
-
-            tracing::debug!("Retrying test `{}`", qualified_test_name);
-            retry_count -= 1;
-            attempt += 1;
-            current_attempt = run_attempt(attempt);
-        }
-
-        if !prior_attempts.is_empty() {
-            // Emit the per-attempt line for the final attempt so output
-            // ordering matches nextest:
-            //   TRY 1 FAIL ...
-            //   TRY 2 PASS ...   (or TRY 2 FAIL for an exhausted retry)
-            // The diagnostic for the final attempt (if any) is collected by
-            // `classify_test_result` and shown in the end-of-run block.
-            let final_kind = attempt_result_kind(py, &current_attempt.result);
-            self.context.report_test_attempt(
-                qualified_test_name,
-                attempt,
-                final_kind,
-                current_attempt.duration,
-            );
-        }
-
-        RetryOutcome {
-            max_attempts,
-            prior_attempts,
-            final_attempt: current_attempt,
-        }
-    }
-
     /// Run a test variant (a specific combination of parametrize values and fixtures).
     fn execute_test_variant(&self, py: Python<'_>, variant: TestVariant<'_>) -> bool {
         let tags = variant.resolved_tags();
@@ -667,9 +592,10 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         }
 
         let output_capture = self.start_output_capture(py);
-        let start_time = std::time::Instant::now();
         let expect_fail_tag = tags.expect_fail_tag();
+        let retry_params = params.clone();
 
+        let setup_start = std::time::Instant::now();
         let (function_arguments, fixture_call_errors, test_finalizers) = self.setup_test_fixtures(
             py,
             &fixture_dependencies,
@@ -677,7 +603,12 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             &auto_use_fixtures,
             params,
         );
-        let setup_duration = start_time.elapsed();
+        let first_attempt = PreparedTestAttempt {
+            function_arguments,
+            fixture_call_errors,
+            test_finalizers,
+            setup_duration: setup_start.elapsed(),
+        };
 
         let fixture_names = fixture_dependencies
             .iter()
@@ -691,7 +622,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         let computed_full_test_name = full_test_name(
             py,
             name.to_string(),
-            &function_arguments,
+            &first_attempt.function_arguments,
             &stmt_function_def.parameters,
             &framework_fixture_names,
         );
@@ -707,49 +638,10 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         let fail_slow_budget = tags
             .fail_slow_tag()
             .map(FailSlowTag::seconds)
-            .map(std::time::Duration::from_secs_f64)
+            .and_then(|seconds| std::time::Duration::try_from_secs_f64(seconds).ok())
             .or_else(|| self.context.settings().fail_slow_for(&eval_ctx));
 
         tracing::debug!("Running test `{}`", qualified_test_name);
-
-        if !fixture_call_errors.is_empty() {
-            let mut diagnostics = fixture_call_errors
-                .into_iter()
-                .map(|error| fixture_failure_diagnostic(py, error))
-                .collect::<Vec<_>>();
-            diagnostics.extend(
-                test_finalizers
-                    .into_iter()
-                    .rev()
-                    .filter_map(|finalizer| finalizer.run(py)),
-            );
-            diagnostics.extend(self.clean_up_scope(py, FixtureScope::Function));
-            let captured_output = Self::finish_output_capture(py, output_capture);
-            let duration = start_time.elapsed();
-            self.maybe_register_slow(
-                &qualified_test_name,
-                duration,
-                self.context.settings().slow_timeout_for(&eval_ctx),
-            );
-            if let Some(budget) = fail_slow_budget
-                && duration > budget
-            {
-                diagnostics.push(fail_slow_exceeded_diagnostic(
-                    source_file,
-                    &stmt_function_def,
-                    budget,
-                    duration,
-                    "setup",
-                ));
-            }
-            let diagnostic = diagnostics.remove(0);
-            return self.context.register_test_case_result(
-                &qualified_test_name,
-                TestExecutionOutcome::error_with_related(diagnostic, diagnostics),
-                duration,
-                captured_output,
-            );
-        }
 
         let test_name_env_result = set_test_name_env(py, &qualified_test_name.to_string());
 
@@ -761,7 +653,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             full_test_name(
                 py,
                 name.function_name().to_string(),
-                &function_arguments,
+                &first_attempt.function_arguments,
                 &stmt_function_def.parameters,
                 &fixture_names,
             ),
@@ -779,41 +671,9 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                 .timeout_for(&eval_ctx)
                 .map(|d| d.as_secs_f64())
         });
-        let run_test = || {
-            set_snapshot_context(snapshot_context.clone());
-            if let Err(err) = &test_name_env_result {
-                return Err(err.clone_ref(py));
-            }
-            if let Err(err) = &async_patch_result {
-                return Err(err.clone_ref(py));
-            }
-            let result = if let Some(seconds) = timeout_seconds {
-                run_test_with_timeout(
-                    py,
-                    &function,
-                    &function_arguments,
-                    is_async,
-                    seconds,
-                    &snapshot_context,
-                )
-            } else {
-                let result = if function_arguments.is_empty() {
-                    function.call0(py)
-                } else {
-                    let py_dict = function_arguments.to_kwargs(py)?;
-                    function.call(py, (), Some(&py_dict))
-                };
-                if is_async {
-                    result.and_then(|coroutine| run_coroutine(py, coroutine))
-                } else {
-                    result
-                }
-            };
-
-            result.map(|value| reject_non_none_return(py, &value))
-        };
 
         let configured_retries = self.context.settings().retry_for(&eval_ctx);
+        let max_attempts = configured_retries.saturating_add(1);
         let expect_fail = expect_fail_tag
             .as_ref()
             .is_some_and(ExpectFailTag::should_expect_fail);
@@ -821,107 +681,228 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         if let Some(coverage) = self.coverage {
             coverage.set_current_context(py, Some(&qualified_name_str));
         }
-        let RetryOutcome {
-            max_attempts,
-            prior_attempts,
-            final_attempt,
-        } = self.run_with_retries(
-            py,
-            &qualified_test_name,
-            configured_retries,
-            expect_fail,
-            run_test,
-        );
-        self.context.report_test_finished(&qualified_test_name);
+        let mut attempt_number = 1;
+        let mut prepared_attempt = Some(first_attempt);
+        let mut prior_attempts = Vec::new();
 
-        let report_ctx = VariantReportCtx {
-            name: &name,
-            source_file: &source_file,
-            stmt_function_def: &stmt_function_def,
-            function_arguments: &function_arguments,
-            expect_fail_tag,
+        let final_attempt = loop {
+            let attempt_env_result = set_attempt_env(py, attempt_number, max_attempts);
+            let prepared = if let Some(prepared) = prepared_attempt.take() {
+                prepared
+            } else {
+                if let Some(coverage) = self.coverage {
+                    coverage.set_current_context(py, None);
+                }
+                let setup_start = std::time::Instant::now();
+                let (function_arguments, fixture_call_errors, test_finalizers) = self
+                    .setup_test_fixtures(
+                        py,
+                        &fixture_dependencies,
+                        &use_fixture_dependencies,
+                        &auto_use_fixtures,
+                        retry_params.clone(),
+                    );
+                if let Some(coverage) = self.coverage {
+                    coverage.set_current_context(py, Some(&qualified_name_str));
+                }
+                PreparedTestAttempt {
+                    function_arguments,
+                    fixture_call_errors,
+                    test_finalizers,
+                    setup_duration: setup_start.elapsed(),
+                }
+            };
+
+            let PreparedTestAttempt {
+                function_arguments,
+                fixture_call_errors,
+                test_finalizers,
+                setup_duration,
+            } = prepared;
+
+            let (outcome, duration, retryable) = if fixture_call_errors.is_empty() {
+                set_snapshot_context(snapshot_context.clone());
+                let prepared_call = attempt_env_result.and_then(|()| {
+                    if let Err(err) = &test_name_env_result {
+                        return Err(err.clone_ref(py));
+                    }
+                    if let Err(err) = &async_patch_result {
+                        return Err(err.clone_ref(py));
+                    }
+                    if function_arguments.is_empty() || timeout_seconds.is_some() {
+                        Ok(None)
+                    } else {
+                        function_arguments.to_kwargs(py).map(Some)
+                    }
+                });
+                let (test_result, call_duration) = match prepared_call {
+                    Ok(py_dict) => {
+                        let call_start = std::time::Instant::now();
+                        let result = if let Some(seconds) = timeout_seconds {
+                            run_test_with_timeout(
+                                py,
+                                &function,
+                                &function_arguments,
+                                is_async,
+                                seconds,
+                                &snapshot_context,
+                            )
+                        } else {
+                            let result = if let Some(py_dict) = py_dict {
+                                function.call(py, (), Some(&py_dict))
+                            } else {
+                                function.call0(py)
+                            };
+                            if is_async {
+                                result.and_then(|coroutine| run_coroutine(py, coroutine))
+                            } else {
+                                result
+                            }
+                        };
+                        let call_duration = call_start.elapsed();
+                        (
+                            result.map(|value| reject_non_none_return(py, &value)),
+                            call_duration,
+                        )
+                    }
+                    Err(err) => (Err(err), std::time::Duration::ZERO),
+                };
+                let retryable_result = should_retry_result(
+                    py,
+                    &test_result,
+                    expect_fail,
+                    qualified_test_name.function_name().function_name(),
+                );
+                let report_ctx = VariantReportCtx {
+                    name: &name,
+                    source_file: &source_file,
+                    stmt_function_def: &stmt_function_def,
+                    function_arguments: &function_arguments,
+                    expect_fail_tag: expect_fail_tag.clone(),
+                };
+                let outcome = Self::classify_test_result(py, test_result, &report_ctx);
+                let skipped = outcome.is_skipped();
+
+                let teardown_start = std::time::Instant::now();
+                let mut finalizer_diagnostics = test_finalizers
+                    .into_iter()
+                    .rev()
+                    .filter_map(|finalizer| finalizer.run(py))
+                    .collect::<Vec<_>>();
+                finalizer_diagnostics.extend(self.clean_up_scope(py, FixtureScope::Function));
+                let phases = PhaseDurations {
+                    setup: setup_duration,
+                    call: call_duration,
+                    teardown: teardown_start.elapsed(),
+                };
+                let duration = phases.total();
+                let budget_exceeded = fail_slow_budget.is_some_and(|budget| duration > budget);
+                let outcome = attach_finalizer_diagnostics(outcome, finalizer_diagnostics);
+                let outcome = apply_fail_slow_budget(
+                    outcome,
+                    duration,
+                    phases,
+                    fail_slow_budget,
+                    &source_file,
+                    &stmt_function_def,
+                );
+                (
+                    outcome,
+                    duration,
+                    retryable_result || (budget_exceeded && !skipped),
+                )
+            } else {
+                let mut diagnostics = fixture_call_errors
+                    .into_iter()
+                    .map(|error| fixture_failure_diagnostic(py, error))
+                    .collect::<Vec<_>>();
+                let teardown_start = std::time::Instant::now();
+                diagnostics.extend(
+                    test_finalizers
+                        .into_iter()
+                        .rev()
+                        .filter_map(|finalizer| finalizer.run(py)),
+                );
+                diagnostics.extend(self.clean_up_scope(py, FixtureScope::Function));
+                let phases = PhaseDurations {
+                    setup: setup_duration,
+                    call: std::time::Duration::ZERO,
+                    teardown: teardown_start.elapsed(),
+                };
+                let duration = phases.total();
+                let budget_exceeded = fail_slow_budget.is_some_and(|budget| duration > budget);
+                let diagnostic = diagnostics.remove(0);
+                let outcome = TestExecutionOutcome::error_with_related(diagnostic, diagnostics);
+                let outcome = apply_fail_slow_budget(
+                    outcome,
+                    duration,
+                    phases,
+                    fail_slow_budget,
+                    &source_file,
+                    &stmt_function_def,
+                );
+                (outcome, duration, budget_exceeded)
+            };
+
+            let attempt = TestLifecycleAttempt {
+                attempt: attempt_number,
+                outcome,
+                duration,
+            };
+            if retryable && attempt_number < max_attempts {
+                self.context.report_test_attempt(
+                    &qualified_test_name,
+                    attempt_number,
+                    attempt.outcome.result_kind(),
+                    duration,
+                );
+                prior_attempts.push(attempt);
+                tracing::debug!("Retrying test `{}`", qualified_test_name);
+                attempt_number += 1;
+            } else {
+                break attempt;
+            }
         };
 
-        let total_duration = start_time.elapsed();
+        if let Some(coverage) = self.coverage {
+            coverage.set_current_context(py, None);
+        }
+        let captured_output = Self::finish_output_capture(py, output_capture);
+        let total_duration = prior_attempts
+            .iter()
+            .map(|attempt| attempt.duration)
+            .sum::<std::time::Duration>()
+            .saturating_add(final_attempt.duration);
+        if !prior_attempts.is_empty() {
+            self.context.report_test_attempt(
+                &qualified_test_name,
+                final_attempt.attempt,
+                final_attempt.outcome.result_kind(),
+                final_attempt.duration,
+            );
+        }
         self.maybe_register_slow(
             &qualified_test_name,
             total_duration,
             self.context.settings().slow_timeout_for(&eval_ctx),
         );
-
-        let final_attempt_number = final_attempt.attempt;
-        let final_attempt_duration = final_attempt.duration;
-        let final_attempt_outcome =
-            Self::classify_test_result(py, final_attempt.result, &report_ctx);
-
-        let teardown_start = std::time::Instant::now();
-        let mut finalizer_diagnostics = test_finalizers
-            .into_iter()
-            .rev()
-            .filter_map(|finalizer| finalizer.run(py))
-            .collect::<Vec<_>>();
-        finalizer_diagnostics.extend(self.clean_up_scope(py, FixtureScope::Function));
-        let teardown_duration = teardown_start.elapsed();
-        let captured_output = Self::finish_output_capture(py, output_capture);
-        if let Some(coverage) = self.coverage {
-            coverage.set_current_context(py, None);
-        }
-
-        // Teardown-inclusive lifecycle duration, used only for the
-        // `fail-slow` budget check below. Distinct from `total_duration`
-        // (captured before teardown), which is what gets reported for
-        // `slow-timeout` and shown in PASS/FAIL lines and machine-readable
-        // reports.
-        let lifecycle_duration = start_time.elapsed();
-        let phase_durations = PhaseDurations {
-            setup: setup_duration,
-            call: final_attempt_duration,
-            teardown: teardown_duration,
-        };
+        self.context.report_test_finished(&qualified_test_name);
 
         if prior_attempts.is_empty() {
-            let outcome =
-                attach_finalizer_diagnostics(final_attempt_outcome, finalizer_diagnostics);
-            let outcome = apply_fail_slow_budget(
-                outcome,
-                lifecycle_duration,
-                phase_durations,
-                fail_slow_budget,
-                &source_file,
-                &stmt_function_def,
-            );
             self.context.register_test_case_result(
                 &qualified_test_name,
-                outcome,
+                final_attempt.outcome,
                 total_duration,
                 captured_output,
             )
         } else {
+            let final_attempt_number = final_attempt.attempt;
+            let outcome = final_attempt.outcome.clone();
             let mut execution_attempts = prior_attempts
                 .into_iter()
-                .map(|attempt| {
-                    TestExecutionAttempt::new(
-                        attempt.attempt,
-                        Self::classify_test_result(py, attempt.result, &report_ctx),
-                        attempt.duration,
-                    )
-                })
+                .map(TestLifecycleAttempt::into_execution_attempt)
                 .collect::<Vec<_>>();
-            execution_attempts.push(TestExecutionAttempt::new(
-                final_attempt_number,
-                final_attempt_outcome.clone(),
-                final_attempt_duration,
-            ));
-            let outcome =
-                attach_finalizer_diagnostics(final_attempt_outcome, finalizer_diagnostics);
-            let outcome = apply_fail_slow_budget(
-                outcome,
-                lifecycle_duration,
-                phase_durations,
-                fail_slow_budget,
-                &source_file,
-                &stmt_function_def,
-            );
+            execution_attempts.push(final_attempt.into_execution_attempt());
             self.context.register_retried_result(
                 &qualified_test_name,
                 outcome,
@@ -1103,20 +1084,6 @@ fn reject_non_none_return(py: Python<'_>, value: &Py<PyAny>) -> TestCallOutcome 
     }
 }
 
-fn attempt_result_kind(
-    py: Python<'_>,
-    test_result: &PyResult<TestCallOutcome>,
-) -> IndividualTestResultKind {
-    match test_result {
-        Ok(TestCallOutcome::ReturnedNone) => IndividualTestResultKind::Passed,
-        Ok(TestCallOutcome::ReturnedValue(_)) => IndividualTestResultKind::Failed,
-        Err(err) if is_skip_exception(py, err) => IndividualTestResultKind::Skipped {
-            reason: extract_skip_reason(py, err),
-        },
-        Err(_) => IndividualTestResultKind::Failed,
-    }
-}
-
 fn should_retry_result(
     py: Python<'_>,
     test_result: &PyResult<TestCallOutcome>,
@@ -1183,13 +1150,7 @@ fn attach_finalizer_diagnostics(
     }
 }
 
-/// Per-phase timings for a single test execution, used to attribute a
-/// `fail-slow` diagnostic to the slowest phase of the test's lifecycle.
-///
-/// `call` is the final (reported) attempt's duration only. When a test was
-/// retried, earlier attempts are not summed in here — the diagnostic
-/// attributes slowness within the attempt that actually determined the
-/// outcome, not the cumulative cost of every retry.
+/// Per-phase timings for one complete test attempt.
 #[derive(Clone, Copy)]
 struct PhaseDurations {
     setup: std::time::Duration,
@@ -1198,6 +1159,12 @@ struct PhaseDurations {
 }
 
 impl PhaseDurations {
+    fn total(&self) -> std::time::Duration {
+        self.setup
+            .saturating_add(self.call)
+            .saturating_add(self.teardown)
+    }
+
     fn slowest(&self) -> &'static str {
         let mut slowest = ("setup", self.setup);
         for candidate in [("call", self.call), ("teardown", self.teardown)] {
@@ -1252,18 +1219,23 @@ enum TestCallOutcome {
     ReturnedValue(String),
 }
 
-/// Outcome of driving a test through the configured retry budget.
-struct RetryOutcome {
-    /// The maximum number of attempts the test was allowed (`retries + 1`).
-    max_attempts: u32,
-    prior_attempts: Vec<TestCallAttempt>,
-    final_attempt: TestCallAttempt,
+struct PreparedTestAttempt {
+    function_arguments: FixtureArguments,
+    fixture_call_errors: Vec<FixtureCallError>,
+    test_finalizers: Vec<Finalizer>,
+    setup_duration: std::time::Duration,
 }
 
-struct TestCallAttempt {
+struct TestLifecycleAttempt {
     attempt: u32,
-    result: PyResult<TestCallOutcome>,
+    outcome: TestExecutionOutcome,
     duration: std::time::Duration,
+}
+
+impl TestLifecycleAttempt {
+    fn into_execution_attempt(self) -> TestExecutionAttempt {
+        TestExecutionAttempt::new(self.attempt, self.outcome, self.duration)
+    }
 }
 
 /// Immutable per-variant state threaded into [`PackageRunner::classify_test_result`].

--- a/crates/karva_test_semantic/src/runner/package_runner.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner.rs
@@ -19,9 +19,9 @@ use ruff_source_file::SourceFile;
 
 use crate::Context;
 use crate::diagnostic::{
-    fixture_failure_diagnostic, fixture_resolution_diagnostic, invalid_parametrize_diagnostic,
-    missing_fixtures_diagnostic, test_failure_diagnostic, test_pass_on_expect_failure_diagnostic,
-    test_returned_value_diagnostic,
+    fail_slow_exceeded_diagnostic, fixture_failure_diagnostic, fixture_resolution_diagnostic,
+    invalid_parametrize_diagnostic, missing_fixtures_diagnostic, test_failure_diagnostic,
+    test_pass_on_expect_failure_diagnostic, test_returned_value_diagnostic,
 };
 use crate::discovery::{DiscoveredModule, DiscoveredPackage, DiscoveredTestFunction};
 use crate::extensions::fixtures::{
@@ -29,6 +29,7 @@ use crate::extensions::fixtures::{
 };
 use crate::extensions::functions::snapshot::{SnapshotContext, set_snapshot_context};
 use crate::extensions::tags::expect_fail::ExpectFailTag;
+use crate::extensions::tags::fail_slow::FailSlowTag;
 use crate::extensions::tags::skip::{extract_skip_reason, is_skip_exception};
 use crate::extensions::tags::timeout::TimeoutTag;
 use crate::output_capture::PythonOutputCapture;
@@ -676,6 +677,7 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             &auto_use_fixtures,
             params,
         );
+        let setup_duration = start_time.elapsed();
 
         let fixture_names = fixture_dependencies
             .iter()
@@ -702,6 +704,11 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             test_name: &qualified_name_str,
             tags: &custom_tag_names,
         };
+        let fail_slow_budget = tags
+            .fail_slow_tag()
+            .map(FailSlowTag::seconds)
+            .map(std::time::Duration::from_secs_f64)
+            .or_else(|| self.context.settings().fail_slow_for(&eval_ctx));
 
         tracing::debug!("Running test `{}`", qualified_test_name);
 
@@ -724,6 +731,17 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
                 duration,
                 self.context.settings().slow_timeout_for(&eval_ctx),
             );
+            if let Some(budget) = fail_slow_budget
+                && duration > budget
+            {
+                diagnostics.push(fail_slow_exceeded_diagnostic(
+                    source_file,
+                    &stmt_function_def,
+                    budget,
+                    duration,
+                    "setup",
+                ));
+            }
             let diagnostic = diagnostics.remove(0);
             return self.context.register_test_case_result(
                 &qualified_test_name,
@@ -836,20 +854,42 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
         let final_attempt_outcome =
             Self::classify_test_result(py, final_attempt.result, &report_ctx);
 
+        let teardown_start = std::time::Instant::now();
         let mut finalizer_diagnostics = test_finalizers
             .into_iter()
             .rev()
             .filter_map(|finalizer| finalizer.run(py))
             .collect::<Vec<_>>();
         finalizer_diagnostics.extend(self.clean_up_scope(py, FixtureScope::Function));
+        let teardown_duration = teardown_start.elapsed();
         let captured_output = Self::finish_output_capture(py, output_capture);
         if let Some(coverage) = self.coverage {
             coverage.set_current_context(py, None);
         }
 
+        // Teardown-inclusive lifecycle duration, used only for the
+        // `fail-slow` budget check below. Distinct from `total_duration`
+        // (captured before teardown), which is what gets reported for
+        // `slow-timeout` and shown in PASS/FAIL lines and machine-readable
+        // reports.
+        let lifecycle_duration = start_time.elapsed();
+        let phase_durations = PhaseDurations {
+            setup: setup_duration,
+            call: final_attempt_duration,
+            teardown: teardown_duration,
+        };
+
         if prior_attempts.is_empty() {
             let outcome =
                 attach_finalizer_diagnostics(final_attempt_outcome, finalizer_diagnostics);
+            let outcome = apply_fail_slow_budget(
+                outcome,
+                lifecycle_duration,
+                phase_durations,
+                fail_slow_budget,
+                &source_file,
+                &stmt_function_def,
+            );
             self.context.register_test_case_result(
                 &qualified_test_name,
                 outcome,
@@ -874,6 +914,14 @@ impl<'ctx, 'a> PackageRunner<'ctx, 'a> {
             ));
             let outcome =
                 attach_finalizer_diagnostics(final_attempt_outcome, finalizer_diagnostics);
+            let outcome = apply_fail_slow_budget(
+                outcome,
+                lifecycle_duration,
+                phase_durations,
+                fail_slow_budget,
+                &source_file,
+                &stmt_function_def,
+            );
             self.context.register_retried_result(
                 &qualified_test_name,
                 outcome,
@@ -1132,6 +1180,70 @@ fn attach_finalizer_diagnostics(
             let diagnostic = diagnostics.remove(0);
             TestExecutionOutcome::error_with_related(diagnostic, diagnostics)
         }
+    }
+}
+
+/// Per-phase timings for a single test execution, used to attribute a
+/// `fail-slow` diagnostic to the slowest phase of the test's lifecycle.
+///
+/// `call` is the final (reported) attempt's duration only. When a test was
+/// retried, earlier attempts are not summed in here — the diagnostic
+/// attributes slowness within the attempt that actually determined the
+/// outcome, not the cumulative cost of every retry.
+#[derive(Clone, Copy)]
+struct PhaseDurations {
+    setup: std::time::Duration,
+    call: std::time::Duration,
+    teardown: std::time::Duration,
+}
+
+impl PhaseDurations {
+    fn slowest(&self) -> &'static str {
+        let mut slowest = ("setup", self.setup);
+        for candidate in [("call", self.call), ("teardown", self.teardown)] {
+            if candidate.1 > slowest.1 {
+                slowest = candidate;
+            }
+        }
+        slowest.0
+    }
+}
+
+/// Fail a test whose full lifecycle exceeded its `fail-slow` budget.
+///
+/// A test that otherwise passed becomes an ordinary `Failed` outcome. A
+/// test that already failed or errored keeps its original diagnostic as
+/// the primary cause and gets the budget diagnostic appended as related
+/// context (via [`attach_finalizer_diagnostics`], which already implements
+/// this composition), so both are visible. A skipped test never ran its
+/// lifecycle and is left untouched.
+fn apply_fail_slow_budget(
+    outcome: TestExecutionOutcome,
+    lifecycle_duration: std::time::Duration,
+    phases: PhaseDurations,
+    budget: Option<std::time::Duration>,
+    source_file: &SourceFile,
+    stmt_function_def: &StmtFunctionDef,
+) -> TestExecutionOutcome {
+    let Some(budget) = budget else {
+        return outcome;
+    };
+    if lifecycle_duration <= budget {
+        return outcome;
+    }
+
+    let fail_slow_diagnostic = fail_slow_exceeded_diagnostic(
+        source_file.clone(),
+        stmt_function_def,
+        budget,
+        lifecycle_duration,
+        phases.slowest(),
+    );
+
+    match outcome {
+        TestExecutionOutcome::Passed => TestExecutionOutcome::failed(fail_slow_diagnostic),
+        TestExecutionOutcome::Skipped { reason } => TestExecutionOutcome::Skipped { reason },
+        other => attach_finalizer_diagnostics(other, vec![fail_slow_diagnostic]),
     }
 }
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -406,6 +406,38 @@ fail-fast = true
 
 ---
 
+### `fail-slow`
+
+Duration budget (in seconds) for a test's full lifecycle (fixture
+setup, the test call, and fixture teardown).
+
+When set, a test is allowed to run to completion — including
+teardown, so cleanup is never skipped — and is then reported as a
+failure if the full lifecycle took longer than this budget. Tests
+can override the limit individually with
+[`@karva.tags.fail_slow`](https://docs.karva.dev/usage/failure-handling/fail-slow/),
+which takes precedence over the configured default.
+
+This is distinct from [`timeout`](#timeout), which kills a test
+mid-execution, and [`slow_timeout`](#slow-timeout), which is purely
+informational and never fails a test.
+
+Defaults to unset, which disables budget checking unless a tag is
+applied to the test.
+
+**Default value**: `null`
+
+**Type**: `float (seconds)`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.karva.profile.default.test]
+fail-slow = 0.25
+```
+
+---
+
 ### `max-fail`
 
 Stop scheduling new tests once this many tests have failed.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -70,7 +70,10 @@ karva test [OPTIONS] [PATH]...
 <ul>
 <li><code>true</code></li>
 <li><code>false</code></li>
-</ul></dd><dt id="karva-test--filter"><a href="#karva-test--filter"><code>--filter</code></a>, <code>-E</code> <i>filter-expressions</i></dt><dd><p>Filter tests using a filterset expression.</p>
+</ul></dd><dt id="karva-test--fail-slow"><a href="#karva-test--fail-slow"><code>--fail-slow</code></a> <i>seconds</i></dt><dd><p>Duration budget, in seconds, for a test's full lifecycle.</p>
+<p>Unlike <code>--timeout</code>, a test is always allowed to finish — including fixture teardown — before being reported as a failure if the total duration exceeded this budget. A test-level &#91;<code>@karva.tags.fail_slow</code>&#93; decorator overrides the default for that specific test.</p>
+<p>Accepts fractional seconds such as <code>--fail-slow=1</code> or <code>--fail-slow=0.25</code>.</p>
+</dd><dt id="karva-test--filter"><a href="#karva-test--filter"><code>--filter</code></a>, <code>-E</code> <i>filter-expressions</i></dt><dd><p>Filter tests using a filterset expression.</p>
 <p>Predicates: <code>test(&lt;matcher&gt;)</code> matches the fully qualified test name; <code>tag(&lt;matcher&gt;)</code> matches any custom tag on the test.</p>
 <p>Matchers: <code>=exact</code>, <code>~substring</code>, <code>/regex/</code>, <code>#glob</code>. The default is substring for <code>test()</code> and exact for <code>tag()</code>. String bodies may be quoted (<code>&quot;...&quot;</code>) to allow spaces or reserved characters.</p>
 <p>Operators: <code>&amp;</code> / <code>and</code>, <code>|</code> / <code>or</code>, <code>not</code> / <code>!</code>, and <code>-</code> as shorthand for &quot;and not&quot;. Use parentheses for grouping. <code>and</code> binds tighter than <code>or</code>.</p>

--- a/docs/usage/failure-handling/fail-slow.md
+++ b/docs/usage/failure-handling/fail-slow.md
@@ -1,0 +1,48 @@
+# Fail slow
+
+A test can complete correctly while still taking longer than an agreed performance budget. `fail-slow` lets a test run to completion — including fixture teardown, so cleanup is never skipped — and then fails it if the full lifecycle took too long.
+
+This is a coarse regression budget, not a benchmarking tool: it does not add statistical sampling or baseline comparisons.
+
+## Basic usage
+
+```python title="test.py"
+import karva
+import time
+
+@karva.tags.fail_slow(0.25)
+def test_index_lookup():
+    time.sleep(0.5)  # fails: exceeded its 0.25s budget
+```
+
+The threshold accepts fractional seconds (`@karva.tags.fail_slow(0.05)`).
+
+## Configuring a default budget
+
+Use the `fail-slow` setting (or `--fail-slow=SECONDS` on the CLI) to apply the same budget to every test in the project:
+
+```bash
+karva test --fail-slow=1.0
+```
+
+```toml
+[tool.karva.profile.default.test]
+fail-slow = 1.0
+```
+
+A test-level `@karva.tags.fail_slow` always wins over the configured default, and per-test [overrides](retries.md#per-test-retry-overrides) win over the profile setting — the same precedence order used by `timeout` and `slow-timeout`.
+
+## What counts toward the budget
+
+The budget covers the test's entire lifecycle: fixture setup, the test call, and fixture teardown. Unlike [`@karva.tags.timeout`](../tags/timeout.md), which kills a test mid-execution, `fail-slow` never interrupts a running test — it lets setup, the call, and teardown all finish, then compares the total duration against the budget.
+
+If a test already fails for another reason (an assertion, a fixture error, a teardown error) and also exceeds its budget, both are reported: the original failure stays the primary cause, and the exceeded budget is noted alongside it.
+
+## Retries
+
+The budget is checked once, after the test's full lifecycle — including any [retries](retries.md) triggered by a genuine failure in the test body — has finished. Retries are never triggered by exceeding the budget alone: a test that passes on its first attempt but runs over budget fails once, without being retried. If a retried test's final attempt both fails for another reason and exceeds the budget, both are reported together, as described above.
+
+## See also
+
+- [Timeout](../tags/timeout.md) for `@karva.tags.timeout`, which kills a test mid-execution instead of letting it finish.
+- [Slow tests](slow-tests.md) for `--slow-timeout`, which only flags slow tests rather than failing them.

--- a/docs/usage/failure-handling/fail-slow.md
+++ b/docs/usage/failure-handling/fail-slow.md
@@ -7,8 +7,9 @@ This is a coarse regression budget, not a benchmarking tool: it does not add sta
 ## Basic usage
 
 ```python title="test.py"
-import karva
 import time
+
+import karva
 
 @karva.tags.fail_slow(0.25)
 def test_index_lookup():
@@ -22,7 +23,7 @@ The threshold accepts fractional seconds (`@karva.tags.fail_slow(0.05)`).
 Use the `fail-slow` setting (or `--fail-slow=SECONDS` on the CLI) to apply the same budget to every test in the project:
 
 ```bash
-karva test --fail-slow=1.0
+uv run karva test --fail-slow=1.0
 ```
 
 ```toml
@@ -36,11 +37,13 @@ A test-level `@karva.tags.fail_slow` always wins over the configured default, an
 
 The budget covers the test's entire lifecycle: fixture setup, the test call, and fixture teardown. Unlike [`@karva.tags.timeout`](../tags/timeout.md), which kills a test mid-execution, `fail-slow` never interrupts a running test — it lets setup, the call, and teardown all finish, then compares the total duration against the budget.
 
+Only work performed within an individual test attempt counts toward its budget. Module, package, and session cleanup happens outside any single attempt and is not assigned to a test. Function-scoped fixtures are recreated for each retry.
+
 If a test already fails for another reason (an assertion, a fixture error, a teardown error) and also exceeds its budget, both are reported: the original failure stays the primary cause, and the exceeded budget is noted alongside it.
 
 ## Retries
 
-The budget is checked once, after the test's full lifecycle — including any [retries](retries.md) triggered by a genuine failure in the test body — has finished. Retries are never triggered by exceeding the budget alone: a test that passes on its first attempt but runs over budget fails once, without being retried. If a retried test's final attempt both fails for another reason and exceeds the budget, both are reported together, as described above.
+Each attempt is checked independently after its full lifecycle finishes. Exceeding the budget is an ordinary retryable failure: a later attempt that stays within budget makes the test flaky. Time from earlier attempts never counts against a later attempt's budget.
 
 ## See also
 

--- a/docs/usage/failure-handling/retries.md
+++ b/docs/usage/failure-handling/retries.md
@@ -44,7 +44,7 @@ retries = 0
 
 In this example tests tagged `network` retry up to five times, tests tagged `unit` never retry, and everything else falls back to `retry = 1`. Overrides defined in a named profile (`[[profile.ci.overrides]]`) take precedence over those defined under `default`.
 
-The same `[[profile.<name>.overrides]]` block also supports `timeout` and `slow-timeout` fields, mirroring the [profile-level timeout](../../configuration/configuration.md) and slow-test threshold. A matching override with a non-positive value disables the corresponding limit for that test, even when the profile sets one.
+The same `[[profile.<name>.overrides]]` block also supports `timeout`, `slow-timeout`, and `fail-slow` fields, mirroring the [profile-level timeout](../../configuration/configuration.md), slow-test threshold, and [fail-slow budget](fail-slow.md). A matching override with a non-positive value disables the corresponding limit for that test, even when the profile sets one.
 
 ```toml
 [profile.default.test]

--- a/docs/usage/failure-handling/slow-tests.md
+++ b/docs/usage/failure-handling/slow-tests.md
@@ -23,7 +23,7 @@ The `SLOW` line is gated behind `--status-level=slow` (or higher); the summary s
 karva test --slow-timeout=2.0 --status-level=slow --final-status-level=slow
 ```
 
-Slow detection is purely informational — it does not fail the run or kill the test. To time-box a test instead, use [`@karva.tags.timeout`](../tags/timeout.md).
+Slow detection is purely informational — it does not fail the run or kill the test. To time-box a test instead, use [`@karva.tags.timeout`](../tags/timeout.md). To fail a test that exceeds a duration budget without killing it mid-execution, use [`fail-slow`](fail-slow.md).
 
 ## Ranking the slowest tests
 

--- a/docs/usage/tags/timeout.md
+++ b/docs/usage/tags/timeout.md
@@ -41,3 +41,4 @@ Fixture setup runs before the timeout starts, so a slow fixture does not count t
 ## See also
 
 - [Slow tests](../failure-handling/slow-tests.md) for `--slow-timeout`, which only flags slow tests rather than failing them.
+- [Fail slow](../failure-handling/fail-slow.md) for `@karva.tags.fail_slow`, which fails a test that exceeds a duration budget without killing it mid-execution.

--- a/python/karva/_karva/tags.pyi
+++ b/python/karva/_karva/tags.pyi
@@ -46,3 +46,14 @@ def timeout(seconds: float) -> Tags:
     Fixture setup runs before the timeout starts, so slow fixtures do not
     count toward the limit.
     """
+
+def fail_slow(seconds: float) -> Tags:
+    """Fail the current test if its full lifecycle takes longer than ``seconds``.
+
+    Unlike ``timeout``, this never kills the test early: fixture setup, the
+    test call, and fixture teardown are always allowed to finish so cleanup
+    is never skipped. Once the lifecycle completes, the test is reported as
+    a failure if the total duration exceeded the configured budget.
+
+    This is a coarse regression budget, not a benchmarking tool.
+    """

--- a/zensical.toml
+++ b/zensical.toml
@@ -29,6 +29,7 @@ nav = [
             { "Failing Fast" = "usage/failure-handling/fail-fast.md"},
             { "Retries" = "usage/failure-handling/retries.md"},
             { "Slow Tests" = "usage/failure-handling/slow-tests.md"},
+            { "Fail Slow" = "usage/failure-handling/fail-slow.md"},
         ]},
         { "Writing Tests" = [
             { "Snapshots" = "usage/writing-tests/snapshots.md"},


### PR DESCRIPTION
## Summary

Closes #984.

- Adds a `fail-slow` config option (`karva.toml`/`pyproject.toml`), a `--fail-slow` CLI flag, and an `@karva.tags.fail_slow(seconds)` tag, all following the same precedence chain (tag > matching override > profile default) already used by `timeout`/`slow-timeout`.
- A test is always allowed to finish its full lifecycle — fixture setup, the call, and teardown, so cleanup is never skipped — and is only then reported as a failure if the total duration exceeded the configured budget. This is distinct from `timeout` (kills mid-execution) and `slow-timeout` (informational only, never fails the test).
- A test that already fails for another reason (assertion, fixture error, etc.) and also exceeds its budget shows both: the original failure stays primary, and the exceeded budget is noted as a related diagnostic alongside it.
- The budget check runs once, after any retries triggered by a genuine failure have already completed — a test that passes on its first attempt but is merely slow is not retried purely for exceeding the budget.
- New docs page (`docs/usage/failure-handling/fail-slow.md`), cross-linked from `timeout.md`/`slow-tests.md`/`retries.md`, plus regenerated CLI/config reference docs.

## Test plan

- [x] `cargo test --workspace` — all unit and integration tests pass (909 integration tests including 18 new fail-slow tests + 2 new override-precedence tests)
- [x] `cargo clippy --workspace --all-targets` — clean, no warnings
- [x] `karva_dev generate-all` doc-freshness checks pass
- [x] Manually verified `@karva.tags.fail_slow`, `--fail-slow`, and `[test] fail-slow` config all resolve correctly via `karva show-config`