### PR TITLE
Add karva.approx

### DIFF
--- a/crates/karva/tests/it/common/mod.rs
+++ b/crates/karva/tests/it/common/mod.rs
@@ -62,6 +62,10 @@ impl TestContext {
         let mut settings = Settings::clone_current();
 
         settings.add_filter(&tempdir_filter(&project_path), "<temp_dir>/");
+        settings.add_filter(
+            &format!(r"{}.*karva[\\/]", regex::escape(venv_path.as_str())),
+            "<karva>/",
+        );
         settings.add_filter(r#"\\(\w\w|\s|\.|")"#, "/$1");
         settings.add_filter(r"\x1b\[[0-9;]*m", "");
         settings.add_filter(r"\[\s*\d+\.\d+s\]", "[TIME]");

--- a/crates/karva/tests/it/common/mod.rs
+++ b/crates/karva/tests/it/common/mod.rs
@@ -62,10 +62,6 @@ impl TestContext {
         let mut settings = Settings::clone_current();
 
         settings.add_filter(&tempdir_filter(&project_path), "<temp_dir>/");
-        settings.add_filter(
-            &format!(r"{}.*karva[\\/]", regex::escape(venv_path.as_str())),
-            "<karva>/",
-        );
         settings.add_filter(r#"\\(\w\w|\s|\.|")"#, "/$1");
         settings.add_filter(r"\x1b\[[0-9;]*m", "");
         settings.add_filter(r"\[\s*\d+\.\d+s\]", "[TIME]");

--- a/crates/karva/tests/it/extensions/functions.rs
+++ b/crates/karva/tests/it/extensions/functions.rs
@@ -81,8 +81,14 @@ fn test_approx_invalid_value_diagnostic() {
         r#"
 import karva
 
-def test_rejects_invalid_values():
+def test_rejects_invalid_sequence_value():
     karva.approx([1, "two"])
+
+def test_rejects_invalid_mapping_value():
+    karva.approx({"count": "two"})
+
+def test_rejects_invalid_scalar_value():
+    karva.approx("two")
         "#,
     );
 
@@ -90,29 +96,63 @@ def test_rejects_invalid_values():
     success: false
     exit_code: 1
     ----- stdout -----
-        Starting 1 test across 1 worker
-            FAIL [TIME] test::test_rejects_invalid_values
+        Starting 3 tests across 1 worker
+            FAIL [TIME] test::test_rejects_invalid_sequence_value
+            FAIL [TIME] test::test_rejects_invalid_mapping_value
+            FAIL [TIME] test::test_rejects_invalid_scalar_value
 
     failures:
 
-    test::test_rejects_invalid_values:
+    test::test_rejects_invalid_mapping_value:
 
-    error[test-failure]: Test `test_rejects_invalid_values` failed
-     --> test.py:4:5
+    error[test-failure]: Test `test_rejects_invalid_mapping_value` failed
+     --> test.py:7:5
       |
-    4 | def test_rejects_invalid_values():
-      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    7 | def test_rejects_invalid_mapping_value():
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
     info: Test failed here
-       --> <karva>/_approx.py:187:13
-        |
-    187 |             raise TypeError(f"karva.approx() expected a numeric value, got {value!r}")
-        |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-        |
-    info: karva.approx() expected a numeric value, got 'two'
+     --> test.py:8:5
+      |
+    8 |     karva.approx({"count": "two"})
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: karva.approx() expected a numeric value at key 'count', got str: 'two'
+
+    test::test_rejects_invalid_scalar_value:
+
+    error[test-failure]: Test `test_rejects_invalid_scalar_value` failed
+      --> test.py:10:5
+       |
+    10 | def test_rejects_invalid_scalar_value():
+       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       |
+    info: Test failed here
+      --> test.py:11:5
+       |
+    11 |     karva.approx("two")
+       |     ^^^^^^^^^^^^^^^^^^^
+       |
+    info: karva.approx() expected a numeric value, got str: 'two'
+
+    test::test_rejects_invalid_sequence_value:
+
+    error[test-failure]: Test `test_rejects_invalid_sequence_value` failed
+     --> test.py:4:5
+      |
+    4 | def test_rejects_invalid_sequence_value():
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: Test failed here
+     --> test.py:5:5
+      |
+    5 |     karva.approx([1, "two"])
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: karva.approx() expected a numeric value at index 1, got str: 'two'
 
     ────────────
-         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+         Summary [TIME] 3 tests run: 0 passed, 3 failed, 0 skipped
 
     ----- stderr -----
     "#);

--- a/crates/karva/tests/it/extensions/functions.rs
+++ b/crates/karva/tests/it/extensions/functions.rs
@@ -5,6 +5,69 @@ use rstest::rstest;
 use crate::common::TestContext;
 
 #[test]
+fn test_approx_matches_pytest() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+from decimal import Decimal
+import math
+
+import karva
+import pytest
+
+CASES = [
+    (0.1 + 0.2, 0.3, {}, True),
+    (1.0001, 1, {}, False),
+    (1.0001, 1, {"rel": 1e-3}, True),
+    (1 + 1e-8, 1, {"abs": 1e-12}, False),
+    (1e-13, 0, {}, True),
+    (complex(1.0000001, 2), complex(1, 2), {}, True),
+    (Decimal("1.0000001"), Decimal("1"), {}, True),
+    ([0.1 + 0.2, 0.6], [0.3, 0.6], {}, True),
+    ([0.3], [0.3, 0.6], {}, False),
+    ({"x": 0.1 + 0.2}, {"x": 0.3}, {}, True),
+    ({"y": 0.3}, {"x": 0.3}, {}, False),
+    (math.nan, math.nan, {}, False),
+    (math.nan, math.nan, {"nan_ok": True}, True),
+    (math.inf, math.inf, {}, True),
+    (-math.inf, math.inf, {}, False),
+]
+
+def test_supported_cases_match_pytest():
+    for actual, expected, kwargs, result in CASES:
+        assert (actual == karva.approx(expected, **kwargs)) == result
+        assert (actual == karva.approx(expected, **kwargs)) == (actual == pytest.approx(expected, **kwargs))
+
+def test_works_on_either_side():
+    assert karva.approx(0.3) == 0.1 + 0.2
+    assert 0.1 + 0.2 == karva.approx(0.3)
+
+def test_rejects_invalid_values():
+    with karva.raises(TypeError, match="expected a numeric value"):
+        karva.approx([1, "two"])
+
+def test_representation_includes_tolerance():
+    assert "0.3 ± 3.0e-07" == repr(karva.approx(0.3))
+        "#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 4 tests across 1 worker
+            PASS [TIME] test::test_supported_cases_match_pytest
+            PASS [TIME] test::test_works_on_either_side
+            PASS [TIME] test::test_rejects_invalid_values
+            PASS [TIME] test::test_representation_includes_tolerance
+    ────────────
+         Summary [TIME] 4 tests run: 4 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_fail_function() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva/tests/it/extensions/functions.rs
+++ b/crates/karva/tests/it/extensions/functions.rs
@@ -15,7 +15,7 @@ import math
 import karva
 import pytest
 
-CASES = [
+@karva.tags.parametrize("actual, expected, kwargs, result", [
     (0.1 + 0.2, 0.3, {}, True),
     (1.0001, 1, {}, False),
     (1.0001, 1, {"rel": 1e-3}, True),
@@ -31,20 +31,14 @@ CASES = [
     (math.nan, math.nan, {"nan_ok": True}, True),
     (math.inf, math.inf, {}, True),
     (-math.inf, math.inf, {}, False),
-]
-
-def test_supported_cases_match_pytest():
-    for actual, expected, kwargs, result in CASES:
-        assert (actual == karva.approx(expected, **kwargs)) == result
-        assert (actual == karva.approx(expected, **kwargs)) == (actual == pytest.approx(expected, **kwargs))
+])
+def test_supported_cases_match_pytest(actual, expected, kwargs, result):
+    assert (actual == karva.approx(expected, **kwargs)) == result
+    assert (actual == karva.approx(expected, **kwargs)) == (actual == pytest.approx(expected, **kwargs))
 
 def test_works_on_either_side():
     assert karva.approx(0.3) == 0.1 + 0.2
     assert 0.1 + 0.2 == karva.approx(0.3)
-
-def test_rejects_invalid_values():
-    with karva.raises(TypeError, match="expected a numeric value"):
-        karva.approx([1, "two"])
 
 def test_representation_includes_tolerance():
     assert "0.3 ± 3.0e-07" == repr(karva.approx(0.3))
@@ -55,16 +49,73 @@ def test_representation_includes_tolerance():
     success: true
     exit_code: 0
     ----- stdout -----
-        Starting 4 tests across 1 worker
-            PASS [TIME] test::test_supported_cases_match_pytest
+        Starting 3 tests across 1 worker
+            PASS [TIME] test::test_supported_cases_match_pytest(actual=0.30000000000000004, expected=0.3, kwargs={}, result=True)
+            PASS [TIME] test::test_supported_cases_match_pytest(actual=1.0001, expected=1, kwargs={}, result=False)
+            PASS [TIME] test::test_supported_cases_match_pytest(actual=1.0001, expected=1, kwargs={'rel': 0.001}, result=True)
+            PASS [TIME] test::test_supported_cases_match_pytest(actual=1.00000001, expected=1, kwargs={'abs': 1e-12}, result=False)
+            PASS [TIME] test::test_supported_cases_match_pytest(actual=1e-13, expected=0, kwargs={}, result=True)
+            PASS [TIME] test::test_supported_cases_match_pytest(actual=(1.0000001+2j), expected=(1+2j), kwargs={}, result=True)
+            PASS [TIME] test::test_supported_cases_match_pytest(actual=1.0000001, expected=1, kwargs={}, result=True)
+            PASS [TIME] test::test_supported_cases_match_pytest(actual=[0.30000000000000004, 0.6], expected=[0.3, 0.6], kwargs={}, result=True)
+            PASS [TIME] test::test_supported_cases_match_pytest(actual=[0.3], expected=[0.3, 0.6], kwargs={}, result=False)
+            PASS [TIME] test::test_supported_cases_match_pytest(actual={'x': 0.30000000000000004}, expected={'x': 0.3}, kwargs={}, result=True)
+            PASS [TIME] test::test_supported_cases_match_pytest(actual={'y': 0.3}, expected={'x': 0.3}, kwargs={}, result=False)
+            PASS [TIME] test::test_supported_cases_match_pytest(actual=nan, expected=nan, kwargs={}, result=False)
+            PASS [TIME] test::test_supported_cases_match_pytest(actual=nan, expected=nan, kwargs={'nan_ok': True}, result=True)
+            PASS [TIME] test::test_supported_cases_match_pytest(actual=inf, expected=inf, kwargs={}, result=True)
+            PASS [TIME] test::test_supported_cases_match_pytest(actual=-inf, expected=inf, kwargs={}, result=False)
             PASS [TIME] test::test_works_on_either_side
-            PASS [TIME] test::test_rejects_invalid_values
             PASS [TIME] test::test_representation_includes_tolerance
     ────────────
-         Summary [TIME] 4 tests run: 4 passed, 0 skipped
+         Summary [TIME] 17 tests run: 17 passed, 0 skipped
 
     ----- stderr -----
     ");
+}
+
+#[test]
+fn test_approx_invalid_value_diagnostic() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+
+def test_rejects_invalid_values():
+    karva.approx([1, "two"])
+        "#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_rejects_invalid_values
+
+    failures:
+
+    test::test_rejects_invalid_values:
+
+    error[test-failure]: Test `test_rejects_invalid_values` failed
+     --> test.py:4:5
+      |
+    4 | def test_rejects_invalid_values():
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: Test failed here
+       --> <karva>/_approx.py:187:13
+        |
+    187 |             raise TypeError(f"karva.approx() expected a numeric value, got {value!r}")
+        |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        |
+    info: karva.approx() expected a numeric value, got 'two'
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    "#);
 }
 
 #[test]

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -6,7 +6,7 @@
 
 use camino::Utf8Path;
 use karva_collector::CollectionError;
-use karva_diagnostic::Traceback;
+use karva_diagnostic::{Traceback, TracebackFrame};
 use karva_logging::time::format_duration;
 use karva_python_semantic::FunctionKind;
 use pyo3::{PyErr, Python};
@@ -739,11 +739,7 @@ fn handle_failed_function_call(
             frames
                 .iter()
                 .rev()
-                .find(|frame| {
-                    frame.source.as_ref().is_some_and(|frame_source| {
-                        frame_source.source_file.name() == source_file.name()
-                    })
-                })
+                .find(|frame| !is_installed_package_frame(frame))
                 .or_else(|| frames.last())
         };
 
@@ -769,6 +765,13 @@ fn handle_failed_function_call(
     if !error_string.is_empty() {
         diagnostic.info(indent_continuation_lines(&error_string));
     }
+}
+
+fn is_installed_package_frame(frame: &TracebackFrame) -> bool {
+    frame
+        .file_path
+        .components()
+        .any(|component| matches!(component.as_str(), "site-packages" | "dist-packages"))
 }
 
 /// Indent continuation lines in a multi-line message so they align under the first line's text.

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -733,7 +733,21 @@ fn handle_failed_function_call(
             }
         }
 
-        if let Some(failure) = frames.last() {
+        let failure = if verbose {
+            frames.last()
+        } else {
+            frames
+                .iter()
+                .rev()
+                .find(|frame| {
+                    frame.source.as_ref().is_some_and(|frame_source| {
+                        frame_source.source_file.name() == source_file.name()
+                    })
+                })
+                .or_else(|| frames.last())
+        };
+
+        if let Some(failure) = failure {
             let message = format!("{} failed here", function_kind.capitalised());
             if let Some(source) = &failure.source {
                 let mut sub = SubDiagnostic::new(SubDiagnosticSeverity::Info, message);

--- a/docs/usage/writing-tests/functions.md
+++ b/docs/usage/writing-tests/functions.md
@@ -1,3 +1,31 @@
+## Approximate comparisons
+
+Use `karva.approx()` when floating-point results should match within a tolerance.
+It uses pytest's defaults: relative tolerance `1e-6` and absolute tolerance
+`1e-12`.
+
+```python title="test.py"
+import karva
+
+def test_total():
+    assert 0.1 + 0.2 == karva.approx(0.3)
+
+def test_coordinates():
+    assert [0.1000001, 0.2] == karva.approx([0.1, 0.2], rel=1e-5)
+```
+
+Mappings, ordered sequences, complex numbers, and `Decimal` values are
+supported. Set `nan_ok=True` to compare NaN values as equal. This is the direct
+replacement for `pytest.approx()` when migrating tests:
+
+```python
+# pytest
+assert value == pytest.approx(expected)
+
+# Karva
+assert value == karva.approx(expected)
+```
+
 ## Skip
 
 If you want to skip a test when its running, use `karva.skip()`.

--- a/python/karva/__init__.py
+++ b/python/karva/__init__.py
@@ -1,5 +1,6 @@
 """Karva is a Python test framework, written in Rust."""
 
+from karva._approx import approx
 from karva._builtins import MockEnv
 from karva._karva import (
     Command,
@@ -33,6 +34,7 @@ __all__: list[str] = [
     "SkipError",
     "SnapshotMismatchError",
     "SnapshotSettings",
+    "approx",
     "assert_cmd_snapshot",
     "assert_json_snapshot",
     "assert_snapshot",

--- a/python/karva/_approx.py
+++ b/python/karva/_approx.py
@@ -57,7 +57,8 @@ class _Approx(Generic[_Expected]):
     def _scalar(self, expected: object) -> _ApproxScalar:
         if not _is_number(expected):
             raise TypeError(
-                f"karva.approx() expected a numeric value, got {expected!r}"
+                "karva.approx() expected a numeric value, "
+                f"got {type(expected).__name__}: {expected!r}"
             )
         return _ApproxScalar(expected, self.rel, self.abs, self.nan_ok)
 
@@ -182,9 +183,13 @@ def _item(value: object) -> object:
 
 
 def _validate_values(values: Iterable[object]) -> None:
-    for value in values:
-        if not _is_number(_item(value)):
-            raise TypeError(f"karva.approx() expected a numeric value, got {value!r}")
+    for index, value in enumerate(values):
+        item = _item(value)
+        if not _is_number(item):
+            raise TypeError(
+                "karva.approx() expected a numeric value "
+                f"at index {index}, got {type(item).__name__}: {item!r}"
+            )
 
 
 def approx(
@@ -195,7 +200,13 @@ def approx(
 ) -> _Approx[Any]:
     """Return an object that compares equal to numbers within given tolerances."""
     if isinstance(expected, Mapping):
-        _validate_values(expected.values())
+        for key, value in expected.items():
+            item = _item(value)
+            if not _is_number(item):
+                raise TypeError(
+                    "karva.approx() expected a numeric value "
+                    f"at key {key!r}, got {type(item).__name__}: {item!r}"
+                )
         return _ApproxMapping(cast(Mapping[object, object], expected), rel, abs, nan_ok)
     if _is_array(expected):
         _validate_values(expected.flat)
@@ -204,7 +215,10 @@ def approx(
         _validate_values(expected)
         return _ApproxSequence(expected, rel, abs, nan_ok)
     if not _is_number(expected):
-        raise TypeError(f"karva.approx() expected a numeric value, got {expected!r}")
+        raise TypeError(
+            "karva.approx() expected a numeric value, "
+            f"got {type(expected).__name__}: {expected!r}"
+        )
     return _ApproxScalar(expected, rel, abs, nan_ok)
 
 

--- a/python/karva/_approx.py
+++ b/python/karva/_approx.py
@@ -1,0 +1,211 @@
+"""Approximate numeric comparisons."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Mapping, Sequence
+from decimal import Decimal
+from numbers import Complex
+from typing import Any, Generic, Protocol, TypeGuard, TypeVar, cast
+
+_Tolerance = float | Decimal
+_Number = Complex | Decimal
+_Expected = TypeVar("_Expected")
+
+
+class _Array(Protocol):
+    flat: Iterable[object]
+    shape: object
+
+    def tolist(self) -> object: ...
+
+
+def _is_number(value: object) -> TypeGuard[_Number]:
+    return not isinstance(value, bool) and isinstance(value, Complex | Decimal)
+
+
+def _is_array(value: object) -> TypeGuard[_Array]:
+    return all(hasattr(value, attribute) for attribute in ("flat", "shape", "tolist"))
+
+
+class _Approx(Generic[_Expected]):
+    __array_priority__ = 100
+    __array_ufunc__ = None
+    __hash__ = None
+
+    def __init__(
+        self,
+        expected: _Expected,
+        rel: _Tolerance | None,
+        absolute: _Tolerance | None,
+        nan_ok: bool,
+    ) -> None:
+        self.expected = expected
+        self.rel = rel
+        self.abs = absolute
+        self.nan_ok = nan_ok
+
+    def __bool__(self) -> bool:
+        raise AssertionError(
+            "approx() is not supported in a boolean context.\n"
+            "Did you mean: `assert actual == approx(expected)`?"
+        )
+
+    def __ne__(self, actual: object) -> bool:
+        return not self == actual
+
+    def _scalar(self, expected: object) -> _ApproxScalar:
+        if not _is_number(expected):
+            raise TypeError(
+                f"karva.approx() expected a numeric value, got {expected!r}"
+            )
+        return _ApproxScalar(expected, self.rel, self.abs, self.nan_ok)
+
+
+class _ApproxScalar(_Approx[_Number]):
+    def __eq__(self, actual: object) -> bool:
+        if _is_array(actual):
+            return all(self == _item(value) for value in actual.flat)
+        if actual == self.expected:
+            return not isinstance(actual, bool) or isinstance(self.expected, bool)
+        if not _is_number(actual):
+            return False
+        if math.isnan(abs(self.expected)):
+            return self.nan_ok and math.isnan(abs(actual))
+        if math.isinf(abs(self.expected)):
+            return False
+        try:
+            expected: Any = self.expected
+            return abs(expected - actual) <= self.tolerance
+        except TypeError:
+            return False
+
+    @property
+    def tolerance(self) -> _Tolerance:
+        if isinstance(self.expected, Decimal):
+            default_absolute = Decimal("1e-12")
+            default_relative = Decimal("1e-6")
+        else:
+            default_absolute = 1e-12
+            default_relative = 1e-6
+
+        absolute = self.abs if self.abs is not None else default_absolute
+        if absolute < 0:
+            raise ValueError(f"absolute tolerance can't be negative: {absolute}")
+        if math.isnan(absolute):
+            raise ValueError("absolute tolerance can't be NaN")
+        if self.abs is not None and self.rel is None:
+            return absolute
+
+        relative = self.rel if self.rel is not None else default_relative
+        try:
+            expected: Any = self.expected
+            relative_tolerance = relative * abs(expected)
+        except TypeError as error:
+            raise TypeError("Decimal comparisons require Decimal tolerances") from error
+        if relative_tolerance < 0:
+            raise ValueError(
+                f"relative tolerance can't be negative: {relative_tolerance}"
+            )
+        if math.isnan(relative_tolerance):
+            raise ValueError("relative tolerance can't be NaN")
+        return max(relative_tolerance, absolute)
+
+    def __repr__(self) -> str:
+        if math.isinf(abs(self.expected)):
+            return str(self.expected)
+        try:
+            tolerance = self.tolerance
+            formatted = (
+                f"{tolerance:n}"
+                if Decimal("1e-3") <= tolerance < Decimal("1e3")
+                else f"{tolerance:.1e}"
+            )
+        except (TypeError, ValueError):
+            formatted = "???"
+        if isinstance(self.expected, complex) and self.expected.imag:
+            formatted += " ∠ ±180°"
+        return f"{self.expected} ± {formatted}"
+
+
+class _ApproxSequence(_Approx[Sequence[object]]):
+    def __eq__(self, actual: object) -> bool:
+        if not isinstance(actual, Sequence) or isinstance(actual, str | bytes):
+            return False
+        return len(actual) == len(self.expected) and all(
+            self._scalar(expected) == value
+            for value, expected in zip(actual, self.expected, strict=True)
+        )
+
+    def __repr__(self) -> str:
+        values = (self._scalar(value) for value in self.expected)
+        if type(self.expected) is tuple:
+            return f"approx({tuple(values)!r})"
+        return f"approx({list(values)!r})"
+
+
+class _ApproxMapping(_Approx[Mapping[object, object]]):
+    def __eq__(self, actual: object) -> bool:
+        if not isinstance(actual, Mapping) or actual.keys() != self.expected.keys():
+            return False
+        actual_mapping = cast(Mapping[Any, object], actual)
+        return all(
+            self._scalar(expected) == actual_mapping[key]
+            for key, expected in self.expected.items()
+        )
+
+    def __repr__(self) -> str:
+        values = {key: self._scalar(value) for key, value in self.expected.items()}
+        return f"approx({values!r})"
+
+
+class _ApproxArray(_Approx[_Array]):
+    def __eq__(self, actual: object) -> bool:
+        if _is_number(actual):
+            return all(
+                self._scalar(_item(value)) == actual for value in self.expected.flat
+            )
+        if not _is_array(actual) or actual.shape != self.expected.shape:
+            return False
+        return all(
+            self._scalar(_item(expected)) == _item(value)
+            for value, expected in zip(actual.flat, self.expected.flat, strict=True)
+        )
+
+    def __repr__(self) -> str:
+        return f"approx({self.expected.tolist()!r})"
+
+
+def _item(value: object) -> object:
+    item = getattr(value, "item", None)
+    return item() if item is not None else value
+
+
+def _validate_values(values: Iterable[object]) -> None:
+    for value in values:
+        if not _is_number(_item(value)):
+            raise TypeError(f"karva.approx() expected a numeric value, got {value!r}")
+
+
+def approx(
+    expected: object,
+    rel: _Tolerance | None = None,
+    abs: _Tolerance | None = None,
+    nan_ok: bool = False,
+) -> _Approx[Any]:
+    """Return an object that compares equal to numbers within given tolerances."""
+    if isinstance(expected, Mapping):
+        _validate_values(expected.values())
+        return _ApproxMapping(cast(Mapping[object, object], expected), rel, abs, nan_ok)
+    if _is_array(expected):
+        _validate_values(expected.flat)
+        return _ApproxArray(expected, rel, abs, nan_ok)
+    if isinstance(expected, Sequence) and not isinstance(expected, str | bytes):
+        _validate_values(expected)
+        return _ApproxSequence(expected, rel, abs, nan_ok)
+    if not _is_number(expected):
+        raise TypeError(f"karva.approx() expected a numeric value, got {expected!r}")
+    return _ApproxScalar(expected, rel, abs, nan_ok)
+
+
+__all__ = ["approx"]


### PR DESCRIPTION
## Summary

Adds typed `karva.approx` comparisons for numeric scalars, complex numbers, decimals, ordered sequences, mappings, and optional array-like objects without a pytest runtime dependency. Documents direct `pytest.approx` migration and validates supported behavior against pytest.

Closes #954.

## Test Plan

`just test -p karva test_approx_matches_pytest`, docs build, and `uvx prek run -a`.