### PR TITLE
Disambiguate duplicate parameter IDs

### DIFF
--- a/crates/karva/tests/it/extensions/tags/parametrize.rs
+++ b/crates/karva/tests/it/extensions/tags/parametrize.rs
@@ -1503,14 +1503,18 @@ def test_values(left, right):
 }
 
 #[rstest]
-fn test_parametrize_rejects_duplicate_ids(#[values("pytest", "karva")] framework: &str) {
+fn test_parametrize_disambiguates_duplicate_ids(#[values("pytest", "karva")] framework: &str) {
     let test_context = TestContext::with_file(
         "test.py",
         &format!(
             r#"
 import {framework}
 
-@{parametrize}("value", [1, 2], ids=["same", "same"])
+@{parametrize}(
+    "value",
+    [1, 2, 3, 4, 5],
+    ids=["same", "same", "same0", "ending1", "ending1"],
+)
 def test_value(value):
     pass
 "#,
@@ -1520,25 +1524,17 @@ def test_value(value):
 
     allow_duplicates! {
         assert_cmd_snapshot!(test_context.command(), @"
-        success: false
-        exit_code: 1
+        success: true
+        exit_code: 0
         ----- stdout -----
             Starting 1 test across 1 worker
-               ERROR [TIME] test::test_value
-
-        failures:
-
-        test::test_value:
-
-        error[invalid-parametrize]: Parameter ID `same` is used more than once
-         --> test.py:5:5
-          |
-        5 | def test_value(value):
-          |     ^^^^^^^^^^
-          |
-
+                PASS [TIME] test::test_value(same1)
+                PASS [TIME] test::test_value(same2)
+                PASS [TIME] test::test_value(same0)
+                PASS [TIME] test::test_value(ending1_0)
+                PASS [TIME] test::test_value(ending1_1)
         ────────────
-             Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
+             Summary [TIME] 5 tests run: 5 passed, 0 skipped
 
         ----- stderr -----
         ");

--- a/crates/karva_test_semantic/src/extensions/tags/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/mod.rs
@@ -339,16 +339,12 @@ impl Tags {
             }
         }
 
-        let mut seen_ids = HashSet::new();
         for params in self.parametrize_args() {
             let Some(id) = params.id() else {
                 continue;
             };
             if id.is_empty() {
                 return Err(InvalidParametrizeError::EmptyId);
-            }
-            if !seen_ids.insert(id.to_string()) {
-                return Err(InvalidParametrizeError::DuplicateId { id: id.to_string() });
             }
         }
 

--- a/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
@@ -64,8 +64,6 @@ pub enum InvalidParametrizeError {
     UnknownName { name: String },
     #[error("Parameter ID cannot be empty")]
     EmptyId,
-    #[error("Parameter ID `{id}` is used more than once")]
-    DuplicateId { id: String },
 }
 
 struct ParametrizeSyntax<'a> {
@@ -167,7 +165,7 @@ impl InvalidParametrizeError {
             Self::UnknownName { name } => {
                 name_diagnostic_location(&syntaxes, name, "not accepted by test", function)
             }
-            Self::EmptyId | Self::DuplicateId { .. } => None,
+            Self::EmptyId => None,
         }
     }
 }
@@ -419,6 +417,42 @@ impl ParametrizationArgs {
 
     pub(crate) fn id(&self) -> Option<&str> {
         self.has_explicit_id.then_some(self.id.as_str())
+    }
+}
+
+fn make_unique_parametrize_ids(parametrizations: &mut [ParametrizationArgs]) {
+    let mut id_counts = HashMap::new();
+    for parametrization in &*parametrizations {
+        if !parametrization.id.is_empty() {
+            *id_counts.entry(parametrization.id.clone()).or_insert(0) += 1;
+        }
+    }
+
+    let mut used_ids = parametrizations
+        .iter()
+        .map(|parametrization| parametrization.id.clone())
+        .collect::<HashSet<_>>();
+    let mut id_suffixes = HashMap::new();
+    for parametrization in parametrizations {
+        if id_counts.get(&parametrization.id).copied().unwrap_or(0) < 2 {
+            continue;
+        }
+
+        let id = &parametrization.id;
+        let separator = if id.ends_with(|character: char| character.is_ascii_digit()) {
+            "_"
+        } else {
+            ""
+        };
+        let counter = id_suffixes.entry(id.clone()).or_insert(0);
+        loop {
+            let candidate = format!("{id}{separator}{counter}");
+            *counter += 1;
+            if used_ids.insert(candidate.clone()) {
+                parametrization.id = candidate;
+                break;
+            }
+        }
     }
 }
 
@@ -706,6 +740,7 @@ impl ParametrizeTag {
             };
             param_args.push(current_param_args);
         }
+        make_unique_parametrize_ids(&mut param_args);
         param_args
     }
 }


### PR DESCRIPTION
## Summary

Disambiguates duplicate explicit parameter IDs with deterministic pytest-compatible suffixes, including existing numeric suffix collisions. Closes #1084.

## Test Plan

Ran `just test -p karva test_parametrize_disambiguates_duplicate_ids`, targeted Clippy, and `uvx prek run -a`.