### PR TITLE
Show traceback calls in verbose output

### DIFF
--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -2082,6 +2082,86 @@ def test_2(): pass
 }
 
 #[test]
+fn test_verbose_output_shows_traceback_calls() {
+    let context = TestContext::with_files([
+        (
+            "test.py",
+            r"
+from middle import call_middle
+
+def test_failure():
+    call_middle()
+",
+        ),
+        (
+            "middle.py",
+            r"
+from bottom import fail
+
+def call_middle():
+    fail()
+",
+        ),
+        (
+            "bottom.py",
+            r#"
+def fail():
+    raise RuntimeError("traceback context")
+"#,
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("-v"), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_failure
+
+    failures:
+
+    test::test_failure:
+
+    error[test-failure]: Test `test_failure` failed
+     --> test.py:4:5
+      |
+    4 | def test_failure():
+      |     ^^^^^^^^^^^^
+      |
+    info: Called `call_middle` here
+     --> test.py:5:5
+      |
+    5 |     call_middle()
+      |     ^^^^^^^^^^^^^
+      |
+    info: Called `fail` here
+     --> middle.py:5:5
+      |
+    5 |     fail()
+      |     ^^^^^^
+      |
+    info: Test failed here
+     --> bottom.py:3:5
+      |
+    3 |     raise RuntimeError("traceback context")
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: traceback context
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    INFO Collected all tests in [TIME]
+    INFO Spawning 1 workers
+    INFO Worker 0 spawned with 1 tests
+    INFO Waiting for 1 workers to complete (Ctrl+C to cancel)
+    INFO Worker 0 completed successfully in [TIME]
+    INFO All workers completed
+    "#);
+}
+
+#[test]
 fn test_trace_verbose_output() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva_diagnostic/src/lib.rs
+++ b/crates/karva_diagnostic/src/lib.rs
@@ -12,4 +12,4 @@ pub use result::{
 };
 
 #[cfg(feature = "traceback")]
-pub use traceback::Traceback;
+pub use traceback::{Traceback, TracebackFrame, TracebackFrameSource};

--- a/crates/karva_diagnostic/src/traceback.rs
+++ b/crates/karva_diagnostic/src/traceback.rs
@@ -6,9 +6,23 @@ use ruff_text_size::{TextRange, TextSize};
 /// Parsed representation of a Python traceback from a `PyErr` object.
 #[derive(Debug, Clone)]
 pub struct Traceback {
-    pub lines: Vec<String>,
+    pub frames: Vec<TracebackFrame>,
+}
 
-    pub error_source_file: SourceFile,
+#[derive(Debug, Clone)]
+pub struct TracebackFrame {
+    pub function_name: String,
+
+    pub file_path: Utf8PathBuf,
+
+    pub line_number: OneIndexed,
+
+    pub source: Option<TracebackFrameSource>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TracebackFrameSource {
+    pub source_file: SourceFile,
 
     pub location: TextRange,
 }
@@ -17,6 +31,7 @@ pub struct Traceback {
 struct TracebackLocation {
     file_path: Utf8PathBuf,
     line_number: OneIndexed,
+    function_name: String,
 }
 
 impl Traceback {
@@ -48,19 +63,25 @@ impl Traceback {
             if traceback_str.is_empty() {
                 return None;
             }
-            let lines = filter_traceback(&traceback_str)
-                .lines()
-                .map(|line| format!(" | {line}"))
+            let frames = get_traceback_locations(&traceback_str)
+                .into_iter()
+                .map(|frame| {
+                    let source = get_source_file_and_range(&frame, source_file).map(
+                        |(source_file, location)| TracebackFrameSource {
+                            source_file,
+                            location,
+                        },
+                    );
+                    TracebackFrame {
+                        function_name: frame.function_name,
+                        file_path: frame.file_path,
+                        line_number: frame.line_number,
+                        source,
+                    }
+                })
                 .collect::<Vec<_>>();
 
-            let (error_source_file, location) =
-                get_source_file_and_range(&traceback_str, source_file)?;
-
-            Some(Self {
-                lines,
-                error_source_file,
-                location,
-            })
+            (!frames.is_empty()).then_some(Self { frames })
         } else {
             None
         }
@@ -68,11 +89,9 @@ impl Traceback {
 }
 
 fn get_source_file_and_range(
-    traceback: &str,
+    traceback_location: &TracebackLocation,
     fallback_source_file: Option<&SourceFile>,
 ) -> Option<(SourceFile, TextRange)> {
-    let traceback_location = get_traceback_location(traceback)?;
-
     if let Some(source_file) = fallback_source_file
         && source_file_matches_path(source_file, &traceback_location.file_path)
     {
@@ -99,15 +118,8 @@ fn source_file_matches_path(source_file: &SourceFile, traceback_path: &Utf8Path)
         || traceback_path.ends_with(source_path)
 }
 
-fn get_traceback_location(traceback: &str) -> Option<TracebackLocation> {
-    // Find the last line that starts with "File \"" (ignoring leading whitespace)
-    for line in traceback.lines().rev() {
-        if let Some(location) = parse_traceback_line(line) {
-            return Some(location);
-        }
-    }
-
-    None
+fn get_traceback_locations(traceback: &str) -> Vec<TracebackLocation> {
+    traceback.lines().filter_map(parse_traceback_line).collect()
 }
 
 /// Parse a traceback line like: `  File "/path/to/file.py", line 42, in function_name`
@@ -117,12 +129,13 @@ fn parse_traceback_line(line: &str) -> Option<TracebackLocation> {
 
     let (filename, rest) = after_file.split_once('"')?;
 
-    let line_str = rest.strip_prefix(", line ")?.split_once(',')?.0;
+    let (line_str, function_name) = rest.strip_prefix(", line ")?.split_once(", in ")?;
     let line_number = line_str.parse::<OneIndexed>().ok()?;
 
     Some(TracebackLocation {
         file_path: Utf8PathBuf::from(filename),
         line_number,
+        function_name: function_name.to_string(),
     })
 }
 
@@ -162,50 +175,9 @@ fn calculate_line_range(source_text: &str, line_number: OneIndexed) -> Option<Te
     None
 }
 
-// Simplified traceback filtering that removes unnecessary traceback headers
-fn filter_traceback(traceback: &str) -> String {
-    let mut filtered = String::new();
-
-    for (i, line) in traceback.lines().enumerate() {
-        if i == 0 && line.contains("Traceback (most recent call last):") {
-            continue;
-        }
-        filtered.push_str(line.strip_prefix("  ").unwrap_or(line));
-        filtered.push('\n');
-    }
-    filtered
-        .trim_end_matches('\n')
-        .trim_end_matches('^')
-        .trim_end()
-        .to_string()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    mod filter_traceback_tests {
-        use super::*;
-
-        #[test]
-        fn test_filter_traceback() {
-            let traceback = r#"Traceback (most recent call last):
-File "test.py", line 1, in <module>
-    raise Exception('Test error')
-Exception: Test error
-"#;
-            insta::assert_snapshot!(filter_traceback(traceback), @r#"
-            File "test.py", line 1, in <module>
-              raise Exception('Test error')
-            Exception: Test error
-            "#);
-        }
-
-        #[test]
-        fn test_filter_traceback_empty() {
-            insta::assert_snapshot!(filter_traceback(""), @"");
-        }
-    }
 
     mod parse_traceback_line_tests {
         use super::*;
@@ -220,6 +192,7 @@ Exception: Test error
                     line_number: OneIndexed(
                         10,
                     ),
+                    function_name: "<module>",
                 },
             )
             "#);
@@ -235,6 +208,7 @@ Exception: Test error
                     line_number: OneIndexed(
                         42,
                     ),
+                    function_name: "function_name",
                 },
             )
             "#);
@@ -267,13 +241,14 @@ Exception: Test error
                     line_number: OneIndexed(
                         99999,
                     ),
+                    function_name: "<module>",
                 },
             )
             "#);
         }
     }
 
-    mod get_traceback_location_tests {
+    mod get_traceback_locations_tests {
         use super::*;
 
         #[test]
@@ -282,15 +257,16 @@ Exception: Test error
   File "test.py", line 10, in <module>
     raise Exception('Test error')
 Exception: Test error"#;
-            insta::assert_debug_snapshot!(get_traceback_location(traceback), @r#"
-            Some(
+            insta::assert_debug_snapshot!(get_traceback_locations(traceback), @r#"
+            [
                 TracebackLocation {
                     file_path: "test.py",
                     line_number: OneIndexed(
                         10,
                     ),
+                    function_name: "<module>",
                 },
-            )
+            ]
             "#);
         }
 
@@ -302,26 +278,34 @@ Exception: Test error"#;
   File "helper.py", line 15, in foo
     bar()
 ValueError: Invalid value"#;
-            insta::assert_debug_snapshot!(get_traceback_location(traceback), @r#"
-            Some(
+            insta::assert_debug_snapshot!(get_traceback_locations(traceback), @r#"
+            [
+                TracebackLocation {
+                    file_path: "main.py",
+                    line_number: OneIndexed(
+                        5,
+                    ),
+                    function_name: "<module>",
+                },
                 TracebackLocation {
                     file_path: "helper.py",
                     line_number: OneIndexed(
                         15,
                     ),
+                    function_name: "foo",
                 },
-            )
+            ]
             "#);
         }
 
         #[test]
         fn test_get_traceback_location_empty() {
-            insta::assert_debug_snapshot!(get_traceback_location(""), @"None");
+            insta::assert_debug_snapshot!(get_traceback_locations(""), @"[]");
         }
 
         #[test]
         fn test_get_traceback_location_no_file_lines() {
-            insta::assert_debug_snapshot!(get_traceback_location("Exception: Test error"), @"None");
+            insta::assert_debug_snapshot!(get_traceback_locations("Exception: Test error"), @"[]");
         }
     }
 
@@ -401,8 +385,16 @@ AssertionError"#;
             )
             .finish();
 
-            let (resolved_source_file, range) =
-                get_source_file_and_range(traceback, Some(&source_file)).unwrap();
+            let locations = get_traceback_locations(traceback);
+            assert_eq!(locations.len(), 1);
+            let Some(location) = locations.first() else {
+                return;
+            };
+            let resolved = get_source_file_and_range(location, Some(&source_file));
+            assert!(resolved.is_some());
+            let Some((resolved_source_file, range)) = resolved else {
+                return;
+            };
 
             assert_eq!(resolved_source_file, source_file);
             assert_eq!(resolved_source_file.slice(range), "assert False");
@@ -420,7 +412,12 @@ AssertionError"#;
             )
             .finish();
 
-            assert!(get_source_file_and_range(traceback, Some(&source_file)).is_none());
+            let locations = get_traceback_locations(traceback);
+            assert_eq!(locations.len(), 1);
+            let Some(location) = locations.first() else {
+                return;
+            };
+            assert!(get_source_file_and_range(location, Some(&source_file)).is_none());
         }
     }
 }

--- a/crates/karva_test_semantic/src/context.rs
+++ b/crates/karva_test_semantic/src/context.rs
@@ -30,6 +30,9 @@ pub struct Context<'a> {
 
     /// Reporter for outputting test progress and results.
     reporter: &'a dyn Reporter,
+
+    /// Whether diagnostics should include the full Python call chain.
+    verbose: bool,
 }
 
 impl<'a> Context<'a> {
@@ -38,6 +41,7 @@ impl<'a> Context<'a> {
         settings: &'a ProjectSettings,
         python_version: PythonVersion,
         reporter: &'a dyn Reporter,
+        verbose: bool,
     ) -> Self {
         Self {
             cwd,
@@ -45,6 +49,7 @@ impl<'a> Context<'a> {
             python_version,
             result: RefCell::new(TestRunResult::default()),
             reporter,
+            verbose,
         }
     }
 
@@ -54,6 +59,10 @@ impl<'a> Context<'a> {
 
     pub(crate) fn settings(&self) -> &'a ProjectSettings {
         self.settings
+    }
+
+    pub(crate) fn is_verbose(&self) -> bool {
+        self.verbose
     }
 
     pub(crate) fn collection_settings(&'a self) -> CollectionSettings<'a> {

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -26,6 +26,12 @@ use crate::runner::{
 use crate::utils::truncate_string;
 use crate::{Context, declare_diagnostic_type};
 
+#[derive(Clone, Copy)]
+struct FailedFunctionCallOptions {
+    function_kind: FunctionKind,
+    verbose: bool,
+}
+
 declare_diagnostic_type! {
     /// ## Failed to collect module
     ///
@@ -357,7 +363,11 @@ pub fn invalid_fixture_finalizer_diagnostic(
     diagnostic
 }
 
-pub fn fixture_failure_diagnostic(py: Python, error: FixtureCallError) -> Diagnostic {
+pub fn fixture_failure_diagnostic(
+    py: Python,
+    error: FixtureCallError,
+    verbose: bool,
+) -> Diagnostic {
     let FixtureCallError {
         fixture_name,
         error,
@@ -377,7 +387,10 @@ pub fn fixture_failure_diagnostic(py: Python, error: FixtureCallError) -> Diagno
         &source_file,
         &stmt_function_def,
         &arguments,
-        FunctionKind::Fixture,
+        FailedFunctionCallOptions {
+            function_kind: FunctionKind::Fixture,
+            verbose,
+        },
         &error,
     );
     diagnostic
@@ -533,6 +546,7 @@ pub fn test_failure_diagnostic(
     stmt_function_def: &StmtFunctionDef,
     arguments: &FixtureArguments,
     error: &PyErr,
+    verbose: bool,
 ) -> Diagnostic {
     let mut diagnostic =
         TEST_FAILURE.diagnostic(format!("Test `{}` failed", stmt_function_def.name));
@@ -543,7 +557,10 @@ pub fn test_failure_diagnostic(
         source_file,
         stmt_function_def,
         arguments,
-        FunctionKind::Test,
+        FailedFunctionCallOptions {
+            function_kind: FunctionKind::Test,
+            verbose,
+        },
         error,
     );
     diagnostic
@@ -637,9 +654,13 @@ fn handle_failed_function_call(
     source_file: &SourceFile,
     stmt_function_def: &StmtFunctionDef,
     arguments: &FixtureArguments,
-    function_kind: FunctionKind,
+    options: FailedFunctionCallOptions,
     error: &PyErr,
 ) {
+    let FailedFunctionCallOptions {
+        function_kind,
+        verbose,
+    } = options;
     annotate_function_name(diagnostic, source_file.clone(), stmt_function_def);
 
     if !arguments.is_empty() {
@@ -656,22 +677,42 @@ fn handle_failed_function_call(
         diagnostic.info(format!("`{truncated_name}`: `{truncated_value}`"));
     }
 
-    if let Some(Traceback {
-        lines: _,
-        error_source_file,
-        location,
-    }) = Traceback::from_error_with_source(py, error, source_file)
-    {
-        let mut sub = SubDiagnostic::new(
-            SubDiagnosticSeverity::Info,
-            format!("{} failed here", function_kind.capitalised()),
-        );
+    if let Some(Traceback { frames }) = Traceback::from_error_with_source(py, error, source_file) {
+        if verbose {
+            for pair in frames.windows(2) {
+                if let [caller, callee] = pair {
+                    let message = format!("Called `{}` here", callee.function_name);
+                    if let Some(source) = &caller.source {
+                        let mut sub = SubDiagnostic::new(SubDiagnosticSeverity::Info, message);
+                        sub.annotate(Annotation::primary(
+                            Span::from(source.source_file.clone()).with_range(source.location),
+                        ));
+                        diagnostic.sub(sub);
+                    } else {
+                        diagnostic.info(format!(
+                            "{message}: {}:{}",
+                            caller.file_path, caller.line_number
+                        ));
+                    }
+                }
+            }
+        }
 
-        let secondary_span = Span::from(error_source_file).with_range(location);
-
-        sub.annotate(Annotation::primary(secondary_span));
-
-        diagnostic.sub(sub);
+        if let Some(failure) = frames.last() {
+            let message = format!("{} failed here", function_kind.capitalised());
+            if let Some(source) = &failure.source {
+                let mut sub = SubDiagnostic::new(SubDiagnosticSeverity::Info, message);
+                sub.annotate(Annotation::primary(
+                    Span::from(source.source_file.clone()).with_range(source.location),
+                ));
+                diagnostic.sub(sub);
+            } else if verbose {
+                diagnostic.info(format!(
+                    "{message}: {}:{}",
+                    failure.file_path, failure.line_number
+                ));
+            }
+        }
     }
 
     let error_string = error.value(py).to_string();

--- a/crates/karva_test_semantic/src/lib.rs
+++ b/crates/karva_test_semantic/src/lib.rs
@@ -35,8 +35,9 @@ pub fn run_tests(
     reporter: &dyn Reporter,
     test_paths: Vec<Result<TestPath, TestPathError>>,
     coverage: Option<&CoverageConfig>,
+    verbose: bool,
 ) -> TestRunResult {
-    let context = Context::new(cwd, settings, python_version, reporter);
+    let context = Context::new(cwd, settings, python_version, reporter, verbose);
 
     attach_with_output(settings.terminal().show_python_output, |py| {
         let cov_session = coverage.and_then(|cfg| match CoverageSession::start(py, cwd, cfg) {

--- a/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
@@ -48,7 +48,7 @@ impl PackageRunner<'_, '_> {
         } else {
             let mut diagnostics = auto_use_errors
                 .into_iter()
-                .map(|error| fixture_failure_diagnostic(py, error))
+                .map(|error| fixture_failure_diagnostic(py, error, self.context.is_verbose()))
                 .collect::<Vec<_>>();
             diagnostics.extend(self.clean_up_scope(py, scope));
             Err(diagnostics)

--- a/crates/karva_test_semantic/src/runner/package_runner/outcome.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/outcome.rs
@@ -39,6 +39,8 @@ pub(super) struct OutcomeContext<'a> {
     pub(super) function_arguments: &'a FixtureArguments,
     /// Active expected-failure policy, when configured.
     pub(super) expect_fail_tag: Option<ExpectFailTag>,
+    /// Whether failure diagnostics should include every Python call frame.
+    pub(super) verbose: bool,
 }
 
 /// Durations for each phase of one complete test attempt.
@@ -160,6 +162,7 @@ pub(super) fn classify_test_result(
             context.stmt_function_def,
             context.function_arguments,
             &error,
+            context.verbose,
         );
         TestExecutionOutcome::failed(diagnostic)
     } else {

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/attempt.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/attempt.rs
@@ -99,6 +99,7 @@ impl VariantRunner<'_, '_, '_, '_, '_> {
                     stmt_function_def: &self.test.stmt_function_def,
                     function_arguments: &function_arguments,
                     expect_fail_tag: settings.expect_fail_tag.clone(),
+                    verbose: self.package_runner.context.is_verbose(),
                 },
             );
             let skipped = outcome.is_skipped();
@@ -139,7 +140,13 @@ impl VariantRunner<'_, '_, '_, '_, '_> {
         } else {
             let mut diagnostics = fixture_call_errors
                 .into_iter()
-                .map(|error| fixture_failure_diagnostic(self.py, error))
+                .map(|error| {
+                    fixture_failure_diagnostic(
+                        self.py,
+                        error,
+                        self.package_runner.context.is_verbose(),
+                    )
+                })
                 .collect::<Vec<_>>();
             let teardown_start = Instant::now();
             diagnostics.extend(

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -144,6 +144,7 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
         reporter.as_ref(),
         test_paths,
         coverage.as_ref(),
+        !verbosity.is_default(),
     );
 
     let diagnostic_format = settings.terminal().output_format.into();


### PR DESCRIPTION
## Summary

Verbose runs now parse every Python traceback frame and show each call with its function, file, line, and source span before the final failure. Default output remains compact, and unreadable frame sources fall back to an exact path and line. Closes #1038.

## Test Plan

`cargo test -p karva_diagnostic --all-features traceback`, `just test -p karva test_verbose_output_shows_traceback_calls`, and `uvx prek run -a`.