### PR TITLE
Support module-level pytest parametrization

### DIFF
--- a/crates/karva/tests/it/extensions/tags/parametrize.rs
+++ b/crates/karva/tests/it/extensions/tags/parametrize.rs
@@ -1151,6 +1151,33 @@ def test_parametrize_with_fixture(a):
 }
 
 #[test]
+fn test_module_level_pytest_parametrize() {
+    let test_context = TestContext::with_file(
+        "test.py",
+        r#"import pytest
+
+pytestmark = pytest.mark.parametrize("value", [1, 2])
+
+def test_value(value):
+    assert value > 0
+"#,
+    );
+
+    assert_cmd_snapshot!(test_context.command(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_value(value=1)
+            PASS [TIME] test::test_value(value=2)
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_parametrize_two_decorators() {
     let test_context = TestContext::with_file(
         "test.py",

--- a/crates/karva_test_semantic/src/discovery/models/function.rs
+++ b/crates/karva_test_semantic/src/discovery/models/function.rs
@@ -2,6 +2,7 @@ use std::rc::Rc;
 
 use karva_python_semantic::QualifiedFunctionName;
 use pyo3::prelude::*;
+use pyo3::types::PyModule;
 use ruff_python_ast::StmtFunctionDef;
 use ruff_source_file::SourceFile;
 
@@ -35,6 +36,7 @@ impl DiscoveredTestFunction {
     pub(crate) fn new(
         py: Python<'_>,
         module: &DiscoveredModule,
+        py_module: &Bound<'_, PyModule>,
         stmt_function_def: Rc<StmtFunctionDef>,
         py_function: Py<PyAny>,
     ) -> PyResult<Self> {
@@ -43,7 +45,13 @@ impl DiscoveredTestFunction {
             module.module_path().clone(),
         );
 
-        let tags = Tags::from_py_any(py, &py_function, Some(&stmt_function_def))?;
+        let mut tags = Tags::from_py_any(py, &py_function, Some(&stmt_function_def))?;
+        if let Ok(marks) = py_module.getattr("pytestmark") {
+            let module_tags =
+                Tags::from_pytest_marks(py, &marks.unbind(), Some(&py_module.dict()))?
+                    .unwrap_or_default();
+            tags.extend(&module_tags);
+        }
 
         Ok(Self {
             name,

--- a/crates/karva_test_semantic/src/discovery/visitor.rs
+++ b/crates/karva_test_semantic/src/discovery/visitor.rs
@@ -141,6 +141,7 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
             match DiscoveredTestFunction::new(
                 self.py,
                 self.module,
+                py_module,
                 Rc::new(stmt_function_def),
                 py_function.unbind(),
             ) {

--- a/crates/karva_test_semantic/src/extensions/tags/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/mod.rs
@@ -290,8 +290,8 @@ impl Tags {
                     tags.push(tag);
                 }
             }
-        } else {
-            return Ok(None);
+        } else if let Some(tag) = Tag::try_from_pytest_mark(marks.bind(py), globals)? {
+            tags.push(tag);
         }
         Ok(Some(Self { inner: tags }))
     }


### PR DESCRIPTION
## Summary

Apply module-level `pytestmark` parametrization to discovered test functions and accept both single marks and mark lists. Closes #1086.

## Test Plan

`just test -p karva extensions::tags::parametrize`, focused Clippy, and `uvx prek run -a`.