### PR TITLE
Require aggregate CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,3 +323,72 @@ jobs:
 
       - name: Build docs
         run: uv run --isolated --only-group docs zensical build
+
+  ci-gate:
+    name: "CI gate"
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    needs:
+      - determine_changes
+      - pre-commit
+      - cargo-shear
+      - cargo-test
+      - wheel-smoke
+      - build-windows-tests
+      - cargo-test-windows
+      - build-docs
+    if: ${{ always() }}
+
+    steps:
+      - name: Require successful validation
+        env:
+          BUILD_DOCS_RESULT: ${{ needs.build-docs.result }}
+          BUILD_WINDOWS_TESTS_RESULT: ${{ needs.build-windows-tests.result }}
+          CARGO_SHEAR_RESULT: ${{ needs.cargo-shear.result }}
+          CARGO_TEST_RESULT: ${{ needs.cargo-test.result }}
+          CARGO_TEST_WINDOWS_RESULT: ${{ needs.cargo-test-windows.result }}
+          CODE_CHANGED: ${{ needs.determine_changes.outputs.code }}
+          DETERMINE_CHANGES_RESULT: ${{ needs.determine_changes.result }}
+          PRE_COMMIT_RESULT: ${{ needs.pre-commit.result }}
+          WHEEL_SMOKE_RESULT: ${{ needs.wheel-smoke.result }}
+        run: |
+          require_success() {
+            if [ "$2" != "success" ]; then
+              echo "::error::$1 finished with result '$2'"
+              exit 1
+            fi
+          }
+
+          require_code_validation() {
+            case "$2" in
+              success)
+                ;;
+              skipped)
+                if [ "$CODE_CHANGED" != "false" ] || [ "$GITHUB_REF" = "refs/heads/main" ]; then
+                  echo "::error::$1 was unexpectedly skipped"
+                  exit 1
+                fi
+                ;;
+              *)
+                echo "::error::$1 finished with result '$2'"
+                exit 1
+                ;;
+            esac
+          }
+
+          require_success "determine changes" "$DETERMINE_CHANGES_RESULT"
+          require_success "pre commit" "$PRE_COMMIT_RESULT"
+          require_success "Build docs" "$BUILD_DOCS_RESULT"
+
+          if [ "$CODE_CHANGED" != "true" ] && [ "$CODE_CHANGED" != "false" ]; then
+            echo "::error::determine changes produced unexpected code output '$CODE_CHANGED'"
+            exit 1
+          fi
+
+          require_code_validation "cargo shear" "$CARGO_SHEAR_RESULT"
+          require_code_validation "cargo test" "$CARGO_TEST_RESULT"
+          require_code_validation "wheel smoke" "$WHEEL_SMOKE_RESULT"
+          require_code_validation "build tests archive | windows" "$BUILD_WINDOWS_TESTS_RESULT"
+          require_code_validation "cargo test | windows" "$CARGO_TEST_WINDOWS_RESULT"


### PR DESCRIPTION
## Summary

Adds one `CI gate` job that aggregates every CI job into a stable required check. It accepts intentional skips for non-code pull requests and fails all unexpected skips or job failures.

## Test Plan

Ran `pinact run` and `uvx prek run -a`.