### PR TITLE
Escape NUL bytes in parameterized test names

### DIFF
--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -2844,6 +2844,11 @@ fn test_karva_test_name_env() {
         r#"
 import os
 import karva
+import pytest
+
+class NullString:
+    def __str__(self):
+        return "\x00"
 
 def test_plain():
     assert os.environ["KARVA_TEST_NAME"] == "test::test_plain"
@@ -2851,6 +2856,15 @@ def test_plain():
 @karva.tags.parametrize("value", [1, 2])
 def test_param(value):
     assert os.environ["KARVA_TEST_NAME"] == f"test::test_param(value={value})"
+
+@pytest.mark.parametrize(("input_value", "expected"), [(b"\x00", "\x00")])
+def test_null_byte(input_value, expected):
+    assert os.environ["KARVA_TEST_NAME"] == r"test::test_null_byte(input_value=b'\x00', expected='\x00')"
+    assert input_value.decode() == expected
+
+@karva.tags.parametrize("value", [NullString()])
+def test_value_derived_null_byte(value):
+    assert os.environ["KARVA_TEST_NAME"] == r"test::test_value_derived_null_byte(value=\x00)"
         "#,
     );
 
@@ -2858,12 +2872,14 @@ def test_param(value):
     success: true
     exit_code: 0
     ----- stdout -----
-        Starting 2 tests across 1 worker
+        Starting 4 tests across 1 worker
             PASS [TIME] test::test_plain
             PASS [TIME] test::test_param(value=1)
             PASS [TIME] test::test_param(value=2)
+            PASS [TIME] test::test_null_byte(input_value=b'/x00', expected='/x00')
+            PASS [TIME] test::test_value_derived_null_byte(value=/x00)
     ────────────
-         Summary [TIME] 3 tests run: 3 passed, 0 skipped
+         Summary [TIME] 5 tests run: 5 passed, 0 skipped
 
     ----- stderr -----
     ");

--- a/crates/karva_test_semantic/src/utils.rs
+++ b/crates/karva_test_semantic/src/utils.rs
@@ -222,13 +222,14 @@ pub(crate) fn set_test_name_env(py: Python<'_>, qualified_name: &str) -> PyResul
 }
 
 pub(crate) fn display_value(value: &Bound<'_, PyAny>) -> String {
-    if value.is_instance_of::<PyString>()
+    let display = if value.is_instance_of::<PyString>()
         && let Ok(repr) = value.repr()
     {
         repr.to_string()
     } else {
         value.to_string()
-    }
+    };
+    display.replace('\0', "\\x00")
 }
 
 fn truncated_display_value(value: &Bound<'_, PyAny>) -> String {


### PR DESCRIPTION
## Summary

Escape NUL bytes in value-derived parameterized test names so displayed identities and `KARVA_TEST_NAME` remain printable and valid. Add regression coverage for pytest byte values and custom values containing a real NUL. Closes #1092.

## Test Plan

`just test -p karva_test_semantic`, `just test -p karva test_karva_test_name_env`, and `uvx prek run -a`.