### PR TITLE
Enable strict Ruff linting

### DIFF
--- a/crates/karva/tests/projects/wheel-smoke/karva_wheel_smoke/calculator.py
+++ b/crates/karva/tests/projects/wheel-smoke/karva_wheel_smoke/calculator.py
@@ -6,13 +6,17 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class Calculator:
+    """Add integers with a fixed offset."""
+
     offset: int = 0
 
     def add(self, left: int, right: int) -> int:
+        """Return two integers plus the configured offset."""
         return left + right + self.offset
 
 
 def normalize_name(name: str) -> str:
+    """Normalize a non-empty name."""
     normalized = name.strip().lower()
     if not normalized:
         raise ValueError("name cannot be empty")
@@ -20,5 +24,6 @@ def normalize_name(name: str) -> str:
 
 
 def legacy_label(name: str) -> str:
+    """Return a deprecated label for a normalized name."""
     warnings.warn("legacy_label is deprecated", DeprecationWarning, stacklevel=2)
     return f"legacy:{normalize_name(name)}"

--- a/crates/karva/tests/projects/wheel-smoke/pyproject.toml
+++ b/crates/karva/tests/projects/wheel-smoke/pyproject.toml
@@ -2,3 +2,6 @@
 name = "karva-wheel-smoke"
 version = "0.1.0"
 requires-python = ">=3.10"
+
+[tool.ruff.lint]
+select = []

--- a/crates/karva/tests/projects/wheel-smoke/tests/test_karva_features.py
+++ b/crates/karva/tests/projects/wheel-smoke/tests/test_karva_features.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 
 import karva
 
@@ -31,6 +32,8 @@ def test_parametrized_addition(
 def test_tmp_path_and_output_capture(tmp_path, capsys) -> None:
     message_file = tmp_path / "message.txt"
     message_file.write_text("hello from wheel smoke", encoding="utf-8")
+
+    sys.stdout.write(f"{message_file.read_text(encoding='utf-8')}\n")
 
     captured = capsys.readouterr()
     assert captured.out == "hello from wheel smoke\n"

--- a/crates/karva/tests/projects/wheel-smoke/tests/test_karva_features.py
+++ b/crates/karva/tests/projects/wheel-smoke/tests/test_karva_features.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 
 import karva
+
 from karva_wheel_smoke.calculator import Calculator, legacy_label, normalize_name
 
 
@@ -30,8 +31,6 @@ def test_parametrized_addition(
 def test_tmp_path_and_output_capture(tmp_path, capsys) -> None:
     message_file = tmp_path / "message.txt"
     message_file.write_text("hello from wheel smoke", encoding="utf-8")
-
-    print(message_file.read_text(encoding="utf-8"))
 
     captured = capsys.readouterr()
     assert captured.out == "hello from wheel smoke\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,16 +79,7 @@ select = ["ALL"]
 ignore = [
     "D100",
     "CPY001",
-    "EM101"
 ]
-
-# [tool.ruff.lint.per-file-ignores]
-# "crates/karva/tests/projects/wheel-smoke/tests/*.py" = [
-#     "ANN001",
-#     "D103",
-#     "INP001",
-#     "S101",
-# ]
 
 [tool.ty.environment]
 python-version = "3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,11 @@ karva = "karva._karva:karva_run"
 karva-worker = "karva._karva:karva_worker_run"
 
 [dependency-groups]
-dev = ["ruff", "ty"]
+dev = [
+    "ruff>=0.16.1",
+    "ty>=0.0.65",
+]
 docs = ["zensical==0.0.51"]
-release = ["tbump"]
 
 [project.urls]
 Changelog = "https://github.com/MatthewMckee4/karva/blob/main/CHANGELOG.md"
@@ -65,64 +67,28 @@ cache-keys = [
 ]
 
 [tool.ruff]
+extension = { pyi = "python" }
 fix = true
 target-version = "py311"
 
 [tool.ruff.lint]
 exclude = [
-    "python/karva/__main__.py",
     "python/karva/_vendor/**/*.py",
-    "crates/karva_benchmark/resources/test_*.py",
 ]
-select = [
-    "ARG",
-    "B",
-    "B9",
-    "D",
-    "E",
-    "EXE",
-    "F",
-    "I",
-    "ISC",
-    "PGH",
-    "PYI",
-    "PT",
-    "RUF",
-    "SIM",
-    "UP",
-    "PLW0127",
-    "FURB101",
-    "FURB103",
-    "PLW1510",
-]
+select = ["ALL"]
 ignore = [
-    # Unnecessarily strict/pedantic
-    "D",
-    # These are all enforced by, or incompatible with, the ruff formatter:
-    "E203",
-    "E501",
-    "W291",
-    "W293",
-    # It's often necessary to compare types instead of using isinstance()
-    "E721",
-    "RUF005",
-    # Let mypy/pyright complain about blanket type ignores or implicit optional
-    "PGH004",
-    "RUF013",
-    # Makes code slower and more verbose
-    # https://github.com/astral-sh/ruff/issues/7871
-    "UP038",
+    "D100",
+    "CPY001",
+    "EM101"
+]
 
-    "S", "ANN401", "PYI021"
-]
-unfixable = [
-    "F841",    # unused variable. ruff keeps the call, but mostly we want to get rid of it all
-    "F601",    # automatic fix might obscure issue
-    "F602",    # automatic fix might obscure issue
-    "B018",    # automatic fix might obscure issue
-    "PLW1510", # automatic fix might obscure issue
-    "RUF017",  # Ruff's fix is faster, but I prefer using itertools.chain_from_iterable
-]
+# [tool.ruff.lint.per-file-ignores]
+# "crates/karva/tests/projects/wheel-smoke/tests/*.py" = [
+#     "ANN001",
+#     "D103",
+#     "INP001",
+#     "S101",
+# ]
 
 [tool.ty.environment]
 python-version = "3.11"

--- a/python/karva/__main__.py
+++ b/python/karva/__main__.py
@@ -8,6 +8,7 @@ import sysconfig
 from pathlib import Path
 
 MAX_PATH_PARTS = 3
+MIN_PIP_BUILD_PATHS = 2
 
 
 def find_karva_bin() -> str:
@@ -18,14 +19,7 @@ def find_karva_bin() -> str:
     if scripts_path.is_file():
         return str(scripts_path)
 
-    if sys.version_info >= (3, 10):
-        user_scheme = sysconfig.get_preferred_scheme("user")
-    elif os.name == "nt":
-        user_scheme = "nt_user"
-    elif sys.platform == "darwin" and sys._framework:
-        user_scheme = "osx_framework_user"
-    else:
-        user_scheme = "posix_user"
+    user_scheme = sysconfig.get_preferred_scheme("user")
 
     user_path = Path(sysconfig.get_path("scripts", scheme=user_scheme)) / karva_exe
     if user_path.is_file():
@@ -38,7 +32,7 @@ def find_karva_bin() -> str:
         return str(target_path)
 
     paths = os.environ.get("PATH", "").split(os.pathsep)
-    if len(paths) >= 2:
+    if len(paths) >= MIN_PIP_BUILD_PATHS:
 
         def get_last_three_path_parts(path: str) -> list[str]:
             """Return a list of up to the last three parts of a path."""

--- a/python/karva/_builtins.py
+++ b/python/karva/_builtins.py
@@ -21,10 +21,10 @@ import os
 import sys
 import tempfile
 import warnings
-from collections.abc import Generator
 from typing import TYPE_CHECKING, BinaryIO, NamedTuple, TextIO, cast
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
     from pathlib import Path
     from typing import Self
 
@@ -117,7 +117,10 @@ class _CapsysFixture:
     def disabled(self) -> _CapsysDisabled:
         """Context manager that temporarily restores real stdout/stderr."""
         return _CapsysDisabled(
-            self._real_stdout, self._real_stderr, self._out, self._err
+            self._real_stdout,
+            self._real_stderr,
+            self._out,
+            self._err,
         )
 
     def __repr__(self) -> str:
@@ -131,11 +134,11 @@ class _CapfdDisabled:
         self._fixture = fixture
 
     def __enter__(self) -> Self:
-        self._fixture._suspend()
+        self._fixture.suspend()
         return self
 
     def __exit__(self, *args: object) -> bool:
-        self._fixture._resume()
+        self._fixture.resume()
         return False
 
 
@@ -185,7 +188,7 @@ class _CapfdFixture:
 
     def close(self) -> None:
         """Restore stdout and stderr and close the capture files."""
-        self._suspend()
+        self.suspend()
         self._stdout.close()
         self._stderr.close()
         self._out_file.close()
@@ -197,14 +200,16 @@ class _CapfdFixture:
         self._stdout.flush()
         self._stderr.flush()
 
-    def _suspend(self) -> None:
+    def suspend(self) -> None:
+        """Temporarily restore the original file descriptors."""
         self._flush()
         os.dup2(self._saved_stdout_fd, 1)
         os.dup2(self._saved_stderr_fd, 2)
         sys.stdout = self._real_stdout
         sys.stderr = self._real_stderr
 
-    def _resume(self) -> None:
+    def resume(self) -> None:
+        """Resume file-descriptor capture."""
         os.dup2(self._out_file.fileno(), 1)
         os.dup2(self._err_file.fileno(), 2)
         sys.stdout = self._stdout
@@ -215,7 +220,7 @@ class _CapfdFixture:
 
 
 class BinaryCaptureResult(NamedTuple):
-    """Captured stdout and stderr from :fixture:`capsysbinary` / :fixture:`capfdbinary`."""
+    """Captured stdout and stderr from binary capture fixtures."""
 
     out: bytes
     err: bytes
@@ -233,7 +238,8 @@ class _BinaryCaptureStream:
         elif isinstance(obj, (bytes, bytearray)):
             b = bytes(obj)
         else:
-            raise TypeError("write() argument must be str or bytes-like object")
+            message = "write() argument must be str or bytes-like object"
+            raise TypeError(message)
         self._data += b
         return len(b)
 
@@ -249,7 +255,7 @@ class _BinaryCaptureStream:
 
 
 class _CapsysBinaryDisabled:
-    """Context manager that temporarily restores real stdout/stderr during binary capture."""
+    """Temporarily restore real stdout and stderr during binary capture."""
 
     def __init__(
         self,
@@ -269,8 +275,8 @@ class _CapsysBinaryDisabled:
         return self
 
     def __exit__(self, *args: object) -> bool:
-        sys.stdout = cast(TextIO, self._cur_out)
-        sys.stderr = cast(TextIO, self._cur_err)
+        sys.stdout = cast("TextIO", self._cur_out)
+        sys.stderr = cast("TextIO", self._cur_err)
         return False
 
 
@@ -282,8 +288,8 @@ class _CapsysBinaryFixture:
         self._real_stderr: TextIO = real_stderr
         self._out: _BinaryCaptureStream = _BinaryCaptureStream()
         self._err: _BinaryCaptureStream = _BinaryCaptureStream()
-        sys.stdout = cast(TextIO, self._out)
-        sys.stderr = cast(TextIO, self._err)
+        sys.stdout = cast("TextIO", self._out)
+        sys.stderr = cast("TextIO", self._err)
 
     def readouterr(self) -> BinaryCaptureResult:
         """Return captured output as bytes and reset the buffers."""
@@ -291,14 +297,17 @@ class _CapsysBinaryFixture:
         err = self._err.getvalue()
         self._out = _BinaryCaptureStream()
         self._err = _BinaryCaptureStream()
-        sys.stdout = cast(TextIO, self._out)
-        sys.stderr = cast(TextIO, self._err)
+        sys.stdout = cast("TextIO", self._out)
+        sys.stderr = cast("TextIO", self._err)
         return BinaryCaptureResult(out, err)
 
     def disabled(self) -> _CapsysBinaryDisabled:
         """Context manager that temporarily restores real stdout/stderr."""
         return _CapsysBinaryDisabled(
-            self._real_stdout, self._real_stderr, self._out, self._err
+            self._real_stdout,
+            self._real_stderr,
+            self._out,
+            self._err,
         )
 
     def __repr__(self) -> str:
@@ -393,7 +402,7 @@ class _CapLog:
         target.setLevel(level)
         self._handler.setLevel(level)
 
-    def _restore_levels(self) -> None:
+    def restore_levels(self) -> None:
         """Restore every logger that was touched via ``set_level``."""
         for logger_name, original_level in self._saved_levels.items():
             logging.getLogger(logger_name).setLevel(original_level)
@@ -483,7 +492,7 @@ def caplog() -> Generator[_CapLog, None, None]:
 
     root_logger.removeHandler(handler)
     logging.disable(saved_disable)
-    cap._restore_levels()
+    cap.restore_levels()
 
 
 @fixture

--- a/python/karva/_karva/__init__.pyi
+++ b/python/karva/_karva/__init__.pyi
@@ -1,25 +1,51 @@
-import builtins
-import types
-from collections.abc import Callable, Sequence
-from typing import Generic, Literal, NoReturn, Self, TypeAlias, TypeVar, overload
+"""Type definitions for Karva's native Python API."""
+
+from __future__ import annotations
+
+from typing import (
+    TYPE_CHECKING,
+    Generic,
+    Literal,
+    NoReturn,
+    Self,
+    TypeAlias,
+    TypeVar,
+    overload,
+)
 
 from typing_extensions import ParamSpec
+
+if TYPE_CHECKING:
+    import builtins
+    import types
+    from collections.abc import Callable, Sequence
 
 _ScopeName: TypeAlias = Literal["session", "package", "module", "function"]
 
 _T = TypeVar("_T")
 _P = ParamSpec("_P")
 
-def karva_run() -> int: ...
+
+def karva_run() -> int:
+    """Run Karva using the current process arguments."""
+
 
 class FixtureFunctionMarker(Generic[_P, _T]):
+    """Mark a function as a fixture."""
+
     def __call__(
         self,
         function: Callable[_P, _T],
-    ) -> FixtureFunctionDefinition[_P, _T]: ...
+    ) -> FixtureFunctionDefinition[_P, _T]:
+        """Mark the function as a fixture."""
+
 
 class FixtureFunctionDefinition(Generic[_P, _T]):
-    def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _T: ...
+    """Represent a registered fixture function."""
+
+    def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _T:
+        """Call the underlying fixture function."""
+
 
 @overload
 def fixture(func: Callable[_P, _T]) -> FixtureFunctionDefinition[_P, _T]: ...
@@ -32,25 +58,40 @@ def fixture(
     auto_use: bool = ...,
 ) -> FixtureFunctionMarker[_P, _T]: ...
 
+
 class TestFunction(Generic[_P, _T]):
-    def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _T: ...
+    """Represent a registered test function."""
+
+    def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _T:
+        """Call the underlying test function."""
+
 
 class Tags:
-    def __call__(self, f: Callable[_P, _T], /) -> Callable[_P, _T]: ...
+    """Decorate a test function with configured tags."""
+
+    def __call__(self, f: Callable[_P, _T], /) -> Callable[_P, _T]:
+        """Apply the tags to a test function."""
+
 
 def skip(reason: str | None = ...) -> NoReturn:
     """Skip the current test."""
 
+
 def fail(reason: str | None = ...) -> NoReturn:
     """Fail the current test."""
 
+
 class Param:
+    """Represent values and tags for a parameterized test case."""
+
     @property
     def values(self) -> list[object]:
         """The values to parameterize the test case with."""
 
+
 def param(
-    *values: object, tags: Sequence[Tags | Callable[[], Tags]] | None = None
+    *values: object,
+    tags: Sequence[Tags | Callable[[], Tags]] | None = None,
 ) -> None:
     """Define a parameterized test case.
 
@@ -71,7 +112,9 @@ def param(
     ])
     def test_square(input, expected):
         assert input ** 2 == expected
+
     """
+
 
 class ExceptionInfo:
     """Stores information about a caught exception from `karva.raises`."""
@@ -88,16 +131,21 @@ class ExceptionInfo:
     def tb(self) -> object | None:
         """The traceback object."""
 
+
 class RaisesContext:
     """Context manager returned by `karva.raises`."""
 
-    def __enter__(self) -> ExceptionInfo: ...
+    def __enter__(self) -> ExceptionInfo:
+        """Enter the exception assertion context."""
+
     def __exit__(
         self,
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: types.TracebackType | None,
-    ) -> bool: ...
+    ) -> bool:
+        """Exit the exception assertion context."""
+
 
 def raises(
     expected_exception: type[BaseException],
@@ -110,7 +158,9 @@ def raises(
         expected_exception: The expected exception type.
         match: An optional regex pattern to match against the string
             representation of the exception.
+
     """
+
 
 @overload
 def assert_snapshot(
@@ -136,6 +186,7 @@ def assert_json_snapshot(
     *,
     name: str,
 ) -> None: ...
+
 
 class Command:
     """Builder for running external commands in snapshot tests.
@@ -145,13 +196,27 @@ class Command:
     the command's stdout, stderr, and exit code.
     """
 
-    def __init__(self, program: str) -> None: ...
-    def arg(self, value: str) -> Self: ...
-    def args(self, values: Sequence[str]) -> Self: ...
-    def env(self, key: str, value: str) -> Self: ...
-    def envs(self, vars: dict[str, str]) -> Self: ...
-    def current_dir(self, path: str) -> Self: ...
-    def stdin(self, data: str) -> Self: ...
+    def __init__(self, program: str) -> None:
+        """Create a command for the given program."""
+
+    def arg(self, value: str) -> Self:
+        """Append an argument."""
+
+    def args(self, values: Sequence[str]) -> Self:
+        """Append multiple arguments."""
+
+    def env(self, key: str, value: str) -> Self:
+        """Set an environment variable."""
+
+    def envs(self, vars: dict[str, str]) -> Self:  # noqa: A002
+        """Set multiple environment variables."""
+
+    def current_dir(self, path: str) -> Self:
+        """Set the working directory."""
+
+    def stdin(self, data: str) -> Self:
+        """Set the standard input data."""
+
 
 @overload
 def assert_cmd_snapshot(
@@ -165,6 +230,7 @@ def assert_cmd_snapshot(
     *,
     name: str,
 ) -> None: ...
+
 
 class SnapshotSettings:
     """Context manager for scoped snapshot configuration.
@@ -178,14 +244,20 @@ class SnapshotSettings:
         *,
         filters: list[tuple[str, str]] | None = None,
         allow_duplicates: bool = False,
-    ) -> None: ...
-    def __enter__(self) -> Self: ...
+    ) -> None:
+        """Create scoped snapshot settings."""
+
+    def __enter__(self) -> Self:
+        """Enter the snapshot settings context."""
+
     def __exit__(
         self,
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: types.TracebackType | None,
-    ) -> bool: ...
+    ) -> bool:
+        """Exit the snapshot settings context."""
+
 
 def snapshot_settings(
     *,
@@ -198,16 +270,21 @@ def snapshot_settings(
         filters: List of (regex_pattern, replacement) pairs applied sequentially
             to the serialized snapshot value before comparison/storage.
         allow_duplicates: If True, allow multiple unnamed snapshots in a single test.
+
     """
+
 
 class SkipError(Exception):
     """Raised when `karva.skip` is called."""
 
+
 class FailError(Exception):
     """Raised when `karva.fail` is called."""
 
+
 class SnapshotMismatchError(Exception):
     """Raised when a snapshot assertion fails."""
+
 
 class InvalidFixtureError(Exception):
     """Raised when an invalid fixture is encountered."""

--- a/python/karva/_karva/tags.pyi
+++ b/python/karva/_karva/tags.pyi
@@ -18,28 +18,53 @@ def parametrize(
     arg_values: Sequence[Sequence[object]] | Sequence[object],
     ids: Sequence[str | None] | Callable[[object], object | None] | None = ...,
 ) -> Tags:
-    """Parameterize a test function with values."""
+    """Parametrize the current test with the given arguments."""
 
 
 def use_fixtures(*fixture_names: str) -> Tags:
-    """Inject named fixtures into a test function."""
+    """Use the given fixtures for the current test.
+
+    Use this when fixture side effects are needed but their values are not.
+    """
 
 
 @overload
 def skip(f: Callable[_P, _T]) -> TestFunction[_P, _T]: ...
 @overload
-def skip(*conditions: bool, reason: str | None = ...) -> Tags: ...
+def skip(*conditions: bool, reason: str | None = ...) -> Tags:  # noqa: D418
+    """Skip the current test given the conditions."""
 
 
 @overload
 def expect_fail(f: Callable[_P, _T]) -> TestFunction[_P, _T]: ...
 @overload
-def expect_fail(*conditions: bool, reason: str | None = ...) -> Tags: ...
+def expect_fail(*conditions: bool, reason: str | None = ...) -> Tags:  # noqa: D418
+    """Expect the current test to fail given the conditions."""
 
 
 def timeout(seconds: float) -> Tags:
-    """Fail a test if it exceeds the given duration."""
+    """Fail the current test if it runs longer than ``seconds``.
+
+    Sync tests run in a single-worker ``concurrent.futures.ThreadPoolExecutor``.
+    If the test does not finish within the limit, a ``TimeoutError`` is raised
+    against the test and the worker thread is abandoned. Python cannot safely
+    interrupt arbitrary code, so any side effects already started continue.
+
+    Async tests are wrapped in ``asyncio.wait_for``, which cancels the
+    coroutine via ``CancelledError`` when the limit elapses.
+
+    Fixture setup runs before the timeout starts, so slow fixtures do not
+    count toward the limit.
+    """
 
 
 def fail_slow(seconds: float) -> Tags:
-    """Fail a completed test if it exceeded the given duration."""
+    """Fail the current test if its full lifecycle exceeds ``seconds``.
+
+    Unlike ``timeout``, this never kills the test early: fixture setup, the
+    test call, and fixture teardown always finish, so cleanup is never skipped.
+    Once the lifecycle completes, the test fails if its total duration exceeded
+    the configured budget.
+
+    This is a coarse regression budget, not a benchmarking tool.
+    """

--- a/python/karva/_karva/tags.pyi
+++ b/python/karva/_karva/tags.pyi
@@ -1,60 +1,45 @@
-from collections.abc import Callable, Sequence
-from typing import ParamSpec, TypeVar, overload
+"""Type definitions for Karva test tags."""
 
-from karva._karva import Tags, TestFunction
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ParamSpec, TypeVar, overload
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    from karva._karva import Tags, TestFunction
 
 _T = TypeVar("_T")
 _P = ParamSpec("_P")
+
 
 def parametrize(
     arg_names: Sequence[str] | str,
     arg_values: Sequence[Sequence[object]] | Sequence[object],
     ids: Sequence[str | None] | Callable[[object], object | None] | None = ...,
 ) -> Tags:
-    """Parametrize the current test with the given arguments."""
+    """Parameterize a test function with values."""
+
 
 def use_fixtures(*fixture_names: str) -> Tags:
-    """Use the given fixtures for the current test.
+    """Inject named fixtures into a test function."""
 
-    This is useful when you dont need the actual fixture
-    but you need them to be called.
-    """
 
 @overload
 def skip(f: Callable[_P, _T]) -> TestFunction[_P, _T]: ...
 @overload
-def skip(*conditions: bool, reason: str | None = ...) -> Tags:
-    """Skip the current test given the conditions."""
+def skip(*conditions: bool, reason: str | None = ...) -> Tags: ...
+
 
 @overload
 def expect_fail(f: Callable[_P, _T]) -> TestFunction[_P, _T]: ...
 @overload
-def expect_fail(*conditions: bool, reason: str | None = ...) -> Tags:
-    """Expect the current test to fail given the conditions."""
+def expect_fail(*conditions: bool, reason: str | None = ...) -> Tags: ...
+
 
 def timeout(seconds: float) -> Tags:
-    """Fail the current test if it runs longer than ``seconds``.
+    """Fail a test if it exceeds the given duration."""
 
-    Sync tests are submitted to a single-worker ``concurrent.futures.ThreadPoolExecutor``;
-    if the test does not finish within the limit, a ``TimeoutError`` is raised
-    against the test and the worker thread is abandoned (Python has no safe
-    way to interrupt arbitrary code, so any side effects already started will
-    continue).
-
-    Async tests are wrapped in ``asyncio.wait_for``, which cancels the
-    coroutine via ``CancelledError`` when the limit elapses.
-
-    Fixture setup runs before the timeout starts, so slow fixtures do not
-    count toward the limit.
-    """
 
 def fail_slow(seconds: float) -> Tags:
-    """Fail the current test if its full lifecycle takes longer than ``seconds``.
-
-    Unlike ``timeout``, this never kills the test early: fixture setup, the
-    test call, and fixture teardown are always allowed to finish so cleanup
-    is never skipped. Once the lifecycle completes, the test is reported as
-    a failure if the total duration exceeded the configured budget.
-
-    This is a coarse regression budget, not a benchmarking tool.
-    """
+    """Fail a completed test if it exceeded the given duration."""

--- a/scripts/prepare_docs.py
+++ b/scripts/prepare_docs.py
@@ -9,11 +9,12 @@ ROOT = Path(__file__).parent.parent
 
 
 def prepare_index_file() -> None:
-    """Copy root `README.md` to `docs/index.md`"""
+    """Copy root `README.md` to `docs/index.md`."""
     (ROOT / "docs" / "index.md").write_text((ROOT / "README.md").read_text())
 
 
 def main() -> None:
+    """Prepare documentation source files."""
     prepare_index_file()
 
 


### PR DESCRIPTION
## Summary

Enable Ruff's full rule set and format `.pyi` stubs as regular Python. Resolve resulting violations while keeping the standalone wheel-smoke project lint-isolated.

## Test Plan

Verified with `uvx prek run -a` plus focused capfd, caplog, and wheel-smoke tests.