### PR TITLE
Report missing fixture dependencies before execution

### DIFF
--- a/crates/karva/tests/it/extensions/fixtures/invalid.rs
+++ b/crates/karva/tests/it/extensions/fixtures/invalid.rs
@@ -261,9 +261,11 @@ fn test_fixture_missing_fixtures() {
         "test.py",
         r"
                 from karva import fixture
+                from pathlib import Path
 
                 @fixture
                 def failing_fixture(missing_fixture):
+                    Path('fixture-ran').touch()
                     return 1
 
                 def test_failing_fixture(failing_fixture):
@@ -282,19 +284,20 @@ fn test_fixture_missing_fixtures() {
 
     test::test_failing_fixture:
 
-    error[fixture-failure]: Fixture `failing_fixture` failed
-     --> test.py:5:5
+    error[missing-fixtures]: Fixture `failing_fixture` has missing fixtures
+     --> test.py:6:5
       |
-    5 | def failing_fixture(missing_fixture):
+    6 | def failing_fixture(missing_fixture):
       |     ^^^^^^^^^^^^^^^
       |
-    info: failing_fixture() missing 1 required positional argument: 'missing_fixture'
+    info: Missing fixtures: `missing_fixture`
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");
+    assert!(!context.root().join("fixture-ran").exists());
 }
 
 #[test]

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -391,6 +391,15 @@ pub fn fixture_resolution_diagnostic(error: FixtureResolutionError) -> Diagnosti
             fixture,
             dependency,
         } => fixture_scope_mismatch_diagnostic(&dependency_path, &fixture, &dependency),
+        FixtureResolutionError::MissingFixtures {
+            fixture,
+            missing_fixtures,
+        } => missing_fixtures_diagnostic(
+            fixture.source_file,
+            &fixture.stmt_function_def,
+            &missing_fixtures,
+            FunctionKind::Fixture,
+        ),
     }
 }
 

--- a/crates/karva_test_semantic/src/runner/fixture_resolver.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_resolver.rs
@@ -18,10 +18,9 @@ use crate::extensions::fixtures::{
 /// Unlike pre-normalization, this resolver finds and normalizes fixtures
 /// on-demand when tests need them. `current` is typed as a trait object so
 /// callers may pass either a test module (normal test / module-autouse
-/// resolution), a conftest module (package-autouse resolution), or the
-/// session package itself (session-autouse resolution) — the latter gives
-/// session-level autouse fixtures visibility into `framework_module` via
-/// the `HasFixtures` impl on `DiscoveredPackage`.
+/// resolution), a package (package-autouse resolution), or the session package
+/// itself (session-autouse resolution). Package providers expose both user and
+/// framework fixtures through their `HasFixtures` implementation.
 pub(super) struct RuntimeFixtureResolver<'a> {
     /// Package chain searched from session root toward the current module.
     parents: &'a [&'a DiscoveredPackage],
@@ -58,6 +57,13 @@ pub enum FixtureResolutionError {
         fixture: FixtureResolutionEntry,
         /// Dependency whose scope cannot satisfy its consumer.
         dependency: FixtureResolutionEntry,
+    },
+    /// Fixture requires names that cannot be resolved.
+    MissingFixtures {
+        /// Fixture declaring the missing dependencies.
+        fixture: FixtureResolutionEntry,
+        /// Unresolved dependency names.
+        missing_fixtures: Vec<String>,
     },
 }
 
@@ -243,6 +249,7 @@ impl<'a> RuntimeFixtureResolver<'a> {
         path: &mut FixturePath<'a>,
     ) -> FixtureResolutionResult<Vec<Rc<NormalizedFixture>>> {
         let mut normalized_fixtures = Vec::with_capacity(fixture_names.len());
+        let mut missing_fixtures = Vec::new();
 
         for dep_name in fixture_names {
             if let Some(fixture) =
@@ -263,12 +270,23 @@ impl<'a> RuntimeFixtureResolver<'a> {
                 }
                 let normalized = self.normalize_fixture(py, fixture, path)?;
                 normalized_fixtures.push(normalized);
-            } else if let Some(fixture) = current_fixture
-                && fixture.name().function_name() == dep_name
-            {
-                let normalized = self.normalize_fixture(py, fixture, path)?;
-                normalized_fixtures.push(normalized);
+            } else if let Some(fixture) = current_fixture {
+                if fixture.name().function_name() == dep_name {
+                    let normalized = self.normalize_fixture(py, fixture, path)?;
+                    normalized_fixtures.push(normalized);
+                } else {
+                    missing_fixtures.push(dep_name.clone());
+                }
             }
+        }
+
+        if let Some(fixture) = current_fixture
+            && !missing_fixtures.is_empty()
+        {
+            return Err(FixtureResolutionError::MissingFixtures {
+                fixture: FixtureResolutionEntry::new(fixture),
+                missing_fixtures,
+            });
         }
 
         Ok(normalized_fixtures)

--- a/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
@@ -23,7 +23,7 @@ impl PackageRunner<'_, '_> {
     /// Resolves and runs auto-use fixtures at the start of one scope.
     ///
     /// `current` is the fixture provider for the scope: the session package,
-    /// a test module, or a package configuration module. Resolution failures
+    /// a test module, or a package. Resolution failures
     /// trigger cleanup for the partially initialized scope before returning.
     pub(super) fn run_auto_use_fixtures<'a>(
         &self,

--- a/crates/karva_test_semantic/src/runner/package_runner/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/mod.rs
@@ -239,9 +239,9 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
         let mut child_parents = parents.to_vec();
         child_parents.push(package);
 
-        if let Some(configuration_module) = package.configuration_module_impl()
+        if package.configuration_module_impl().is_some()
             && let Err(mut diagnostics) =
-                self.run_auto_use_fixtures(py, parents, configuration_module, FixtureScope::Package)
+                self.run_auto_use_fixtures(py, parents, package, FixtureScope::Package)
         {
             let diagnostic = diagnostics.remove(0);
             self.register_error_package_tests(package, &diagnostic, &diagnostics);


### PR DESCRIPTION
## Summary

Report unresolved fixture dependencies as `missing-fixtures` before invoking the fixture, preserving clear compatibility diagnostics instead of surfacing a runtime `TypeError`. Package autouse resolution now uses the package fixture provider so framework fixtures remain visible during validation. Fixes #1065.

## Test plan

Verified with `just test`, workspace Clippy with warnings denied, and `uvx prek run -a`.