### PR TITLE
Quote string values in test names

### DIFF
--- a/crates/karva/tests/it/async.rs
+++ b/crates/karva/tests/it/async.rs
@@ -166,7 +166,7 @@ def test_teardown_ran():
     exit_code: 0
     ----- stdout -----
         Starting 2 tests across 1 worker
-            PASS [TIME] test::test_async_gen_fixture(async_resource=resource)
+            PASS [TIME] test::test_async_gen_fixture(async_resource='resource')
             PASS [TIME] test::test_teardown_ran
     ────────────
          Summary [TIME] 2 tests run: 2 passed, 0 skipped

--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -1281,11 +1281,11 @@ def test_1(fixture_very_very_very_very_very_long_name):
     exit_code: 1
     ----- stdout -----
         Starting 1 test across 1 worker
-            FAIL [TIME] test_file::test_1(fixture_very_very_very_very...=fixture_very_very_very_very...)
+            FAIL [TIME] test_file::test_1(fixture_very_very_very_very...='fixture_very_very_very_ve...')
 
     failures:
 
-    test_file::test_1(fixture_very_very_very_very...=fixture_very_very_very_very...):
+    test_file::test_1(fixture_very_very_very_very...='fixture_very_very_very_ve...'):
 
     error[test-failure]: Test `test_1` failed
      --> test_file.py:8:5

--- a/crates/karva/tests/it/extensions/fixtures/autouse.rs
+++ b/crates/karva/tests/it/extensions/fixtures/autouse.rs
@@ -137,8 +137,8 @@ fn test_auto_use_fixture(#[values("pytest", "karva")] framework: &str) {
         exit_code: 0
         ----- stdout -----
             Starting 2 tests across 1 worker
-                PASS [TIME] test::test_string_only(order=['a'], first_entry=a)
-                PASS [TIME] test::test_string_and_int(order=['a'], first_entry=a)
+                PASS [TIME] test::test_string_only(order=['a'], first_entry='a')
+                PASS [TIME] test::test_string_and_int(order=['a'], first_entry='a')
         ────────────
              Summary [TIME] 2 tests run: 2 passed, 0 skipped
 

--- a/crates/karva/tests/it/extensions/fixtures/basic.rs
+++ b/crates/karva/tests/it/extensions/fixtures/basic.rs
@@ -732,7 +732,7 @@ def invoke():
     exit_code: 0
     ----- stdout -----
         Starting 1 test across 1 worker
-            PASS [TIME] test_invoke::test_invoke(invoke=invoked)
+            PASS [TIME] test_invoke::test_invoke(invoke='invoked')
     ────────────
          Summary [TIME] 1 test run: 1 passed, 0 skipped
 
@@ -776,7 +776,7 @@ def test_uses_imported_fixture(imported_fixture):
     exit_code: 0
     ----- stdout -----
         Starting 1 test across 1 worker
-            PASS [TIME] test_imported_fixture::test_uses_imported_fixture(imported_fixture=imported)
+            PASS [TIME] test_imported_fixture::test_uses_imported_fixture(imported_fixture='imported')
     ────────────
          Summary [TIME] 1 test run: 1 passed, 0 skipped
 

--- a/crates/karva/tests/it/extensions/fixtures/generators.rs
+++ b/crates/karva/tests/it/extensions/fixtures/generators.rs
@@ -90,8 +90,8 @@ async def test_after_cleanup(async_resource):
     exit_code: 0
     ----- stdout -----
         Starting 2 tests across 1 worker
-            PASS [TIME] test::test_resource(async_resource=resource)
-            PASS [TIME] test::test_after_cleanup(async_resource=resource)
+            PASS [TIME] test::test_resource(async_resource='resource')
+            PASS [TIME] test::test_after_cleanup(async_resource='resource')
     ────────────
          Summary [TIME] 2 tests run: 2 passed, 0 skipped
 

--- a/crates/karva/tests/it/extensions/fixtures/parametrized.rs
+++ b/crates/karva/tests/it/extensions/fixtures/parametrized.rs
@@ -36,7 +36,7 @@ fn test_fixture_basic(#[values("pytest", "karva")] framework: &str) {
         exit_code: 0
         ----- stdout -----
             Starting 1 test across 1 worker
-                PASS [TIME] test::test_with_fixture(my_fixture=value)
+                PASS [TIME] test::test_with_fixture(my_fixture='value')
         ────────────
              Summary [TIME] 1 test run: 1 passed, 0 skipped
 
@@ -126,8 +126,8 @@ fn test_fixture_module_scope(#[values("pytest", "karva")] framework: &str) {
         exit_code: 0
         ----- stdout -----
             Starting 2 tests across 1 worker
-                PASS [TIME] test::test_first(module_fixture=MODULE)
-                PASS [TIME] test::test_second(module_fixture=MODULE)
+                PASS [TIME] test::test_first(module_fixture='MODULE')
+                PASS [TIME] test::test_second(module_fixture='MODULE')
         ────────────
              Summary [TIME] 2 tests run: 2 passed, 0 skipped
 
@@ -170,7 +170,7 @@ fn test_fixture_with_generator(#[values("pytest", "karva")] framework: &str) {
         exit_code: 0
         ----- stdout -----
             Starting 2 tests across 1 worker
-                PASS [TIME] test::test_with_setup(setup_fixture=resource)
+                PASS [TIME] test::test_with_setup(setup_fixture='resource')
                 PASS [TIME] test::test_verify_finalizer_ran
         ────────────
              Summary [TIME] 2 tests run: 2 passed, 0 skipped
@@ -260,7 +260,7 @@ fn test_fixture_with_multiple_fixtures(#[values("pytest", "karva")] framework: &
         exit_code: 0
         ----- stdout -----
             Starting 1 test across 1 worker
-                PASS [TIME] test::test_combination(number=100, letter=X)
+                PASS [TIME] test::test_combination(number=100, letter='X')
         ────────────
              Summary [TIME] 1 test run: 1 passed, 0 skipped
 
@@ -296,8 +296,8 @@ fn test_fixture_with_test_parametrize(#[values("pytest", "karva")] framework: &s
         exit_code: 0
         ----- stdout -----
             Starting 1 test across 1 worker
-                PASS [TIME] test::test_both(fixture_value=fixture_value, test_param=10)
-                PASS [TIME] test::test_both(fixture_value=fixture_value, test_param=20)
+                PASS [TIME] test::test_both(fixture_value='fixture_value', test_param=10)
+                PASS [TIME] test::test_both(fixture_value='fixture_value', test_param=20)
         ────────────
              Summary [TIME] 2 tests run: 2 passed, 0 skipped
 
@@ -343,7 +343,7 @@ fn test_fixture_generator_finalizer_order(#[values("pytest", "karva")] framework
         exit_code: 0
         ----- stdout -----
             Starting 2 tests across 1 worker
-                PASS [TIME] test::test_one(ordered_fixture=value)
+                PASS [TIME] test::test_one(ordered_fixture='value')
                 PASS [TIME] test::test_check_order
         ────────────
              Summary [TIME] 2 tests run: 2 passed, 0 skipped
@@ -467,7 +467,7 @@ fn test_fixture_finalizer_with_state(#[values("pytest", "karva")] framework: &st
         exit_code: 0
         ----- stdout -----
             Starting 2 tests across 1 worker
-                PASS [TIME] test::test_uses_resource(resource=resource)
+                PASS [TIME] test::test_uses_resource(resource='resource')
                 PASS [TIME] test::test_all_cleaned_up
         ────────────
              Summary [TIME] 2 tests run: 2 passed, 0 skipped
@@ -527,7 +527,7 @@ fn test_complex_fixture_generator_finalizer_order(#[values("pytest", "karva")] f
         exit_code: 0
         ----- stdout -----
             Starting 2 tests across 1 worker
-                PASS [TIME] test::test_one(ordered_fixture=value1, ordered_fixture2=value2)
+                PASS [TIME] test::test_one(ordered_fixture='value1', ordered_fixture2='value2')
                 PASS [TIME] test::test_check_order
         ────────────
              Summary [TIME] 2 tests run: 2 passed, 0 skipped

--- a/crates/karva/tests/it/extensions/snapshot/named.rs
+++ b/crates/karva/tests/it/extensions/snapshot/named.rs
@@ -365,26 +365,26 @@ def test_translate(lang):
     exit_code: 0
     ----- stdout -----
         Starting 1 test across 1 worker
-            PASS [TIME] test::test_translate(lang=en)
-            PASS [TIME] test::test_translate(lang=fr)
+            PASS [TIME] test::test_translate(lang='en')
+            PASS [TIME] test::test_translate(lang='fr')
     ────────────
          Summary [TIME] 2 tests run: 2 passed, 0 skipped
 
     ----- stderr -----
     ");
 
-    let en = context.read_file("snapshots/test__test_translate--greeting(lang=en).snap");
-    insta::assert_snapshot!(en, @r"
+    let en = context.read_file("snapshots/test__test_translate--greeting(lang='en').snap");
+    insta::assert_snapshot!(en, @"
     ---
-    source: test.py:6::test_translate(lang=en)
+    source: test.py:6::test_translate(lang='en')
     ---
     hello_en
     ");
 
-    let fr = context.read_file("snapshots/test__test_translate--greeting(lang=fr).snap");
-    insta::assert_snapshot!(fr, @r"
+    let fr = context.read_file("snapshots/test__test_translate--greeting(lang='fr').snap");
+    insta::assert_snapshot!(fr, @"
     ---
-    source: test.py:6::test_translate(lang=fr)
+    source: test.py:6::test_translate(lang='fr')
     ---
     hello_fr
     ");

--- a/crates/karva/tests/it/extensions/tags/fail_slow.rs
+++ b/crates/karva/tests/it/extensions/tags/fail_slow.rs
@@ -142,12 +142,12 @@ def test_after():
     exit_code: 1
     ----- stdout -----
         Starting 2 tests across 1 worker
-            FAIL [TIME] test::test_slow(resource=resource)
+            FAIL [TIME] test::test_slow(resource='resource')
             PASS [TIME] test::test_after
 
     failures:
 
-    test::test_slow(resource=resource):
+    test::test_slow(resource='resource'):
 
     error[fail-slow-exceeded]: Test `test_slow` exceeded its fail-slow budget
       --> test.py:14:5

--- a/crates/karva/tests/it/extensions/tags/parametrize.rs
+++ b/crates/karva/tests/it/extensions/tags/parametrize.rs
@@ -1291,6 +1291,57 @@ def test_pair(number, label):
     }
 }
 
+#[rstest]
+fn test_parametrize_quotes_default_string_ids(#[values("pytest", "karva")] framework: &str) {
+    let test_context = TestContext::with_file(
+        "test.py",
+        &format!(
+            r#"
+import {framework}
+
+@{framework}.fixture
+def label():
+    return "fixture"
+
+@{parametrize}("value", ["plain", "can't"])
+def test_strings(label, value):
+    assert label == "fixture"
+
+@{parametrize}("left", ["one"])
+@{parametrize}("right", [2], ids=["two"])
+def test_stacked(left, right):
+    assert left == "one"
+    assert right == 2
+
+def no_id(value):
+    return None
+
+@{parametrize}("value", ["callable"], ids=no_id)
+def test_callable(value):
+    assert value == "callable"
+"#,
+            parametrize = get_parametrize_function(framework),
+        ),
+    );
+
+    allow_duplicates! {
+        assert_cmd_snapshot!(test_context.command(), @r#"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+            Starting 3 tests across 1 worker
+                PASS [TIME] test::test_strings(label='fixture', value='plain')
+                PASS [TIME] test::test_strings(label='fixture', value="can't")
+                PASS [TIME] test::test_stacked(two-'one')
+                PASS [TIME] test::test_callable('callable')
+        ────────────
+             Summary [TIME] 4 tests run: 4 passed, 0 skipped
+
+        ----- stderr -----
+        "#);
+    }
+}
+
 #[test]
 fn test_pytest_parametrize_ids_use_pytest_positional_index() {
     let test_context = TestContext::with_file(

--- a/crates/karva/tests/it/extensions/tags/timeout.rs
+++ b/crates/karva/tests/it/extensions/tags/timeout.rs
@@ -619,7 +619,7 @@ def test_after_resource():
     exit_code: 0
     ----- stdout -----
         Starting 2 tests across 1 worker
-            PASS [TIME] test::test_resource(resource=resource)
+            PASS [TIME] test::test_resource(resource='resource')
             PASS [TIME] test::test_after_resource
     ────────────
          Summary [TIME] 2 tests run: 2 passed, 0 skipped

--- a/crates/karva/tests/it/extensions/tags/use_fixtures.rs
+++ b/crates/karva/tests/it/extensions/tags/use_fixtures.rs
@@ -97,7 +97,7 @@ def test_combined_fixtures(param_fixture):
     exit_code: 0
     ----- stdout -----
         Starting 1 test across 1 worker
-            PASS [TIME] test::test_combined_fixtures(param_fixture=param_value)
+            PASS [TIME] test::test_combined_fixtures(param_fixture='param_value')
     ────────────
          Summary [TIME] 1 test run: 1 passed, 0 skipped
 
@@ -308,7 +308,7 @@ def test_mixed_fixtures(shared_fixture):
     exit_code: 0
     ----- stdout -----
         Starting 1 test across 1 worker
-            PASS [TIME] test::test_mixed_fixtures(shared_fixture=shared_value)
+            PASS [TIME] test::test_mixed_fixtures(shared_fixture='shared_value')
     ────────────
          Summary [TIME] 1 test run: 1 passed, 0 skipped
 

--- a/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
@@ -12,6 +12,7 @@ use thiserror::Error;
 
 use crate::extensions::functions::Param;
 use crate::extensions::tags::Tags;
+use crate::utils::display_value;
 
 #[derive(Debug)]
 pub struct ParametrizeAnnotation {
@@ -425,7 +426,7 @@ pub fn default_param_id(py: Python<'_>, values: &[Arc<Py<PyAny>>]) -> String {
     values
         .iter()
         .filter_map(|value| value.cast_bound::<PyAny>(py).ok())
-        .map(ToString::to_string)
+        .map(display_value)
         .collect::<Vec<_>>()
         .join("-")
 }
@@ -493,7 +494,7 @@ pub(super) fn apply_parametrize_ids(
             for value in &parametrization.values {
                 let generated = ids.call1((value.bind(py),))?;
                 if generated.is_none() {
-                    parts.push(value.bind(py).to_string());
+                    parts.push(display_value(value.bind(py)));
                 } else {
                     parts.push(generated.to_string());
                 }

--- a/crates/karva_test_semantic/src/utils.rs
+++ b/crates/karva_test_semantic/src/utils.rs
@@ -4,7 +4,7 @@ use camino::Utf8Path;
 use karva_static::WorkerEnvVars;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
-use pyo3::types::{PyAnyMethods, PyCFunction, PyDict, PyTuple};
+use pyo3::types::{PyAnyMethods, PyCFunction, PyDict, PyString, PyTuple};
 use pyo3::{PyResult, Python};
 use ruff_python_ast::Parameters;
 
@@ -221,6 +221,40 @@ pub(crate) fn set_test_name_env(py: Python<'_>, qualified_name: &str) -> PyResul
     Ok(())
 }
 
+pub(crate) fn display_value(value: &Bound<'_, PyAny>) -> String {
+    if value.is_instance_of::<PyString>()
+        && let Ok(repr) = value.repr()
+    {
+        repr.to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+fn truncated_display_value(value: &Bound<'_, PyAny>) -> String {
+    let display = display_value(value);
+    if display.chars().count() <= TRUNCATE_LENGTH {
+        return display;
+    }
+    if value.is_instance_of::<PyString>()
+        && let Ok(raw_value) = value.extract::<String>()
+    {
+        let mut truncated = raw_value.chars().take(TRUNCATE_LENGTH).collect::<String>();
+        loop {
+            let candidate = PyString::new(value.py(), &format!("{truncated}..."));
+            if let Ok(repr) = candidate.repr()
+                && repr.to_string().chars().count() <= TRUNCATE_LENGTH
+            {
+                return repr.to_string();
+            }
+            if truncated.pop().is_none() {
+                break;
+            }
+        }
+    }
+    truncate_string(&display)
+}
+
 /// Adds a directory path to Python's sys.path at the specified index.
 pub(crate) fn add_to_sys_path(py: Python<'_>, path: &Utf8Path, index: isize) -> PyResult<()> {
     let sys_module = py.import("sys")?;
@@ -248,7 +282,7 @@ pub(crate) fn full_test_name(
             if name_only_arguments.contains(&key.as_str()) {
                 let _ = write!(args_str, "{truncated_key}");
             } else if let Ok(value) = value.cast_bound::<PyAny>(py) {
-                let trimmed_value_str = truncate_string(&value.to_string());
+                let trimmed_value_str = truncated_display_value(value);
                 let _ = write!(args_str, "{truncated_key}={trimmed_value_str}");
             }
         }


### PR DESCRIPTION
## Summary

Render string-valued test arguments with Python `repr()` so test names distinguish strings from other values while preserving explicit IDs and existing formatting for non-string objects. Preserve closing quotes when long values are truncated.

## Test Plan

Verified the Karva suite during snapshot regeneration, reran focused quoting, truncation, and snapshot tests, and ran `uvx prek run -a`.