### PR TITLE
Stabilize fail-slow retry timing test

### DIFF
--- a/crates/karva/tests/it/extensions/tags/fail_slow.rs
+++ b/crates/karva/tests/it/extensions/tags/fail_slow.rs
@@ -299,9 +299,11 @@ import os
 import time
 import karva
 
-@karva.tags.fail_slow(0.2)
+# A 0.15s sleep exceeded a 0.2s budget on macOS CI. Keep enough headroom for
+# one attempt while two 1s attempts still exceed the per-attempt budget.
+@karva.tags.fail_slow(1.5)
 def test_retry():
-    time.sleep(0.15)
+    time.sleep(1)
     assert os.environ["KARVA_ATTEMPT"] == "2"
         "#,
     );


### PR DESCRIPTION
## Summary

Widens the timing gap in the fail-slow retry integration test so scheduler delays cannot turn a valid retry into a budget failure. The old 50 ms margin flaked repeatedly on macOS CI; the new values retain the assertion that retry durations are checked per attempt rather than summed.

## Test Plan

Repeated the focused test with retries disabled and ran `uvx prek run -a`.