### PR TITLE
Honor keyword xfail conditions

### DIFF
--- a/crates/karva/tests/it/extensions/tags/expect_fail.rs
+++ b/crates/karva/tests/it/extensions/tags/expect_fail.rs
@@ -784,6 +784,35 @@ def test_1():
 }
 
 #[test]
+fn test_pytest_expect_fail_keyword_condition_without_reason_rejected() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import pytest
+
+@pytest.mark.xfail(condition=True)
+def test_1():
+    assert False
+",
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+    diagnostics:
+
+    error[failed-to-import-module]: Failed to import python module `test`: pytest xfail mark requires a reason when using boolean conditions
+
+    ────────────
+         Summary [TIME] 0 tests run: 0 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_pytest_expect_fail_non_string_reason_is_preserved() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva/tests/it/extensions/tags/expect_fail.rs
+++ b/crates/karva/tests/it/extensions/tags/expect_fail.rs
@@ -249,6 +249,32 @@ def test_1():
     }
 }
 
+#[test]
+fn test_pytest_expect_fail_with_false_keyword_condition() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import pytest
+
+@pytest.mark.xfail(condition=False, reason='Condition is false')
+def test_1():
+    assert True
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_1
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
 #[rstest]
 fn test_expect_fail_with_expression(#[values("pytest", "karva")] framework: &str) {
     let context = TestContext::with_file(

--- a/crates/karva/tests/it/extensions/tags/parametrize.rs
+++ b/crates/karva/tests/it/extensions/tags/parametrize.rs
@@ -1743,6 +1743,34 @@ def test_square(input, expected):
 }
 
 #[test]
+fn test_parametrize_with_pytest_param_false_keyword_xfail_condition() {
+    let test_context = TestContext::with_file(
+        "test.py",
+        r#"
+import pytest
+
+@pytest.mark.parametrize("value", [
+    pytest.param(1, marks=pytest.mark.xfail(condition=False, reason="not broken")),
+])
+def test_value(value):
+    assert value == 1
+"#,
+    );
+
+    assert_cmd_snapshot!(test_context.command(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_value(value=1)
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_parametrize_with_karva_param_single_arg() {
     let test_context = TestContext::with_file(
         "test.py",

--- a/crates/karva_test_semantic/src/extensions/tags/expect_fail.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/expect_fail.rs
@@ -42,8 +42,12 @@ impl ExpectFailTag {
         py_mark: &Bound<'_, PyAny>,
         globals: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<Option<Self>> {
-        let parsed = parse_pytest_mark_args(py_mark, globals)?;
+        let mut parsed = parse_pytest_mark_args(py_mark, globals)?;
         let kwargs = py_mark.getattr("kwargs")?;
+        if let Ok(condition) = kwargs.get_item("condition") {
+            parsed.conditions.push(condition.is_truthy()?);
+            parsed.requires_reason = true;
+        }
         let reason = if let Ok(reason_item) = kwargs.get_item("reason") {
             Some(reason_item.str()?.to_string_lossy().into_owned())
         } else {


### PR DESCRIPTION
## Summary

Honor pytest `xfail(condition=...)` keyword conditions for function and parametrized-case marks. Fixes #1083.

## Test Plan

Focused integration tests and `uvx prek run -a` pass.