### PR TITLE
Fix module-level skip reporting

### DIFF
--- a/crates/karva/tests/it/extensions/functions.rs
+++ b/crates/karva/tests/it/extensions/functions.rs
@@ -218,6 +218,73 @@ def test_conditional_skip():
     }
 }
 
+#[test]
+fn test_module_level_skip_with_passing_module() {
+    let context = TestContext::with_files([
+        (
+            "test_skipped.py",
+            r#"
+import karva
+
+karva.skip("no gpu available")
+
+def test_never_reached():
+    assert False
+            "#,
+        ),
+        (
+            "test_passed.py",
+            r"
+def test_passes():
+    assert True
+            ",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--status-level=skip"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            SKIP [TIME] test_skipped::<module>: no gpu available
+            PASS [TIME] test_passed::test_passes
+    ────────────
+         Summary [TIME] 2 tests run: 1 passed, 1 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_all_modules_skipped_at_module_level() {
+    let context = TestContext::with_file(
+        "test_gpu.py",
+        r#"
+import karva
+
+karva.skip("no gpu available")
+
+def test_gpu():
+    assert False
+
+def test_more_gpu():
+    assert False
+        "#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--status-level=skip"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            SKIP [TIME] test_gpu::<module>: no gpu available
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 skipped
+
+    ----- stderr -----
+    ");
+}
+
 #[rstest]
 fn test_runtime_skip_does_not_retry(#[values("pytest", "karva")] framework: &str) {
     let context = TestContext::with_file(

--- a/crates/karva_test_semantic/src/context.rs
+++ b/crates/karva_test_semantic/src/context.rs
@@ -7,7 +7,7 @@ use karva_diagnostic::{
     TestExecutionOutcome, TestRunResult,
 };
 use karva_metadata::ProjectSettings;
-use karva_python_semantic::QualifiedTestName;
+use karva_python_semantic::{ModulePath, QualifiedFunctionName, QualifiedTestName};
 use ruff_db::diagnostic::Diagnostic;
 use ruff_python_ast::PythonVersion;
 
@@ -104,6 +104,19 @@ impl<'a> Context<'a> {
         );
 
         passed
+    }
+
+    pub(crate) fn register_module_skip(&self, module_path: &ModulePath, reason: Option<String>) {
+        let name = QualifiedTestName::new(
+            QualifiedFunctionName::new("<module>".to_string(), module_path.clone()),
+            None,
+        );
+        self.register_test_case_result(
+            &name,
+            TestExecutionOutcome::Skipped { reason },
+            std::time::Duration::ZERO,
+            None,
+        );
     }
 
     /// Forward a per-attempt outcome to the reporter. Does not touch

--- a/crates/karva_test_semantic/src/discovery/visitor.rs
+++ b/crates/karva_test_semantic/src/discovery/visitor.rs
@@ -21,6 +21,7 @@ use crate::diagnostic::{
 use crate::discovery::{DiscoveredModule, DiscoveredTestFunction};
 use crate::extensions::fixtures::DiscoveredFixture;
 use crate::extensions::fixtures::python::FixtureFunctionDefinition;
+use crate::extensions::tags::skip::{extract_skip_reason, is_skip_exception};
 
 /// Visitor for discovering test functions and fixture definitions in a given module.
 ///
@@ -70,11 +71,18 @@ impl<'ctx, 'py, 'a, 'b> FunctionDefinitionVisitor<'ctx, 'py, 'a, 'b> {
                 self.py_module = Some(py_module);
             }
             Err(error) => {
-                report_failed_to_import_module(
-                    self.context,
-                    self.module.name(),
-                    &error.value(self.py).to_string(),
-                );
+                if is_skip_exception(self.py, &error) {
+                    self.context.register_module_skip(
+                        self.module.module_path(),
+                        extract_skip_reason(self.py, &error),
+                    );
+                } else {
+                    report_failed_to_import_module(
+                        self.context,
+                        self.module.name(),
+                        &error.value(self.py).to_string(),
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Treat a skip exception raised while importing a test module as one skipped module result, preserving its reason and preventing an all-skipped run from becoming a no-tests error. Fixes #1062.

## Test Plan

`uvx prek run -a` and focused integration and no-tests regression tests pass; `just test` hit an unrelated process-termination permission warning, and that failing test passed in isolation.