### PR TITLE
Generate JSON Schema for karva.toml

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 * text=auto eol=lf
+*.md.snap linguist-language=Markdown
+karva.schema.json -diff linguist-generated=true text=auto eol=lf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,6 +647,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,6 +1251,7 @@ dependencies = [
  "markdown",
  "pretty_assertions",
  "ruff_options_metadata",
+ "schemars",
  "serde_json",
 ]
 
@@ -1278,6 +1285,7 @@ dependencies = [
  "insta",
  "karva_combine",
  "karva_static",
+ "schemars",
  "serde",
  "tracing",
  "tracing-flame",
@@ -1312,6 +1320,7 @@ dependencies = [
  "ruff_db",
  "ruff_options_metadata",
  "ruff_python_ast",
+ "schemars",
  "semver",
  "serde",
  "tempfile",
@@ -2062,6 +2071,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2415,6 +2444,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2458,6 +2512,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,6 +1245,7 @@ dependencies = [
  "markdown",
  "pretty_assertions",
  "ruff_options_metadata",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ ruff_python_trivia = { git = "https://github.com/astral-sh/ruff/", branch = "mai
 ruff_source_file = { git = "https://github.com/astral-sh/ruff/", branch = "main" }
 ruff_text_size = { git = "https://github.com/astral-sh/ruff/", branch = "main" }
 rusqlite = { version = "0.40.1", default-features = false, features = ["bundled"] }
+schemars = { version = "1.0.4" }
 semver = { version = "1.0.28", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.150" }

--- a/crates/karva_dev/Cargo.toml
+++ b/crates/karva_dev/Cargo.toml
@@ -13,7 +13,7 @@ license = { workspace = true }
 
 [dependencies]
 karva_cli = { workspace = true }
-karva_metadata = { workspace = true }
+karva_metadata = { workspace = true, features = ["schemars"] }
 karva_static = { workspace = true }
 
 anyhow = { workspace = true }
@@ -24,6 +24,7 @@ itertools = { workspace = true }
 markdown = { workspace = true }
 pretty_assertions = { workspace = true }
 ruff_options_metadata = { workspace = true }
+schemars = { workspace = true }
 serde_json = { workspace = true }
 
 [lints]

--- a/crates/karva_dev/Cargo.toml
+++ b/crates/karva_dev/Cargo.toml
@@ -24,6 +24,7 @@ itertools = { workspace = true }
 markdown = { workspace = true }
 pretty_assertions = { workspace = true }
 ruff_options_metadata = { workspace = true }
+serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/karva_dev/src/generate_json_schema.rs
+++ b/crates/karva_dev/src/generate_json_schema.rs
@@ -1,0 +1,178 @@
+//! Generate a JSON Schema for `karva.toml`.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Result, bail};
+use karva_metadata::{Config, Options, OverrideOptions};
+use ruff_options_metadata::{OptionField, OptionSet, OptionsMetadata, Visit};
+use serde_json::{Map, Value, json};
+
+use crate::{Mode, apply_mode};
+
+#[derive(clap::Args)]
+pub struct Args {
+    /// Write the generated schema to stdout (rather than to `karva.schema.json`).
+    #[arg(long, default_value_t, value_enum)]
+    pub mode: Mode,
+}
+
+pub fn main(args: &Args) -> Result<()> {
+    let generated = serde_json::to_string_pretty(&generate()?)? + "\n";
+    apply_mode(args.mode, "karva.schema.json", &generated)
+}
+
+fn generate() -> Result<Value> {
+    let mut root = schema_for_set(Config::metadata())?;
+    properties_mut(&mut root)?.insert("profile".to_string(), profile_map_schema()?);
+
+    let object = object_mut(&mut root)?;
+    object.insert(
+        "$schema".to_string(),
+        json!("https://json-schema.org/draft/2020-12/schema"),
+    );
+    object.insert("title".to_string(), json!("Karva configuration"));
+    Ok(root)
+}
+
+fn profile_map_schema() -> Result<Value> {
+    Ok(json!({
+        "type": "object",
+        "propertyNames": {
+            "pattern": "^[A-Za-z0-9_-]+$",
+            "not": { "pattern": "^default-" }
+        },
+        "additionalProperties": profile_schema()?
+    }))
+}
+
+fn profile_schema() -> Result<Value> {
+    let mut schema = schema_for_set(Options::metadata())?;
+    properties_mut(&mut schema)?.insert(
+        "overrides".to_string(),
+        json!({
+            "type": "array",
+            "items": override_schema()?,
+            "default": []
+        }),
+    );
+    Ok(schema)
+}
+
+fn override_schema() -> Result<Value> {
+    let mut schema = schema_for_set(OverrideOptions::metadata())?;
+    object_mut(&mut schema)?.insert("required".to_string(), json!(["filter"]));
+    Ok(schema)
+}
+
+fn schema_for_set(set: OptionSet) -> Result<Value> {
+    let mut visitor = CollectOptionsVisitor::default();
+    set.record(&mut visitor);
+
+    let mut properties = BTreeMap::new();
+    for (name, field) in visitor.fields {
+        properties.insert(name, schema_for_field(&field)?);
+    }
+    for (name, group) in visitor.groups {
+        properties.insert(name, schema_for_set(group)?);
+    }
+
+    let mut schema = json!({
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": false
+    });
+    if let Some(description) = set.documentation() {
+        object_mut(&mut schema)?.insert("description".to_string(), json!(description));
+    }
+    Ok(schema)
+}
+
+fn schema_for_field(field: &OptionField) -> Result<Value> {
+    let mut schema = schema_for_value_type(field.value_type)?;
+    let object = object_mut(&mut schema)?;
+    object.insert("description".to_string(), json!(field.doc));
+    if field.default != "required" {
+        object.insert("default".to_string(), default_value(field)?);
+    }
+    Ok(schema)
+}
+
+fn schema_for_value_type(value_type: &str) -> Result<Value> {
+    let schema = match value_type {
+        "bool" | "true | false" => json!({ "type": "boolean" }),
+        "list[str]" => json!({ "type": "array", "items": { "type": "string" } }),
+        "path" | "string" => json!({ "type": "string" }),
+        "positive integer" => json!({ "type": "integer", "minimum": 1 }),
+        "u32" => json!({ "type": "integer", "minimum": 0 }),
+        "float (seconds)" => json!({ "type": "number" }),
+        "float (0..=100)" => json!({ "type": "number", "minimum": 0, "maximum": 100 }),
+        value_type if value_type.contains(" | ") => json!({
+            "type": "string",
+            "enum": value_type.split(" | ").collect::<Vec<_>>()
+        }),
+        _ => bail!("unsupported option value type `{value_type}` in JSON Schema generator"),
+    };
+    Ok(schema)
+}
+
+fn default_value(field: &OptionField) -> Result<Value> {
+    let value = match field.default {
+        "null" => Value::Null,
+        "true" => Value::Bool(true),
+        "false" => Value::Bool(false),
+        default
+            if default.starts_with('"')
+                || (matches!(
+                    field.value_type,
+                    "positive integer" | "u32" | "float (seconds)" | "float (0..=100)"
+                ) && default != "unlimited") =>
+        {
+            serde_json::from_str(default)?
+        }
+        default => json!(default),
+    };
+    Ok(value)
+}
+
+fn object_mut(value: &mut Value) -> Result<&mut Map<String, Value>> {
+    value
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("generated schema node is not an object"))
+}
+
+fn properties_mut(value: &mut Value) -> Result<&mut Map<String, Value>> {
+    object_mut(value)?
+        .get_mut("properties")
+        .and_then(Value::as_object_mut)
+        .ok_or_else(|| anyhow::anyhow!("generated object schema has no properties"))
+}
+
+#[derive(Default)]
+struct CollectOptionsVisitor {
+    fields: Vec<(String, OptionField)>,
+    groups: Vec<(String, OptionSet)>,
+}
+
+impl Visit for CollectOptionsVisitor {
+    fn record_field(&mut self, name: &str, field: OptionField) {
+        self.fields.push((name.to_string(), field));
+    }
+
+    fn record_set(&mut self, name: &str, group: OptionSet) {
+        self.groups.push((name.to_string(), group));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+
+    use super::{Args, main};
+    use crate::Mode;
+
+    #[test]
+    #[cfg(unix)]
+    fn json_schema_up_to_date() -> Result<()> {
+        main(&Args { mode: Mode::Check })
+    }
+}

--- a/crates/karva_dev/src/generate_json_schema.rs
+++ b/crates/karva_dev/src/generate_json_schema.rs
@@ -1,11 +1,8 @@
 //! Generate a JSON Schema for `karva.toml`.
 
-use std::collections::BTreeMap;
-
-use anyhow::{Result, bail};
-use karva_metadata::{Config, Options, OverrideOptions};
-use ruff_options_metadata::{OptionField, OptionSet, OptionsMetadata, Visit};
-use serde_json::{Map, Value, json};
+use anyhow::Result;
+use karva_metadata::Config;
+use schemars::generate::SchemaSettings;
 
 use crate::{Mode, apply_mode};
 
@@ -17,150 +14,10 @@ pub struct Args {
 }
 
 pub fn main(args: &Args) -> Result<()> {
-    let generated = serde_json::to_string_pretty(&generate()?)? + "\n";
+    let generator = SchemaSettings::draft07().into_generator();
+    let schema = generator.into_root_schema_for::<Config>();
+    let generated = serde_json::to_string_pretty(&schema)? + "\n";
     apply_mode(args.mode, "karva.schema.json", &generated)
-}
-
-fn generate() -> Result<Value> {
-    let mut root = schema_for_set(Config::metadata())?;
-    properties_mut(&mut root)?.insert("profile".to_string(), profile_map_schema()?);
-
-    let object = object_mut(&mut root)?;
-    object.insert(
-        "$schema".to_string(),
-        json!("https://json-schema.org/draft/2020-12/schema"),
-    );
-    object.insert("title".to_string(), json!("Karva configuration"));
-    Ok(root)
-}
-
-fn profile_map_schema() -> Result<Value> {
-    Ok(json!({
-        "type": "object",
-        "propertyNames": {
-            "pattern": "^[A-Za-z0-9_-]+$",
-            "not": { "pattern": "^default-" }
-        },
-        "additionalProperties": profile_schema()?
-    }))
-}
-
-fn profile_schema() -> Result<Value> {
-    let mut schema = schema_for_set(Options::metadata())?;
-    properties_mut(&mut schema)?.insert(
-        "overrides".to_string(),
-        json!({
-            "type": "array",
-            "items": override_schema()?,
-            "default": []
-        }),
-    );
-    Ok(schema)
-}
-
-fn override_schema() -> Result<Value> {
-    let mut schema = schema_for_set(OverrideOptions::metadata())?;
-    object_mut(&mut schema)?.insert("required".to_string(), json!(["filter"]));
-    Ok(schema)
-}
-
-fn schema_for_set(set: OptionSet) -> Result<Value> {
-    let mut visitor = CollectOptionsVisitor::default();
-    set.record(&mut visitor);
-
-    let mut properties = BTreeMap::new();
-    for (name, field) in visitor.fields {
-        properties.insert(name, schema_for_field(&field)?);
-    }
-    for (name, group) in visitor.groups {
-        properties.insert(name, schema_for_set(group)?);
-    }
-
-    let mut schema = json!({
-        "type": "object",
-        "properties": properties,
-        "additionalProperties": false
-    });
-    if let Some(description) = set.documentation() {
-        object_mut(&mut schema)?.insert("description".to_string(), json!(description));
-    }
-    Ok(schema)
-}
-
-fn schema_for_field(field: &OptionField) -> Result<Value> {
-    let mut schema = schema_for_value_type(field.value_type)?;
-    let object = object_mut(&mut schema)?;
-    object.insert("description".to_string(), json!(field.doc));
-    if field.default != "required" {
-        object.insert("default".to_string(), default_value(field)?);
-    }
-    Ok(schema)
-}
-
-fn schema_for_value_type(value_type: &str) -> Result<Value> {
-    let schema = match value_type {
-        "bool" | "true | false" => json!({ "type": "boolean" }),
-        "list[str]" => json!({ "type": "array", "items": { "type": "string" } }),
-        "path" | "string" => json!({ "type": "string" }),
-        "positive integer" => json!({ "type": "integer", "minimum": 1 }),
-        "u32" => json!({ "type": "integer", "minimum": 0 }),
-        "float (seconds)" => json!({ "type": "number" }),
-        "float (0..=100)" => json!({ "type": "number", "minimum": 0, "maximum": 100 }),
-        value_type if value_type.contains(" | ") => json!({
-            "type": "string",
-            "enum": value_type.split(" | ").collect::<Vec<_>>()
-        }),
-        _ => bail!("unsupported option value type `{value_type}` in JSON Schema generator"),
-    };
-    Ok(schema)
-}
-
-fn default_value(field: &OptionField) -> Result<Value> {
-    let value = match field.default {
-        "null" => Value::Null,
-        "true" => Value::Bool(true),
-        "false" => Value::Bool(false),
-        default
-            if default.starts_with('"')
-                || (matches!(
-                    field.value_type,
-                    "positive integer" | "u32" | "float (seconds)" | "float (0..=100)"
-                ) && default != "unlimited") =>
-        {
-            serde_json::from_str(default)?
-        }
-        default => json!(default),
-    };
-    Ok(value)
-}
-
-fn object_mut(value: &mut Value) -> Result<&mut Map<String, Value>> {
-    value
-        .as_object_mut()
-        .ok_or_else(|| anyhow::anyhow!("generated schema node is not an object"))
-}
-
-fn properties_mut(value: &mut Value) -> Result<&mut Map<String, Value>> {
-    object_mut(value)?
-        .get_mut("properties")
-        .and_then(Value::as_object_mut)
-        .ok_or_else(|| anyhow::anyhow!("generated object schema has no properties"))
-}
-
-#[derive(Default)]
-struct CollectOptionsVisitor {
-    fields: Vec<(String, OptionField)>,
-    groups: Vec<(String, OptionSet)>,
-}
-
-impl Visit for CollectOptionsVisitor {
-    fn record_field(&mut self, name: &str, field: OptionField) {
-        self.fields.push((name.to_string(), field));
-    }
-
-    fn record_set(&mut self, name: &str, group: OptionSet) {
-        self.groups.push((name.to_string(), group));
-    }
 }
 
 #[cfg(test)]
@@ -171,7 +28,6 @@ mod tests {
     use crate::Mode;
 
     #[test]
-    #[cfg(unix)]
     fn json_schema_up_to_date() -> Result<()> {
         main(&Args { mode: Mode::Check })
     }

--- a/crates/karva_dev/src/main.rs
+++ b/crates/karva_dev/src/main.rs
@@ -14,6 +14,7 @@ use pretty_assertions::StrComparison;
 
 mod generate_cli_reference;
 mod generate_env_vars;
+mod generate_json_schema;
 mod generate_options;
 
 const ROOT_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../");
@@ -88,6 +89,8 @@ enum Command {
     GenerateCliReference(generate_cli_reference::Args),
     /// Generate environment variables reference.
     GenerateEnvVars(generate_env_vars::Args),
+    /// Generate JSON Schema for `karva.toml`.
+    GenerateJsonSchema(generate_json_schema::Args),
     /// Generate options reference.
     GenerateOptions(generate_options::Args),
     /// Generate all developer documentation and references.
@@ -101,9 +104,11 @@ fn main() -> Result<ExitCode> {
         Command::GenerateAll => {
             generate_cli_reference::main(&generate_cli_reference::Args { mode: Mode::Write })?;
             generate_env_vars::main(&generate_env_vars::Args { mode: Mode::Write })?;
+            generate_json_schema::main(&generate_json_schema::Args { mode: Mode::Write })?;
             generate_options::main(&generate_options::Args { mode: Mode::Write })?;
         }
         Command::GenerateEnvVars(args) => generate_env_vars::main(&args)?,
+        Command::GenerateJsonSchema(args) => generate_json_schema::main(&args)?,
         Command::GenerateOptions(args) => generate_options::main(&args)?,
     }
     Ok(ExitCode::SUCCESS)

--- a/crates/karva_logging/Cargo.toml
+++ b/crates/karva_logging/Cargo.toml
@@ -10,6 +10,9 @@ repository.workspace = true
 authors.workspace = true
 license.workspace = true
 
+[features]
+schemars = ["dep:schemars"]
+
 [dependencies]
 karva_combine = { workspace = true }
 karva_static = { workspace = true }
@@ -17,6 +20,7 @@ karva_static = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 colored = { workspace = true }
+schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 tracing = { workspace = true, features = ["release_max_level_debug"] }
 tracing-flame = { workspace = true }

--- a/crates/karva_logging/src/status_level.rs
+++ b/crates/karva_logging/src/status_level.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
     Deserialize,
     clap::ValueEnum,
 )]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 pub enum StatusLevel {
     /// Don't display any test result lines (or the "Starting" header).
@@ -80,6 +81,7 @@ impl Combine for StatusLevel {
     Deserialize,
     clap::ValueEnum,
 )]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 pub enum FinalStatusLevel {
     /// Don't display the summary line or any diagnostic blocks.

--- a/crates/karva_metadata/Cargo.toml
+++ b/crates/karva_metadata/Cargo.toml
@@ -13,6 +13,9 @@ license.workspace = true
 [package.metadata.cargo-shear]
 ignored = ["ruff_options_metadata"]
 
+[features]
+schemars = ["dep:schemars", "karva_logging/schemars"]
+
 [dependencies]
 karva_combine = { workspace = true }
 karva_logging = { workspace = true }
@@ -26,6 +29,7 @@ regex = { workspace = true }
 ruff_db = { workspace = true }
 ruff_options_metadata = { workspace = true }
 ruff_python_ast = { workspace = true }
+schemars = { workspace = true, optional = true }
 semver = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/karva_metadata/src/max_fail.rs
+++ b/crates/karva_metadata/src/max_fail.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 #[derive(
     Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord,
 )]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(transparent)]
 pub struct MaxFail(Option<NonZeroU32>);
 

--- a/crates/karva_metadata/src/options/config.rs
+++ b/crates/karva_metadata/src/options/config.rs
@@ -19,6 +19,7 @@ pub const DEFAULT_PROFILE: &str = "default";
 /// implicit `default` profile is always available; other profiles inherit
 /// from it (and can override individual fields).
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, OptionsMetadata)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct Config {
     /// `SemVer` requirement that the running karva binary must satisfy.
@@ -34,6 +35,7 @@ pub struct Config {
             required-version = ">=0.5.0"
         "#
     )]
+    #[cfg_attr(feature = "schemars", schemars(with = "Option<String>"))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub required_version: Option<VersionReq>,
 

--- a/crates/karva_metadata/src/options/config.rs
+++ b/crates/karva_metadata/src/options/config.rs
@@ -15,9 +15,9 @@ pub const DEFAULT_PROFILE: &str = "default";
 
 /// File-level configuration: a collection of named profiles.
 ///
-/// Mirrors nextest: every option group lives inside `[profile.<name>]`. The
-/// implicit `default` profile is always available; other profiles inherit
-/// from it (and can override individual fields).
+/// Every option group lives inside `[profile.<name>]`. The implicit `default`
+/// profile is always available; named profiles inherit from it and can
+/// override individual fields.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, OptionsMetadata)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]

--- a/crates/karva_metadata/src/options/config.rs
+++ b/crates/karva_metadata/src/options/config.rs
@@ -43,8 +43,22 @@ pub struct Config {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub required_version: Option<VersionReq>,
 
+    #[cfg_attr(feature = "schemars", schemars(schema_with = "profile_schema"))]
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub profile: BTreeMap<String, Options>,
+}
+
+#[cfg(feature = "schemars")]
+fn profile_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    let options = generator.subschema_for::<Options>();
+    schemars::json_schema!({
+        "type": "object",
+        "propertyNames": {
+            "pattern": "^[A-Za-z0-9_-]+$",
+            "not": { "pattern": "^default-" }
+        },
+        "additionalProperties": options
+    })
 }
 
 impl Config {

--- a/crates/karva_metadata/src/options/config.rs
+++ b/crates/karva_metadata/src/options/config.rs
@@ -20,10 +20,6 @@ pub const DEFAULT_PROFILE: &str = "default";
 /// override individual fields.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, OptionsMetadata)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[cfg_attr(
-    feature = "schemars",
-    schemars(extend("$id" = "https://www.schemastore.org/karva.json"))
-)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct Config {
     /// `SemVer` requirement that the running karva binary must satisfy.

--- a/crates/karva_metadata/src/options/config.rs
+++ b/crates/karva_metadata/src/options/config.rs
@@ -20,6 +20,10 @@ pub const DEFAULT_PROFILE: &str = "default";
 /// override individual fields.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, OptionsMetadata)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "schemars",
+    schemars(extend("$id" = "https://www.schemastore.org/karva.json"))
+)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct Config {
     /// `SemVer` requirement that the running karva binary must satisfy.

--- a/crates/karva_metadata/src/options/config.rs
+++ b/crates/karva_metadata/src/options/config.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use camino::{Utf8Path, Utf8PathBuf};
 use fs_err as fs;
 use karva_combine::Combine;
+use karva_macros::OptionsMetadata;
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -17,7 +18,7 @@ pub const DEFAULT_PROFILE: &str = "default";
 /// Mirrors nextest: every option group lives inside `[profile.<name>]`. The
 /// implicit `default` profile is always available; other profiles inherit
 /// from it (and can override individual fields).
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, OptionsMetadata)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct Config {
     /// `SemVer` requirement that the running karva binary must satisfy.
@@ -26,6 +27,13 @@ pub struct Config {
     /// match the requirement. This is useful in CI and for shared
     /// repositories where every developer should be on a known-good
     /// version.
+    #[option(
+        default = r#"null"#,
+        value_type = "string",
+        example = r#"
+            required-version = ">=0.5.0"
+        "#
+    )]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub required_version: Option<VersionReq>,
 

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -86,15 +86,29 @@ impl Options {
 /// Mirrors `[[profile.<name>.overrides]]` in `karva.toml`. Each override
 /// pairs a filter expression with one or more option fields to apply when
 /// the filter matches a given test.
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, OptionsMetadata)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct OverrideOptions {
     /// A filter expression evaluated against each test. Tests whose name
     /// or tags match the expression pick up this override's settings.
+    #[option(
+        default = "required",
+        value_type = "string",
+        example = r#"
+            filter = "tag(slow)"
+        "#
+    )]
     pub filter: ValidatedFilter,
 
     /// Number of times to retry a matching test before giving up. Mirrors
     /// the profile-level [`retry`](#retry) field.
+    #[option(
+        default = "null",
+        value_type = "u32",
+        example = r#"
+            retries = 2
+        "#
+    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retries: Option<u32>,
 
@@ -102,6 +116,13 @@ pub struct OverrideOptions {
     /// Mirrors the profile-level [`timeout`](#timeout) field. A value of
     /// `0` (or any non-positive value) disables the hard timeout for the
     /// matching test.
+    #[option(
+        default = "null",
+        value_type = "float (seconds)",
+        example = r#"
+            timeout = 30.0
+        "#
+    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout: Option<TestTimeoutSecs>,
 
@@ -109,12 +130,26 @@ pub struct OverrideOptions {
     /// slow. Mirrors the profile-level
     /// [`slow-timeout`](#slow-timeout) field. A non-positive value
     /// disables slow tracking for the matching test.
+    #[option(
+        default = "null",
+        value_type = "float (seconds)",
+        example = r#"
+            slow-timeout = 1.0
+        "#
+    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub slow_timeout: Option<SlowTimeoutSecs>,
 
     /// Duration budget (in seconds) for a matching test's full lifecycle.
     /// Mirrors the profile-level [`fail-slow`](#fail-slow) field. A
     /// non-positive value disables the budget for the matching test.
+    #[option(
+        default = "null",
+        value_type = "float (seconds)",
+        example = r#"
+            fail-slow = 10.0
+        "#
+    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fail_slow: Option<FailSlowSecs>,
 }

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -21,6 +21,7 @@ use crate::settings::{
 };
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, OptionsMetadata)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct Options {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -87,6 +88,7 @@ impl Options {
 /// pairs a filter expression with one or more option fields to apply when
 /// the filter matches a given test.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, OptionsMetadata)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct OverrideOptions {
     /// A filter expression evaluated against each test. Tests whose name
@@ -98,6 +100,7 @@ pub struct OverrideOptions {
             filter = "tag(slow)"
         "#
     )]
+    #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     pub filter: ValidatedFilter,
 
     /// Number of times to retry a matching test before giving up. Mirrors
@@ -169,6 +172,7 @@ impl OverrideOptions {
 #[derive(
     Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize, OptionsMetadata, Combine,
 )]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct SrcOptions {
     /// Whether to automatically exclude files that are ignored by `.ignore`,
@@ -215,6 +219,7 @@ impl SrcOptions {
 #[derive(
     Debug, Default, Clone, Eq, PartialEq, Combine, Serialize, Deserialize, OptionsMetadata,
 )]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct TerminalOptions {
     /// The format to use for printing diagnostic messages.
@@ -292,6 +297,7 @@ impl TerminalOptions {
 #[derive(
     Debug, Default, Clone, Eq, PartialEq, Combine, Serialize, Deserialize, OptionsMetadata,
 )]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct TestOptions {
     /// The prefix to use for test functions.
@@ -511,6 +517,7 @@ impl TestOptions {
 }
 
 #[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize, OptionsMetadata)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct CoverageOptions {
     /// Source paths to measure coverage for.
@@ -666,6 +673,7 @@ impl CoverageOptions {
 #[derive(
     Debug, Default, Clone, Eq, PartialEq, Combine, Serialize, Deserialize, OptionsMetadata,
 )]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct JunitOptions {
     /// Output path for the `JUnit` XML report.
@@ -731,6 +739,7 @@ impl JunitOptions {
 
 /// Coverage report type.
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub enum CovReport {
     /// Compact terminal table (default).
@@ -774,6 +783,7 @@ impl CovReport {
 
 /// The diagnostic output format.
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub enum OutputFormat {
     #[default]

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -17,6 +17,7 @@ pub enum RunIgnoredMode {
 }
 
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub enum NoTestsMode {
     #[default]
@@ -43,6 +44,7 @@ impl Combine for NoTestsMode {
 /// equality is used (`NaN` is not a valid value because the option is
 /// validated at parse time).
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(transparent)]
 pub struct SlowTimeoutSecs(pub f64);
 
@@ -74,6 +76,7 @@ impl Combine for SlowTimeoutSecs {
 /// this duration are killed and reported as failures (see
 /// [`crate::settings::TestSettings::timeout`]).
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(transparent)]
 pub struct TestTimeoutSecs(pub f64);
 
@@ -107,6 +110,7 @@ impl Combine for TestTimeoutSecs {
 /// full lifecycle — including fixture teardown — and is then reported as a
 /// failure (see [`crate::settings::TestSettings::fail_slow`]).
 #[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(transparent)]
 pub struct FailSlowSecs(pub f64);
 
@@ -151,6 +155,7 @@ impl Combine for FailSlowSecs {
 
 /// A global run timeout expressed in seconds.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(transparent)]
 pub struct RunTimeoutSecs(pub f64);
 
@@ -178,6 +183,7 @@ impl Combine for RunTimeoutSecs {
 
 /// Grace period between graceful termination and force-kill, in seconds.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(transparent)]
 pub struct TerminationGracePeriodSecs(pub f64);
 
@@ -210,6 +216,7 @@ impl Combine for TerminationGracePeriodSecs {
 /// straightforward. `NaN` is rejected at parse time so bit-wise equality is
 /// safe here.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(transparent)]
 pub struct CovFailUnder(pub f64);
 

--- a/karva.schema.json
+++ b/karva.schema.json
@@ -1,0 +1,289 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "File-level configuration: a collection of named profiles.\n\nMirrors nextest: every option group lives inside `[profile.<name>]`. The\nimplicit `default` profile is always available; other profiles inherit\nfrom it (and can override individual fields).",
+  "properties": {
+    "profile": {
+      "additionalProperties": {
+        "additionalProperties": false,
+        "properties": {
+          "coverage": {
+            "additionalProperties": false,
+            "properties": {
+              "branch": {
+                "default": false,
+                "description": "Whether to measure branch coverage in addition to line coverage.",
+                "type": "boolean"
+              },
+              "fail-under": {
+                "default": null,
+                "description": "Minimum total coverage percentage required for the run to succeed.\n\nWhen set, the test command exits with a non-zero status if the\nreported `TOTAL` coverage is below this value, even when every test\npassed. Has no effect when tests already failed (the exit code is\nalready non-zero).",
+                "maximum": 100,
+                "minimum": 0,
+                "type": "number"
+              },
+              "include": {
+                "default": null,
+                "description": "Include only coverage report files matching these globs.\n\nGlobs are matched against the project-relative file path shown in the\ncoverage report, such as `src/package/module.py`. When unset, all files\nunder the configured coverage sources are included unless omitted.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "omit": {
+                "default": null,
+                "description": "Exclude coverage report files matching these globs.\n\nGlobs are matched against the project-relative file path shown in the\ncoverage report, such as `src/package/module.py`. Omit filters are\napplied after include filters.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "report": {
+                "default": "term",
+                "description": "Coverage report type.\n\n`term` (default) prints a compact terminal table.\n`term-missing` extends it with a `Missing` column listing the\nuncovered line numbers per file.",
+                "enum": [
+                  "term",
+                  "term-missing",
+                  "xml",
+                  "json",
+                  "html"
+                ],
+                "type": "string"
+              },
+              "report-path": {
+                "default": null,
+                "description": "Optional output path for machine-readable coverage reports.\n\nWhen `report = \"xml\"` or `report = \"json\"`, this path controls where\nthe file is written. When `report = \"html\"`, it controls the output\ndirectory. If omitted, karva writes to `coverage.xml`,\n`coverage.json`, or `htmlcov/` in the project root.",
+                "type": "string"
+              },
+              "sources": {
+                "default": null,
+                "description": "Source paths to measure coverage for.\n\nEquivalent to passing `--cov=<path>` on the command line; may be\nlisted multiple times. An empty entry (`\"\"`) measures the current\nworking directory, matching pytest-cov's bare `--cov`.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "junit": {
+            "additionalProperties": false,
+            "properties": {
+              "path": {
+                "default": null,
+                "description": "Output path for the `JUnit` XML report.\n\nWhen unset, no `JUnit` report is written.",
+                "type": "string"
+              },
+              "report-name": {
+                "default": "karva-tests",
+                "description": "Name of the top-level `JUnit` test suite collection.",
+                "type": "string"
+              },
+              "store-failure-output": {
+                "default": true,
+                "description": "Whether to include captured stdout and stderr for failing tests.",
+                "type": "boolean"
+              },
+              "store-success-output": {
+                "default": false,
+                "description": "Whether to include captured stdout and stderr for passing tests.",
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "overrides": {
+            "default": [],
+            "items": {
+              "additionalProperties": false,
+              "description": "A single per-test override entry.\n\nMirrors `[[profile.<name>.overrides]]` in `karva.toml`. Each override\npairs a filter expression with one or more option fields to apply when\nthe filter matches a given test.",
+              "properties": {
+                "fail-slow": {
+                  "default": null,
+                  "description": "Duration budget (in seconds) for a matching test's full lifecycle.\nMirrors the profile-level [`fail-slow`](#fail-slow) field. A\nnon-positive value disables the budget for the matching test.",
+                  "type": "number"
+                },
+                "filter": {
+                  "description": "A filter expression evaluated against each test. Tests whose name\nor tags match the expression pick up this override's settings.",
+                  "type": "string"
+                },
+                "retries": {
+                  "default": null,
+                  "description": "Number of times to retry a matching test before giving up. Mirrors\nthe profile-level [`retry`](#retry) field.",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "slow-timeout": {
+                  "default": null,
+                  "description": "Threshold (in seconds) above which a matching test is flagged as\nslow. Mirrors the profile-level\n[`slow-timeout`](#slow-timeout) field. A non-positive value\ndisables slow tracking for the matching test.",
+                  "type": "number"
+                },
+                "timeout": {
+                  "default": null,
+                  "description": "Hard per-test timeout, in seconds, applied to matching tests.\nMirrors the profile-level [`timeout`](#timeout) field. A value of\n`0` (or any non-positive value) disables the hard timeout for the\nmatching test.",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "filter"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "src": {
+            "additionalProperties": false,
+            "properties": {
+              "include": {
+                "default": null,
+                "description": "A list of files and directories to check.\nIncluding a file or directory will make it so that it (and its contents)\nare tested.\n\n- `tests` matches a directory named `tests`\n- `tests/test.py` matches a file named `test.py` in the `tests` directory",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "respect-ignore-files": {
+                "default": true,
+                "description": "Whether to automatically exclude files that are ignored by `.ignore`,\n`.gitignore`, `.git/info/exclude`, and global `gitignore` files.\nEnabled by default.",
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "terminal": {
+            "additionalProperties": false,
+            "properties": {
+              "final-status-level": {
+                "default": "pass",
+                "description": "Test summary information to display at the end of the run.\n\nModeled after `cargo-nextest`'s `--final-status-level`. Levels are\ncumulative in the same way as [`status_level`](#status-level).\n\nDefaults to `pass`.",
+                "enum": [
+                  "none",
+                  "fail",
+                  "retry",
+                  "slow",
+                  "pass",
+                  "skip",
+                  "all"
+                ],
+                "type": "string"
+              },
+              "output-format": {
+                "default": "full",
+                "description": "The format to use for printing diagnostic messages.\n\nDefaults to `full`.",
+                "enum": [
+                  "full",
+                  "concise"
+                ],
+                "type": "string"
+              },
+              "show-python-output": {
+                "default": true,
+                "description": "Whether to show the python output.\n\nThis is the output the `print` goes to etc.",
+                "type": "boolean"
+              },
+              "status-level": {
+                "default": "pass",
+                "description": "Test result statuses to display during the run.\n\nModeled after `cargo-nextest`'s `--status-level`. Levels are\ncumulative: `pass` shows passing and failed tests, `skip` adds\nskipped tests on top, and so on. `retry` and `slow` are accepted\nfor forward-compatibility but currently behave like `fail`.\n\nDefaults to `pass`.",
+                "enum": [
+                  "none",
+                  "fail",
+                  "retry",
+                  "slow",
+                  "pass",
+                  "skip",
+                  "all"
+                ],
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "test": {
+            "additionalProperties": false,
+            "properties": {
+              "fail-fast": {
+                "default": false,
+                "description": "Whether to stop at the first test failure.\n\nThis is a legacy alias for [`max_fail`](#max-fail): `true`\ncorresponds to `max-fail = 1` and `false` leaves the limit unset.\nWhen both are set, `max-fail` takes precedence.\n\nDefaults to `false`.",
+                "type": "boolean"
+              },
+              "fail-slow": {
+                "default": null,
+                "description": "Duration budget (in seconds) for a test's full lifecycle (fixture\nsetup, the test call, and fixture teardown).\n\nWhen set, a test is allowed to run to completion — including\nteardown, so cleanup is never skipped — and is then reported as a\nfailure if the full lifecycle took longer than this budget. Tests\ncan override the limit individually with\n[`@karva.tags.fail_slow`](https://docs.karva.dev/usage/failure-handling/fail-slow/),\nwhich takes precedence over the configured default.\n\nThis is distinct from [`timeout`](#timeout), which kills a test\nmid-execution, and [`slow_timeout`](#slow-timeout), which is purely\ninformational and never fails a test.\n\nDefaults to unset, which disables budget checking unless a tag is\napplied to the test.",
+                "type": "number"
+              },
+              "max-fail": {
+                "default": "unlimited",
+                "description": "Stop scheduling new tests once this many tests have failed.\n\nAccepts a positive integer. Omitting the field (the default) lets\nevery test run regardless of how many fail. Setting `max-fail = 1`\nis equivalent to the legacy `fail-fast = true`.\n\nWhen both [`fail_fast`](#fail-fast) and `max-fail` are set,\n`max-fail` takes precedence.",
+                "minimum": 1,
+                "type": "integer"
+              },
+              "no-tests": {
+                "default": "auto",
+                "description": "Configures behavior when no tests are found to run.\n\n`auto` (the default) fails when no filter expressions were given, and\npasses silently when filters were given. Use `fail` to always fail,\n`warn` to always warn, or `pass` to always succeed silently.",
+                "enum": [
+                  "auto",
+                  "pass",
+                  "warn",
+                  "fail"
+                ],
+                "type": "string"
+              },
+              "retry": {
+                "default": 0,
+                "description": "When set, we will retry failed tests up to this number of times.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "run-timeout": {
+                "default": null,
+                "description": "Wall-clock limit (in seconds) for the entire run.\n\nWhen the run takes longer than this duration, karva stops the\nremaining workers and exits with a failure status. This is a safety\nnet for CI to bound runaway suites; it does not affect individual\ntest results that already completed.\n\nDefaults to unset, which lets the run take as long as it needs.",
+                "type": "number"
+              },
+              "slow-timeout": {
+                "default": null,
+                "description": "Threshold (in seconds) after which a test is flagged as slow.\n\nWhen set, tests that take longer than this duration are reported with\na `SLOW` status line and counted in the run summary. The `SLOW` line\nis gated on `--status-level=slow` (or higher); the summary always\nshows the slow count when `--final-status-level=slow` is set.\n\nDefaults to unset, which disables slow-test detection.",
+                "type": "number"
+              },
+              "termination-grace-period": {
+                "default": 10.0,
+                "description": "Grace period (in seconds) between graceful worker termination and\nforce-kill.\n\nKarva uses this when stopping workers because of Ctrl+C, fail-fast, or\n`run-timeout`. Set to `0` to send the force-kill signal immediately\nafter the graceful termination signal.\n\nDefaults to 10 seconds.",
+                "type": "number"
+              },
+              "test-function-prefix": {
+                "default": "test",
+                "description": "The prefix to use for test functions.\n\nDefaults to `test`.",
+                "type": "string"
+              },
+              "timeout": {
+                "default": null,
+                "description": "Hard per-test timeout (in seconds).\n\nWhen set, every test that runs longer than this duration is killed\nand reported as a failure. Tests can override the limit individually\nwith [`@karva.tags.timeout`](https://docs.karva.dev/usage/tags/timeout/),\nwhich takes precedence over the configured default.\n\nDefaults to unset, which disables hard timeouts unless a tag is\napplied to the test.",
+                "type": "number"
+              },
+              "try-import-fixtures": {
+                "default": false,
+                "description": "When set, we will try to import functions in each test file as well as parsing the ast to find them.\n\nThis is often slower, so it is not recommended for most projects.",
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "propertyNames": {
+        "not": {
+          "pattern": "^default-"
+        },
+        "pattern": "^[A-Za-z0-9_-]+$"
+      },
+      "type": "object"
+    },
+    "required-version": {
+      "default": null,
+      "description": "`SemVer` requirement that the running karva binary must satisfy.\n\nWhen set, karva refuses to run if the installed version does not\nmatch the requirement. This is useful in CI and for shared\nrepositories where every developer should be on a known-good\nversion.",
+      "type": "string"
+    }
+  },
+  "title": "Karva configuration",
+  "type": "object"
+}

--- a/karva.schema.json
+++ b/karva.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "https://www.schemastore.org/karva.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Config",
   "description": "File-level configuration: a collection of named profiles.\n\nEvery option group lives inside `[profile.<name>]`. The implicit `default`\nprofile is always available; named profiles inherit from it and can\noverride individual fields.",

--- a/karva.schema.json
+++ b/karva.schema.json
@@ -1,289 +1,597 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "additionalProperties": false,
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Config",
   "description": "File-level configuration: a collection of named profiles.\n\nMirrors nextest: every option group lives inside `[profile.<name>]`. The\nimplicit `default` profile is always available; other profiles inherit\nfrom it (and can override individual fields).",
+  "type": "object",
   "properties": {
     "profile": {
+      "type": "object",
       "additionalProperties": {
-        "additionalProperties": false,
-        "properties": {
-          "coverage": {
-            "additionalProperties": false,
-            "properties": {
-              "branch": {
-                "default": false,
-                "description": "Whether to measure branch coverage in addition to line coverage.",
-                "type": "boolean"
-              },
-              "fail-under": {
-                "default": null,
-                "description": "Minimum total coverage percentage required for the run to succeed.\n\nWhen set, the test command exits with a non-zero status if the\nreported `TOTAL` coverage is below this value, even when every test\npassed. Has no effect when tests already failed (the exit code is\nalready non-zero).",
-                "maximum": 100,
-                "minimum": 0,
-                "type": "number"
-              },
-              "include": {
-                "default": null,
-                "description": "Include only coverage report files matching these globs.\n\nGlobs are matched against the project-relative file path shown in the\ncoverage report, such as `src/package/module.py`. When unset, all files\nunder the configured coverage sources are included unless omitted.",
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "omit": {
-                "default": null,
-                "description": "Exclude coverage report files matching these globs.\n\nGlobs are matched against the project-relative file path shown in the\ncoverage report, such as `src/package/module.py`. Omit filters are\napplied after include filters.",
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "report": {
-                "default": "term",
-                "description": "Coverage report type.\n\n`term` (default) prints a compact terminal table.\n`term-missing` extends it with a `Missing` column listing the\nuncovered line numbers per file.",
-                "enum": [
-                  "term",
-                  "term-missing",
-                  "xml",
-                  "json",
-                  "html"
-                ],
-                "type": "string"
-              },
-              "report-path": {
-                "default": null,
-                "description": "Optional output path for machine-readable coverage reports.\n\nWhen `report = \"xml\"` or `report = \"json\"`, this path controls where\nthe file is written. When `report = \"html\"`, it controls the output\ndirectory. If omitted, karva writes to `coverage.xml`,\n`coverage.json`, or `htmlcov/` in the project root.",
-                "type": "string"
-              },
-              "sources": {
-                "default": null,
-                "description": "Source paths to measure coverage for.\n\nEquivalent to passing `--cov=<path>` on the command line; may be\nlisted multiple times. An empty entry (`\"\"`) measures the current\nworking directory, matching pytest-cov's bare `--cov`.",
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            },
-            "type": "object"
-          },
-          "junit": {
-            "additionalProperties": false,
-            "properties": {
-              "path": {
-                "default": null,
-                "description": "Output path for the `JUnit` XML report.\n\nWhen unset, no `JUnit` report is written.",
-                "type": "string"
-              },
-              "report-name": {
-                "default": "karva-tests",
-                "description": "Name of the top-level `JUnit` test suite collection.",
-                "type": "string"
-              },
-              "store-failure-output": {
-                "default": true,
-                "description": "Whether to include captured stdout and stderr for failing tests.",
-                "type": "boolean"
-              },
-              "store-success-output": {
-                "default": false,
-                "description": "Whether to include captured stdout and stderr for passing tests.",
-                "type": "boolean"
-              }
-            },
-            "type": "object"
-          },
-          "overrides": {
-            "default": [],
-            "items": {
-              "additionalProperties": false,
-              "description": "A single per-test override entry.\n\nMirrors `[[profile.<name>.overrides]]` in `karva.toml`. Each override\npairs a filter expression with one or more option fields to apply when\nthe filter matches a given test.",
-              "properties": {
-                "fail-slow": {
-                  "default": null,
-                  "description": "Duration budget (in seconds) for a matching test's full lifecycle.\nMirrors the profile-level [`fail-slow`](#fail-slow) field. A\nnon-positive value disables the budget for the matching test.",
-                  "type": "number"
-                },
-                "filter": {
-                  "description": "A filter expression evaluated against each test. Tests whose name\nor tags match the expression pick up this override's settings.",
-                  "type": "string"
-                },
-                "retries": {
-                  "default": null,
-                  "description": "Number of times to retry a matching test before giving up. Mirrors\nthe profile-level [`retry`](#retry) field.",
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "slow-timeout": {
-                  "default": null,
-                  "description": "Threshold (in seconds) above which a matching test is flagged as\nslow. Mirrors the profile-level\n[`slow-timeout`](#slow-timeout) field. A non-positive value\ndisables slow tracking for the matching test.",
-                  "type": "number"
-                },
-                "timeout": {
-                  "default": null,
-                  "description": "Hard per-test timeout, in seconds, applied to matching tests.\nMirrors the profile-level [`timeout`](#timeout) field. A value of\n`0` (or any non-positive value) disables the hard timeout for the\nmatching test.",
-                  "type": "number"
-                }
-              },
-              "required": [
-                "filter"
-              ],
-              "type": "object"
-            },
-            "type": "array"
-          },
-          "src": {
-            "additionalProperties": false,
-            "properties": {
-              "include": {
-                "default": null,
-                "description": "A list of files and directories to check.\nIncluding a file or directory will make it so that it (and its contents)\nare tested.\nWhen unset, Karva checks the `tests` directory if it exists, otherwise\nit checks the project root.\n\n- `tests` matches a directory named `tests`\n- `tests/test.py` matches a file named `test.py` in the `tests` directory",
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "respect-ignore-files": {
-                "default": true,
-                "description": "Whether to automatically exclude files that are ignored by `.ignore`,\n`.gitignore`, `.git/info/exclude`, and global `gitignore` files.\nEnabled by default.",
-                "type": "boolean"
-              }
-            },
-            "type": "object"
-          },
-          "terminal": {
-            "additionalProperties": false,
-            "properties": {
-              "final-status-level": {
-                "default": "pass",
-                "description": "Test summary information to display at the end of the run.\n\nModeled after `cargo-nextest`'s `--final-status-level`. Levels are\ncumulative in the same way as [`status_level`](#status-level).\n\nDefaults to `pass`.",
-                "enum": [
-                  "none",
-                  "fail",
-                  "retry",
-                  "slow",
-                  "pass",
-                  "skip",
-                  "all"
-                ],
-                "type": "string"
-              },
-              "output-format": {
-                "default": "full",
-                "description": "The format to use for printing diagnostic messages.\n\nDefaults to `full`.",
-                "enum": [
-                  "full",
-                  "concise"
-                ],
-                "type": "string"
-              },
-              "show-python-output": {
-                "default": true,
-                "description": "Whether to show the python output.\n\nThis is the output the `print` goes to etc.",
-                "type": "boolean"
-              },
-              "status-level": {
-                "default": "pass",
-                "description": "Test result statuses to display during the run.\n\nModeled after `cargo-nextest`'s `--status-level`. Levels are\ncumulative: `pass` shows passing and failed tests, `skip` adds\nskipped tests on top, and so on. `retry` and `slow` are accepted\nfor forward-compatibility but currently behave like `fail`.\n\nDefaults to `pass`.",
-                "enum": [
-                  "none",
-                  "fail",
-                  "retry",
-                  "slow",
-                  "pass",
-                  "skip",
-                  "all"
-                ],
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "test": {
-            "additionalProperties": false,
-            "properties": {
-              "fail-fast": {
-                "default": false,
-                "description": "Whether to stop at the first test failure.\n\nThis is a legacy alias for [`max_fail`](#max-fail): `true`\ncorresponds to `max-fail = 1` and `false` leaves the limit unset.\nWhen both are set, `max-fail` takes precedence.\n\nDefaults to `false`.",
-                "type": "boolean"
-              },
-              "fail-slow": {
-                "default": null,
-                "description": "Duration budget (in seconds) for a test's full lifecycle (fixture\nsetup, the test call, and fixture teardown).\n\nWhen set, a test is allowed to run to completion — including\nteardown, so cleanup is never skipped — and is then reported as a\nfailure if the full lifecycle took longer than this budget. Tests\ncan override the limit individually with\n[`@karva.tags.fail_slow`](https://docs.karva.dev/usage/failure-handling/fail-slow/),\nwhich takes precedence over the configured default.\n\nThis is distinct from [`timeout`](#timeout), which kills a test\nmid-execution, and [`slow_timeout`](#slow-timeout), which is purely\ninformational and never fails a test.\n\nDefaults to unset, which disables budget checking unless a tag is\napplied to the test.",
-                "type": "number"
-              },
-              "max-fail": {
-                "default": "unlimited",
-                "description": "Stop scheduling new tests once this many tests have failed.\n\nAccepts a positive integer. Omitting the field (the default) lets\nevery test run regardless of how many fail. Setting `max-fail = 1`\nis equivalent to the legacy `fail-fast = true`.\n\nWhen both [`fail_fast`](#fail-fast) and `max-fail` are set,\n`max-fail` takes precedence.",
-                "minimum": 1,
-                "type": "integer"
-              },
-              "no-tests": {
-                "default": "auto",
-                "description": "Configures behavior when no tests are found to run.\n\n`auto` (the default) fails when no filter expressions were given, and\npasses silently when filters were given. Use `fail` to always fail,\n`warn` to always warn, or `pass` to always succeed silently.",
-                "enum": [
-                  "auto",
-                  "pass",
-                  "warn",
-                  "fail"
-                ],
-                "type": "string"
-              },
-              "retry": {
-                "default": 0,
-                "description": "When set, we will retry failed tests up to this number of times.",
-                "minimum": 0,
-                "type": "integer"
-              },
-              "run-timeout": {
-                "default": null,
-                "description": "Wall-clock limit (in seconds) for the entire run.\n\nWhen the run takes longer than this duration, karva stops the\nremaining workers and exits with a failure status. This is a safety\nnet for CI to bound runaway suites; it does not affect individual\ntest results that already completed.\n\nDefaults to unset, which lets the run take as long as it needs.",
-                "type": "number"
-              },
-              "slow-timeout": {
-                "default": null,
-                "description": "Threshold (in seconds) after which a test is flagged as slow.\n\nWhen set, tests that take longer than this duration are reported with\na `SLOW` status line and counted in the run summary. The `SLOW` line\nis gated on `--status-level=slow` (or higher); the summary always\nshows the slow count when `--final-status-level=slow` is set.\n\nDefaults to unset, which disables slow-test detection.",
-                "type": "number"
-              },
-              "termination-grace-period": {
-                "default": 10.0,
-                "description": "Grace period (in seconds) between graceful worker termination and\nforce-kill.\n\nKarva uses this when stopping workers because of Ctrl+C, fail-fast, or\n`run-timeout`. Set to `0` to send the force-kill signal immediately\nafter the graceful termination signal.\n\nDefaults to 10 seconds.",
-                "type": "number"
-              },
-              "test-function-prefix": {
-                "default": "test",
-                "description": "The prefix to use for test functions.\n\nDefaults to `test`.",
-                "type": "string"
-              },
-              "timeout": {
-                "default": null,
-                "description": "Hard per-test timeout (in seconds).\n\nWhen set, every test that runs longer than this duration is killed\nand reported as a failure. Tests can override the limit individually\nwith [`@karva.tags.timeout`](https://docs.karva.dev/usage/tags/timeout/),\nwhich takes precedence over the configured default.\n\nDefaults to unset, which disables hard timeouts unless a tag is\napplied to the test.",
-                "type": "number"
-              },
-              "try-import-fixtures": {
-                "default": false,
-                "description": "When set, we will try to import functions in each test file as well as parsing the ast to find them.\n\nThis is often slower, so it is not recommended for most projects.",
-                "type": "boolean"
-              }
-            },
-            "type": "object"
-          }
-        },
-        "type": "object"
-      },
-      "propertyNames": {
-        "not": {
-          "pattern": "^default-"
-        },
-        "pattern": "^[A-Za-z0-9_-]+$"
-      },
-      "type": "object"
+        "$ref": "#/definitions/Options"
+      }
     },
     "required-version": {
-      "default": null,
       "description": "`SemVer` requirement that the running karva binary must satisfy.\n\nWhen set, karva refuses to run if the installed version does not\nmatch the requirement. This is useful in CI and for shared\nrepositories where every developer should be on a known-good\nversion.",
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     }
   },
-  "title": "Karva configuration",
-  "type": "object"
+  "additionalProperties": false,
+  "definitions": {
+    "CovFailUnder": {
+      "description": "A coverage threshold expressed as a percentage (`0..=100`).\n\nWraps `f64` for the same reason as [`SlowTimeoutSecs`]: keeps the\nsurrounding [`crate::options::CoverageOptions`] `Eq`/`Combine` derives\nstraightforward. `NaN` is rejected at parse time so bit-wise equality is\nsafe here.",
+      "type": "number",
+      "format": "double"
+    },
+    "CovReport": {
+      "description": "Coverage report type.",
+      "oneOf": [
+        {
+          "description": "Compact terminal table (default).",
+          "type": "string",
+          "const": "term"
+        },
+        {
+          "description": "Terminal table with a `Missing` column listing uncovered line numbers.",
+          "type": "string",
+          "const": "term-missing"
+        },
+        {
+          "description": "Cobertura XML written to disk for CI integrations.",
+          "type": "string",
+          "const": "xml"
+        },
+        {
+          "description": "JSON written to disk for machine-readable coverage consumption.",
+          "type": "string",
+          "const": "json"
+        },
+        {
+          "description": "HTML written to disk for interactive browsing.",
+          "type": "string",
+          "const": "html"
+        }
+      ]
+    },
+    "CoverageOptions": {
+      "type": "object",
+      "properties": {
+        "branch": {
+          "description": "Whether to measure branch coverage in addition to line coverage.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "fail-under": {
+          "description": "Minimum total coverage percentage required for the run to succeed.\n\nWhen set, the test command exits with a non-zero status if the\nreported `TOTAL` coverage is below this value, even when every test\npassed. Has no effect when tests already failed (the exit code is\nalready non-zero).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CovFailUnder"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "include": {
+          "description": "Include only coverage report files matching these globs.\n\nGlobs are matched against the project-relative file path shown in the\ncoverage report, such as `src/package/module.py`. When unset, all files\nunder the configured coverage sources are included unless omitted.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "omit": {
+          "description": "Exclude coverage report files matching these globs.\n\nGlobs are matched against the project-relative file path shown in the\ncoverage report, such as `src/package/module.py`. Omit filters are\napplied after include filters.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "report": {
+          "description": "Coverage report type.\n\n`term` (default) prints a compact terminal table.\n`term-missing` extends it with a `Missing` column listing the\nuncovered line numbers per file.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CovReport"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "report-path": {
+          "description": "Optional output path for machine-readable coverage reports.\n\nWhen `report = \"xml\"` or `report = \"json\"`, this path controls where\nthe file is written. When `report = \"html\"`, it controls the output\ndirectory. If omitted, karva writes to `coverage.xml`,\n`coverage.json`, or `htmlcov/` in the project root.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sources": {
+          "description": "Source paths to measure coverage for.\n\nEquivalent to passing `--cov=<path>` on the command line; may be\nlisted multiple times. An empty entry (`\"\"`) measures the current\nworking directory, matching pytest-cov's bare `--cov`.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "FailSlowSecs": {
+      "description": "A per-test duration budget expressed in seconds.\n\nWraps `f64` for the same reason as [`SlowTimeoutSecs`]. Unlike\n[`SlowTimeoutSecs`] (informational) or [`TestTimeoutSecs`] (kills the\ntest mid-flight), a test exceeding this budget is allowed to finish its\nfull lifecycle — including fixture teardown — and is then reported as a\nfailure (see [`crate::settings::TestSettings::fail_slow`]).",
+      "type": "number",
+      "format": "double"
+    },
+    "FinalStatusLevel": {
+      "description": "Which final summary information to display at the end of the run.\n\nModeled after `cargo-nextest`'s `--final-status-level`. Levels are\ncumulative in the same way as [`StatusLevel`].",
+      "oneOf": [
+        {
+          "description": "Don't display the summary line or any diagnostic blocks.",
+          "type": "string",
+          "const": "none"
+        },
+        {
+          "description": "Only display the summary line and diagnostics on failure.",
+          "type": "string",
+          "const": "fail"
+        },
+        {
+          "description": "Display the summary line plus diagnostics on failure or when any\ntest was retried. The summary line gains a `N retried` count whenever\na retry happened.",
+          "type": "string",
+          "const": "retry"
+        },
+        {
+          "description": "Same as `retry` until a slow-test threshold is implemented.",
+          "type": "string",
+          "const": "slow"
+        },
+        {
+          "description": "Always display the summary line and diagnostics (default).",
+          "type": "string",
+          "const": "pass"
+        },
+        {
+          "description": "Same as `pass` until skip-specific summary lines are emitted.",
+          "type": "string",
+          "const": "skip"
+        },
+        {
+          "description": "Always display every summary status.",
+          "type": "string",
+          "const": "all"
+        }
+      ]
+    },
+    "JunitOptions": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "description": "Output path for the `JUnit` XML report.\n\nWhen unset, no `JUnit` report is written.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "report-name": {
+          "description": "Name of the top-level `JUnit` test suite collection.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "store-failure-output": {
+          "description": "Whether to include captured stdout and stderr for failing tests.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "store-success-output": {
+          "description": "Whether to include captured stdout and stderr for passing tests.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "MaxFail": {
+      "description": "Controls how many tests may fail before karva stops scheduling new ones.\n\nModelled on nextest's `--max-fail` flag. A value of `None` means karva\nnever stops scheduling tests; a value of `Some(n)` stops once `n` tests\nhave failed, which generalizes the legacy `--fail-fast` flag (equivalent\nto `Some(1)`).",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint32",
+      "minimum": 1
+    },
+    "NoTestsMode": {
+      "type": "string",
+      "enum": [
+        "auto",
+        "pass",
+        "warn",
+        "fail"
+      ]
+    },
+    "Options": {
+      "type": "object",
+      "properties": {
+        "coverage": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CoverageOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "junit": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/JunitOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "overrides": {
+          "description": "Per-test configuration overrides.\n\nEach entry pairs a [filter expression](#filter) with one or more\noption overrides. The first override whose filter matches the\nrunning test wins for any given option. Fields left unset on a\nmatching override fall through to the next match (or the\nprofile-level default).",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OverrideOptions"
+          }
+        },
+        "src": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SrcOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "terminal": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TerminalOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "test": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TestOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "OutputFormat": {
+      "description": "The diagnostic output format.",
+      "type": "string",
+      "enum": [
+        "full",
+        "concise"
+      ]
+    },
+    "OverrideOptions": {
+      "description": "A single per-test override entry.\n\nMirrors `[[profile.<name>.overrides]]` in `karva.toml`. Each override\npairs a filter expression with one or more option fields to apply when\nthe filter matches a given test.",
+      "type": "object",
+      "properties": {
+        "fail-slow": {
+          "description": "Duration budget (in seconds) for a matching test's full lifecycle.\nMirrors the profile-level [`fail-slow`](#fail-slow) field. A\nnon-positive value disables the budget for the matching test.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FailSlowSecs"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "filter": {
+          "description": "A filter expression evaluated against each test. Tests whose name\nor tags match the expression pick up this override's settings.",
+          "type": "string"
+        },
+        "retries": {
+          "description": "Number of times to retry a matching test before giving up. Mirrors\nthe profile-level [`retry`](#retry) field.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0
+        },
+        "slow-timeout": {
+          "description": "Threshold (in seconds) above which a matching test is flagged as\nslow. Mirrors the profile-level\n[`slow-timeout`](#slow-timeout) field. A non-positive value\ndisables slow tracking for the matching test.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SlowTimeoutSecs"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "timeout": {
+          "description": "Hard per-test timeout, in seconds, applied to matching tests.\nMirrors the profile-level [`timeout`](#timeout) field. A value of\n`0` (or any non-positive value) disables the hard timeout for the\nmatching test.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TestTimeoutSecs"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "filter"
+      ]
+    },
+    "RunTimeoutSecs": {
+      "description": "A global run timeout expressed in seconds.",
+      "type": "number",
+      "format": "double"
+    },
+    "SlowTimeoutSecs": {
+      "description": "A slow-test threshold expressed in seconds.\n\nWraps `f64` so the surrounding [`crate::options::TestOptions`] can keep\nderiving `Eq`/`Combine` without pulling `f64` into those bounds. Bit-wise\nequality is used (`NaN` is not a valid value because the option is\nvalidated at parse time).",
+      "type": "number",
+      "format": "double"
+    },
+    "SrcOptions": {
+      "type": "object",
+      "properties": {
+        "include": {
+          "description": "A list of files and directories to check.\nIncluding a file or directory will make it so that it (and its contents)\nare tested.\nWhen unset, Karva checks the `tests` directory if it exists, otherwise\nit checks the project root.\n\n- `tests` matches a directory named `tests`\n- `tests/test.py` matches a file named `test.py` in the `tests` directory",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "respect-ignore-files": {
+          "description": "Whether to automatically exclude files that are ignored by `.ignore`,\n`.gitignore`, `.git/info/exclude`, and global `gitignore` files.\nEnabled by default.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "StatusLevel": {
+      "description": "Which test result statuses to display during the run.\n\nModeled after `cargo-nextest`'s `--status-level`. Levels are cumulative:\neach level displays its own status plus all earlier statuses.",
+      "oneOf": [
+        {
+          "description": "Don't display any test result lines (or the \"Starting\" header).",
+          "type": "string",
+          "const": "none"
+        },
+        {
+          "description": "Only display failed test results.",
+          "type": "string",
+          "const": "fail"
+        },
+        {
+          "description": "Display failed test results plus a `TRY N FAIL` line for each failed\nattempt that was retried.",
+          "type": "string",
+          "const": "retry"
+        },
+        {
+          "description": "Display failed, retried, and slow test results. Karva does not yet\nhave a slow-test threshold, so this currently behaves like `retry`.",
+          "type": "string",
+          "const": "slow"
+        },
+        {
+          "description": "Display failed, retried, slow, and passing test results (default).",
+          "type": "string",
+          "const": "pass"
+        },
+        {
+          "description": "Additionally display skipped test results.",
+          "type": "string",
+          "const": "skip"
+        },
+        {
+          "description": "Display all test result statuses.",
+          "type": "string",
+          "const": "all"
+        }
+      ]
+    },
+    "TerminalOptions": {
+      "type": "object",
+      "properties": {
+        "final-status-level": {
+          "description": "Test summary information to display at the end of the run.\n\nModeled after `cargo-nextest`'s `--final-status-level`. Levels are\ncumulative in the same way as [`status_level`](#status-level).\n\nDefaults to `pass`.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FinalStatusLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "output-format": {
+          "description": "The format to use for printing diagnostic messages.\n\nDefaults to `full`.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OutputFormat"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "show-python-output": {
+          "description": "Whether to show the python output.\n\nThis is the output the `print` goes to etc.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "status-level": {
+          "description": "Test result statuses to display during the run.\n\nModeled after `cargo-nextest`'s `--status-level`. Levels are\ncumulative: `pass` shows passing and failed tests, `skip` adds\nskipped tests on top, and so on. `retry` and `slow` are accepted\nfor forward-compatibility but currently behave like `fail`.\n\nDefaults to `pass`.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StatusLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "TerminationGracePeriodSecs": {
+      "description": "Grace period between graceful termination and force-kill, in seconds.",
+      "type": "number",
+      "format": "double"
+    },
+    "TestOptions": {
+      "type": "object",
+      "properties": {
+        "fail-fast": {
+          "description": "Whether to stop at the first test failure.\n\nThis is a legacy alias for [`max_fail`](#max-fail): `true`\ncorresponds to `max-fail = 1` and `false` leaves the limit unset.\nWhen both are set, `max-fail` takes precedence.\n\nDefaults to `false`.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "fail-slow": {
+          "description": "Duration budget (in seconds) for a test's full lifecycle (fixture\nsetup, the test call, and fixture teardown).\n\nWhen set, a test is allowed to run to completion — including\nteardown, so cleanup is never skipped — and is then reported as a\nfailure if the full lifecycle took longer than this budget. Tests\ncan override the limit individually with\n[`@karva.tags.fail_slow`](https://docs.karva.dev/usage/failure-handling/fail-slow/),\nwhich takes precedence over the configured default.\n\nThis is distinct from [`timeout`](#timeout), which kills a test\nmid-execution, and [`slow_timeout`](#slow-timeout), which is purely\ninformational and never fails a test.\n\nDefaults to unset, which disables budget checking unless a tag is\napplied to the test.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FailSlowSecs"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max-fail": {
+          "description": "Stop scheduling new tests once this many tests have failed.\n\nAccepts a positive integer. Omitting the field (the default) lets\nevery test run regardless of how many fail. Setting `max-fail = 1`\nis equivalent to the legacy `fail-fast = true`.\n\nWhen both [`fail_fast`](#fail-fast) and `max-fail` are set,\n`max-fail` takes precedence.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MaxFail"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "no-tests": {
+          "description": "Configures behavior when no tests are found to run.\n\n`auto` (the default) fails when no filter expressions were given, and\npasses silently when filters were given. Use `fail` to always fail,\n`warn` to always warn, or `pass` to always succeed silently.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NoTestsMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "retry": {
+          "description": "When set, we will retry failed tests up to this number of times.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0
+        },
+        "run-timeout": {
+          "description": "Wall-clock limit (in seconds) for the entire run.\n\nWhen the run takes longer than this duration, karva stops the\nremaining workers and exits with a failure status. This is a safety\nnet for CI to bound runaway suites; it does not affect individual\ntest results that already completed.\n\nDefaults to unset, which lets the run take as long as it needs.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RunTimeoutSecs"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "slow-timeout": {
+          "description": "Threshold (in seconds) after which a test is flagged as slow.\n\nWhen set, tests that take longer than this duration are reported with\na `SLOW` status line and counted in the run summary. The `SLOW` line\nis gated on `--status-level=slow` (or higher); the summary always\nshows the slow count when `--final-status-level=slow` is set.\n\nDefaults to unset, which disables slow-test detection.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SlowTimeoutSecs"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "termination-grace-period": {
+          "description": "Grace period (in seconds) between graceful worker termination and\nforce-kill.\n\nKarva uses this when stopping workers because of Ctrl+C, fail-fast, or\n`run-timeout`. Set to `0` to send the force-kill signal immediately\nafter the graceful termination signal.\n\nDefaults to 10 seconds.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TerminationGracePeriodSecs"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "test-function-prefix": {
+          "description": "The prefix to use for test functions.\n\nDefaults to `test`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "timeout": {
+          "description": "Hard per-test timeout (in seconds).\n\nWhen set, every test that runs longer than this duration is killed\nand reported as a failure. Tests can override the limit individually\nwith [`@karva.tags.timeout`](https://docs.karva.dev/usage/tags/timeout/),\nwhich takes precedence over the configured default.\n\nDefaults to unset, which disables hard timeouts unless a tag is\napplied to the test.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TestTimeoutSecs"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "try-import-fixtures": {
+          "description": "When set, we will try to import functions in each test file as well as parsing the ast to find them.\n\nThis is often slower, so it is not recommended for most projects.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "TestTimeoutSecs": {
+      "description": "A per-test timeout expressed in seconds.\n\nWraps `f64` for the same reason as [`SlowTimeoutSecs`]. Tests exceeding\nthis duration are killed and reported as failures (see\n[`crate::settings::TestSettings::timeout`]).",
+      "type": "number",
+      "format": "double"
+    }
+  }
 }

--- a/karva.schema.json
+++ b/karva.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Config",
-  "description": "File-level configuration: a collection of named profiles.\n\nMirrors nextest: every option group lives inside `[profile.<name>]`. The\nimplicit `default` profile is always available; other profiles inherit\nfrom it (and can override individual fields).",
+  "description": "File-level configuration: a collection of named profiles.\n\nEvery option group lives inside `[profile.<name>]`. The implicit `default`\nprofile is always available; named profiles inherit from it and can\noverride individual fields.",
   "type": "object",
   "properties": {
     "profile": {

--- a/karva.schema.json
+++ b/karva.schema.json
@@ -9,6 +9,12 @@
       "type": "object",
       "additionalProperties": {
         "$ref": "#/definitions/Options"
+      },
+      "propertyNames": {
+        "not": {
+          "pattern": "^default-"
+        },
+        "pattern": "^[A-Za-z0-9_-]+$"
       }
     },
     "required-version": {

--- a/karva.schema.json
+++ b/karva.schema.json
@@ -136,7 +136,7 @@
             "properties": {
               "include": {
                 "default": null,
-                "description": "A list of files and directories to check.\nIncluding a file or directory will make it so that it (and its contents)\nare tested.\n\n- `tests` matches a directory named `tests`\n- `tests/test.py` matches a file named `test.py` in the `tests` directory",
+                "description": "A list of files and directories to check.\nIncluding a file or directory will make it so that it (and its contents)\nare tested.\nWhen unset, Karva checks the `tests` directory if it exists, otherwise\nit checks the project root.\n\n- `tests` matches a directory named `tests`\n- `tests/test.py` matches a file named `test.py` in the `tests` directory",
                 "items": {
                   "type": "string"
                 },

--- a/karva.schema.json
+++ b/karva.schema.json
@@ -1,5 +1,4 @@
 {
-  "$id": "https://www.schemastore.org/karva.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Config",
   "description": "File-level configuration: a collection of named profiles.\n\nEvery option group lives inside `[profile.<name>]`. The implicit `default`\nprofile is always available; named profiles inherit from it and can\noverride individual fields.",


### PR DESCRIPTION
## Summary

Generate `karva.schema.json` directly from the serde configuration types with `schemars`, matching Ruff and ty while preserving existing `OptionsMetadata` for documentation. Wire generation into `generate-all` and freshness checks. This implements the core of #1064.

## Next Steps

SchemaStore publication is deferred until Karva has broader adoption and tracked in #1091.

## Test Plan

`uvx prek run -a`; JSON Schema metaschema and valid/invalid configuration samples checked.