### PR TITLE
Add warning assertion helpers

### DIFF
--- a/crates/karva/tests/it/extensions/fixtures/fixture_support.rs
+++ b/crates/karva/tests/it/extensions/fixtures/fixture_support.rs
@@ -154,6 +154,11 @@ def test_warns_matches_message_regex():
         warnings.warn("value 42", UserWarning)
 
 
+def test_warns_defaults_to_any_warning():
+    with karva.warns():
+        warnings.warn("warning")
+
+
 def test_deprecated_call_accepts_deprecation_warnings():
     with karva.deprecated_call():
         warnings.warn("deprecated", DeprecationWarning)
@@ -169,7 +174,7 @@ def test_deprecated_call_accepts_deprecation_warnings():
     exit_code: 0
     ----- stdout -----
     ────────────
-         Summary [TIME] 3 tests run: 3 passed, 0 skipped
+         Summary [TIME] 4 tests run: 4 passed, 0 skipped
 
     ----- stderr -----
     ");
@@ -186,6 +191,9 @@ import karva
 
 
 def test_warns_failure_messages():
+    with karva.raises(TypeError, match="derived from Warning"):
+        karva.warns(ValueError)
+
     with karva.raises(AssertionError, match="No warnings of type.*UserWarning"):
         with karva.warns(UserWarning):
             pass
@@ -225,6 +233,82 @@ def test_warns_restores_filters_when_block_raises():
 
     ----- stderr -----
     ");
+}
+
+#[test]
+fn test_warning_assertion_diagnostics() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import warnings
+
+import karva
+
+
+def test_missing_warning():
+    with karva.warns(UserWarning):
+        pass
+
+
+def test_warning_message_mismatch():
+    with karva.warns(UserWarning, match="expected message"):
+        warnings.warn("different message", UserWarning)
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            FAIL [TIME] test::test_missing_warning
+            FAIL [TIME] test::test_warning_message_mismatch
+
+    failures:
+
+    test::test_missing_warning:
+
+    error[test-failure]: Test `test_missing_warning` failed
+     --> test.py:7:5
+      |
+    7 | def test_missing_warning():
+      |     ^^^^^^^^^^^^^^^^^^^^
+      |
+    info: Test failed here
+     --> test.py:8:5
+      |
+    8 |     with karva.warns(UserWarning):
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: DID NOT WARN. No warnings of type (<class 'UserWarning'>,) were emitted.
+           Emitted warnings: [].
+
+    test::test_warning_message_mismatch:
+
+    error[test-failure]: Test `test_warning_message_mismatch` failed
+      --> test.py:12:5
+       |
+    12 | def test_warning_message_mismatch():
+       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       |
+    info: Test failed here
+      --> test.py:13:5
+       |
+    13 |     with karva.warns(UserWarning, match="expected message"):
+       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       |
+    info: Regex pattern 'expected message' did not match any emitted warning.
+           Emitted warnings: [UserWarning('different message')].
+
+    captured stderr:
+    <temp_dir>/test.py:14: UserWarning: different message
+      warnings.warn("different message", UserWarning)
+
+    ────────────
+         Summary [TIME] 2 tests run: 0 passed, 2 failed, 0 skipped
+
+    ----- stderr -----
+    "#);
 }
 
 // =============================================================================

--- a/crates/karva/tests/it/extensions/fixtures/fixture_support.rs
+++ b/crates/karva/tests/it/extensions/fixtures/fixture_support.rs
@@ -2,7 +2,7 @@
 //! `testing/test_tmpdir.py` (commit `8ecf49ec2`), focused on the subset of
 //! pytest behavior maintained by Karva's fixture support:
 //!
-//! - `WarningsRecorder` semantics (`_pytest/recwarn.py`),
+//! - warning recorder and assertion helper semantics (`_pytest/recwarn.py`),
 //! - `make_numbered_dir` / `cleanup_numbered_dir` / `rm_rf` from
 //!   `_pytest/pathlib.py`,
 //! - the `TempPathFactory.mktemp` naming contract from `_pytest/tmpdir.py`.
@@ -13,10 +13,10 @@
 //! actually imported at runtime, not via Rust unit tests that sidestep the
 //! wheel layout.
 //!
-//! Tests from pytest that depend on `pytester`, `WarningsChecker`,
-//! `pytest.warns`, the `Config`-backed `TempPathFactory.from_config`, or the
-//! `--basetemp` / retention-policy machinery are intentionally not ported,
-//! because karva does not expose those entry points.
+//! Tests from pytest that depend on `pytester`, the `Config`-backed
+//! `TempPathFactory.from_config`, or the `--basetemp` / retention-policy
+//! machinery are intentionally not ported because Karva does not expose those
+//! entry points.
 //!
 //! See the pytest license block in the repository `LICENSE` file for the
 //! applicable copyright notice.
@@ -125,6 +125,103 @@ def test_captures_deprecation_warning(recwarn):
     ----- stdout -----
     ────────────
          Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_warning_assertion_helpers() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import re
+import warnings
+
+import karva
+
+
+def test_warns_records_multiple_warnings():
+    with karva.warns((UserWarning, RuntimeWarning)) as recorded:
+        warnings.warn("first", UserWarning)
+        warnings.warn("second", RuntimeWarning)
+
+    assert [str(warning.message) for warning in recorded] == ["first", "second"]
+
+
+def test_warns_matches_message_regex():
+    with karva.warns(UserWarning, match=re.compile(r"value \d+")):
+        warnings.warn("value 42", UserWarning)
+
+
+def test_deprecated_call_accepts_deprecation_warnings():
+    with karva.deprecated_call():
+        warnings.warn("deprecated", DeprecationWarning)
+    with karva.deprecated_call():
+        warnings.warn("pending", PendingDeprecationWarning)
+    with karva.deprecated_call(match="future"):
+        warnings.warn("future change", FutureWarning)
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--status-level=none"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 3 tests run: 3 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_warning_assertion_failures_and_cleanup() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import warnings
+
+import karva
+
+
+def test_warns_failure_messages():
+    with karva.raises(AssertionError, match="No warnings of type.*UserWarning"):
+        with karva.warns(UserWarning):
+            pass
+
+    with karva.raises(AssertionError, match="missing.*did not match"):
+        with karva.warns(UserWarning, match="missing"):
+            warnings.warn("present", UserWarning)
+
+
+def test_warns_nested_contexts():
+    with karva.warns(RuntimeWarning) as outer:
+        with karva.warns(UserWarning) as inner:
+            warnings.warn("outer", RuntimeWarning)
+            warnings.warn("inner", UserWarning)
+
+    assert len(inner) == 2
+    assert len(outer) == 1
+    assert outer[0].category is RuntimeWarning
+
+
+def test_warns_restores_filters_when_block_raises():
+    original_filters = warnings.filters[:]
+    with karva.raises(ValueError, match="unrelated"):
+        with karva.warns(UserWarning):
+            raise ValueError("unrelated")
+
+    assert warnings.filters == original_filters
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--status-level=none"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 3 tests run: 3 passed, 0 skipped
 
     ----- stderr -----
     ");

--- a/docs/usage/fixtures/builtin.md
+++ b/docs/usage/fixtures/builtin.md
@@ -295,6 +295,37 @@ def test_capfdbinary_stderr(capfdbinary):
 
 ## Capturing Warnings
 
+Use `karva.warns()` to assert that a block emits a warning. Pass `match` to
+match its message with a regular expression. The context manager records every
+warning emitted by the block.
+
+```py title="test.py"
+import warnings
+
+import karva
+
+
+def test_deprecation():
+    with karva.warns(DeprecationWarning, match="use new_api") as recorded:
+        warnings.warn("use new_api instead", DeprecationWarning)
+
+    assert len(recorded) == 1
+```
+
+`karva.deprecated_call()` accepts `DeprecationWarning`,
+`PendingDeprecationWarning`, and `FutureWarning`.
+
+```py title="test.py"
+import warnings
+
+import karva
+
+
+def test_old_entrypoint():
+    with karva.deprecated_call(match="entrypoint"):
+        warnings.warn("old entrypoint", FutureWarning)
+```
+
 The `recwarn` fixture captures every warning raised during the test. It behaves like a list of `warnings.WarningMessage` objects — you can index into it, iterate it, and take its length.
 
 ```py title="test.py"

--- a/python/karva/__init__.py
+++ b/python/karva/__init__.py
@@ -2,6 +2,7 @@
 
 from karva._approx import approx
 from karva._builtins import MockEnv
+from karva._fixtures.recwarn import deprecated_call, warns
 from karva._karva import (
     Command,
     ExceptionInfo,
@@ -38,6 +39,7 @@ __all__: list[str] = [
     "assert_cmd_snapshot",
     "assert_json_snapshot",
     "assert_snapshot",
+    "deprecated_call",
     "fail",
     "fixture",
     "karva_run",
@@ -46,4 +48,5 @@ __all__: list[str] = [
     "skip",
     "snapshot_settings",
     "tags",
+    "warns",
 ]

--- a/python/karva/_fixtures/recwarn.py
+++ b/python/karva/_fixtures/recwarn.py
@@ -1,10 +1,8 @@
 """Record warnings during test function execution.
 
-Adapted from pytest's ``_pytest/recwarn.py`` (commit 8ecf49ec2). Only the
-``WarningsRecorder`` class is included; the ``WarningsChecker``/``warns``/
-``deprecated_call`` helpers are intentionally omitted because karva does
-not yet expose ``pytest.warns``. The ``recwarn`` fixture wrapper lives in
-``karva._builtins`` where the framework-fixture discoverer can see it.
+Adapted from pytest's ``_pytest/recwarn.py`` (commit 8ecf49ec2). The
+``recwarn`` fixture wrapper lives in ``karva._builtins`` where the
+framework-fixture discoverer can see it.
 
 The following adaptations were made:
 
@@ -18,10 +16,12 @@ applicable copyright notice.
 from __future__ import annotations
 
 import builtins
+import re
 import warnings
 from collections.abc import Iterator
+from pprint import pformat
 from types import TracebackType
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, final
 
 if TYPE_CHECKING:
     from typing import Self
@@ -108,4 +108,92 @@ class WarningsRecorder(warnings.catch_warnings):
         self._entered = False
 
 
-__all__ = ["WarningsRecorder"]
+@final
+class WarningsChecker(WarningsRecorder):
+    """Record warnings and require one matching warning."""
+
+    def __init__(
+        self,
+        expected_warning: type[Warning] | tuple[type[Warning], ...] = Warning,
+        match_expr: str | re.Pattern[str] | None = None,
+    ) -> None:
+        super().__init__()
+
+        expected_warnings = (
+            expected_warning
+            if isinstance(expected_warning, tuple)
+            else (expected_warning,)
+        )
+        if not all(
+            isinstance(warning_type, type) and issubclass(warning_type, Warning)
+            for warning_type in expected_warnings
+        ):
+            raise TypeError(
+                f"exceptions must be derived from Warning, not {type(expected_warning)}"
+            )
+
+        self.expected_warning = expected_warnings
+        self.match_expr = match_expr
+
+    def matches(self, warning: warnings.WarningMessage) -> bool:
+        """Return whether a recorded warning matches the expectation."""
+        return issubclass(warning.category, self.expected_warning) and (
+            self.match_expr is None
+            or re.search(self.match_expr, str(warning.message)) is not None
+        )
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        super().__exit__(exc_type, exc_val, exc_tb)
+
+        if exc_type is not None:
+            return
+
+        __tracebackhide__ = True
+        emitted = pformat([record.message for record in self], indent=2)
+        try:
+            if not any(
+                issubclass(warning.category, self.expected_warning) for warning in self
+            ):
+                raise AssertionError(
+                    "DID NOT WARN. No warnings of type "
+                    f"{self.expected_warning} were emitted.\n Emitted warnings: {emitted}."
+                )
+            if not any(self.matches(warning) for warning in self):
+                raise AssertionError(
+                    f"Regex pattern {self.match_expr!r} did not match any emitted warning.\n"
+                    f" Emitted warnings: {emitted}."
+                )
+        finally:
+            for warning in self:
+                if not self.matches(warning):
+                    warnings.warn_explicit(
+                        message=warning.message,
+                        category=warning.category,
+                        filename=warning.filename,
+                        lineno=warning.lineno,
+                        source=warning.source,
+                    )
+
+
+def warns(
+    expected_warning: type[Warning] | tuple[type[Warning], ...] = Warning,
+    *,
+    match: str | re.Pattern[str] | None = None,
+) -> WarningsRecorder:
+    """Assert that a block emits a matching warning and return all warnings."""
+    return WarningsChecker(expected_warning, match_expr=match)
+
+
+def deprecated_call(*, match: str | re.Pattern[str] | None = None) -> WarningsRecorder:
+    """Assert that a block emits a deprecation-related warning."""
+    return warns(
+        (DeprecationWarning, PendingDeprecationWarning, FutureWarning), match=match
+    )
+
+
+__all__ = ["WarningsRecorder", "deprecated_call", "warns"]


### PR DESCRIPTION
## Summary

Add typed `karva.warns` and `karva.deprecated_call` context managers with regex matching, nested warning handling, filter restoration, and recorded warning access. Document their pytest-compatible use. Closes #955.

## Test Plan

Ran `just test -p karva fixture_support`, built the docs, and ran `uvx prek run -a`.