### PR TITLE
Represent runtime fixture failure causality

### DIFF
--- a/crates/karva/src/commands/test/junit.rs
+++ b/crates/karva/src/commands/test/junit.rs
@@ -4,7 +4,9 @@ use std::fmt::Write as _;
 use anyhow::{Context as _, Result};
 use camino::Utf8Path;
 use karva_cache::AggregatedResults;
-use karva_diagnostic::{RenderedDiagnostic, TestCaseAttempt, TestCaseOutcome, TestCaseResult};
+use karva_diagnostic::{
+    FixtureFailure, RenderedDiagnostic, TestCaseAttempt, TestCaseOutcome, TestCaseResult,
+};
 use karva_metadata::JunitSettings;
 use karva_project::path::absolute;
 
@@ -138,6 +140,7 @@ fn write_case(xml: &mut String, settings: &JunitSettings, case: &TestCaseResult)
     }
 
     xml.push_str(">\n");
+    write_fixture_failure_properties(xml, case)?;
     match case.outcome() {
         TestCaseOutcome::Passed => {
             if case.is_junit_flaky_failure() {
@@ -172,6 +175,7 @@ fn write_case(xml: &mut String, settings: &JunitSettings, case: &TestCaseResult)
         TestCaseOutcome::Error {
             diagnostic,
             related,
+            ..
         } => write_diagnostic_element(xml, "error", diagnostic, related, None)?,
         TestCaseOutcome::Skipped { reason } => {
             if let Some(reason) = reason {
@@ -189,6 +193,51 @@ fn write_case(xml: &mut String, settings: &JunitSettings, case: &TestCaseResult)
     }
 
     xml.push_str("    </testcase>\n");
+    Ok(())
+}
+
+fn write_fixture_failure_properties(xml: &mut String, case: &TestCaseResult) -> Result<()> {
+    let has_attempt_failures = case
+        .attempts()
+        .iter()
+        .any(|attempt| !attempt.outcome().fixture_failures().is_empty());
+    if !has_attempt_failures && case.outcome().fixture_failures().is_empty() {
+        return Ok(());
+    }
+
+    xml.push_str("      <properties>\n");
+    if has_attempt_failures {
+        for attempt in case.attempts() {
+            for failure in attempt.outcome().fixture_failures() {
+                write_fixture_failure_property(xml, Some(attempt.attempt()), failure)?;
+            }
+        }
+    } else {
+        for failure in case.outcome().fixture_failures() {
+            write_fixture_failure_property(xml, None, failure)?;
+        }
+    }
+    xml.push_str("      </properties>\n");
+    Ok(())
+}
+
+fn write_fixture_failure_property(
+    xml: &mut String,
+    attempt: Option<u32>,
+    failure: &FixtureFailure,
+) -> Result<()> {
+    let name = attempt.map_or_else(
+        || "karva.fixture_failure".to_string(),
+        |attempt| format!("karva.fixture_failure.attempt.{attempt}"),
+    );
+    let chain = failure.dependency_chain().join(" -> ");
+    writeln!(
+        xml,
+        "        <property name=\"{}\" value=\"{} [{}]\"/>",
+        escape_xml(&name),
+        escape_xml(&failure.description()),
+        escape_xml(&chain),
+    )?;
     Ok(())
 }
 

--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -346,7 +346,7 @@ fn write_test_failures_block(
         let Some(diagnostic) = case.outcome().diagnostic() else {
             continue;
         };
-        writeln!(stdout, "{}:", case.full_name())?;
+        write_test_failure_header(stdout, case)?;
         if case.captured_output().is_none() {
             for (other_index, other) in failed_tests.iter().enumerate().skip(index + 1) {
                 if other.captured_output().is_none()
@@ -354,7 +354,7 @@ fn write_test_failures_block(
                     && other.outcome().related_diagnostics() == case.outcome().related_diagnostics()
                 {
                     emitted[other_index] = true;
-                    writeln!(stdout, "{}:", other.full_name())?;
+                    write_test_failure_header(stdout, other)?;
                 }
             }
         }
@@ -370,6 +370,26 @@ fn write_test_failures_block(
         }
     }
 
+    Ok(())
+}
+
+fn write_test_failure_header(
+    stdout: &mut Stdout,
+    case: &karva_diagnostic::TestCaseResult,
+) -> Result<()> {
+    write!(stdout, "{}", case.full_name())?;
+    let fixture_failures = case.outcome().fixture_failures();
+    if !fixture_failures.is_empty() {
+        write!(stdout, " (")?;
+        for (index, failure) in fixture_failures.iter().enumerate() {
+            if index > 0 {
+                write!(stdout, "; ")?;
+            }
+            write!(stdout, "{}", failure.description())?;
+        }
+        write!(stdout, ")")?;
+    }
+    writeln!(stdout, ":")?;
     Ok(())
 }
 

--- a/crates/karva/src/commands/test/result_report.rs
+++ b/crates/karva/src/commands/test/result_report.rs
@@ -5,8 +5,8 @@ use camino::Utf8Path;
 use karva_cache::AggregatedResults;
 use karva_cli::ResultFormat;
 use karva_diagnostic::{
-    CapturedTestOutput, RenderedDiagnostic, TestCaseAttempt, TestCaseOutcome, TestCaseResult,
-    TestCaseRetry,
+    CapturedTestOutput, FixtureFailure, RenderedDiagnostic, TestCaseAttempt, TestCaseOutcome,
+    TestCaseResult, TestCaseRetry,
 };
 use karva_project::path::absolute;
 use serde::Serialize;
@@ -192,6 +192,8 @@ struct TestReport<'a> {
     captured_output: Option<CapturedOutputReport<'a>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     diagnostic: Option<DiagnosticReport<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fixture_failures: Option<&'a [FixtureFailure]>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     related_diagnostics: Vec<DiagnosticReport<'a>>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -224,6 +226,8 @@ impl<'a> TestReport<'a> {
             retry,
             captured_output: case.captured_output().map(CapturedOutputReport::new),
             diagnostic: diagnostic.map(DiagnosticReport::new),
+            fixture_failures: (!case.outcome().fixture_failures().is_empty())
+                .then_some(case.outcome().fixture_failures()),
             related_diagnostics: case
                 .outcome()
                 .related_diagnostics()
@@ -244,6 +248,8 @@ struct AttemptReport<'a> {
     captured_output: Option<CapturedOutputReport<'a>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     diagnostic: Option<DiagnosticReport<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fixture_failures: Option<&'a [FixtureFailure]>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     related_diagnostics: Vec<DiagnosticReport<'a>>,
 }
@@ -266,6 +272,8 @@ impl<'a> AttemptReport<'a> {
             duration_seconds: attempt.duration().as_secs_f64(),
             captured_output: attempt.captured_output().map(CapturedOutputReport::new),
             diagnostic,
+            fixture_failures: (!attempt.outcome().fixture_failures().is_empty())
+                .then_some(attempt.outcome().fixture_failures()),
             related_diagnostics: attempt
                 .outcome()
                 .related_diagnostics()

--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -478,7 +478,7 @@ fn test_fail_concise_output() {
 
     test_fail.py:5:5: error[invalid-fixture-finalizer] Discovered an invalid fixture finalizer `fixture_1`
 
-    test_fail::test_2:
+    test_fail::test_2 (requires fixture `fixture_2`):
 
     test_fail.py:13:5: error[fixture-failure] Fixture `fixture_2` failed
 
@@ -1438,7 +1438,7 @@ def test_2(y): pass
 
     failures:
 
-    test_file::test_1:
+    test_file::test_1 (requires fixture `x`):
 
     error[fixture-failure]: Fixture `x` failed
      --> foo.py:5:5

--- a/crates/karva/tests/it/extensions/fixtures/autouse.rs
+++ b/crates/karva/tests/it/extensions/fixtures/autouse.rs
@@ -220,8 +220,8 @@ def test_something_else():
 
     failures:
 
-    test::test_something:
-    test::test_something_else:
+    test::test_something (uses auto-use fixture `failing_fixture`):
+    test::test_something_else (uses auto-use fixture `failing_fixture`):
 
     error[fixture-failure]: Fixture `failing_fixture` failed
      --> test.py:5:5
@@ -319,7 +319,7 @@ def test_unreachable():
 
     failures:
 
-    test::test_unreachable:
+    test::test_unreachable (uses auto-use fixture `failing_setup_fixture`):
 
     error[fixture-failure]: Fixture `failing_setup_fixture` failed
       --> test.py:10:5
@@ -379,7 +379,7 @@ def test_something():
 
     failures:
 
-    test::test_something:
+    test::test_something (uses auto-use fixture `auto_fixture`):
 
     error[fixture-failure]: Fixture `failing_dep` failed
      --> test.py:5:5
@@ -437,8 +437,8 @@ def test_second():
 
     failures:
 
-    test::test_first:
-    test::test_second:
+    test::test_first (uses auto-use fixture `failing_scoped_fixture`):
+    test::test_second (uses auto-use fixture `failing_scoped_fixture`):
 
     error[fixture-failure]: Fixture `failing_scoped_fixture` failed
      --> test.py:5:5

--- a/crates/karva/tests/it/extensions/fixtures/invalid.rs
+++ b/crates/karva/tests/it/extensions/fixtures/invalid.rs
@@ -232,7 +232,7 @@ fn test_fixture_fails_to_run() {
 
     failures:
 
-    test::test_failing_fixture:
+    test::test_failing_fixture (requires fixture `failing_fixture`):
 
     error[fixture-failure]: Fixture `failing_fixture` failed
      --> test.py:5:5
@@ -372,7 +372,7 @@ fn test_failing_yield_fixture() {
 
     failures:
 
-    test::test_failing_fixture:
+    test::test_failing_fixture (requires fixture `fixture`):
 
     error[fixture-failure]: Fixture `fixture` failed
      --> test.py:5:5
@@ -514,7 +514,7 @@ fn test_fixture_dependency_chain_failure() {
 
     failures:
 
-    test::test_with_db:
+    test::test_with_db (requires fixture `db`):
 
     error[fixture-failure]: Fixture `config` failed
      --> test.py:5:5

--- a/crates/karva/tests/it/extensions/tags/fail_slow.rs
+++ b/crates/karva/tests/it/extensions/tags/fail_slow.rs
@@ -395,7 +395,7 @@ def test_example(broken):
 
     failures:
 
-    test::test_example:
+    test::test_example (requires fixture `broken`):
 
     error[fixture-failure]: Fixture `broken` failed
       --> test.py:11:5

--- a/crates/karva/tests/it/extensions/tags/use_fixtures.rs
+++ b/crates/karva/tests/it/extensions/tags/use_fixtures.rs
@@ -35,6 +35,65 @@ def test_with_use_fixture():
 }
 
 #[test]
+fn test_use_fixtures_setup_failure() {
+    let test_context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+
+@karva.fixture
+def dependency():
+    raise RuntimeError("setup failed")
+
+@karva.fixture
+def setup_fixture(dependency):
+    return dependency
+
+@karva.tags.use_fixtures("setup_fixture")
+def test_blocked():
+    raise AssertionError("test body ran")
+"#,
+    );
+
+    assert_cmd_snapshot!(test_context.command(), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+           ERROR [TIME] test::test_blocked
+
+    failures:
+
+    test::test_blocked (uses fixture `setup_fixture` via `use_fixtures`):
+
+    error[fixture-failure]: Fixture `dependency` failed
+     --> test.py:5:5
+      |
+    5 | def dependency():
+      |     ^^^^^^^^^^
+      |
+    info: Fixture `setup_fixture` requires `dependency`
+     --> test.py:9:5
+      |
+    9 | def setup_fixture(dependency):
+      |     ^^^^^^^^^^^^^
+      |
+    info: Fixture failed here
+     --> test.py:6:5
+      |
+    6 |     raise RuntimeError("setup failed")
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: setup failed
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
+
+    ----- stderr -----
+    "#);
+}
+
+#[test]
 fn test_use_fixtures_multiple_fixtures() {
     let test_context = TestContext::with_file(
         "test.py",

--- a/crates/karva/tests/it/junit.rs
+++ b/crates/karva/tests/it/junit.rs
@@ -616,7 +616,7 @@ def test_failure():
       |     ^^^^^^^^^^^^
       |
 
-    test_fixture::test_unreachable:
+    test_fixture::test_unreachable (uses auto-use fixture `broken_fixture`):
 
     error[fixture-failure]: Fixture `broken_fixture` failed
      --> test_fixture.py:5:5
@@ -663,6 +663,9 @@ def test_failure():
       </testsuite>
       <testsuite name="test_fixture" tests="1" failures="0" skipped="0" errors="1" time="[TIME]">
         <testcase classname="test_fixture" name="test_unreachable" time="[TIME]">
+          <properties>
+            <property name="karva.fixture_failure" value="uses auto-use fixture `broken_fixture` [broken_fixture]"/>
+          </properties>
           <error message="Fixture `broken_fixture` failed" type="fixture-failure">error[fixture-failure]: Fixture `broken_fixture` failed
      --&gt; test_fixture.py:5:5
       |

--- a/crates/karva/tests/it/result_report.rs
+++ b/crates/karva/tests/it/result_report.rs
@@ -286,6 +286,146 @@ fn writes_jsonl_result_records() {
 }
 
 #[test]
+fn reports_fixture_failure_causality_for_parameters_and_retries() {
+    let context = TestContext::with_file(
+        "test_fixture.py",
+        r#"
+import karva
+
+@karva.fixture
+def root():
+    raise RuntimeError("setup failed")
+
+@karva.fixture
+def nested(root):
+    return root
+
+@karva.tags.parametrize("value", [1, 2])
+def test_blocked(nested, value):
+    raise AssertionError("test body ran")
+"#,
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
+            "--retry=1",
+            "--status-level=none",
+            "--result-output=reports/results.json",
+        ]),
+        @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    failures:
+
+    test_fixture::test_blocked(value=1) (requires fixture `nested`):
+    test_fixture::test_blocked(value=2) (requires fixture `nested`):
+
+    error[fixture-failure]: Fixture `root` failed
+     --> test_fixture.py:5:5
+      |
+    5 | def root():
+      |     ^^^^
+      |
+    info: Fixture `nested` requires `root`
+     --> test_fixture.py:9:5
+      |
+    9 | def nested(root):
+      |     ^^^^^^
+      |
+    info: Fixture failed here
+     --> test_fixture.py:6:5
+      |
+    6 |     raise RuntimeError("setup failed")
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: setup failed
+
+    ────────────
+         Summary [TIME] 2 tests run: 0 passed, 2 errors, 0 skipped
+
+    ----- stderr -----
+    "#
+    );
+
+    let report: Value = serde_json::from_str(&context.read_file("reports/results.json"))
+        .expect("result report should be valid JSON");
+    let tests = report["tests"]
+        .as_array()
+        .expect("tests should be an array");
+    assert_eq!(tests.len(), 2);
+    for test in tests {
+        let expected = serde_json::json!([{
+            "fixture": "nested",
+            "usage": "required",
+            "dependency_chain": ["nested", "root"],
+        }]);
+        assert_eq!(test["fixture_failures"], expected);
+        assert_eq!(test["attempts"][0]["fixture_failures"], expected);
+        assert_eq!(test["attempts"][1]["fixture_failures"], expected);
+    }
+
+    insta::allow_duplicates! {
+        assert_cmd_snapshot!(
+            context.command_no_parallel().args([
+                "--retry=1",
+                "--status-level=none",
+                "--result-output=reports/results.jsonl",
+                "--result-format=jsonl",
+                "--no-cache",
+            ]),
+            @r#"
+        success: false
+        exit_code: 1
+        ----- stdout -----
+
+        failures:
+
+        test_fixture::test_blocked(value=1) (requires fixture `nested`):
+        test_fixture::test_blocked(value=2) (requires fixture `nested`):
+
+        error[fixture-failure]: Fixture `root` failed
+         --> test_fixture.py:5:5
+          |
+        5 | def root():
+          |     ^^^^
+          |
+        info: Fixture `nested` requires `root`
+         --> test_fixture.py:9:5
+          |
+        9 | def nested(root):
+          |     ^^^^^^
+          |
+        info: Fixture failed here
+         --> test_fixture.py:6:5
+          |
+        6 |     raise RuntimeError("setup failed")
+          |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          |
+        info: setup failed
+
+        ────────────
+             Summary [TIME] 2 tests run: 0 passed, 2 errors, 0 skipped
+
+        ----- stderr -----
+        "#
+        );
+    }
+    let records = context
+        .read_file("reports/results.jsonl")
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).expect("record should be valid JSON"))
+        .collect::<Vec<_>>();
+    for test in records.iter().filter(|record| record["type"] == "test") {
+        assert_eq!(
+            test["fixture_failures"][0]["dependency_chain"],
+            serde_json::json!(["nested", "root"]),
+        );
+    }
+}
+
+#[test]
 fn flaky_result_fail_marks_json_run_failed() {
     let context = TestContext::with_file(
         "test_flaky.py",

--- a/crates/karva_diagnostic/src/lib.rs
+++ b/crates/karva_diagnostic/src/lib.rs
@@ -5,10 +5,10 @@ mod traceback;
 
 pub use reporter::{DummyReporter, Reporter, TestCaseReporter};
 pub use result::{
-    CapturedTestOutput, DisplayFlakyTest, DisplayFlakyTests, FlakyTest, IndividualTestResultKind,
-    RenderedDiagnostic, TestCaseAttempt, TestCaseOutcome, TestCaseResult, TestCaseRetry,
-    TestExecutionAttempt, TestExecutionOutcome, TestExecutionResult, TestResultKind,
-    TestResultStats, TestRunResult,
+    CapturedTestOutput, DisplayFlakyTest, DisplayFlakyTests, FixtureFailure, FixtureUsage,
+    FlakyTest, IndividualTestResultKind, RenderedDiagnostic, TestCaseAttempt, TestCaseOutcome,
+    TestCaseResult, TestCaseRetry, TestExecutionAttempt, TestExecutionOutcome, TestExecutionResult,
+    TestResultKind, TestResultStats, TestRunResult,
 };
 
 #[cfg(feature = "traceback")]

--- a/crates/karva_diagnostic/src/result/case.rs
+++ b/crates/karva_diagnostic/src/result/case.rs
@@ -272,6 +272,8 @@ pub enum TestCaseOutcome<D = RenderedDiagnostic> {
         diagnostic: D,
         #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
         related: Vec<D>,
+        #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
+        fixture_failures: Vec<FixtureFailure>,
     },
     Skipped {
         reason: Option<String>,
@@ -291,9 +293,18 @@ impl<D> TestCaseOutcome<D> {
     }
 
     pub fn error_with_related(diagnostic: D, related: Vec<D>) -> Self {
+        Self::error_with_fixture_failures(diagnostic, related, Vec::new())
+    }
+
+    pub fn error_with_fixture_failures(
+        diagnostic: D,
+        related: Vec<D>,
+        fixture_failures: Vec<FixtureFailure>,
+    ) -> Self {
         Self::Error {
             diagnostic,
             related,
+            fixture_failures,
         }
     }
 
@@ -327,6 +338,15 @@ impl<D> TestCaseOutcome<D> {
         }
     }
 
+    pub fn fixture_failures(&self) -> &[FixtureFailure] {
+        match self {
+            Self::Error {
+                fixture_failures, ..
+            } => fixture_failures,
+            Self::Passed | Self::Failed { .. } | Self::Skipped { .. } => &[],
+        }
+    }
+
     pub fn result_kind(&self) -> IndividualTestResultKind {
         match self {
             Self::Passed => IndividualTestResultKind::Passed,
@@ -357,16 +377,65 @@ impl<D> TestCaseOutcome<D> {
             Self::Error {
                 diagnostic,
                 related,
+                fixture_failures,
             } => TestCaseOutcome::Error {
                 diagnostic: map(&diagnostic)?,
                 related: related
                     .into_iter()
                     .map(|diagnostic| map(&diagnostic))
                     .collect::<Result<Vec<_>, _>>()?,
+                fixture_failures,
             },
             Self::Skipped { reason } => TestCaseOutcome::Skipped { reason },
         })
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FixtureFailure {
+    fixture: String,
+    usage: FixtureUsage,
+    dependency_chain: Vec<String>,
+}
+
+impl FixtureFailure {
+    pub fn new(fixture: String, usage: FixtureUsage, dependency_chain: Vec<String>) -> Self {
+        Self {
+            fixture,
+            usage,
+            dependency_chain,
+        }
+    }
+
+    pub fn fixture(&self) -> &str {
+        &self.fixture
+    }
+
+    pub fn usage(&self) -> FixtureUsage {
+        self.usage
+    }
+
+    pub fn dependency_chain(&self) -> &[String] {
+        &self.dependency_chain
+    }
+
+    pub fn description(&self) -> String {
+        match self.usage {
+            FixtureUsage::Required => format!("requires fixture `{}`", self.fixture),
+            FixtureUsage::UseFixtures => {
+                format!("uses fixture `{}` via `use_fixtures`", self.fixture)
+            }
+            FixtureUsage::AutoUse => format!("uses auto-use fixture `{}`", self.fixture),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FixtureUsage {
+    Required,
+    UseFixtures,
+    AutoUse,
 }
 
 pub type TestExecutionResult = TestCaseResult<Diagnostic>;

--- a/crates/karva_diagnostic/src/result/mod.rs
+++ b/crates/karva_diagnostic/src/result/mod.rs
@@ -13,8 +13,8 @@ use ruff_db::diagnostic::Diagnostic;
 use crate::reporter::Reporter;
 
 pub use case::{
-    TestCaseAttempt, TestCaseOutcome, TestCaseResult, TestCaseRetry, TestExecutionAttempt,
-    TestExecutionOutcome, TestExecutionResult,
+    FixtureFailure, FixtureUsage, TestCaseAttempt, TestCaseOutcome, TestCaseResult, TestCaseRetry,
+    TestExecutionAttempt, TestExecutionOutcome, TestExecutionResult,
 };
 pub use diagnostic::RenderedDiagnostic;
 pub use flaky::{DisplayFlakyTest, DisplayFlakyTests, FlakyTest};

--- a/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
@@ -5,6 +5,7 @@ use std::ops::Deref;
 use std::rc::Rc;
 use std::sync::Arc;
 
+use karva_diagnostic::{FixtureFailure, FixtureUsage};
 use pyo3::prelude::*;
 use pyo3::types::PyIterator;
 use ruff_db::diagnostic::Diagnostic;
@@ -31,27 +32,31 @@ impl PackageRunner<'_, '_> {
         parents: &'a [&'a crate::discovery::DiscoveredPackage],
         current: &'a (dyn HasFixtures<'a> + 'a),
         scope: FixtureScope,
-    ) -> Result<(), Vec<Diagnostic>> {
+    ) -> Result<(), FixtureSetupFailures> {
         let mut resolver = RuntimeFixtureResolver::new(parents, current);
         let auto_use_fixtures = match resolver.get_normalized_auto_use_fixtures(py, scope) {
             Ok(fixtures) => fixtures,
             Err(error) => {
                 let mut diagnostics = vec![fixture_resolution_diagnostic(error)];
                 diagnostics.extend(self.clean_up_scope(py, scope));
-                return Err(diagnostics);
+                return Err(FixtureSetupFailures {
+                    diagnostics,
+                    fixture_failures: Vec::new(),
+                });
             }
         };
 
-        let auto_use_errors = self.run_fixtures(py, &auto_use_fixtures);
+        let auto_use_errors = self.run_fixtures(py, &auto_use_fixtures, FixtureUsage::AutoUse);
         if auto_use_errors.is_empty() {
             Ok(())
         } else {
-            let mut diagnostics = auto_use_errors
-                .into_iter()
-                .map(|error| fixture_failure_diagnostic(py, error, self.context.is_verbose()))
-                .collect::<Vec<_>>();
+            let (mut diagnostics, fixture_failures) =
+                fixture_failure_diagnostics(py, auto_use_errors, self.context.is_verbose());
             diagnostics.extend(self.clean_up_scope(py, scope));
-            Err(diagnostics)
+            Err(FixtureSetupFailures {
+                diagnostics,
+                fixture_failures,
+            })
         }
     }
 
@@ -68,7 +73,8 @@ impl PackageRunner<'_, '_> {
         params: HashMap<String, Arc<Py<PyAny>>>,
     ) -> PreparedFixtures {
         let mut test_finalizers = Vec::new();
-        let mut fixture_call_errors = self.run_fixtures(py, use_fixture_dependencies);
+        let mut fixture_call_errors =
+            self.run_fixtures(py, use_fixture_dependencies, FixtureUsage::UseFixtures);
         let mut function_arguments = FixtureArguments::default();
 
         for fixture in fixture_dependencies {
@@ -81,11 +87,15 @@ impl PackageRunner<'_, '_> {
                         test_finalizers.push(finalizer);
                     }
                 }
-                Err(error) => fixture_call_errors.push(error),
+                Err(error) => fixture_call_errors.push(PreparedFixtureFailure::new(
+                    fixture.function_name(),
+                    FixtureUsage::Required,
+                    error,
+                )),
             }
         }
 
-        fixture_call_errors.extend(self.run_fixtures(py, auto_use_fixtures));
+        fixture_call_errors.extend(self.run_fixtures(py, auto_use_fixtures, FixtureUsage::AutoUse));
 
         for (key, value) in params {
             function_arguments.insert(
@@ -197,13 +207,18 @@ impl PackageRunner<'_, '_> {
         &self,
         py: Python<'_>,
         fixtures: &[P],
-    ) -> Vec<FixtureCallError> {
+        usage: FixtureUsage,
+    ) -> Vec<PreparedFixtureFailure> {
         let mut errors = Vec::new();
         for fixture in fixtures {
             match self.run_fixture(py, fixture) {
                 Ok((_, Some(finalizer))) => self.finalizer_cache.add_finalizer(finalizer),
                 Ok((_, None)) => {}
-                Err(error) => errors.push(error),
+                Err(error) => errors.push(PreparedFixtureFailure::new(
+                    fixture.function_name(),
+                    usage,
+                    error,
+                )),
             }
         }
         errors
@@ -215,9 +230,63 @@ pub(super) struct PreparedFixtures {
     /// Keyword arguments passed to the Python test function.
     pub(super) function_arguments: FixtureArguments,
     /// Fixture setup failures that prevent the test call.
-    pub(super) fixture_call_errors: Vec<FixtureCallError>,
+    pub(super) fixture_call_errors: Vec<PreparedFixtureFailure>,
     /// Function-scoped finalizers run after this attempt.
     pub(super) test_finalizers: Vec<Finalizer>,
+}
+
+pub(super) struct FixtureSetupFailures {
+    pub(super) diagnostics: Vec<Diagnostic>,
+    pub(super) fixture_failures: Vec<FixtureFailure>,
+}
+
+pub(super) struct PreparedFixtureFailure {
+    pub(super) error: FixtureCallError,
+    pub(super) fixture_failure: FixtureFailure,
+}
+
+impl PreparedFixtureFailure {
+    fn new(requested_fixture: &str, usage: FixtureUsage, error: FixtureCallError) -> Self {
+        let mut dependency_chain = vec![requested_fixture.to_string()];
+        dependency_chain.extend(
+            error
+                .dependency_chain
+                .iter()
+                .rev()
+                .map(|entry| entry.name.clone())
+                .filter(|name| name != requested_fixture),
+        );
+        if dependency_chain
+            .last()
+            .is_none_or(|name| name != &error.fixture_name)
+        {
+            dependency_chain.push(error.fixture_name.clone());
+        }
+        Self {
+            fixture_failure: FixtureFailure::new(
+                requested_fixture.to_string(),
+                usage,
+                dependency_chain,
+            ),
+            error,
+        }
+    }
+}
+
+pub(super) fn fixture_failure_diagnostics(
+    py: Python<'_>,
+    failures: Vec<PreparedFixtureFailure>,
+    verbose: bool,
+) -> (Vec<Diagnostic>, Vec<FixtureFailure>) {
+    failures
+        .into_iter()
+        .map(|failure| {
+            (
+                fixture_failure_diagnostic(py, failure.error, verbose),
+                failure.fixture_failure,
+            )
+        })
+        .unzip()
 }
 
 /// Failure raised while preparing or calling a fixture.

--- a/crates/karva_test_semantic/src/runner/package_runner/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/mod.rs
@@ -3,7 +3,7 @@
 use std::cell::Cell;
 
 use karva_coverage::CoverageSession;
-use karva_diagnostic::TestExecutionOutcome;
+use karva_diagnostic::{FixtureFailure, TestExecutionOutcome};
 use karva_python_semantic::QualifiedTestName;
 use pyo3::prelude::*;
 use ruff_db::diagnostic::Diagnostic;
@@ -78,10 +78,15 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
         test: &DiscoveredTestFunction,
         diagnostic: Diagnostic,
         related: Vec<Diagnostic>,
+        fixture_failures: Vec<FixtureFailure>,
     ) {
         self.context.register_test_case_result(
             &QualifiedTestName::new(test.name.clone(), None),
-            TestExecutionOutcome::error_with_related(diagnostic, related),
+            TestExecutionOutcome::error_with_fixture_failures(
+                diagnostic,
+                related,
+                fixture_failures,
+            ),
             std::time::Duration::ZERO,
             None,
         );
@@ -94,9 +99,15 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
         module: &DiscoveredModule,
         diagnostic: &Diagnostic,
         related: &[Diagnostic],
+        fixture_failures: &[FixtureFailure],
     ) {
         for test in module.test_functions() {
-            self.register_error_test(test, diagnostic.clone(), related.to_vec());
+            self.register_error_test(
+                test,
+                diagnostic.clone(),
+                related.to_vec(),
+                fixture_failures.to_vec(),
+            );
             if self.max_fail_reached() {
                 return;
             }
@@ -109,15 +120,16 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
         package: &DiscoveredPackage,
         diagnostic: &Diagnostic,
         related: &[Diagnostic],
+        fixture_failures: &[FixtureFailure],
     ) {
         for module in package.modules().values() {
-            self.register_error_module_tests(module, diagnostic, related);
+            self.register_error_module_tests(module, diagnostic, related, fixture_failures);
             if self.max_fail_reached() {
                 return;
             }
         }
         for child_package in package.packages().values() {
-            self.register_error_package_tests(child_package, diagnostic, related);
+            self.register_error_package_tests(child_package, diagnostic, related, fixture_failures);
             if self.max_fail_reached() {
                 return;
             }
@@ -139,7 +151,7 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
                         &test.stmt_function_def,
                         &error,
                     );
-                    self.register_error_test(test, diagnostic, Vec::new());
+                    self.register_error_test(test, diagnostic, Vec::new(), Vec::new());
                     valid = false;
                     if self.max_fail_reached() {
                         return false;
@@ -164,11 +176,16 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
             return;
         }
 
-        if let Err(mut diagnostics) =
+        if let Err(mut failure) =
             self.run_auto_use_fixtures(py, &[], session, FixtureScope::Session)
         {
-            let diagnostic = diagnostics.remove(0);
-            self.register_error_package_tests(session, &diagnostic, &diagnostics);
+            let diagnostic = failure.diagnostics.remove(0);
+            self.register_error_package_tests(
+                session,
+                &diagnostic,
+                &failure.diagnostics,
+                &failure.fixture_failures,
+            );
             return;
         }
 
@@ -183,11 +200,16 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
         module: &DiscoveredModule,
         parents: &[&DiscoveredPackage],
     ) -> bool {
-        if let Err(mut diagnostics) =
+        if let Err(mut failure) =
             self.run_auto_use_fixtures(py, parents, module, FixtureScope::Module)
         {
-            let diagnostic = diagnostics.remove(0);
-            self.register_error_module_tests(module, &diagnostic, &diagnostics);
+            let diagnostic = failure.diagnostics.remove(0);
+            self.register_error_module_tests(
+                module,
+                &diagnostic,
+                &failure.diagnostics,
+                &failure.fixture_failures,
+            );
             return false;
         }
 
@@ -200,6 +222,7 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
                     self.register_error_test(
                         test,
                         fixture_resolution_diagnostic(error),
+                        Vec::new(),
                         Vec::new(),
                     );
                     passed = false;
@@ -240,11 +263,16 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
         child_parents.push(package);
 
         if package.configuration_module_impl().is_some()
-            && let Err(mut diagnostics) =
+            && let Err(mut failure) =
                 self.run_auto_use_fixtures(py, parents, package, FixtureScope::Package)
         {
-            let diagnostic = diagnostics.remove(0);
-            self.register_error_package_tests(package, &diagnostic, &diagnostics);
+            let diagnostic = failure.diagnostics.remove(0);
+            self.register_error_package_tests(
+                package,
+                &diagnostic,
+                &failure.diagnostics,
+                &failure.fixture_failures,
+            );
             return false;
         }
 

--- a/crates/karva_test_semantic/src/runner/package_runner/outcome.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/outcome.rs
@@ -199,11 +199,13 @@ pub(super) fn attach_finalizer_diagnostics(
         TestExecutionOutcome::Error {
             diagnostic,
             mut related,
+            fixture_failures,
         } => {
             related.append(&mut diagnostics);
             TestExecutionOutcome::Error {
                 diagnostic,
                 related,
+                fixture_failures,
             }
         }
         TestExecutionOutcome::Passed | TestExecutionOutcome::Skipped { .. } => {

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/attempt.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/attempt.rs
@@ -5,14 +5,13 @@ use std::time::{Duration, Instant};
 use karva_diagnostic::{CapturedTestOutput, TestExecutionAttempt, TestExecutionOutcome};
 use pyo3::prelude::*;
 
-use crate::diagnostic::fixture_failure_diagnostic;
 use crate::extensions::fixtures::FixtureScope;
 use crate::extensions::functions::snapshot::set_snapshot_context;
 use crate::utils::{run_coroutine, run_test_with_timeout};
 
 use super::{VariantRunner, VariantSettings, finish_output_capture};
 use crate::output_capture::PythonOutputCapture;
-use crate::runner::package_runner::fixture::PreparedFixtures;
+use crate::runner::package_runner::fixture::{PreparedFixtures, fixture_failure_diagnostics};
 use crate::runner::package_runner::outcome::{
     OutcomeContext, PhaseDurations, apply_fail_slow_budget, attach_finalizer_diagnostics,
     classify_test_result, reject_non_none_return, should_retry_result,
@@ -141,16 +140,11 @@ impl VariantRunner<'_, '_, '_, '_, '_> {
                 retryable_result || teardown_failed || (budget_exceeded && !skipped),
             )
         } else {
-            let mut diagnostics = fixture_call_errors
-                .into_iter()
-                .map(|error| {
-                    fixture_failure_diagnostic(
-                        self.py,
-                        error,
-                        self.package_runner.context.is_verbose(),
-                    )
-                })
-                .collect::<Vec<_>>();
+            let (mut diagnostics, fixture_failures) = fixture_failure_diagnostics(
+                self.py,
+                fixture_call_errors,
+                self.package_runner.context.is_verbose(),
+            );
             let teardown_start = Instant::now();
             diagnostics.extend(
                 test_finalizers
@@ -169,7 +163,11 @@ impl VariantRunner<'_, '_, '_, '_, '_> {
             };
             let duration = phases.total();
             let diagnostic = diagnostics.remove(0);
-            let outcome = TestExecutionOutcome::error_with_related(diagnostic, diagnostics);
+            let outcome = TestExecutionOutcome::error_with_fixture_failures(
+                diagnostic,
+                diagnostics,
+                fixture_failures,
+            );
             let outcome = apply_fail_slow_budget(
                 outcome,
                 duration,


### PR DESCRIPTION
## Summary

Represent runtime fixture setup failures as typed test-result causality, preserving shared root diagnostics while identifying required, use_fixtures, and auto-use relationships across terminal, JUnit, JSON, and JSONL output. Closes #1078.

## Test Plan

Ran focused fixture and result-report integration tests, workspace Clippy, and uvx prek run -a.