### PR TITLE
Default test discovery to tests directory

### DIFF
--- a/crates/karva/tests/it/configuration/mod.rs
+++ b/crates/karva/tests/it/configuration/mod.rs
@@ -126,6 +126,34 @@ def test_in_other(): pass
 }
 
 #[test]
+fn test_defaults_to_tests_directory_when_present() {
+    let context = TestContext::with_files([
+        (
+            "tests/test_in_tests.py",
+            r"
+def test_in_tests(): pass
+",
+        ),
+        (
+            "test_in_root.py",
+            r"
+def test_in_root(): pass
+",
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command().arg("--status-level=none"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_src_include_single_file() {
     let context = TestContext::with_files([
         (

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -19,7 +19,7 @@ use crate::verbosity::Verbosity;
 pub struct SubTestCommand {
     /// List of files or directories to test.
     #[clap(
-        help = "List of files, directories, or test functions to test [default: the project root]",
+        help = "List of files, directories, or test functions to test [default: tests if it exists, otherwise the project root]",
         value_name = "PATH"
     )]
     pub paths: Vec<String>,

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -152,6 +152,8 @@ pub struct SrcOptions {
     /// A list of files and directories to check.
     /// Including a file or directory will make it so that it (and its contents)
     /// are tested.
+    /// When unset, Karva checks the `tests` directory if it exists, otherwise
+    /// it checks the project root.
     ///
     /// - `tests` matches a directory named `tests`
     /// - `tests/test.py` matches a file named `test.py` in the `tests` directory

--- a/crates/karva_project/src/lib.rs
+++ b/crates/karva_project/src/lib.rs
@@ -90,7 +90,9 @@ impl Project {
 
     pub fn test_paths(&self) -> Vec<Result<TestPath, TestPathError>> {
         if self.settings.src().include_paths.is_empty() {
-            return vec![TestPath::new(self.cwd().as_str())];
+            let tests = self.cwd().join("tests");
+            let path = if tests.is_dir() { &tests } else { self.cwd() };
+            return vec![TestPath::new(path.as_str())];
         }
 
         self.settings

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -259,6 +259,8 @@ store-success-output = true
 A list of files and directories to check.
 Including a file or directory will make it so that it (and its contents)
 are tested.
+When unset, Karva checks the `tests` directory if it exists, otherwise
+it checks the project root.
 
 - `tests` matches a directory named `tests`
 - `tests/test.py` matches a file named `test.py` in the `tests` directory

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -34,7 +34,7 @@ karva test [OPTIONS] [PATH]...
 
 <h3 class="cli-reference">Arguments</h3>
 
-<dl class="cli-reference"><dt id="karva-test--paths"><a href="#karva-test--paths"><code>PATHS</code></a></dt><dd><p>List of files, directories, or test functions to test &#91;default: the project root&#93;</p>
+<dl class="cli-reference"><dt id="karva-test--paths"><a href="#karva-test--paths"><code>PATHS</code></a></dt><dd><p>List of files, directories, or test functions to test &#91;default: tests if it exists, otherwise the project root&#93;</p>
 </dd></dl>
 
 <h3 class="cli-reference">Options</h3>


### PR DESCRIPTION
## Summary

Default test discovery to `tests/` when that directory exists, while preserving project-root fallback and explicit `[src].include` paths. Document the dynamic default in configuration and CLI references.

## Test Plan

Focused tests, Clippy, and pre-commit hooks pass; the full suite hit an unrelated shared-venv `karva-worker` race, and its failing case passed in isolation.