### PR TITLE
Give retries fresh fixture lifecycles

### DIFF
--- a/crates/karva/src/commands/test/result_report.rs
+++ b/crates/karva/src/commands/test/result_report.rs
@@ -241,6 +241,8 @@ struct AttemptReport<'a> {
     status: TestStatus,
     duration_seconds: f64,
     #[serde(skip_serializing_if = "Option::is_none")]
+    captured_output: Option<CapturedOutputReport<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     diagnostic: Option<DiagnosticReport<'a>>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     related_diagnostics: Vec<DiagnosticReport<'a>>,
@@ -262,6 +264,7 @@ impl<'a> AttemptReport<'a> {
             attempt: attempt.attempt(),
             status,
             duration_seconds: attempt.duration().as_secs_f64(),
+            captured_output: attempt.captured_output().map(CapturedOutputReport::new),
             diagnostic,
             related_diagnostics: attempt
                 .outcome()

--- a/crates/karva/tests/it/extensions/fixtures/mod.rs
+++ b/crates/karva/tests/it/extensions/fixtures/mod.rs
@@ -9,3 +9,4 @@ pub mod more_builtins;
 pub mod parametrized;
 pub mod pytest_monkeypatch;
 pub mod pytest_vendor_tests;
+pub mod retries;

--- a/crates/karva/tests/it/extensions/fixtures/retries.rs
+++ b/crates/karva/tests/it/extensions/fixtures/retries.rs
@@ -1,0 +1,210 @@
+use insta_cmd::assert_cmd_snapshot;
+
+use crate::common::TestContext;
+
+#[test]
+fn retry_recreates_function_fixtures_and_keeps_broader_scopes() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import os
+
+import karva
+
+current_auto = None
+current_used = None
+teardowns = []
+
+@karva.fixture(scope="module")
+def shared():
+    return []
+
+@karva.fixture
+def values():
+    value = []
+    yield value
+    teardowns.append("values")
+
+@karva.fixture(auto_use=True)
+def automatic():
+    global current_auto
+    current_auto = []
+    yield
+    teardowns.append("automatic")
+
+@karva.fixture
+def used():
+    global current_used
+    current_used = []
+    yield
+    teardowns.append("used")
+
+@karva.tags.use_fixtures("used")
+@karva.tags.parametrize("case", [1])
+def test_retry(values, shared, case):
+    assert values == []
+    assert current_auto == []
+    assert current_used == []
+    if os.environ["KARVA_ATTEMPT"] == "2":
+        assert teardowns == ["values", "automatic", "used"]
+        assert shared == [1]
+    values.append(case)
+    current_auto.append(case)
+    current_used.append(case)
+    shared.append(case)
+    assert os.environ["KARVA_ATTEMPT"] == "2"
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--retry=1"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+      TRY 1 FAIL [TIME] test::test_retry(values=[], shared=[], case=1)
+      TRY 2 PASS [TIME] test::test_retry(values=[], shared=[], case=1)
+    ────────────
+         Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test::test_retry(values=[], shared=[], case=1)
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn retry_recreates_async_generator_fixtures() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import os
+
+import karva
+
+teardowns = 0
+
+@karva.fixture
+async def values():
+    global teardowns
+    yield []
+    teardowns += 1
+
+async def test_retry(values):
+    assert values == []
+    if os.environ["KARVA_ATTEMPT"] == "2":
+        assert teardowns == 1
+    values.append(1)
+    assert os.environ["KARVA_ATTEMPT"] == "2"
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--retry=1"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+      TRY 1 FAIL [TIME] test::test_retry(values=[])
+      TRY 2 PASS [TIME] test::test_retry(values=[])
+    ────────────
+         Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test::test_retry(values=[])
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn retry_handles_fixture_setup_and_teardown_failures() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import os
+
+import karva
+
+setups = 0
+cleanups = []
+
+@karva.fixture
+def setup_once():
+    global setups
+    setups += 1
+    if setups == 1:
+        raise RuntimeError("setup failed")
+
+def test_setup(setup_once):
+    assert setups == 2
+
+@karva.fixture
+def remaining_cleanup():
+    yield
+    cleanups.append("remaining")
+
+@karva.fixture
+def broken_teardown(remaining_cleanup):
+    yield
+    if os.environ["KARVA_ATTEMPT"] == "1":
+        raise RuntimeError("teardown failed")
+
+def test_teardown(broken_teardown):
+    if os.environ["KARVA_ATTEMPT"] == "2":
+        assert cleanups == ["remaining"]
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--retry=1"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+     TRY 1 ERROR [TIME] test::test_setup
+      TRY 2 PASS [TIME] test::test_setup
+     TRY 1 ERROR [TIME] test::test_teardown(broken_teardown=None)
+      TRY 2 PASS [TIME] test::test_teardown(broken_teardown=None)
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed (2 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test::test_setup
+       FLAKY 2/2 [TIME] test::test_teardown(broken_teardown=None)
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn retry_recreates_cleanup_aware_builtin_fixtures() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import os
+import logging
+import warnings
+
+def test_retry(capsys, caplog, monkeypatch, recwarn):
+    if os.environ["KARVA_ATTEMPT"] == "2":
+        assert os.environ.get("RETRY_VALUE") is None
+        assert capsys.readouterr().out == ""
+        assert caplog.records == []
+        assert len(recwarn) == 0
+    monkeypatch.setenv("RETRY_VALUE", "set")
+    logging.warning("attempt log")
+    warnings.warn("attempt warning")
+    print("attempt output")
+    assert len(recwarn) == 1
+    assert capsys.readouterr().out == "attempt output\n"
+    assert os.environ["KARVA_ATTEMPT"] == "2"
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--retry=1"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+      TRY 1 FAIL [TIME] test::test_retry(capsys, caplog, monkeypatch, recwarn)
+      TRY 2 PASS [TIME] test::test_retry(capsys, caplog, monkeypatch, recwarn)
+    ────────────
+         Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test::test_retry(capsys, caplog, monkeypatch, recwarn)
+
+    ----- stderr -----
+    ");
+}

--- a/crates/karva/tests/it/result_report.rs
+++ b/crates/karva/tests/it/result_report.rs
@@ -142,6 +142,9 @@ fn writes_json_result_report() {
               "attempt": 1,
               "status": "failed",
               "duration_seconds": "[TIME]",
+              "captured_output": {
+                "stderr": "fail stderr\n"
+              },
               "diagnostic": {
                 "code": "test-failure",
                 "severity": "error",
@@ -153,6 +156,9 @@ fn writes_json_result_report() {
               "attempt": 2,
               "status": "failed",
               "duration_seconds": "[TIME]",
+              "captured_output": {
+                "stderr": "fail stderr\n"
+              },
               "diagnostic": {
                 "code": "test-failure",
                 "severity": "error",
@@ -181,6 +187,9 @@ fn writes_json_result_report() {
               "attempt": 1,
               "status": "failed",
               "duration_seconds": "[TIME]",
+              "captured_output": {
+                "stdout": "flaky attempt 1\n"
+              },
               "diagnostic": {
                 "code": "test-failure",
                 "severity": "error",
@@ -191,7 +200,10 @@ fn writes_json_result_report() {
             {
               "attempt": 2,
               "status": "passed",
-              "duration_seconds": "[TIME]"
+              "duration_seconds": "[TIME]",
+              "captured_output": {
+                "stdout": "flaky attempt 2\n"
+              }
             }
           ]
         },

--- a/crates/karva_diagnostic/src/result/case.rs
+++ b/crates/karva_diagnostic/src/result/case.rs
@@ -147,14 +147,22 @@ pub struct TestCaseAttempt<D = RenderedDiagnostic> {
     attempt: u32,
     outcome: TestCaseOutcome<D>,
     duration: Duration,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    captured_output: Option<CapturedTestOutput>,
 }
 
 impl<D> TestCaseAttempt<D> {
-    pub fn new(attempt: u32, outcome: TestCaseOutcome<D>, duration: Duration) -> Self {
+    pub fn new(
+        attempt: u32,
+        outcome: TestCaseOutcome<D>,
+        duration: Duration,
+        captured_output: Option<CapturedTestOutput>,
+    ) -> Self {
         Self {
             attempt,
             outcome,
             duration,
+            captured_output,
         }
     }
 
@@ -170,6 +178,10 @@ impl<D> TestCaseAttempt<D> {
         self.duration
     }
 
+    pub fn captured_output(&self) -> Option<&CapturedTestOutput> {
+        self.captured_output.as_ref()
+    }
+
     fn try_map_diagnostic<T, E>(
         self,
         mut map: impl FnMut(&D) -> Result<T, E>,
@@ -178,6 +190,7 @@ impl<D> TestCaseAttempt<D> {
             attempt: self.attempt,
             outcome: self.outcome.try_map_diagnostic(&mut map)?,
             duration: self.duration,
+            captured_output: self.captured_output,
         })
     }
 }

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/attempt.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/attempt.rs
@@ -2,7 +2,7 @@
 
 use std::time::{Duration, Instant};
 
-use karva_diagnostic::{TestExecutionAttempt, TestExecutionOutcome};
+use karva_diagnostic::{CapturedTestOutput, TestExecutionAttempt, TestExecutionOutcome};
 use pyo3::prelude::*;
 
 use crate::diagnostic::fixture_failure_diagnostic;
@@ -10,7 +10,8 @@ use crate::extensions::fixtures::FixtureScope;
 use crate::extensions::functions::snapshot::set_snapshot_context;
 use crate::utils::{run_coroutine, run_test_with_timeout};
 
-use super::{VariantRunner, VariantSettings};
+use super::{VariantRunner, VariantSettings, finish_output_capture};
+use crate::output_capture::PythonOutputCapture;
 use crate::runner::package_runner::fixture::PreparedFixtures;
 use crate::runner::package_runner::outcome::{
     OutcomeContext, PhaseDurations, apply_fail_slow_budget, attach_finalizer_diagnostics,
@@ -36,6 +37,7 @@ impl VariantRunner<'_, '_, '_, '_, '_> {
                     test_finalizers,
                 },
             setup_duration,
+            output_capture,
         } = prepared;
 
         let (outcome, duration, retryable) = if fixture_call_errors.is_empty() {
@@ -113,6 +115,7 @@ impl VariantRunner<'_, '_, '_, '_, '_> {
                 self.package_runner
                     .clean_up_scope(self.py, FixtureScope::Function),
             );
+            let teardown_failed = !finalizer_diagnostics.is_empty();
             let phases = PhaseDurations {
                 setup: setup_duration,
                 call: call_duration,
@@ -134,7 +137,7 @@ impl VariantRunner<'_, '_, '_, '_, '_> {
             (
                 outcome,
                 duration,
-                retryable_result || (budget_exceeded && !skipped),
+                retryable_result || teardown_failed || (budget_exceeded && !skipped),
             )
         } else {
             let mut diagnostics = fixture_call_errors
@@ -158,9 +161,6 @@ impl VariantRunner<'_, '_, '_, '_, '_> {
                 teardown: teardown_start.elapsed(),
             };
             let duration = phases.total();
-            let retryable = settings
-                .fail_slow_budget
-                .is_some_and(|budget| duration > budget);
             let diagnostic = diagnostics.remove(0);
             let outcome = TestExecutionOutcome::error_with_related(diagnostic, diagnostics);
             let outcome = apply_fail_slow_budget(
@@ -171,14 +171,17 @@ impl VariantRunner<'_, '_, '_, '_, '_> {
                 &self.test.source_file,
                 &self.test.stmt_function_def,
             );
-            (outcome, duration, retryable)
+            (outcome, duration, true)
         };
+
+        let captured_output = finish_output_capture(self.py, output_capture);
 
         AttemptResult {
             lifecycle: TestLifecycleAttempt {
                 attempt: attempt_number,
                 outcome,
                 duration,
+                captured_output,
             },
             retryable,
         }
@@ -191,6 +194,8 @@ pub(super) struct PreparedTestAttempt {
     pub(super) fixtures: PreparedFixtures,
     /// Duration of fixture and parameter preparation.
     pub(super) setup_duration: Duration,
+    /// Python stdout and stderr capture spanning setup, call, and teardown.
+    pub(super) output_capture: Option<PythonOutputCapture>,
 }
 
 /// Completed call lifecycle plus retry decision.
@@ -209,11 +214,18 @@ pub(super) struct TestLifecycleAttempt {
     pub(super) outcome: TestExecutionOutcome,
     /// Full setup, call, and teardown duration.
     pub(super) duration: Duration,
+    /// Output captured only during this attempt.
+    pub(super) captured_output: Option<CapturedTestOutput>,
 }
 
 impl TestLifecycleAttempt {
     /// Converts internal lifecycle state to diagnostic reporting state.
     pub(super) fn into_execution_attempt(self) -> TestExecutionAttempt {
-        TestExecutionAttempt::new(self.attempt, self.outcome, self.duration)
+        TestExecutionAttempt::new(
+            self.attempt,
+            self.outcome,
+            self.duration,
+            self.captured_output,
+        )
     }
 }

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
@@ -104,10 +104,9 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             return result;
         }
 
-        let output_capture = self.start_output_capture();
         let retry_params = self.params.clone();
         let first_params = std::mem::take(&mut self.params);
-        let first_attempt = self.prepare_attempt(first_params);
+        let first_attempt = self.prepare_attempt(first_params, self.start_output_capture());
         let settings = self.settings(&first_attempt.fixtures.function_arguments);
         let function = self.test.py_function.clone_ref(self.py);
         let test_name_env_result =
@@ -153,11 +152,15 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             }
         };
 
-        self.finish(&settings, output_capture, prior_attempts, final_attempt)
+        self.finish(&settings, prior_attempts, final_attempt)
     }
 
     /// Prepares fixture values and records setup duration for one attempt.
-    fn prepare_attempt(&self, params: HashMap<String, Arc<Py<PyAny>>>) -> PreparedTestAttempt {
+    fn prepare_attempt(
+        &self,
+        params: HashMap<String, Arc<Py<PyAny>>>,
+        output_capture: Option<PythonOutputCapture>,
+    ) -> PreparedTestAttempt {
         let setup_start = Instant::now();
         let fixtures = self.package_runner.prepare_test_fixtures(
             self.py,
@@ -169,6 +172,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
         PreparedTestAttempt {
             fixtures,
             setup_duration: setup_start.elapsed(),
+            output_capture,
         }
     }
 
@@ -179,7 +183,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
         settings: &VariantSettings,
     ) -> PreparedTestAttempt {
         self.set_coverage_context(None);
-        let prepared = self.prepare_attempt(params);
+        let prepared = self.prepare_attempt(params, self.start_output_capture());
         self.set_coverage_context(Some(&settings.qualified_name));
         prepared
     }
@@ -290,12 +294,16 @@ impl<'runner, 'context, 'settings, 'test, 'py>
     fn finish(
         &self,
         settings: &VariantSettings,
-        output_capture: Option<PythonOutputCapture>,
         prior_attempts: Vec<TestLifecycleAttempt>,
         final_attempt: TestLifecycleAttempt,
     ) -> bool {
         self.set_coverage_context(None);
-        let captured_output = finish_output_capture(self.py, output_capture);
+        let captured_output = combine_captured_output(
+            prior_attempts
+                .iter()
+                .chain(std::iter::once(&final_attempt))
+                .filter_map(|attempt| attempt.captured_output.as_ref()),
+        );
         let total_duration = prior_attempts
             .iter()
             .map(|attempt| attempt.duration)
@@ -463,4 +471,18 @@ fn finish_output_capture(
             None
         }
     }
+}
+
+/// Combines attempt output for existing terminal and `JUnit` consumers.
+fn combine_captured_output<'a>(
+    outputs: impl Iterator<Item = &'a CapturedTestOutput>,
+) -> Option<CapturedTestOutput> {
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    for output in outputs {
+        stdout.push_str(output.stdout());
+        stderr.push_str(output.stderr());
+    }
+    let output = CapturedTestOutput::new(stdout, stderr);
+    (!output.is_empty()).then_some(output)
 }


### PR DESCRIPTION
## Summary

Recreate function-scoped fixtures for every retry, retry setup and teardown failures, and retain captured output per attempt while preserving broader fixture scopes. Closes #980.

## Test Plan

`just test`, strict workspace Clippy, and `uvx prek run -a`.