### PR TITLE
Pin CI Python to 3.14.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
-  PYTHON_VERSION: "3.14"
+  # Keep this exact version preinstalled before nextest starts.
+  PYTHON_VERSION: "3.14.4"
   RUSTUP_MAX_RETRIES: 10
   NEXTEST_PROFILE: ci
 
@@ -156,6 +157,9 @@ jobs:
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           python-version: "3.10"
+
+      - name: "Install integration test Python"
+        run: uv python install "$PYTHON_VERSION"
 
       - name: Setup Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0


### PR DESCRIPTION
## Summary

CI for #1059 downloaded Python 3.14.6 inside nextest timeout windows. Pin integration-test Python to 3.14.4 and install it before nextest so subprocesses reuse prepared interpreter.

## Test Plan

Ran `pinact run` and `uvx prek run -a`.