### PR TITLE
Rewrite assertions before test execution

### DIFF
--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -177,6 +177,35 @@ fn test_one_test_passes() {
 }
 
 #[test]
+fn test_assertion_message_is_rewritten() {
+    let context = TestContext::with_file(
+        "test_assertion.py",
+        r"
+        def validate(value):
+            assert value > 5
+
+        def test_assertion_message():
+            try:
+                validate(4)
+            except AssertionError as error:
+                assert str(error) == 'assert 4 > 5'
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test_assertion::test_assertion_message
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_one_test_fail() {
     let context = TestContext::with_file(
         "test_fail.py",
@@ -209,6 +238,7 @@ fn test_one_test_fail() {
     3 |     assert False
       |     ^^^^^^^^^^^^
       |
+    info: assert False
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -426,6 +456,7 @@ fn test_failure_diagnostic_uses_discovered_source_after_file_is_deleted() {
     6 |     assert False
       |     ^^^^^^^^^^^^
       |
+    info: assert False
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -530,6 +561,7 @@ fn test_two_test_fails() {
     3 |     assert False
       |     ^^^^^^^^^^^^
       |
+    info: assert False
 
     tests.test_fail::test_fail2:
 
@@ -699,6 +731,7 @@ fn test_failed_output_is_captured() {
     10 |     assert False
        |     ^^^^^^^^^^^^
        |
+    info: assert False
 
     captured stdout:
     stdout from failure
@@ -834,6 +867,7 @@ fn test_quiet_output_failing() {
     3 |     assert False
       |     ^^^^^^^^^^^^
       |
+    info: assert False
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -942,6 +976,7 @@ fn test_fixture_generator_two_yields_failing_test() {
     10 |     assert fixture_generator == 2
        |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        |
+    info: assert 1 == 2
 
     error[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `fixture_generator`
      --> test.py:5:5
@@ -1169,6 +1204,7 @@ def test_9():
     5 |     assert False
       |     ^^^^^^^^^^^^
       |
+    info: assert False
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -1301,6 +1337,7 @@ def test_1(fixture_very_very_very_very_very_long_name):
     9 |     assert False
       |     ^^^^^^^^^^^^
       |
+    info: assert False
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -2066,6 +2103,7 @@ def test_needs_retry():
     5 |     assert os.environ["KARVA_ATTEMPT"] == "2"
       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
+    info: assert os.environ["KARVA_ATTEMPT"] == "2"
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -2406,6 +2444,7 @@ def test_2(): assert False
     3 | def test_2(): assert False
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
+    info: assert False
 
     ────────────
          Summary [TIME] 2 tests run: 1 passed, 1 failed, 0 skipped
@@ -2447,6 +2486,7 @@ def test_fail(): assert False
     2 | def test_fail(): assert False
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
+    info: assert False
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -2490,6 +2530,7 @@ def test_always_fails(): assert False
     2 | def test_always_fails(): assert False
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
+    info: assert False
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -2692,6 +2733,7 @@ def test_always_fails(): assert False
     11 | def test_always_fails(): assert False
        | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        |
+    info: assert False
 
     ────────────
          Summary [TIME] 3 tests run: 2 passed (1 flaky), 1 failed, 0 skipped
@@ -2793,6 +2835,7 @@ def test_always_fails(): assert False
     2 | def test_always_fails(): assert False
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
+    info: assert False
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -3136,6 +3179,7 @@ def test_3(): pass
     2 | def test_1(): assert False
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
+    info: assert False
 
     test::test_2:
 
@@ -3151,6 +3195,7 @@ def test_3(): pass
     3 | def test_2(): assert False
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
+    info: assert False
 
     ────────────
          Summary [TIME] 3 tests run: 1 passed, 2 failed, 0 skipped
@@ -3196,6 +3241,7 @@ def test_3(): pass
     2 | def test_1(): assert False
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
+    info: assert False
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -3242,6 +3288,7 @@ def test_3(): assert False
     2 | def test_1(): assert False
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
+    info: assert False
 
     test::test_2:
 
@@ -3257,6 +3304,7 @@ def test_3(): assert False
     3 | def test_2(): assert False
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
+    info: assert False
 
     ────────────
          Summary [TIME] 2 tests run: 0 passed, 2 failed, 0 skipped

--- a/crates/karva/tests/it/configuration/mod.rs
+++ b/crates/karva/tests/it/configuration/mod.rs
@@ -512,6 +512,7 @@ def test_c():
     3 |     assert False
       |     ^^^^^^^^^^^^
       |
+    info: assert False
 
     test::test_b:
 
@@ -527,6 +528,7 @@ def test_c():
     6 |     assert False
       |     ^^^^^^^^^^^^
       |
+    info: assert False
 
     ────────────
          Summary [TIME] 2 tests run: 0 passed, 2 failed, 0 skipped
@@ -619,6 +621,7 @@ def test_second():
     3 |     assert False
       |     ^^^^^^^^^^^^
       |
+    info: assert False
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -678,6 +681,7 @@ def test_third():
     3 |     assert False
       |     ^^^^^^^^^^^^
       |
+    info: assert False
 
     test::test_third:
 
@@ -693,6 +697,7 @@ def test_third():
     9 |     assert False
       |     ^^^^^^^^^^^^
       |
+    info: assert False
 
     ────────────
          Summary [TIME] 3 tests run: 1 passed, 2 failed, 0 skipped
@@ -1253,6 +1258,7 @@ def test_second():
     3 |     assert False
       |     ^^^^^^^^^^^^
       |
+    info: assert False
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped

--- a/crates/karva/tests/it/configuration/overrides.rs
+++ b/crates/karva/tests/it/configuration/overrides.rs
@@ -93,6 +93,7 @@ def test_flaky():
     3 |     assert False
       |     ^^^^^^^^^^^^
       |
+    info: assert False
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -152,6 +153,7 @@ def test_unit():
     6 |     assert False
       |     ^^^^^^^^^^^^
       |
+    info: assert False
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped

--- a/crates/karva/tests/it/durations.rs
+++ b/crates/karva/tests/it/durations.rs
@@ -165,6 +165,7 @@ fn durations_with_failing_tests() {
     8 |     assert False
       |     ^^^^^^^^^^^^
       |
+    info: assert False
 
     2 slowest tests:
       test_durations::test_fail ([TIME])

--- a/crates/karva/tests/it/extensions/tags/fail_slow.rs
+++ b/crates/karva/tests/it/extensions/tags/fail_slow.rs
@@ -205,6 +205,7 @@ def test_slow_and_wrong():
     8 |     assert False
       |     ^^^^^^^^^^^^
       |
+    info: assert False
 
     error[fail-slow-exceeded]: Test `test_slow_and_wrong` exceeded its fail-slow budget
      --> test.py:6:5

--- a/crates/karva/tests/it/extensions/tags/parametrize.rs
+++ b/crates/karva/tests/it/extensions/tags/parametrize.rs
@@ -1151,6 +1151,7 @@ def test_order(third, second, first):
     16 |     assert False
        |     ^^^^^^^^^^^^
        |
+    info: assert False
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped

--- a/crates/karva/tests/it/junit.rs
+++ b/crates/karva/tests/it/junit.rs
@@ -89,6 +89,7 @@ def test_skip():
     11 |     assert False
        |     ^^^^^^^^^^^^
        |
+    info: assert False
 
     captured stdout:
     fail stdout
@@ -120,6 +121,7 @@ def test_skip():
     11 |     assert False
        |     ^^^^^^^^^^^^
        |
+    info: assert False
 
     </failure>
           <system-out>fail stdout
@@ -194,6 +196,7 @@ def test_flaky():
     5 |     assert False
       |     ^^^^^^^^^^^^
       |
+    info: assert False
 
     ────────────
          Summary [TIME] 2 tests run: 1 passed (1 flaky), 1 failed, 0 skipped
@@ -221,6 +224,7 @@ def test_flaky():
     5 |     assert False
       |     ^^^^^^^^^^^^
       |
+    info: assert False
 
     </failure>
           <rerunFailure message="Test `test_fail` failed" type="test-failure" time="[TIME]">error[test-failure]: Test `test_fail` failed
@@ -235,6 +239,7 @@ def test_flaky():
     5 |     assert False
       |     ^^^^^^^^^^^^
       |
+    info: assert False
 
     </rerunFailure>
         </testcase>
@@ -251,6 +256,7 @@ def test_flaky():
     9 |     assert os.environ[&quot;KARVA_ATTEMPT&quot;] == &quot;2&quot;
       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
+    info: assert os.environ[&quot;KARVA_ATTEMPT&quot;] == &quot;2&quot;
 
     </flakyFailure>
           <system-out>attempt 1
@@ -319,6 +325,7 @@ def test_flaky():
     5 |     assert os.environ[&quot;KARVA_ATTEMPT&quot;] == &quot;2&quot;
       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
+    info: assert os.environ[&quot;KARVA_ATTEMPT&quot;] == &quot;2&quot;
 
     </flakyFailure>
         </testcase>
@@ -396,6 +403,7 @@ def test_lenient():
     10 |     assert os.environ[&quot;KARVA_ATTEMPT&quot;] == &quot;2&quot;
        |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        |
+    info: assert os.environ[&quot;KARVA_ATTEMPT&quot;] == &quot;2&quot;
 
     </flakyFailure>
         </testcase>
@@ -413,6 +421,7 @@ def test_lenient():
     7 |     assert os.environ[&quot;KARVA_ATTEMPT&quot;] == &quot;2&quot;
       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
+    info: assert os.environ[&quot;KARVA_ATTEMPT&quot;] == &quot;2&quot;
 
     </flakyFailure>
         </testcase>
@@ -615,6 +624,7 @@ def test_failure():
     3 |     assert False
       |     ^^^^^^^^^^^^
       |
+    info: assert False
 
     test_fixture::test_unreachable:
 
@@ -657,6 +667,7 @@ def test_failure():
     3 |     assert False
       |     ^^^^^^^^^^^^
       |
+    info: assert False
 
     </failure>
         </testcase>

--- a/crates/karva/tests/it/last_failed.rs
+++ b/crates/karva/tests/it/last_failed.rs
@@ -37,6 +37,7 @@ fn last_failed_reruns_only_failures() {
     3 | def test_fail(): assert False
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
+    info: assert False
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -80,6 +81,7 @@ fn last_failed_lf_alias() {
     3 | def test_fail(): assert False
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
+    info: assert False
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -180,6 +182,7 @@ def test_fail_b(): assert False
     3 | def test_fail_a(): assert False
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
+    info: assert False
 
     test_b::test_fail_b:
 
@@ -195,6 +198,7 @@ def test_fail_b(): assert False
     3 | def test_fail_b(): assert False
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
+    info: assert False
 
     ────────────
          Summary [TIME] 2 tests run: 0 passed, 2 failed, 0 skipped
@@ -245,6 +249,7 @@ def test_fail_b(): assert False
     3 | def test_fail_a(): assert False
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
+    info: assert False
 
     ────────────
          Summary [TIME] 2 tests run: 0 passed, 1 failed, 1 skipped
@@ -294,6 +299,7 @@ def test_fail_b(): assert False
     3 | def test_fail_a(): assert False
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
+    info: assert False
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -349,6 +355,7 @@ def test_new_fail(): assert False
     3 | def test_fail(): assert False
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
+    info: assert False
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped

--- a/crates/karva/tests/it/result_report.rs
+++ b/crates/karva/tests/it/result_report.rs
@@ -75,6 +75,7 @@ fn writes_json_result_report() {
     12 |     assert False
        |     ^^^^^^^^^^^^
        |
+    info: assert False
 
     captured stderr:
     fail stderr
@@ -135,7 +136,7 @@ fn writes_json_result_report() {
             "code": "test-failure",
             "severity": "error",
             "message": "Test `test_fail` failed",
-            "rendered": "error[test-failure]: Test `test_fail` failed\n  --> test_report.py:10:5\n   |/n10 | def test_fail():\n   |     ^^^^^^^^^\n   |/ninfo: Test failed here\n  --> test_report.py:12:5\n   |/n12 |     assert False\n   |     ^^^^^^^^^^^^\n   |\n\n"
+            "rendered": "error[test-failure]: Test `test_fail` failed\n  --> test_report.py:10:5\n   |/n10 | def test_fail():\n   |     ^^^^^^^^^\n   |/ninfo: Test failed here\n  --> test_report.py:12:5\n   |/n12 |     assert False\n   |     ^^^^^^^^^^^^\n   |/ninfo: assert False\n\n"
           },
           "attempts": [
             {
@@ -149,7 +150,7 @@ fn writes_json_result_report() {
                 "code": "test-failure",
                 "severity": "error",
                 "message": "Test `test_fail` failed",
-                "rendered": "error[test-failure]: Test `test_fail` failed\n  --> test_report.py:10:5\n   |/n10 | def test_fail():\n   |     ^^^^^^^^^\n   |/ninfo: Test failed here\n  --> test_report.py:12:5\n   |/n12 |     assert False\n   |     ^^^^^^^^^^^^\n   |\n\n"
+                "rendered": "error[test-failure]: Test `test_fail` failed\n  --> test_report.py:10:5\n   |/n10 | def test_fail():\n   |     ^^^^^^^^^\n   |/ninfo: Test failed here\n  --> test_report.py:12:5\n   |/n12 |     assert False\n   |     ^^^^^^^^^^^^\n   |/ninfo: assert False\n\n"
               }
             },
             {
@@ -163,7 +164,7 @@ fn writes_json_result_report() {
                 "code": "test-failure",
                 "severity": "error",
                 "message": "Test `test_fail` failed",
-                "rendered": "error[test-failure]: Test `test_fail` failed\n  --> test_report.py:10:5\n   |/n10 | def test_fail():\n   |     ^^^^^^^^^\n   |/ninfo: Test failed here\n  --> test_report.py:12:5\n   |/n12 |     assert False\n   |     ^^^^^^^^^^^^\n   |\n\n"
+                "rendered": "error[test-failure]: Test `test_fail` failed\n  --> test_report.py:10:5\n   |/n10 | def test_fail():\n   |     ^^^^^^^^^\n   |/ninfo: Test failed here\n  --> test_report.py:12:5\n   |/n12 |     assert False\n   |     ^^^^^^^^^^^^\n   |/ninfo: assert False\n\n"
               }
             }
           ]
@@ -194,7 +195,7 @@ fn writes_json_result_report() {
                 "code": "test-failure",
                 "severity": "error",
                 "message": "Test `test_flaky` failed",
-                "rendered": "error[test-failure]: Test `test_flaky` failed\n  --> test_report.py:21:5\n   |/n21 | def test_flaky():\n   |     ^^^^^^^^^^\n   |/ninfo: Test failed here\n  --> test_report.py:26:5\n   |/n26 |     assert count >= 1\n   |     ^^^^^^^^^^^^^^^^^\n   |\n\n"
+                "rendered": "error[test-failure]: Test `test_flaky` failed\n  --> test_report.py:21:5\n   |/n21 | def test_flaky():\n   |     ^^^^^^^^^^\n   |/ninfo: Test failed here\n  --> test_report.py:26:5\n   |/n26 |     assert count >= 1\n   |     ^^^^^^^^^^^^^^^^^\n   |/ninfo: assert 0 >= 1\n\n"
               }
             },
             {
@@ -270,6 +271,7 @@ fn writes_jsonl_result_records() {
     6 |     assert False
       |     ^^^^^^^^^^^^
       |
+    info: assert False
 
     ────────────
          Summary [TIME] 2 tests run: 1 passed, 1 failed, 0 skipped
@@ -279,7 +281,7 @@ fn writes_jsonl_result_records() {
     );
 
     assert_snapshot!(context.read_file("reports/events.jsonl"), @r#"
-    {"schema_version":2,"type":"test","module":"test_events","name":"test_fail","full_name":"test_events::test_fail","status":"failed","duration_seconds":"[TIME]","diagnostic":{"code":"test-failure","severity":"error","message":"Test `test_fail` failed","rendered":"error[test-failure]: Test `test_fail` failed\n --> test_events.py:5:5\n  |/n5 | def test_fail():\n  |     ^^^^^^^^^\n  |/ninfo: Test failed here\n --> test_events.py:6:5\n  |/n6 |     assert False\n  |     ^^^^^^^^^^^^\n  |\n\n"}}
+    {"schema_version":2,"type":"test","module":"test_events","name":"test_fail","full_name":"test_events::test_fail","status":"failed","duration_seconds":"[TIME]","diagnostic":{"code":"test-failure","severity":"error","message":"Test `test_fail` failed","rendered":"error[test-failure]: Test `test_fail` failed\n --> test_events.py:5:5\n  |/n5 | def test_fail():\n  |     ^^^^^^^^^\n  |/ninfo: Test failed here\n --> test_events.py:6:5\n  |/n6 |     assert False\n  |     ^^^^^^^^^^^^\n  |/ninfo: assert False\n\n"}}
     {"schema_version":2,"type":"test","module":"test_events","name":"test_pass","full_name":"test_events::test_pass","status":"passed","duration_seconds":"[TIME]"}
     {"schema_version":2,"type":"run_finished","status":"failed","elapsed_seconds":"[TIME]","stats":{"total":2,"passed":1,"failed":1,"errors":0,"skipped":0,"flaky":0,"slow":0}}
     "#);
@@ -351,7 +353,7 @@ def test_flaky():
                 "code": "test-failure",
                 "severity": "error",
                 "message": "Test `test_flaky` failed",
-                "rendered": "error[test-failure]: Test `test_flaky` failed\n --> test_flaky.py:4:5\n  |/n4 | def test_flaky():\n  |     ^^^^^^^^^^\n  |/ninfo: Test failed here\n --> test_flaky.py:5:5\n  |/n5 |     assert os.environ[/"KARVA_ATTEMPT/"] == /"2/"\n  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  |\n\n"
+                "rendered": "error[test-failure]: Test `test_flaky` failed\n --> test_flaky.py:4:5\n  |/n4 | def test_flaky():\n  |     ^^^^^^^^^^\n  |/ninfo: Test failed here\n --> test_flaky.py:5:5\n  |/n5 |     assert os.environ[/"KARVA_ATTEMPT/"] == /"2/"\n  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  |/ninfo: assert os.environ[/"KARVA_ATTEMPT/"] == /"2/"\n\n"
               }
             },
             {
@@ -399,7 +401,7 @@ def test_flaky():
     "
     );
     assert_snapshot!(context.read_file("results.jsonl"), @r#"
-    {"schema_version":2,"type":"test","module":"test_flaky","name":"test_flaky","full_name":"test_flaky::test_flaky","status":"passed","duration_seconds":"[TIME]","flaky":true,"retry":{"attempts":2,"max_attempts":2},"attempts":[{"attempt":1,"status":"failed","duration_seconds":"[TIME]","diagnostic":{"code":"test-failure","severity":"error","message":"Test `test_flaky` failed","rendered":"error[test-failure]: Test `test_flaky` failed\n --> test_flaky.py:4:5\n  |/n4 | def test_flaky():\n  |     ^^^^^^^^^^\n  |/ninfo: Test failed here\n --> test_flaky.py:5:5\n  |/n5 |     assert os.environ[/"KARVA_ATTEMPT/"] == /"2/"\n  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  |\n\n"}},{"attempt":2,"status":"passed","duration_seconds":"[TIME]"}]}
+    {"schema_version":2,"type":"test","module":"test_flaky","name":"test_flaky","full_name":"test_flaky::test_flaky","status":"passed","duration_seconds":"[TIME]","flaky":true,"retry":{"attempts":2,"max_attempts":2},"attempts":[{"attempt":1,"status":"failed","duration_seconds":"[TIME]","diagnostic":{"code":"test-failure","severity":"error","message":"Test `test_flaky` failed","rendered":"error[test-failure]: Test `test_flaky` failed\n --> test_flaky.py:4:5\n  |/n4 | def test_flaky():\n  |     ^^^^^^^^^^\n  |/ninfo: Test failed here\n --> test_flaky.py:5:5\n  |/n5 |     assert os.environ[/"KARVA_ATTEMPT/"] == /"2/"\n  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  |/ninfo: assert os.environ[/"KARVA_ATTEMPT/"] == /"2/"\n\n"}},{"attempt":2,"status":"passed","duration_seconds":"[TIME]"}]}
     {"schema_version":2,"type":"run_finished","status":"failed","elapsed_seconds":"[TIME]","stats":{"total":1,"passed":1,"failed":0,"errors":0,"skipped":0,"flaky":1,"slow":0}}
     "#);
 }
@@ -593,6 +595,7 @@ fn writes_related_test_diagnostics() {
     10 |     assert False
        |     ^^^^^^^^^^^^
        |
+    info: assert False
 
     error[invalid-fixture-finalizer]: Discovered an invalid fixture finalizer `broken_teardown`
      --> test_related.py:5:5
@@ -634,7 +637,7 @@ fn writes_related_test_diagnostics() {
             "code": "test-failure",
             "severity": "error",
             "message": "Test `test_failure` failed",
-            "rendered": "error[test-failure]: Test `test_failure` failed\n --> test_related.py:9:5\n  |/n9 | def test_failure(broken_teardown):\n  |     ^^^^^^^^^^^^\n  |/ninfo: Test ran with arguments:/ninfo: `broken_teardown`: `None`/ninfo: Test failed here\n  --> test_related.py:10:5\n   |/n10 |     assert False\n   |     ^^^^^^^^^^^^\n   |\n\n"
+            "rendered": "error[test-failure]: Test `test_failure` failed\n --> test_related.py:9:5\n  |/n9 | def test_failure(broken_teardown):\n  |     ^^^^^^^^^^^^\n  |/ninfo: Test ran with arguments:/ninfo: `broken_teardown`: `None`/ninfo: Test failed here\n  --> test_related.py:10:5\n   |/n10 |     assert False\n   |     ^^^^^^^^^^^^\n   |/ninfo: assert False\n\n"
           },
           "related_diagnostics": [
             {

--- a/crates/karva/tests/it/run_ignored.rs
+++ b/crates/karva/tests/it/run_ignored.rs
@@ -44,6 +44,7 @@ fn runignored_runs_only_skipped_tests() {
     6 |     assert False
       |     ^^^^^^^^^^^^
       |
+    info: assert False
 
     test::test_skipped_with_reason:
 
@@ -59,6 +60,7 @@ fn runignored_runs_only_skipped_tests() {
     10 |     assert False
        |     ^^^^^^^^^^^^
        |
+    info: assert False
 
     ────────────
          Summary [TIME] 3 tests run: 0 passed, 2 failed, 1 skipped
@@ -95,6 +97,7 @@ fn runignored_all_runs_skipped_alongside_normal() {
     6 |     assert False
       |     ^^^^^^^^^^^^
       |
+    info: assert False
 
     test::test_skipped_with_reason:
 
@@ -110,6 +113,7 @@ fn runignored_all_runs_skipped_alongside_normal() {
     10 |     assert False
        |     ^^^^^^^^^^^^
        |
+    info: assert False
 
     ────────────
          Summary [TIME] 3 tests run: 1 passed, 2 failed, 0 skipped

--- a/crates/karva_test_semantic/src/discovery/discoverer.rs
+++ b/crates/karva_test_semantic/src/discovery/discoverer.rs
@@ -12,7 +12,7 @@ use ruff_python_parser::{Mode, ParseOptions, parse_unchecked};
 
 use crate::Context;
 use crate::collection::TestFunctionCollector;
-use crate::diagnostic::report_collection_error;
+use crate::diagnostic::{report_collection_error, report_failed_to_import_module};
 use crate::discovery::visitor::{discover, is_generator};
 use crate::discovery::{DiscoveredModule, DiscoveredPackage};
 use crate::extensions::fixtures::{DiscoveredFixture, RejectedFixture};
@@ -64,6 +64,15 @@ impl<'ctx, 'a> StandardDiscoverer<'ctx, 'a> {
                 return DiscoveredPackage::new(cwd.to_path_buf());
             }
         };
+
+        if let Err(error) = register_assertion_rewrite(py, &collected_package) {
+            report_failed_to_import_module(
+                self.context,
+                "karva._assertion",
+                &error.value(py).to_string(),
+            );
+            return DiscoveredPackage::new(cwd.to_path_buf());
+        }
 
         let mut session_package = self.convert_package(py, collected_package);
 
@@ -131,6 +140,33 @@ impl<'ctx, 'a> StandardDiscoverer<'ctx, 'a> {
 
         module
     }
+}
+
+fn register_assertion_rewrite(
+    py: Python<'_>,
+    collected_package: &CollectedPackage,
+) -> PyResult<()> {
+    fn collect_paths(package: &CollectedPackage, paths: &mut Vec<String>) {
+        if let Some(module) = &package.configuration_module {
+            paths.push(module.path.path().to_string());
+        }
+        paths.extend(
+            package
+                .modules
+                .values()
+                .map(|module| module.path.path().to_string()),
+        );
+        for package in package.packages.values() {
+            collect_paths(package, paths);
+        }
+    }
+
+    let mut paths = Vec::new();
+    collect_paths(collected_package, &mut paths);
+    py.import("karva._assertion")?
+        .getattr("register_assertion_rewrite")?
+        .call1((paths,))?;
+    Ok(())
 }
 
 /// Discovers all fixtures defined in `karva._builtins` by importing the module at

--- a/python/karva/_assertion.py
+++ b/python/karva/_assertion.py
@@ -1,0 +1,129 @@
+"""Assertion rewriting for test modules."""
+
+import ast
+import io
+import os
+import sys
+import tokenize
+from collections.abc import Sequence
+from importlib.abc import MetaPathFinder
+from importlib.machinery import ModuleSpec, PathFinder, SourceFileLoader
+from importlib.util import decode_source
+from types import CodeType, ModuleType
+from typing import Any
+
+
+def _normalized_path(path: str) -> str:
+    return os.path.normcase(os.path.realpath(path))
+
+
+def _format_assertion(
+    expression: str,
+    local_vars: dict[str, Any],
+    global_vars: dict[str, Any],
+) -> str:
+    values = global_vars | local_vars
+    tokens = list(tokenize.generate_tokens(io.StringIO(expression).readline))
+    line_offsets = [0]
+    for line in expression.splitlines(keepends=True):
+        line_offsets.append(line_offsets[-1] + len(line))
+
+    replacements: list[tuple[int, int, str]] = []
+    significant = [
+        token
+        for token in tokens
+        if token.type
+        not in {tokenize.ENCODING, tokenize.ENDMARKER, tokenize.INDENT, tokenize.DEDENT}
+    ]
+    for index, token in enumerate(significant):
+        if (
+            token.type != tokenize.NAME
+            or token.string not in values
+            or isinstance(values[token.string], ModuleType)
+        ):
+            continue
+        previous = significant[index - 1].string if index else None
+        following = (
+            significant[index + 1].string if index + 1 < len(significant) else None
+        )
+        if previous == "." or following == "(":
+            continue
+        start = line_offsets[token.start[0] - 1] + token.start[1]
+        end = line_offsets[token.end[0] - 1] + token.end[1]
+        replacements.append((start, end, repr(values[token.string])))
+
+    rendered = expression
+    for start, end, value in reversed(replacements):
+        rendered = f"{rendered[:start]}{value}{rendered[end:]}"
+    return f"assert {rendered}"
+
+
+class _AssertionTransformer(ast.NodeTransformer):
+    def __init__(self, source: str) -> None:
+        self.source = source
+
+    def visit_Assert(self, node: ast.Assert) -> ast.Assert:
+        self.generic_visit(node)
+        if node.msg is not None:
+            return node
+
+        expression = ast.get_source_segment(self.source, node.test) or ast.unparse(
+            node.test
+        )
+        node.msg = ast.Call(
+            func=ast.Name(id="_karva_format_assertion", ctx=ast.Load()),
+            args=[
+                ast.Constant(value=expression),
+                ast.Call(
+                    func=ast.Name(id="locals", ctx=ast.Load()), args=[], keywords=[]
+                ),
+                ast.Call(
+                    func=ast.Name(id="globals", ctx=ast.Load()), args=[], keywords=[]
+                ),
+            ],
+            keywords=[],
+        )
+        return node
+
+
+class _AssertionRewritingLoader(SourceFileLoader):
+    def get_code(self, fullname: str) -> CodeType:
+        del fullname
+        text = decode_source(self.get_data(self.path))
+        tree = _AssertionTransformer(text).visit(ast.parse(text, self.path))
+        ast.fix_missing_locations(tree)
+        return compile(tree, self.path, "exec", dont_inherit=True)
+
+    def exec_module(self, module: ModuleType) -> None:
+        module.__dict__["_karva_format_assertion"] = _format_assertion
+        super().exec_module(module)
+
+
+class _AssertionRewritingFinder(MetaPathFinder):
+    def __init__(self, paths: set[str]) -> None:
+        self.paths = paths
+
+    def find_spec(
+        self,
+        fullname: str,
+        path: Sequence[str] | None,
+        target: ModuleType | None = None,
+    ) -> ModuleSpec | None:
+        spec = PathFinder.find_spec(fullname, path, target)
+        if (
+            spec is not None
+            and spec.origin is not None
+            and _normalized_path(spec.origin) in self.paths
+            and isinstance(spec.loader, SourceFileLoader)
+        ):
+            spec.loader = _AssertionRewritingLoader(fullname, spec.origin)
+        return spec
+
+
+def register_assertion_rewrite(paths: list[str]) -> None:
+    normalized = {_normalized_path(path) for path in paths}
+    for finder in sys.meta_path:
+        if isinstance(finder, _AssertionRewritingFinder):
+            finder.paths.update(normalized)
+            return
+    sys.meta_path.insert(0, _AssertionRewritingFinder(normalized))


### PR DESCRIPTION
## Summary

Rewrite assertions while importing collected test modules so message-less `AssertionError` values include the evaluated expression. Fixes #1082.

## Test Plan

`cargo insta test -p karva --accept --test-runner nextest` and `uvx prek run -a`.