### PR TITLE
Document missing test runner behavior

### DIFF
--- a/docs/get-started/tutorial.md
+++ b/docs/get-started/tutorial.md
@@ -46,6 +46,7 @@ uv run karva test
 
 ## Where to next
 
+- [Writing Tests](../usage/writing-tests/tests.md) — learn collection rules and async support.
 - [Filtering Tests](../usage/running-tests/filtering.md) — pick which tests run with the `-E` filter DSL.
 - [Fixtures](../usage/fixtures/fixtures.md) — share setup and teardown between tests.
 - [Snapshots](../usage/writing-tests/snapshots.md) — pin large outputs to a file.

--- a/docs/usage/failure-handling/run-timeout.md
+++ b/docs/usage/failure-handling/run-timeout.md
@@ -1,0 +1,30 @@
+# Run timeout
+
+`--run-timeout` puts a wall-clock limit on a test run. Its deadline starts
+before collection, so collection, partitioning, and worker startup consume the
+same budget as test execution. Use it as a CI tripwire for a runaway suite; use
+[`@karva.tags.timeout`](../tags/timeout.md) when one test needs its own limit.
+
+Measure healthy CI runs first, choose a timeout that leaves room for normal
+variance, and pass that measured value in seconds:
+
+```bash
+uv run karva test --run-timeout="$KARVA_CI_RUN_TIMEOUT"
+```
+
+The same limit can be stored as `run-timeout` under the profile's `test`
+configuration.
+
+When the deadline expires, Karva stops remaining workers and fails the run.
+Completed test results are still reported. Configured report files are also
+written: native JSON/JSONL marks the run as failed, while JUnit contains the
+completed results. CI should therefore honor karva's process exit status rather
+than inferring timeout success from JUnit alone.
+
+## Worker shutdown
+
+Karva first asks workers to terminate gracefully. Workers that remain alive
+after `termination-grace-period` are force-killed. Configure the grace period
+long enough for any process signal handlers that must finish.
+
+The same shutdown sequence applies to `Ctrl-C` and fail-fast cancellation.

--- a/docs/usage/failure-handling/run-timeout.md
+++ b/docs/usage/failure-handling/run-timeout.md
@@ -6,11 +6,8 @@ same budget as test execution. Use it as a CI tripwire for a runaway suite; use
 [`@karva.tags.timeout`](../tags/timeout.md) when one test needs its own limit.
 
 Measure healthy CI runs first, choose a timeout that leaves room for normal
-variance, and pass that measured value in seconds:
-
-```bash
-uv run karva test --run-timeout="$KARVA_CI_RUN_TIMEOUT"
-```
+variance, then pass it as `--run-timeout=SECONDS`, replacing `SECONDS` with
+that measured value.
 
 The same limit can be stored as `run-timeout` under the profile's `test`
 configuration.

--- a/docs/usage/running-tests/filtering.md
+++ b/docs/usage/running-tests/filtering.md
@@ -11,6 +11,25 @@ karva test -E 'test(/^auth::/) & not tag(flaky)'
 karva test -E '(tag(fast) | tag(unit)) - tag(flaky)'
 ```
 
+## Adding custom tags
+
+Any attribute under `karva.tags` that is not a built-in tag creates a custom
+tag. No registration is required:
+
+```python title="test_checkout.py"
+import karva
+
+
+@karva.tags.integration
+def test_checkout():
+    assert checkout()
+```
+
+Pytest marks are also recognized as custom tags, so
+`@pytest.mark.integration` matches the same `tag(integration)` predicate.
+Arguments attached to custom tags do not affect filtering; filters match the
+tag name.
+
 When `-E` is passed more than once, a test runs if it matches **any** of
 the expressions (OR across flags):
 
@@ -181,6 +200,17 @@ two are equivalent).
 On top of the old capabilities, the new DSL adds substring, exact, and
 glob matchers — previously only regex matching was possible for test
 names, and only exact matching for tags.
+
+## When nothing matches
+
+With the default `--no-tests=auto`, collecting no tests fails the run when no
+filter was supplied, but a valid filter that matches nothing exits
+successfully. This makes optional CI shards and local filters easy to compose
+without hiding an empty suite.
+
+Use `--no-tests=pass`, `--no-tests=warn`, or `--no-tests=fail` to choose the
+behavior explicitly. The same setting is available as `no-tests` in the
+profile's `test` configuration.
 
 ## Grammar
 

--- a/docs/usage/running-tests/parallel.md
+++ b/docs/usage/running-tests/parallel.md
@@ -54,3 +54,16 @@ karva test --partition slice:3/3
 ```
 
 Slices are computed deterministically from the current test set, so the same revision splits the same way on every machine. Adding or removing tests can shift which slice a given test falls into, so this is less stable per-test than a hash-based scheme but does not need any historical data.
+
+Use `hash:M/N` when stable assignment matters more than even slices. Each
+qualified test name maps to one stable bucket, so adding or removing a test
+does not move any other test:
+
+```bash
+uv run karva test --partition hash:1/3
+uv run karva test --partition hash:2/3
+uv run karva test --partition hash:3/3
+```
+
+Hash buckets can be uneven. Run every bucket together to cover the complete
+suite.

--- a/docs/usage/running-tests/reports.md
+++ b/docs/usage/running-tests/reports.md
@@ -1,0 +1,59 @@
+# Test reports
+
+Karva can write JUnit XML for CI systems or native JSON/JSONL for custom tools.
+Report paths are resolved from the project root, and missing parent directories
+are created automatically.
+
+## JUnit XML
+
+Configure JUnit output in a profile:
+
+```toml
+[tool.karva.profile.ci.junit]
+path = "reports/test-results.xml"
+report-name = "karva-tests"
+store-failure-output = true
+store-success-output = false
+```
+
+```bash
+uv run karva test --profile ci
+```
+
+JUnit suites are grouped by Python module. Assertion failures use `<failure>`,
+fixture and collection errors use `<error>`, and skipped tests use `<skipped>`.
+Retry history is preserved with `flakyFailure` and `rerunFailure` elements.
+Captured stdout and stderr are included according to the two `store-*-output`
+settings.
+
+## JSON
+
+`--result-output` writes one JSON document by default:
+
+```bash
+uv run karva test --result-output reports/results.json
+```
+
+The document contains a schema version, final run status, elapsed time,
+aggregate statistics, and one record per test. Test records include qualified
+names, status, duration, skip reason, captured output, diagnostics, and retry
+attempts when applicable. Collection and import diagnostics that do not belong
+to one test are stored separately as run diagnostics.
+
+Result output is plain text without ANSI styling, regardless of terminal color
+settings.
+
+## JSONL
+
+Use JSONL when a consumer should process records independently:
+
+```bash
+uv run karva test \
+  --result-output reports/results.jsonl \
+  --result-format jsonl
+```
+
+Karva writes a `test` record for each test, a `run_diagnostic` record for each
+unattached collection or import diagnostic, then one `run_finished` record
+with final status and aggregate statistics. Every line includes the schema
+version and record type.

--- a/docs/usage/tags/skip.md
+++ b/docs/usage/tags/skip.md
@@ -24,6 +24,19 @@ def test_function():
 
 Then running `uv run karva test` will result in one skipped test.
 
+## Running skipped tests
+
+Use `--run-ignored=only` to run only tests whose skip condition is active, or
+`--run-ignored=all` to run them alongside normal tests. Active skip decorators
+are ignored for these tests, so their bodies run and can pass or fail normally.
+
+```bash
+uv run karva test --run-ignored=only
+uv run karva test --run-ignored=all
+```
+
+Tests with false skip conditions are not considered ignored.
+
 ## Reason
 
 You can provide a `str` reason as a positional or keyword argument.

--- a/docs/usage/writing-tests/tests.md
+++ b/docs/usage/writing-tests/tests.md
@@ -1,0 +1,83 @@
+# Writing tests
+
+Karva collects module-level Python functions whose names start with `test` by
+default. Test files do not need a `test_` prefix: Karva searches every `.py`
+file under the selected paths and ignores files that contain no tests.
+
+```python title="tests/check_calculator.py"
+def test_addition():
+    assert 1 + 2 == 3
+```
+
+Run the whole project, a directory, a file, or one function:
+
+```bash
+uv run karva test
+uv run karva test tests/
+uv run karva test tests/check_calculator.py
+uv run karva test tests/check_calculator.py::test_addition
+```
+
+Use `--test-prefix` or `test-function-prefix` in configuration when your suite
+uses another naming convention. Karva does not collect class methods; see
+[Project Non-Goals](../non-goals.md#class-based-tests).
+
+## Project and path discovery
+
+With no path arguments, Karva searches upward from the current directory for
+`karva.toml` or a `[tool.karva]` table in `pyproject.toml`, then uses that
+directory as the project root. If no Karva configuration exists, it uses the
+nearest plain `pyproject.toml`, or the current directory when neither exists.
+Discovery does not cross a `.git` boundary.
+
+Karva respects `.gitignore` files by default. Pass `--no-ignore` to include
+Git-ignored Python files, or set `respect-ignore-files = false` under the
+profile's `src` configuration.
+
+## Test results
+
+A passing test returns `None`, either explicitly or by reaching the end of the
+function. Returning any other value fails the test with a diagnostic; use an
+assertion instead.
+
+Generator test functions are rejected before their bodies run. Use
+[`@karva.tags.parametrize`](../tags/parametrize.md) to create multiple cases.
+Generator fixtures remain supported for setup and teardown.
+
+## Async tests and fixtures
+
+Async tests run without a plugin or marker:
+
+```python title="tests/test_service.py"
+import asyncio
+
+
+async def test_service():
+    result = await asyncio.sleep(0, result=42)
+    assert result == 42
+```
+
+Fixtures may also be async functions or async generators. Sync and async tests
+can consume either sync or async fixtures:
+
+```python title="tests/test_service.py"
+import karva
+
+
+@karva.fixture
+async def service():
+    client = await create_client()
+    yield client
+    await client.close()
+
+
+def test_sync_code_can_use_async_fixture(service):
+    assert service.is_ready()
+
+
+async def test_async_code_can_use_async_fixture(service):
+    assert await service.healthcheck()
+```
+
+Async generator fixture teardown is awaited after its consumer finishes, just
+like teardown after `yield` in a sync fixture.

--- a/zensical.toml
+++ b/zensical.toml
@@ -24,14 +24,17 @@ nav = [
             { "Parallel Execution" = "usage/running-tests/parallel.md"},
             { "Watch Mode" = "usage/running-tests/watch.md"},
             { "Cache" = "usage/running-tests/cache.md"},
+            { "Test Reports" = "usage/running-tests/reports.md"},
         ]},
         { "Failure Handling" = [
             { "Failing Fast" = "usage/failure-handling/fail-fast.md"},
             { "Retries" = "usage/failure-handling/retries.md"},
             { "Slow Tests" = "usage/failure-handling/slow-tests.md"},
             { "Fail Slow" = "usage/failure-handling/fail-slow.md"},
+            { "Run Timeout" = "usage/failure-handling/run-timeout.md"},
         ]},
         { "Writing Tests" = [
+            { "Basics" = "usage/writing-tests/tests.md"},
             { "Snapshots" = "usage/writing-tests/snapshots.md"},
             { "Coverage" = "usage/writing-tests/coverage.md"},
             { "Other Functions" = "usage/writing-tests/functions.md"},


### PR DESCRIPTION
## Summary

Document important user-facing behavior that was only implicit in tests or scattered reference entries: collection and async rules, custom tags, empty filters, CI reports, run timeouts, hash partitioning, and running skipped tests. Add the new guides to navigation so users can find them from the tutorial.

## Test Plan

Built the Zensical site and ran `uvx prek run -a`.