### PR TITLE
Format and document Python stubs

### DIFF
--- a/crates/karva/tests/projects/wheel-smoke/karva_wheel_smoke/calculator.py
+++ b/crates/karva/tests/projects/wheel-smoke/karva_wheel_smoke/calculator.py
@@ -6,13 +6,17 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class Calculator:
+    """Add integers with a fixed offset."""
+
     offset: int = 0
 
     def add(self, left: int, right: int) -> int:
+        """Return two integers plus the configured offset."""
         return left + right + self.offset
 
 
 def normalize_name(name: str) -> str:
+    """Normalize a non-empty name."""
     normalized = name.strip().lower()
     if not normalized:
         raise ValueError("name cannot be empty")
@@ -20,5 +24,6 @@ def normalize_name(name: str) -> str:
 
 
 def legacy_label(name: str) -> str:
+    """Return a deprecated label for a normalized name."""
     warnings.warn("legacy_label is deprecated", DeprecationWarning, stacklevel=2)
     return f"legacy:{normalize_name(name)}"

--- a/crates/karva/tests/projects/wheel-smoke/tests/test_karva_features.py
+++ b/crates/karva/tests/projects/wheel-smoke/tests/test_karva_features.py
@@ -8,6 +8,7 @@ from karva_wheel_smoke.calculator import Calculator, legacy_label, normalize_nam
 
 @karva.fixture
 def calculator() -> Calculator:
+    """Provide a calculator with a fixed offset."""
     return Calculator(offset=2)
 
 
@@ -24,10 +25,12 @@ def test_parametrized_addition(
     right: int,
     expected: int,
 ) -> None:
+    """Verify parametrized fixture inputs."""
     assert calculator.add(left, right) == expected
 
 
 def test_tmp_path_and_output_capture(tmp_path, capsys) -> None:
+    """Verify temporary paths and output capture."""
     message_file = tmp_path / "message.txt"
     message_file.write_text("hello from wheel smoke", encoding="utf-8")
 
@@ -39,6 +42,7 @@ def test_tmp_path_and_output_capture(tmp_path, capsys) -> None:
 
 
 def test_warning_capture(recwarn) -> None:
+    """Verify warning capture."""
     assert legacy_label("  Example  ") == "legacy:example"
 
     warning = recwarn.pop(DeprecationWarning)
@@ -46,21 +50,25 @@ def test_warning_capture(recwarn) -> None:
 
 
 def test_monkeypatch(monkeypatch) -> None:
+    """Verify environment patching."""
     monkeypatch.setenv("KARVA_WHEEL_SMOKE", "installed")
 
     assert os.environ["KARVA_WHEEL_SMOKE"] == "installed"
 
 
 def test_raises_helper() -> None:
+    """Verify exception assertions."""
     with karva.raises(ValueError, match="empty"):
         normalize_name("  ")
 
 
 @karva.tags.expect_fail(reason="exercise expected failure handling")
 def test_expected_failure_tag() -> None:
+    """Verify expected-failure handling."""
     raise AssertionError("expected failure")
 
 
 @karva.tags.skip(reason="exercise skip handling")
 def test_skip_tag() -> None:
+    """Verify skip handling."""
     raise AssertionError("skip tag did not skip this test")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,8 +99,7 @@ select = [
     "PLW1510",
 ]
 ignore = [
-    # Unnecessarily strict/pedantic
-    "D",
+    "D100",
     # These are all enforced by, or incompatible with, the ruff formatter:
     "E203",
     "E501",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,10 @@ karva = "karva._karva:karva_run"
 karva-worker = "karva._karva:karva_worker_run"
 
 [dependency-groups]
-dev = ["ruff", "ty"]
+dev = [
+    "ruff>=0.16.1",
+    "ty>=0.0.65",
+]
 docs = ["zensical==0.0.51"]
 release = ["tbump"]
 
@@ -65,6 +68,7 @@ cache-keys = [
 ]
 
 [tool.ruff]
+extension = { pyi = "python" }
 fix = true
 target-version = "py311"
 
@@ -72,7 +76,6 @@ target-version = "py311"
 exclude = [
     "python/karva/__main__.py",
     "python/karva/_vendor/**/*.py",
-    "crates/karva_benchmark/resources/test_*.py",
 ]
 select = [
     "ARG",

--- a/python/karva/_karva/__init__.pyi
+++ b/python/karva/_karva/__init__.pyi
@@ -10,7 +10,9 @@ _ScopeName: TypeAlias = Literal["session", "package", "module", "function"]
 _T = TypeVar("_T")
 _P = ParamSpec("_P")
 
+
 def karva_run() -> int: ...
+
 
 class FixtureFunctionMarker(Generic[_P, _T]):
     def __call__(
@@ -18,8 +20,10 @@ class FixtureFunctionMarker(Generic[_P, _T]):
         function: Callable[_P, _T],
     ) -> FixtureFunctionDefinition[_P, _T]: ...
 
+
 class FixtureFunctionDefinition(Generic[_P, _T]):
     def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _T: ...
+
 
 @overload
 def fixture(func: Callable[_P, _T]) -> FixtureFunctionDefinition[_P, _T]: ...
@@ -32,22 +36,28 @@ def fixture(
     auto_use: bool = ...,
 ) -> FixtureFunctionMarker[_P, _T]: ...
 
+
 class TestFunction(Generic[_P, _T]):
     def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _T: ...
+
 
 class Tags:
     def __call__(self, f: Callable[_P, _T], /) -> Callable[_P, _T]: ...
 
+
 def skip(reason: str | None = ...) -> NoReturn:
     """Skip the current test."""
 
+
 def fail(reason: str | None = ...) -> NoReturn:
     """Fail the current test."""
+
 
 class Param:
     @property
     def values(self) -> list[object]:
         """The values to parameterize the test case with."""
+
 
 def param(
     *values: object, tags: Sequence[Tags | Callable[[], Tags]] | None = None
@@ -73,6 +83,7 @@ def param(
         assert input ** 2 == expected
     """
 
+
 class ExceptionInfo:
     """Stores information about a caught exception from `karva.raises`."""
 
@@ -88,6 +99,7 @@ class ExceptionInfo:
     def tb(self) -> object | None:
         """The traceback object."""
 
+
 class RaisesContext:
     """Context manager returned by `karva.raises`."""
 
@@ -98,6 +110,7 @@ class RaisesContext:
         exc_val: BaseException | None,
         exc_tb: types.TracebackType | None,
     ) -> bool: ...
+
 
 def raises(
     expected_exception: type[BaseException],
@@ -112,6 +125,7 @@ def raises(
             representation of the exception.
     """
 
+
 @overload
 def assert_snapshot(
     value: object,
@@ -136,6 +150,7 @@ def assert_json_snapshot(
     *,
     name: str,
 ) -> None: ...
+
 
 class Command:
     """Builder for running external commands in snapshot tests.
@@ -153,6 +168,7 @@ class Command:
     def current_dir(self, path: str) -> Self: ...
     def stdin(self, data: str) -> Self: ...
 
+
 @overload
 def assert_cmd_snapshot(
     cmd: Command,
@@ -165,6 +181,7 @@ def assert_cmd_snapshot(
     *,
     name: str,
 ) -> None: ...
+
 
 class SnapshotSettings:
     """Context manager for scoped snapshot configuration.
@@ -187,6 +204,7 @@ class SnapshotSettings:
         exc_tb: types.TracebackType | None,
     ) -> bool: ...
 
+
 def snapshot_settings(
     *,
     filters: list[tuple[str, str]] | None = None,
@@ -200,14 +218,18 @@ def snapshot_settings(
         allow_duplicates: If True, allow multiple unnamed snapshots in a single test.
     """
 
+
 class SkipError(Exception):
     """Raised when `karva.skip` is called."""
+
 
 class FailError(Exception):
     """Raised when `karva.fail` is called."""
 
+
 class SnapshotMismatchError(Exception):
     """Raised when a snapshot assertion fails."""
+
 
 class InvalidFixtureError(Exception):
     """Raised when an invalid fixture is encountered."""

--- a/python/karva/_karva/__init__.pyi
+++ b/python/karva/_karva/__init__.pyi
@@ -11,18 +11,25 @@ _T = TypeVar("_T")
 _P = ParamSpec("_P")
 
 
-def karva_run() -> int: ...
+def karva_run() -> int:
+    """Run Karva using the current process arguments."""
 
 
 class FixtureFunctionMarker(Generic[_P, _T]):
+    """Mark a function as a fixture."""
+
     def __call__(
         self,
         function: Callable[_P, _T],
-    ) -> FixtureFunctionDefinition[_P, _T]: ...
+    ) -> FixtureFunctionDefinition[_P, _T]:
+        """Mark the function as a fixture."""
 
 
 class FixtureFunctionDefinition(Generic[_P, _T]):
-    def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _T: ...
+    """Represent a registered fixture function."""
+
+    def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _T:
+        """Call the underlying fixture function."""
 
 
 @overload
@@ -38,11 +45,17 @@ def fixture(
 
 
 class TestFunction(Generic[_P, _T]):
-    def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _T: ...
+    """Represent a registered test function."""
+
+    def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _T:
+        """Call the underlying test function."""
 
 
 class Tags:
-    def __call__(self, f: Callable[_P, _T], /) -> Callable[_P, _T]: ...
+    """Decorate a test function with configured tags."""
+
+    def __call__(self, f: Callable[_P, _T], /) -> Callable[_P, _T]:
+        """Apply the tags to a test function."""
 
 
 def skip(reason: str | None = ...) -> NoReturn:
@@ -54,6 +67,8 @@ def fail(reason: str | None = ...) -> NoReturn:
 
 
 class Param:
+    """Represent values and tags for a parametrized test case."""
+
     @property
     def values(self) -> list[object]:
         """The values to parameterize the test case with."""
@@ -81,6 +96,7 @@ def param(
     ])
     def test_square(input, expected):
         assert input ** 2 == expected
+
     """
 
 
@@ -103,13 +119,16 @@ class ExceptionInfo:
 class RaisesContext:
     """Context manager returned by `karva.raises`."""
 
-    def __enter__(self) -> ExceptionInfo: ...
+    def __enter__(self) -> ExceptionInfo:
+        """Enter the exception assertion context."""
+
     def __exit__(
         self,
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: types.TracebackType | None,
-    ) -> bool: ...
+    ) -> bool:
+        """Exit the exception assertion context."""
 
 
 def raises(
@@ -123,6 +142,7 @@ def raises(
         expected_exception: The expected exception type.
         match: An optional regex pattern to match against the string
             representation of the exception.
+
     """
 
 
@@ -160,13 +180,26 @@ class Command:
     the command's stdout, stderr, and exit code.
     """
 
-    def __init__(self, program: str) -> None: ...
-    def arg(self, value: str) -> Self: ...
-    def args(self, values: Sequence[str]) -> Self: ...
-    def env(self, key: str, value: str) -> Self: ...
-    def envs(self, vars: dict[str, str]) -> Self: ...
-    def current_dir(self, path: str) -> Self: ...
-    def stdin(self, data: str) -> Self: ...
+    def __init__(self, program: str) -> None:
+        """Create a command for the given program."""
+
+    def arg(self, value: str) -> Self:
+        """Append an argument."""
+
+    def args(self, values: Sequence[str]) -> Self:
+        """Append multiple arguments."""
+
+    def env(self, key: str, value: str) -> Self:
+        """Set an environment variable."""
+
+    def envs(self, vars: dict[str, str]) -> Self:
+        """Set multiple environment variables."""
+
+    def current_dir(self, path: str) -> Self:
+        """Set the working directory."""
+
+    def stdin(self, data: str) -> Self:
+        """Set the standard input data."""
 
 
 @overload
@@ -195,14 +228,19 @@ class SnapshotSettings:
         *,
         filters: list[tuple[str, str]] | None = None,
         allow_duplicates: bool = False,
-    ) -> None: ...
-    def __enter__(self) -> Self: ...
+    ) -> None:
+        """Create scoped snapshot settings."""
+
+    def __enter__(self) -> Self:
+        """Enter the snapshot settings context."""
+
     def __exit__(
         self,
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: types.TracebackType | None,
-    ) -> bool: ...
+    ) -> bool:
+        """Exit the snapshot settings context."""
 
 
 def snapshot_settings(
@@ -216,6 +254,7 @@ def snapshot_settings(
         filters: List of (regex_pattern, replacement) pairs applied sequentially
             to the serialized snapshot value before comparison/storage.
         allow_duplicates: If True, allow multiple unnamed snapshots in a single test.
+
     """
 
 

--- a/python/karva/_karva/tags.pyi
+++ b/python/karva/_karva/tags.pyi
@@ -26,14 +26,14 @@ def use_fixtures(*fixture_names: str) -> Tags:
 @overload
 def skip(f: Callable[_P, _T]) -> TestFunction[_P, _T]: ...
 @overload
-def skip(*conditions: bool, reason: str | None = ...) -> Tags:
+def skip(*conditions: bool, reason: str | None = ...) -> Tags:  # noqa: D418
     """Skip the current test given the conditions."""
 
 
 @overload
 def expect_fail(f: Callable[_P, _T]) -> TestFunction[_P, _T]: ...
 @overload
-def expect_fail(*conditions: bool, reason: str | None = ...) -> Tags:
+def expect_fail(*conditions: bool, reason: str | None = ...) -> Tags:  # noqa: D418
     """Expect the current test to fail given the conditions."""
 
 

--- a/python/karva/_karva/tags.pyi
+++ b/python/karva/_karva/tags.pyi
@@ -6,12 +6,14 @@ from karva._karva import Tags, TestFunction
 _T = TypeVar("_T")
 _P = ParamSpec("_P")
 
+
 def parametrize(
     arg_names: Sequence[str] | str,
     arg_values: Sequence[Sequence[object]] | Sequence[object],
     ids: Sequence[str | None] | Callable[[object], object | None] | None = ...,
 ) -> Tags:
     """Parametrize the current test with the given arguments."""
+
 
 def use_fixtures(*fixture_names: str) -> Tags:
     """Use the given fixtures for the current test.
@@ -20,17 +22,20 @@ def use_fixtures(*fixture_names: str) -> Tags:
     but you need them to be called.
     """
 
+
 @overload
 def skip(f: Callable[_P, _T]) -> TestFunction[_P, _T]: ...
 @overload
 def skip(*conditions: bool, reason: str | None = ...) -> Tags:
     """Skip the current test given the conditions."""
 
+
 @overload
 def expect_fail(f: Callable[_P, _T]) -> TestFunction[_P, _T]: ...
 @overload
 def expect_fail(*conditions: bool, reason: str | None = ...) -> Tags:
     """Expect the current test to fail given the conditions."""
+
 
 def timeout(seconds: float) -> Tags:
     """Fail the current test if it runs longer than ``seconds``.
@@ -47,6 +52,7 @@ def timeout(seconds: float) -> Tags:
     Fixture setup runs before the timeout starts, so slow fixtures do not
     count toward the limit.
     """
+
 
 def fail_slow(seconds: float) -> Tags:
     """Fail the current test if its full lifecycle takes longer than ``seconds``.

--- a/scripts/prepare_docs.py
+++ b/scripts/prepare_docs.py
@@ -9,11 +9,12 @@ ROOT = Path(__file__).parent.parent
 
 
 def prepare_index_file() -> None:
-    """Copy root `README.md` to `docs/index.md`"""
+    """Copy root `README.md` to `docs/index.md`."""
     (ROOT / "docs" / "index.md").write_text((ROOT / "README.md").read_text())
 
 
 def main() -> None:
+    """Prepare documentation source files."""
     prepare_index_file()
 
 


### PR DESCRIPTION
## Summary

Require current Ruff and ty versions, format `.pyi` files as regular Python, and lint benchmark resources. Enable Ruff docstring rules except module docstrings and document all resulting public APIs.

## Test Plan

Verified with `uvx prek run -a`.