### PR TITLE
Collapse missing fixtures before parameter expansion

### DIFF
--- a/crates/karva/tests/it/extensions/tags/parametrize.rs
+++ b/crates/karva/tests/it/extensions/tags/parametrize.rs
@@ -1070,6 +1070,88 @@ def test_dict_keys(value):
 }
 
 #[test]
+fn test_parametrize_with_missing_fixture_reports_base_test_once() {
+    let test_context = TestContext::with_file(
+        "test.py",
+        r#"
+import pytest
+
+@pytest.mark.parametrize("value", range(3))
+def test_example(value, plugin_fixture):
+    plugin_fixture.check(value)
+"#,
+    );
+
+    assert_cmd_snapshot!(test_context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+           ERROR [TIME] test::test_example
+
+    failures:
+
+    test::test_example:
+
+    error[missing-fixtures]: Test `test_example` has missing fixtures
+     --> test.py:5:5
+      |
+    5 | def test_example(value, plugin_fixture):
+      |     ^^^^^^^^^^^^
+      |
+    info: Missing fixtures: `plugin_fixture`
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_parametrize_with_missing_fixture_does_not_run_auto_use_fixture() {
+    let test_context = TestContext::with_file(
+        "test.py",
+        r#"
+import pytest
+
+@pytest.fixture(autouse=True)
+def auto_fixture():
+    raise AssertionError("auto-use fixture ran")
+
+@pytest.mark.parametrize("value", range(3))
+def test_example(value, plugin_fixture):
+    plugin_fixture.check(value)
+"#,
+    );
+
+    assert_cmd_snapshot!(test_context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+           ERROR [TIME] test::test_example
+
+    failures:
+
+    test::test_example:
+
+    error[missing-fixtures]: Test `test_example` has missing fixtures
+     --> test.py:9:5
+      |
+    9 | def test_example(value, plugin_fixture):
+      |     ^^^^^^^^^^^^
+      |
+    info: Missing fixtures: `plugin_fixture`
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_parametrized_variants_retry_independently() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -410,6 +410,16 @@ pub fn fixture_resolution_diagnostic(error: FixtureResolutionError) -> Diagnosti
             missing_fixtures,
             rejected_fixtures,
         } => fixture_missing_fixtures_diagnostic(&fixture, &missing_fixtures, &rejected_fixtures),
+        FixtureResolutionError::MissingTestFixtures {
+            stmt_function_def,
+            source_file,
+            missing_fixtures,
+        } => missing_fixtures_diagnostic(
+            source_file,
+            &stmt_function_def,
+            &missing_fixtures,
+            FunctionKind::Test,
+        ),
     }
 }
 

--- a/crates/karva_test_semantic/src/extensions/tags/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/mod.rs
@@ -322,6 +322,18 @@ impl Tags {
         param_args
     }
 
+    pub(crate) fn parametrize_names(&self) -> HashSet<&str> {
+        self.inner
+            .iter()
+            .filter_map(|tag| match tag {
+                Tag::Parametrize(parametrize) => Some(parametrize.names()),
+                _ => None,
+            })
+            .flatten()
+            .map(String::as_str)
+            .collect()
+    }
+
     pub(crate) fn validate_parametrize(
         &self,
         function: &StmtFunctionDef,

--- a/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
@@ -403,10 +403,6 @@ pub struct ParametrizationArgs {
 }
 
 impl ParametrizationArgs {
-    pub(crate) fn values(&self) -> &HashMap<String, Arc<Py<PyAny>>> {
-        &self.values
-    }
-
     pub(crate) fn extend(&mut self, other: Self) {
         self.values.extend(other.values);
         self.tags.extend(&other.tags);
@@ -596,6 +592,10 @@ fn extract_parametrize_args<'py>(
 }
 
 impl ParametrizeTag {
+    pub(crate) fn names(&self) -> &[String] {
+        &self.names
+    }
+
     pub(crate) fn new(names: Vec<String>, parametrizations: Vec<Parametrization>) -> Self {
         Self {
             names,

--- a/crates/karva_test_semantic/src/runner/fixture_resolver.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_resolver.rs
@@ -7,7 +7,7 @@ use pyo3::prelude::*;
 use ruff_python_ast::StmtFunctionDef;
 use ruff_source_file::SourceFile;
 
-use crate::discovery::DiscoveredPackage;
+use crate::discovery::{DiscoveredPackage, DiscoveredTestFunction};
 use crate::extensions::fixtures::{
     DiscoveredFixture, FixtureScope, HasFixtures, NormalizedFixture, RejectedFixture,
     RequiresFixtures, get_auto_use_fixtures,
@@ -66,6 +66,15 @@ pub enum FixtureResolutionError {
         missing_fixtures: Vec<String>,
         /// Missing dependencies that were rejected during discovery.
         rejected_fixtures: Vec<RejectedFixture>,
+    },
+    /// Test requires names that cannot be resolved.
+    MissingTestFixtures {
+        /// Test definition used to locate the diagnostic.
+        stmt_function_def: Rc<StmtFunctionDef>,
+        /// Source containing the test definition.
+        source_file: SourceFile,
+        /// Unresolved fixture names.
+        missing_fixtures: Vec<String>,
     },
 }
 
@@ -219,14 +228,36 @@ impl<'a> RuntimeFixtureResolver<'a> {
     pub(super) fn resolve_test_fixtures(
         &mut self,
         py: Python,
-        fixture_names: &[String],
+        test: &DiscoveredTestFunction,
         parametrize_param_names: &HashSet<&str>,
     ) -> FixtureResolutionResult<Vec<Rc<NormalizedFixture>>> {
+        let fixture_names = test.stmt_function_def.required_fixtures(py);
         let regular_fixture_names: Vec<String> = fixture_names
             .iter()
             .filter(|name| !parametrize_param_names.contains(name.as_str()))
             .cloned()
             .collect();
+
+        // Wrapped and Hypothesis decorators can supply arguments declared in source.
+        let decorator_supplies_arguments = test.py_function.getattr(py, "__wrapped__").is_ok()
+            || test.py_function.getattr(py, "hypothesis").is_ok();
+        let missing_fixtures = if decorator_supplies_arguments {
+            Vec::new()
+        } else {
+            regular_fixture_names
+                .iter()
+                .filter(|name| find_fixture(None, name, self.parents, self.current).is_none())
+                .cloned()
+                .collect::<Vec<_>>()
+        };
+
+        if !missing_fixtures.is_empty() {
+            return Err(FixtureResolutionError::MissingTestFixtures {
+                stmt_function_def: Rc::clone(&test.stmt_function_def),
+                source_file: test.source_file.clone(),
+                missing_fixtures,
+            });
+        }
 
         let mut path = FixturePath::default();
         self.get_dependent_fixtures(py, None, &regular_fixture_names, &mut path)

--- a/crates/karva_test_semantic/src/runner/test_iterator.rs
+++ b/crates/karva_test_semantic/src/runner/test_iterator.rs
@@ -1,13 +1,13 @@
 //! Expansion of one discovered test into executable parameter/fixture variants.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
 
 use pyo3::prelude::*;
 
 use crate::discovery::DiscoveredTestFunction;
-use crate::extensions::fixtures::{NormalizedFixture, RequiresFixtures};
+use crate::extensions::fixtures::NormalizedFixture;
 use crate::extensions::tags::Tags;
 use crate::extensions::tags::parametrize::ParametrizationArgs;
 use crate::runner::fixture_resolver::{FixtureResolutionResult, RuntimeFixtureResolver};
@@ -102,16 +102,7 @@ impl<'a> TestVariantIterator<'a> {
         test: &'a DiscoveredTestFunction,
         resolver: &mut RuntimeFixtureResolver,
     ) -> FixtureResolutionResult<Self> {
-        let test_params = test.tags.parametrize_args();
-
-        let parametrize_param_names: HashSet<&str> = test_params
-            .iter()
-            .flat_map(|params| params.values().keys().map(String::as_str))
-            .collect();
-
-        // Only use the function parameter names, NOT the use_fixtures names.
-        // use_fixtures are run for side effects but not passed as arguments.
-        let function_param_names = test.stmt_function_def.required_fixtures(py);
+        let parametrize_param_names = test.tags.parametrize_names();
 
         let auto_use_fixtures = resolver.get_normalized_auto_use_fixtures(
             py,
@@ -119,11 +110,12 @@ impl<'a> TestVariantIterator<'a> {
         )?;
 
         let fixture_dependencies =
-            resolver.resolve_test_fixtures(py, &function_param_names, &parametrize_param_names)?;
+            resolver.resolve_test_fixtures(py, test, &parametrize_param_names)?;
 
         let use_fixture_names = test.tags.required_fixtures_names();
         let use_fixture_dependencies = resolver.resolve_use_fixtures(py, &use_fixture_names)?;
 
+        let test_params = test.tags.parametrize_args();
         let param_args = if test_params.is_empty() {
             vec![ParametrizationArgs::default()]
         } else {


### PR DESCRIPTION
## Summary

Resolve missing test fixtures before generating parametrized variants, so unavailable plugin fixtures and typos produce one diagnostic for the base test instead of one error per case. Closes #1088.

## Test Plan

Focused fixture and parametrization integration tests; `uvx prek run -a`.