### PR TITLE
Allow flaky tests to fail the run

### DIFF
--- a/crates/karva/src/commands/test/junit.rs
+++ b/crates/karva/src/commands/test/junit.rs
@@ -5,13 +5,14 @@ use anyhow::{Context as _, Result};
 use camino::Utf8Path;
 use karva_cache::AggregatedResults;
 use karva_diagnostic::{RenderedDiagnostic, TestCaseAttempt, TestCaseOutcome, TestCaseResult};
-use karva_metadata::JunitSettings;
+use karva_metadata::{FlakyResult, JunitSettings};
 use karva_project::path::absolute;
 
 pub(super) fn write_junit_report(
     settings: &JunitSettings,
     results: &AggregatedResults,
     project_root: &Utf8Path,
+    flaky_result: FlakyResult,
 ) -> Result<()> {
     let Some(path) = settings.path.as_deref() else {
         return Ok(());
@@ -23,14 +24,18 @@ pub(super) fn write_junit_report(
             .with_context(|| format!("failed to create JUnit report directory `{parent}`"))?;
     }
 
-    let xml = build_junit_xml(settings, results)?;
+    let xml = build_junit_xml(settings, results, flaky_result)?;
     std::fs::write(&output_path, xml)
         .with_context(|| format!("failed to write JUnit report `{output_path}`"))?;
 
     Ok(())
 }
 
-fn build_junit_xml(settings: &JunitSettings, results: &AggregatedResults) -> Result<String> {
+fn build_junit_xml(
+    settings: &JunitSettings,
+    results: &AggregatedResults,
+    flaky_result: FlakyResult,
+) -> Result<String> {
     let suites = test_cases_by_module(&results.test_cases);
     let run_errors = results
         .run_diagnostics
@@ -43,6 +48,11 @@ fn build_junit_xml(settings: &JunitSettings, results: &AggregatedResults) -> Res
         .map(TestCaseResult::duration)
         .sum::<std::time::Duration>()
         .as_secs_f64();
+    let flaky_failures = if flaky_result == FlakyResult::Fail {
+        results.stats.flaky()
+    } else {
+        0
+    };
 
     let mut xml = String::new();
     xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
@@ -51,13 +61,13 @@ fn build_junit_xml(settings: &JunitSettings, results: &AggregatedResults) -> Res
         "<testsuites name=\"{}\" tests=\"{}\" failures=\"{}\" skipped=\"{}\" errors=\"{}\" time=\"{total_time:.6}\">",
         escape_xml(&settings.report_name),
         results.stats.total() + run_errors,
-        results.stats.failed(),
+        results.stats.failed() + flaky_failures,
         results.stats.skipped(),
         results.stats.errors() + run_errors,
     )?;
 
     for (module_name, cases) in suites {
-        write_suite(&mut xml, settings, module_name, cases)?;
+        write_suite(&mut xml, settings, module_name, cases, flaky_result)?;
     }
     write_run_diagnostics_suite(&mut xml, settings, &results.run_diagnostics)?;
 
@@ -70,11 +80,14 @@ fn write_suite(
     settings: &JunitSettings,
     module_name: &str,
     cases: Vec<&TestCaseResult>,
+    flaky_result: FlakyResult,
 ) -> Result<()> {
     let tests = cases.len();
     let failures = cases
         .iter()
-        .filter(|case| case.outcome().is_failed())
+        .filter(|case| {
+            case.outcome().is_failed() || (flaky_result == FlakyResult::Fail && is_flaky(case))
+        })
         .count();
     let skipped = cases
         .iter()
@@ -97,14 +110,19 @@ fn write_suite(
     )?;
 
     for case in cases {
-        write_case(xml, settings, case)?;
+        write_case(xml, settings, case, flaky_result)?;
     }
 
     xml.push_str("  </testsuite>\n");
     Ok(())
 }
 
-fn write_case(xml: &mut String, settings: &JunitSettings, case: &TestCaseResult) -> Result<()> {
+fn write_case(
+    xml: &mut String,
+    settings: &JunitSettings,
+    case: &TestCaseResult,
+    flaky_result: FlakyResult,
+) -> Result<()> {
     let time = junit_case_duration(case).as_secs_f64();
     let output = case.captured_output();
     let include_output = match case.outcome() {
@@ -134,7 +152,13 @@ fn write_case(xml: &mut String, settings: &JunitSettings, case: &TestCaseResult)
 
     xml.push_str(">\n");
     match case.outcome() {
-        TestCaseOutcome::Passed => {}
+        TestCaseOutcome::Passed => {
+            if flaky_result == FlakyResult::Fail && is_flaky(case) {
+                xml.push_str(
+                    "      <failure message=\"Flaky test failed by policy\" type=\"flaky\">Flaky tests are configured to fail the run.</failure>\n",
+                );
+            }
+        }
         TestCaseOutcome::Failed {
             diagnostic,
             related,
@@ -179,6 +203,10 @@ fn write_case(xml: &mut String, settings: &JunitSettings, case: &TestCaseResult)
 
     xml.push_str("    </testcase>\n");
     Ok(())
+}
+
+fn is_flaky(case: &TestCaseResult) -> bool {
+    matches!(case.outcome(), TestCaseOutcome::Passed) && case.retry().is_some()
 }
 
 fn write_attempts(xml: &mut String, case: &TestCaseResult) -> Result<()> {

--- a/crates/karva/src/commands/test/junit.rs
+++ b/crates/karva/src/commands/test/junit.rs
@@ -5,14 +5,13 @@ use anyhow::{Context as _, Result};
 use camino::Utf8Path;
 use karva_cache::AggregatedResults;
 use karva_diagnostic::{RenderedDiagnostic, TestCaseAttempt, TestCaseOutcome, TestCaseResult};
-use karva_metadata::{FlakyResult, JunitSettings};
+use karva_metadata::JunitSettings;
 use karva_project::path::absolute;
 
 pub(super) fn write_junit_report(
     settings: &JunitSettings,
     results: &AggregatedResults,
     project_root: &Utf8Path,
-    flaky_result: FlakyResult,
 ) -> Result<()> {
     let Some(path) = settings.path.as_deref() else {
         return Ok(());
@@ -24,18 +23,14 @@ pub(super) fn write_junit_report(
             .with_context(|| format!("failed to create JUnit report directory `{parent}`"))?;
     }
 
-    let xml = build_junit_xml(settings, results, flaky_result)?;
+    let xml = build_junit_xml(settings, results)?;
     std::fs::write(&output_path, xml)
         .with_context(|| format!("failed to write JUnit report `{output_path}`"))?;
 
     Ok(())
 }
 
-fn build_junit_xml(
-    settings: &JunitSettings,
-    results: &AggregatedResults,
-    flaky_result: FlakyResult,
-) -> Result<String> {
+fn build_junit_xml(settings: &JunitSettings, results: &AggregatedResults) -> Result<String> {
     let suites = test_cases_by_module(&results.test_cases);
     let run_errors = results
         .run_diagnostics
@@ -48,11 +43,11 @@ fn build_junit_xml(
         .map(TestCaseResult::duration)
         .sum::<std::time::Duration>()
         .as_secs_f64();
-    let flaky_failures = if flaky_result == FlakyResult::Fail {
-        results.stats.flaky()
-    } else {
-        0
-    };
+    let flaky_failures = results
+        .test_cases
+        .iter()
+        .filter(|case| case.is_junit_flaky_failure())
+        .count();
 
     let mut xml = String::new();
     xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
@@ -67,7 +62,7 @@ fn build_junit_xml(
     )?;
 
     for (module_name, cases) in suites {
-        write_suite(&mut xml, settings, module_name, cases, flaky_result)?;
+        write_suite(&mut xml, settings, module_name, cases)?;
     }
     write_run_diagnostics_suite(&mut xml, settings, &results.run_diagnostics)?;
 
@@ -80,14 +75,11 @@ fn write_suite(
     settings: &JunitSettings,
     module_name: &str,
     cases: Vec<&TestCaseResult>,
-    flaky_result: FlakyResult,
 ) -> Result<()> {
     let tests = cases.len();
     let failures = cases
         .iter()
-        .filter(|case| {
-            case.outcome().is_failed() || (flaky_result == FlakyResult::Fail && is_flaky(case))
-        })
+        .filter(|case| case.outcome().is_failed() || case.is_junit_flaky_failure())
         .count();
     let skipped = cases
         .iter()
@@ -110,19 +102,14 @@ fn write_suite(
     )?;
 
     for case in cases {
-        write_case(xml, settings, case, flaky_result)?;
+        write_case(xml, settings, case)?;
     }
 
     xml.push_str("  </testsuite>\n");
     Ok(())
 }
 
-fn write_case(
-    xml: &mut String,
-    settings: &JunitSettings,
-    case: &TestCaseResult,
-    flaky_result: FlakyResult,
-) -> Result<()> {
+fn write_case(xml: &mut String, settings: &JunitSettings, case: &TestCaseResult) -> Result<()> {
     let time = junit_case_duration(case).as_secs_f64();
     let output = case.captured_output();
     let include_output = match case.outcome() {
@@ -153,7 +140,7 @@ fn write_case(
     xml.push_str(">\n");
     match case.outcome() {
         TestCaseOutcome::Passed => {
-            if flaky_result == FlakyResult::Fail && is_flaky(case) {
+            if case.is_junit_flaky_failure() {
                 xml.push_str(
                     "      <failure message=\"Flaky test failed by policy\" type=\"flaky\">Flaky tests are configured to fail the run.</failure>\n",
                 );
@@ -203,10 +190,6 @@ fn write_case(
 
     xml.push_str("    </testcase>\n");
     Ok(())
-}
-
-fn is_flaky(case: &TestCaseResult) -> bool {
-    matches!(case.outcome(), TestCaseOutcome::Passed) && case.retry().is_some()
 }
 
 fn write_attempts(xml: &mut String, case: &TestCaseResult) -> Result<()> {

--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -12,9 +12,7 @@ use karva_cache::{AggregatedResults, DisplayFlakyTests};
 use karva_cli::TestCommand;
 use karva_logging::{Printer, Stdout, set_colored_override, setup_tracing};
 use karva_metadata::filter::FiltersetSet;
-use karva_metadata::{
-    CovReport, FlakyResult, NoTestsMode, ProjectMetadata, ProjectOptionsOverrides,
-};
+use karva_metadata::{CovReport, NoTestsMode, ProjectMetadata, ProjectOptionsOverrides};
 use karva_project::Project;
 use karva_project::path::absolute;
 use karva_python_semantic::current_python_version;
@@ -104,14 +102,8 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
         timed_out,
     } = karva_runner::run_parallel_tests(&project, &config, &sub_command, printer)?;
 
-    let flaky_result = project.settings().test().flaky_result;
-    print_test_output(printer, start_time, &result, durations, flaky_result)?;
-    junit::write_junit_report(
-        project.settings().junit(),
-        &result,
-        project.cwd(),
-        flaky_result,
-    )?;
+    print_test_output(printer, start_time, &result, durations)?;
+    junit::write_junit_report(project.settings().junit(), &result, project.cwd())?;
     let write_result_report = |exit_status| {
         result_report::write_result_report(
             result_output.as_deref(),
@@ -249,7 +241,7 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
         return Ok(exit_status);
     }
 
-    let flaky_failed = flaky_result == FlakyResult::Fail && result.stats.flaky() > 0;
+    let flaky_failed = result.has_flaky_failures();
     let exit_status = if result.is_success() && !coverage_below_threshold && !flaky_failed {
         ExitStatus::Success
     } else {
@@ -285,7 +277,6 @@ pub fn print_test_output(
     start_time: Instant,
     result: &AggregatedResults,
     durations: Option<usize>,
-    flaky_result: FlakyResult,
 ) -> Result<()> {
     let mut details = printer.stream_for_details().lock();
 
@@ -312,7 +303,7 @@ pub fn print_test_output(
 
     drop(details);
 
-    let flaky_failed = flaky_result == FlakyResult::Fail && result.stats.flaky() > 0;
+    let flaky_failed = result.has_flaky_failures();
     let success = result.is_success() && !flaky_failed;
     let mut summary = printer
         .stream_for_summary(success, result.stats.flaky() > 0)

--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -12,7 +12,9 @@ use karva_cache::{AggregatedResults, DisplayFlakyTests};
 use karva_cli::TestCommand;
 use karva_logging::{Printer, Stdout, set_colored_override, setup_tracing};
 use karva_metadata::filter::FiltersetSet;
-use karva_metadata::{CovReport, NoTestsMode, ProjectMetadata, ProjectOptionsOverrides};
+use karva_metadata::{
+    CovReport, FlakyResult, NoTestsMode, ProjectMetadata, ProjectOptionsOverrides,
+};
 use karva_project::Project;
 use karva_project::path::absolute;
 use karva_python_semantic::current_python_version;
@@ -102,8 +104,14 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
         timed_out,
     } = karva_runner::run_parallel_tests(&project, &config, &sub_command, printer)?;
 
-    print_test_output(printer, start_time, &result, durations)?;
-    junit::write_junit_report(project.settings().junit(), &result, project.cwd())?;
+    let flaky_result = project.settings().test().flaky_result;
+    print_test_output(printer, start_time, &result, durations, flaky_result)?;
+    junit::write_junit_report(
+        project.settings().junit(),
+        &result,
+        project.cwd(),
+        flaky_result,
+    )?;
     let write_result_report = |exit_status| {
         result_report::write_result_report(
             result_output.as_deref(),
@@ -241,7 +249,8 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
         return Ok(exit_status);
     }
 
-    let exit_status = if result.is_success() && !coverage_below_threshold {
+    let flaky_failed = flaky_result == FlakyResult::Fail && result.stats.flaky() > 0;
+    let exit_status = if result.is_success() && !coverage_below_threshold && !flaky_failed {
         ExitStatus::Success
     } else {
         ExitStatus::Failure
@@ -276,6 +285,7 @@ pub fn print_test_output(
     start_time: Instant,
     result: &AggregatedResults,
     durations: Option<usize>,
+    flaky_result: FlakyResult,
 ) -> Result<()> {
     let mut details = printer.stream_for_details().lock();
 
@@ -302,13 +312,17 @@ pub fn print_test_output(
 
     drop(details);
 
-    let success = result.is_success();
+    let flaky_failed = flaky_result == FlakyResult::Fail && result.stats.flaky() > 0;
+    let success = result.is_success() && !flaky_failed;
     let mut summary = printer
         .stream_for_summary(success, result.stats.flaky() > 0)
         .lock();
 
     write!(summary, "{}", result.stats.display(start_time, success))?;
     write!(summary, "{}", DisplayFlakyTests::new(&result.flaky_tests))?;
+    if flaky_failed {
+        writeln!(summary, "flaky failure: flaky tests caused the run to fail")?;
+    }
 
     Ok(())
 }

--- a/crates/karva/src/commands/test/watch.rs
+++ b/crates/karva/src/commands/test/watch.rs
@@ -25,13 +25,7 @@ fn run_and_print(
     let start_time = Instant::now();
     match karva_runner::run_parallel_tests(project, config, sub_command, printer) {
         Ok(output) => {
-            if let Err(err) = print_test_output(
-                printer,
-                start_time,
-                &output.results,
-                durations,
-                project.settings().test().flaky_result,
-            ) {
+            if let Err(err) = print_test_output(printer, start_time, &output.results, durations) {
                 tracing::error!("Failed to print test output: {err}");
             }
             if output.timed_out

--- a/crates/karva/src/commands/test/watch.rs
+++ b/crates/karva/src/commands/test/watch.rs
@@ -25,7 +25,13 @@ fn run_and_print(
     let start_time = Instant::now();
     match karva_runner::run_parallel_tests(project, config, sub_command, printer) {
         Ok(output) => {
-            if let Err(err) = print_test_output(printer, start_time, &output.results, durations) {
+            if let Err(err) = print_test_output(
+                printer,
+                start_time,
+                &output.results,
+                durations,
+                project.settings().test().flaky_result,
+            ) {
                 tracing::error!("Failed to print test output: {err}");
             }
             if output.timed_out

--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -2032,6 +2032,49 @@ def test_flaky():
 }
 
 #[test]
+fn flaky_result_does_not_enable_retries() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import os
+
+def test_needs_retry():
+    assert os.environ["KARVA_ATTEMPT"] == "2"
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--flaky-result=fail"), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_needs_retry
+
+    failures:
+
+    test::test_needs_retry:
+
+    error[test-failure]: Test `test_needs_retry` failed
+     --> test.py:4:5
+      |
+    4 | def test_needs_retry():
+      |     ^^^^^^^^^^^^^^^^
+      |
+    info: Test failed here
+     --> test.py:5:5
+      |
+    5 |     assert os.environ["KARVA_ATTEMPT"] == "2"
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    "#);
+}
+
+#[test]
 fn test_extra_verbose_output() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva/tests/it/configuration/overrides.rs
+++ b/crates/karva/tests/it/configuration/overrides.rs
@@ -1,4 +1,5 @@
 use insta_cmd::assert_cmd_snapshot;
+use karva_static::EnvVars;
 
 use crate::common::TestContext;
 
@@ -157,6 +158,86 @@ def test_unit():
 
     ----- stderr -----
     ");
+}
+
+#[test]
+fn override_flaky_result_and_explicit_global_override() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.default.test]
+retry = 1
+flaky-result = "pass"
+
+[[profile.default.overrides]]
+filter = "tag(strict)"
+flaky-result = "fail"
+"#,
+        ),
+        (
+            "test.py",
+            r#"
+import os
+import karva
+
+@karva.tags.strict
+def test_flaky():
+    assert os.environ["KARVA_ATTEMPT"] == "2"
+"#,
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+      TRY 1 FAIL [TIME] test::test_flaky
+      TRY 2 PASS [TIME] test::test_flaky
+    ────────────
+         Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test::test_flaky
+    flaky failure: flaky tests caused the run to fail
+
+    ----- stderr -----
+    ");
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .arg("--flaky-result=pass"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+      TRY 1 FAIL [TIME] test::test_flaky
+      TRY 2 PASS [TIME] test::test_flaky
+    ────────────
+         Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test::test_flaky
+
+    ----- stderr -----
+    "
+    );
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .env(EnvVars::KARVA_FLAKY_RESULT, "pass"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+      TRY 1 FAIL [TIME] test::test_flaky
+      TRY 2 PASS [TIME] test::test_flaky
+    ────────────
+         Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test::test_flaky
+
+    ----- stderr -----
+    "
+    );
 }
 
 #[test]

--- a/crates/karva/tests/it/configuration/profile.rs
+++ b/crates/karva/tests/it/configuration/profile.rs
@@ -276,6 +276,118 @@ def verify_b(): pass
 }
 
 #[test]
+fn flaky_result_profile_inheritance_and_cli_precedence() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.default.test]
+retry = 1
+flaky-result = "pass"
+
+[profile.ci.test]
+flaky-result = "fail"
+"#,
+        ),
+        (
+            "test.py",
+            r#"
+import os
+
+def test_flaky():
+    assert os.environ["KARVA_ATTEMPT"] == "2"
+"#,
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--profile=ci"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+      TRY 1 FAIL [TIME] test::test_flaky
+      TRY 2 PASS [TIME] test::test_flaky
+    ────────────
+         Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test::test_flaky
+    flaky failure: flaky tests caused the run to fail
+
+    ----- stderr -----
+    ");
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .args(["--profile=ci", "--flaky-result=pass"]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+      TRY 1 FAIL [TIME] test::test_flaky
+      TRY 2 PASS [TIME] test::test_flaky
+    ────────────
+         Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test::test_flaky
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
+fn flaky_result_environment_and_cli_precedence() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import os
+
+def test_flaky():
+    assert os.environ["KARVA_ATTEMPT"] == "2"
+"#,
+    );
+
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .args(["--retry=1"])
+            .env(karva_static::EnvVars::KARVA_FLAKY_RESULT, "fail"),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+      TRY 1 FAIL [TIME] test::test_flaky
+      TRY 2 PASS [TIME] test::test_flaky
+    ────────────
+         Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test::test_flaky
+    flaky failure: flaky tests caused the run to fail
+
+    ----- stderr -----
+    "
+    );
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .args(["--retry=1", "--flaky-result=pass"])
+            .env(karva_static::EnvVars::KARVA_FLAKY_RESULT, "fail"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+      TRY 1 FAIL [TIME] test::test_flaky
+      TRY 2 PASS [TIME] test::test_flaky
+    ────────────
+         Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test::test_flaky
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
 fn profile_pyproject_toml() {
     let context = TestContext::with_files([
         (

--- a/crates/karva/tests/it/junit.rs
+++ b/crates/karva/tests/it/junit.rs
@@ -328,6 +328,100 @@ def test_flaky():
 }
 
 #[test]
+fn junit_flaky_fail_status_supports_per_test_overrides() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.default.test]
+retry = 1
+flaky-result = "fail"
+
+[profile.default.junit]
+path = "results.xml"
+flaky-fail-status = "success"
+
+[[profile.default.overrides]]
+filter = "tag(strict)"
+
+[profile.default.overrides.junit]
+flaky-fail-status = "failure"
+"#,
+        ),
+        (
+            "test_flaky.py",
+            r#"
+import os
+import karva
+
+@karva.tags.strict
+def test_strict():
+    assert os.environ["KARVA_ATTEMPT"] == "2"
+
+def test_lenient():
+    assert os.environ["KARVA_ATTEMPT"] == "2"
+"#,
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().arg("--status-level=none"),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed (2 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test_flaky::test_lenient
+       FLAKY 2/2 [TIME] test_flaky::test_strict
+    flaky failure: flaky tests caused the run to fail
+
+    ----- stderr -----
+    "
+    );
+    assert_snapshot!(normalize_junit_xml(&context.read_file("results.xml")), @r#"
+    <?xml version="1.0" encoding="UTF-8"?>
+    <testsuites name="karva-tests" tests="2" failures="1" skipped="0" errors="0" time="[TIME]">
+      <testsuite name="test_flaky" tests="2" failures="1" skipped="0" errors="0" time="[TIME]">
+        <testcase classname="test_flaky" name="test_lenient" time="[TIME]">
+          <flakyFailure message="Test `test_lenient` failed" type="test-failure" time="[TIME]">error[test-failure]: Test `test_lenient` failed
+     --&gt; test_flaky.py:9:5
+      |
+    9 | def test_lenient():
+      |     ^^^^^^^^^^^^
+      |
+    info: Test failed here
+      --&gt; test_flaky.py:10:5
+       |
+    10 |     assert os.environ[&quot;KARVA_ATTEMPT&quot;] == &quot;2&quot;
+       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       |
+
+    </flakyFailure>
+        </testcase>
+        <testcase classname="test_flaky" name="test_strict" time="[TIME]">
+          <failure message="Flaky test failed by policy" type="flaky">Flaky tests are configured to fail the run.</failure>
+          <flakyFailure message="Test `test_strict` failed" type="test-failure" time="[TIME]">error[test-failure]: Test `test_strict` failed
+     --&gt; test_flaky.py:6:5
+      |
+    6 | def test_strict():
+      |     ^^^^^^^^^^^
+      |
+    info: Test failed here
+     --&gt; test_flaky.py:7:5
+      |
+    7 |     assert os.environ[&quot;KARVA_ATTEMPT&quot;] == &quot;2&quot;
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+
+    </flakyFailure>
+        </testcase>
+      </testsuite>
+    </testsuites>
+    "#);
+}
+
+#[test]
 fn junit_reports_fail_slow_teardown_duration() {
     let context = TestContext::with_files([
         (

--- a/crates/karva/tests/it/junit.rs
+++ b/crates/karva/tests/it/junit.rs
@@ -263,6 +263,71 @@ def test_flaky():
 }
 
 #[test]
+fn junit_marks_policy_failed_flaky_test_as_failure() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.default.junit]
+path = "results.xml"
+"#,
+        ),
+        (
+            "test_flaky.py",
+            r#"
+import os
+
+def test_flaky():
+    assert os.environ["KARVA_ATTEMPT"] == "2"
+"#,
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
+            "--retry=1",
+            "--flaky-result=fail",
+            "--status-level=none",
+        ]),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test_flaky::test_flaky
+    flaky failure: flaky tests caused the run to fail
+
+    ----- stderr -----
+    "
+    );
+    assert_snapshot!(normalize_junit_xml(&context.read_file("results.xml")), @r#"
+    <?xml version="1.0" encoding="UTF-8"?>
+    <testsuites name="karva-tests" tests="1" failures="1" skipped="0" errors="0" time="[TIME]">
+      <testsuite name="test_flaky" tests="1" failures="1" skipped="0" errors="0" time="[TIME]">
+        <testcase classname="test_flaky" name="test_flaky" time="[TIME]">
+          <failure message="Flaky test failed by policy" type="flaky">Flaky tests are configured to fail the run.</failure>
+          <flakyFailure message="Test `test_flaky` failed" type="test-failure" time="[TIME]">error[test-failure]: Test `test_flaky` failed
+     --&gt; test_flaky.py:4:5
+      |
+    4 | def test_flaky():
+      |     ^^^^^^^^^^
+      |
+    info: Test failed here
+     --&gt; test_flaky.py:5:5
+      |
+    5 |     assert os.environ[&quot;KARVA_ATTEMPT&quot;] == &quot;2&quot;
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+
+    </flakyFailure>
+        </testcase>
+      </testsuite>
+    </testsuites>
+    "#);
+}
+
+#[test]
 fn junit_reports_fail_slow_teardown_duration() {
     let context = TestContext::with_files([
         (

--- a/crates/karva/tests/it/result_report.rs
+++ b/crates/karva/tests/it/result_report.rs
@@ -286,6 +286,125 @@ fn writes_jsonl_result_records() {
 }
 
 #[test]
+fn flaky_result_fail_marks_json_run_failed() {
+    let context = TestContext::with_file(
+        "test_flaky.py",
+        r#"
+import os
+
+def test_flaky():
+    assert os.environ["KARVA_ATTEMPT"] == "2"
+"#,
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
+            "--retry=1",
+            "--flaky-result=fail",
+            "--status-level=none",
+            "--result-output=results.json",
+        ]),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test_flaky::test_flaky
+    flaky failure: flaky tests caused the run to fail
+
+    ----- stderr -----
+    "
+    );
+    assert_snapshot!(context.read_file("results.json"), @r#"
+    {
+      "schema_version": 2,
+      "status": "failed",
+      "elapsed_seconds": "[TIME]",
+      "stats": {
+        "total": 1,
+        "passed": 1,
+        "failed": 0,
+        "errors": 0,
+        "skipped": 0,
+        "flaky": 1,
+        "slow": 0
+      },
+      "tests": [
+        {
+          "module": "test_flaky",
+          "name": "test_flaky",
+          "full_name": "test_flaky::test_flaky",
+          "status": "passed",
+          "duration_seconds": "[TIME]",
+          "flaky": true,
+          "retry": {
+            "attempts": 2,
+            "max_attempts": 2
+          },
+          "attempts": [
+            {
+              "attempt": 1,
+              "status": "failed",
+              "duration_seconds": "[TIME]",
+              "diagnostic": {
+                "code": "test-failure",
+                "severity": "error",
+                "message": "Test `test_flaky` failed",
+                "rendered": "error[test-failure]: Test `test_flaky` failed\n --> test_flaky.py:4:5\n  |/n4 | def test_flaky():\n  |     ^^^^^^^^^^\n  |/ninfo: Test failed here\n --> test_flaky.py:5:5\n  |/n5 |     assert os.environ[/"KARVA_ATTEMPT/"] == /"2/"\n  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  |\n\n"
+              }
+            },
+            {
+              "attempt": 2,
+              "status": "passed",
+              "duration_seconds": "[TIME]"
+            }
+          ]
+        }
+      ]
+    }
+    "#);
+}
+
+#[test]
+fn flaky_result_fail_marks_jsonl_run_failed() {
+    let context = TestContext::with_file(
+        "test_flaky.py",
+        r#"
+import os
+
+def test_flaky():
+    assert os.environ["KARVA_ATTEMPT"] == "2"
+"#,
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
+            "--retry=1",
+            "--flaky-result=fail",
+            "--status-level=none",
+            "--result-output=results.jsonl",
+            "--result-format=jsonl",
+        ]),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test_flaky::test_flaky
+    flaky failure: flaky tests caused the run to fail
+
+    ----- stderr -----
+    "
+    );
+    assert_snapshot!(context.read_file("results.jsonl"), @r#"
+    {"schema_version":2,"type":"test","module":"test_flaky","name":"test_flaky","full_name":"test_flaky::test_flaky","status":"passed","duration_seconds":"[TIME]","flaky":true,"retry":{"attempts":2,"max_attempts":2},"attempts":[{"attempt":1,"status":"failed","duration_seconds":"[TIME]","diagnostic":{"code":"test-failure","severity":"error","message":"Test `test_flaky` failed","rendered":"error[test-failure]: Test `test_flaky` failed\n --> test_flaky.py:4:5\n  |/n4 | def test_flaky():\n  |     ^^^^^^^^^^\n  |/ninfo: Test failed here\n --> test_flaky.py:5:5\n  |/n5 |     assert os.environ[/"KARVA_ATTEMPT/"] == /"2/"\n  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  |\n\n"}},{"attempt":2,"status":"passed","duration_seconds":"[TIME]"}]}
+    {"schema_version":2,"type":"run_finished","status":"failed","elapsed_seconds":"[TIME]","stats":{"total":1,"passed":1,"failed":0,"errors":0,"skipped":0,"flaky":1,"slow":0}}
+    "#);
+}
+
+#[test]
 fn fail_slow_reports_teardown_duration_in_json_and_jsonl() {
     let context = TestContext::with_file(
         "test_fail_slow.py",

--- a/crates/karva/tests/it/show_config.rs
+++ b/crates/karva/tests/it/show_config.rs
@@ -24,6 +24,7 @@ fn show_config_default_profile() {
     test-function-prefix = "test"
     try-import-fixtures = false
     retry = 0
+    flaky-result = "pass"
     no-tests = "auto"
 
     [coverage]
@@ -73,6 +74,7 @@ output-format = "concise"
     max-fail = 1
     try-import-fixtures = false
     retry = 0
+    flaky-result = "pass"
     no-tests = "auto"
 
     [coverage]
@@ -123,6 +125,7 @@ output-format = "concise"
     test-function-prefix = "check"
     try-import-fixtures = false
     retry = 3
+    flaky-result = "pass"
     no-tests = "auto"
 
     [coverage]
@@ -176,6 +179,7 @@ fail-under = 90
     test-function-prefix = "test"
     try-import-fixtures = false
     retry = 0
+    flaky-result = "pass"
     no-tests = "auto"
     slow-timeout = 0.5
     timeout = 120.0
@@ -230,6 +234,7 @@ slow-timeout = 0.5
     test-function-prefix = "test"
     try-import-fixtures = false
     retry = 0
+    flaky-result = "pass"
     no-tests = "auto"
 
     [coverage]

--- a/crates/karva/tests/it/show_config.rs
+++ b/crates/karva/tests/it/show_config.rs
@@ -36,6 +36,7 @@ fn show_config_default_profile() {
     [junit]
     report-name = "karva-tests"
     store-failure-output = true
+    flaky-fail-status = "failure"
 
     ----- stderr -----
     "#);
@@ -86,6 +87,7 @@ output-format = "concise"
     [junit]
     report-name = "karva-tests"
     store-failure-output = true
+    flaky-fail-status = "failure"
 
     ----- stderr -----
     "#);
@@ -137,6 +139,7 @@ output-format = "concise"
     [junit]
     report-name = "karva-tests"
     store-failure-output = true
+    flaky-fail-status = "failure"
 
     ----- stderr -----
     "#);
@@ -195,6 +198,7 @@ fail-under = 90
     [junit]
     report-name = "karva-tests"
     store-failure-output = true
+    flaky-fail-status = "failure"
 
     ----- stderr -----
     "#);
@@ -246,6 +250,7 @@ slow-timeout = 0.5
     [junit]
     report-name = "karva-tests"
     store-failure-output = true
+    flaky-fail-status = "failure"
 
     [[overrides]]
     filter = "tag(network)"

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -62,6 +62,10 @@ impl AggregatedResults {
             .any(RenderedDiagnostic::is_error)
     }
 
+    pub fn has_flaky_failures(&self) -> bool {
+        self.test_cases.iter().any(TestCaseResult::is_flaky_failure)
+    }
+
     pub fn register_interrupted_test(&mut self, name: &str, duration: Duration) {
         let function_name = base_test_name(name);
         self.stats.add(TestResultKind::Failed);

--- a/crates/karva_cli/src/enums.rs
+++ b/crates/karva_cli/src/enums.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use camino::Utf8PathBuf;
 use ruff_db::diagnostic::DiagnosticFormat;
 
-use karva_metadata::{NoTestsMode, RunIgnoredMode};
+use karva_metadata::{FlakyResult as FlakyResultMode, NoTestsMode, RunIgnoredMode};
 
 /// Coverage report selection parsed from `--cov-report`.
 #[derive(Clone, Hash, Debug, PartialEq, Eq, PartialOrd, Ord, Default)]
@@ -182,6 +182,22 @@ impl From<NoTests> for NoTestsMode {
             NoTests::Pass => Self::Pass,
             NoTests::Warn => Self::Warn,
             NoTests::Fail => Self::Fail,
+        }
+    }
+}
+
+/// Whether flaky tests pass or fail the run.
+#[derive(Copy, Clone, Hash, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub enum FlakyResult {
+    Pass,
+    Fail,
+}
+
+impl From<FlakyResult> for FlakyResultMode {
+    fn from(value: FlakyResult) -> Self {
+        match value {
+            FlakyResult::Pass => Self::Pass,
+            FlakyResult::Fail => Self::Fail,
         }
     }
 }

--- a/crates/karva_cli/src/enums.rs
+++ b/crates/karva_cli/src/enums.rs
@@ -3,7 +3,10 @@ use std::str::FromStr;
 use camino::Utf8PathBuf;
 use ruff_db::diagnostic::DiagnosticFormat;
 
-use karva_metadata::{FlakyResult as FlakyResultMode, NoTestsMode, RunIgnoredMode};
+use karva_metadata::{
+    FlakyResult as FlakyResultMode, JunitFlakyFailStatus as JunitFlakyFailStatusMode, NoTestsMode,
+    RunIgnoredMode,
+};
 
 /// Coverage report selection parsed from `--cov-report`.
 #[derive(Clone, Hash, Debug, PartialEq, Eq, PartialOrd, Ord, Default)]
@@ -198,6 +201,21 @@ impl From<FlakyResult> for FlakyResultMode {
         match value {
             FlakyResult::Pass => Self::Pass,
             FlakyResult::Fail => Self::Fail,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Hash, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub enum JunitFlakyFailStatus {
+    Failure,
+    Success,
+}
+
+impl From<JunitFlakyFailStatus> for JunitFlakyFailStatusMode {
+    fn from(value: JunitFlakyFailStatus) -> Self {
+        match value {
+            JunitFlakyFailStatus::Failure => Self::Failure,
+            JunitFlakyFailStatus::Success => Self::Success,
         }
     }
 }

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -12,7 +12,9 @@ mod test;
 mod verbosity;
 
 pub use cache::{CacheAction, CacheCommand};
-pub use enums::{CovContext, CovReport, NoTests, OutputFormat, ResultFormat, RunIgnored};
+pub use enums::{
+    CovContext, CovReport, FlakyResult, NoTests, OutputFormat, ResultFormat, RunIgnored,
+};
 pub use exit_status::ExitStatus;
 pub use partition::PartitionSelection;
 pub use show_config::ShowConfigCommand;

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -13,7 +13,8 @@ mod verbosity;
 
 pub use cache::{CacheAction, CacheCommand};
 pub use enums::{
-    CovContext, CovReport, FlakyResult, NoTests, OutputFormat, ResultFormat, RunIgnored,
+    CovContext, CovReport, FlakyResult, JunitFlakyFailStatus, NoTests, OutputFormat, ResultFormat,
+    RunIgnored,
 };
 pub use exit_status::ExitStatus;
 pub use partition::PartitionSelection;

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -4,13 +4,15 @@ use camino::Utf8PathBuf;
 use clap::Parser;
 use karva_logging::{FinalStatusLevel, StatusLevel, TerminalColor};
 use karva_metadata::{
-    CovFailUnder, CoverageOptions, FailSlowSecs, MaxFail, Options, OverrideOptions, RunTimeoutSecs,
-    SlowTimeoutSecs, SrcOptions, TerminalOptions, TerminationGracePeriodSecs, TestOptions,
-    TestTimeoutSecs,
+    CovFailUnder, CoverageOptions, FailSlowSecs, JunitOptions, MaxFail, Options, OverrideOptions,
+    RunTimeoutSecs, SlowTimeoutSecs, SrcOptions, TerminalOptions, TerminationGracePeriodSecs,
+    TestOptions, TestTimeoutSecs,
 };
 use karva_static::EnvVars;
 
-use crate::enums::{CovReport, FlakyResult, NoTests, OutputFormat, ResultFormat, RunIgnored};
+use crate::enums::{
+    CovReport, FlakyResult, JunitFlakyFailStatus, NoTests, OutputFormat, ResultFormat, RunIgnored,
+};
 use crate::partition::PartitionSelection;
 use crate::verbosity::Verbosity;
 
@@ -107,6 +109,19 @@ pub struct SubTestCommand {
     /// When set, the test will retry failed tests up to this number of times.
     #[clap(long, help_heading = "Runner options")]
     pub retry: Option<u32>,
+
+    /// Whether tests that pass only after a retry should pass or fail the run.
+    #[arg(
+        long,
+        value_name = "ACTION",
+        env = EnvVars::KARVA_FLAKY_RESULT,
+        help_heading = "Runner options"
+    )]
+    pub flaky_result: Option<FlakyResult>,
+
+    /// Internal transport for the resolved `JUnit` flaky status.
+    #[arg(long, hide = true)]
+    pub junit_flaky_fail_status: Option<JunitFlakyFailStatus>,
 
     /// Threshold in seconds after which a test is flagged as slow.
     ///
@@ -330,15 +345,6 @@ pub struct TestCommand {
     #[clap(long, value_name = "SECONDS", help_heading = "Runner options")]
     pub run_timeout: Option<f64>,
 
-    /// Whether tests that pass only after a retry should pass or fail the run.
-    #[arg(
-        long,
-        value_name = "ACTION",
-        env = EnvVars::KARVA_FLAKY_RESULT,
-        help_heading = "Runner options"
-    )]
-    pub flaky_result: Option<FlakyResult>,
-
     /// Grace period before force-killing workers during shutdown, in seconds.
     ///
     /// When karva stops workers because of Ctrl+C, fail-fast, or
@@ -469,7 +475,7 @@ impl SubTestCommand {
                 max_fail,
                 try_import_fixtures: self.try_import_fixtures,
                 retry: self.retry,
-                flaky_result: None,
+                flaky_result: self.flaky_result.map(Into::into),
                 no_tests: self.no_tests.map(Into::into),
                 slow_timeout: self.slow_timeout.map(SlowTimeoutSecs),
                 fail_slow: self.fail_slow.map(FailSlowSecs),
@@ -491,7 +497,10 @@ impl SubTestCommand {
                 fail_under: self.cov_fail_under.map(CovFailUnder),
                 disabled: self.no_cov.then_some(true),
             }),
-            junit: None,
+            junit: self.junit_flaky_fail_status.map(|status| JunitOptions {
+                flaky_fail_status: Some(status.into()),
+                ..JunitOptions::default()
+            }),
             overrides: self.override_json,
         }
     }
@@ -500,7 +509,6 @@ impl SubTestCommand {
 impl TestCommand {
     pub fn into_options(self) -> Options {
         let run_timeout = self.run_timeout;
-        let flaky_result = self.flaky_result;
         let termination_grace_period = self.termination_grace_period;
         let mut sub_command = self.sub_command;
         if self.no_capture {
@@ -509,7 +517,6 @@ impl TestCommand {
         let mut options = sub_command.into_options();
         if let Some(test) = options.test.as_mut() {
             test.run_timeout = run_timeout.map(RunTimeoutSecs);
-            test.flaky_result = flaky_result.map(Into::into);
             test.termination_grace_period =
                 termination_grace_period.map(TerminationGracePeriodSecs);
         }

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -10,7 +10,7 @@ use karva_metadata::{
 };
 use karva_static::EnvVars;
 
-use crate::enums::{CovReport, NoTests, OutputFormat, ResultFormat, RunIgnored};
+use crate::enums::{CovReport, FlakyResult, NoTests, OutputFormat, ResultFormat, RunIgnored};
 use crate::partition::PartitionSelection;
 use crate::verbosity::Verbosity;
 
@@ -330,6 +330,15 @@ pub struct TestCommand {
     #[clap(long, value_name = "SECONDS", help_heading = "Runner options")]
     pub run_timeout: Option<f64>,
 
+    /// Whether tests that pass only after a retry should pass or fail the run.
+    #[arg(
+        long,
+        value_name = "ACTION",
+        env = EnvVars::KARVA_FLAKY_RESULT,
+        help_heading = "Runner options"
+    )]
+    pub flaky_result: Option<FlakyResult>,
+
     /// Grace period before force-killing workers during shutdown, in seconds.
     ///
     /// When karva stops workers because of Ctrl+C, fail-fast, or
@@ -460,6 +469,7 @@ impl SubTestCommand {
                 max_fail,
                 try_import_fixtures: self.try_import_fixtures,
                 retry: self.retry,
+                flaky_result: None,
                 no_tests: self.no_tests.map(Into::into),
                 slow_timeout: self.slow_timeout.map(SlowTimeoutSecs),
                 fail_slow: self.fail_slow.map(FailSlowSecs),
@@ -490,6 +500,7 @@ impl SubTestCommand {
 impl TestCommand {
     pub fn into_options(self) -> Options {
         let run_timeout = self.run_timeout;
+        let flaky_result = self.flaky_result;
         let termination_grace_period = self.termination_grace_period;
         let mut sub_command = self.sub_command;
         if self.no_capture {
@@ -498,6 +509,7 @@ impl TestCommand {
         let mut options = sub_command.into_options();
         if let Some(test) = options.test.as_mut() {
             test.run_timeout = run_timeout.map(RunTimeoutSecs);
+            test.flaky_result = flaky_result.map(Into::into);
             test.termination_grace_period =
                 termination_grace_period.map(TerminationGracePeriodSecs);
         }

--- a/crates/karva_diagnostic/src/result/case.rs
+++ b/crates/karva_diagnostic/src/result/case.rs
@@ -8,6 +8,14 @@ use super::diagnostic::RenderedDiagnostic;
 use super::kind::IndividualTestResultKind;
 use super::output::CapturedTestOutput;
 
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "serde skip_serializing_if passes a reference to the field"
+)]
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TestCaseResult<D = RenderedDiagnostic> {
     module_name: String,
@@ -113,6 +121,18 @@ impl<D> TestCaseResult<D> {
         self.retry.as_ref()
     }
 
+    pub fn is_flaky_failure(&self) -> bool {
+        self.retry
+            .as_ref()
+            .is_some_and(TestCaseRetry::is_flaky_failure)
+    }
+
+    pub fn is_junit_flaky_failure(&self) -> bool {
+        self.retry
+            .as_ref()
+            .is_some_and(TestCaseRetry::is_junit_flaky_failure)
+    }
+
     pub fn captured_output(&self) -> Option<&CapturedTestOutput> {
         self.captured_output.as_ref()
     }
@@ -199,6 +219,10 @@ impl<D> TestCaseAttempt<D> {
 pub struct TestCaseRetry {
     attempts: u32,
     max_attempts: u32,
+    #[serde(default, skip_serializing_if = "is_false")]
+    flaky_failure: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    junit_flaky_failure: bool,
 }
 
 impl TestCaseRetry {
@@ -206,7 +230,16 @@ impl TestCaseRetry {
         Self {
             attempts,
             max_attempts,
+            flaky_failure: false,
+            junit_flaky_failure: false,
         }
+    }
+
+    #[must_use]
+    pub fn with_failure_policy(mut self, flaky_failure: bool, junit_flaky_failure: bool) -> Self {
+        self.flaky_failure = flaky_failure;
+        self.junit_flaky_failure = junit_flaky_failure;
+        self
     }
 
     pub fn attempts(&self) -> u32 {
@@ -215,6 +248,14 @@ impl TestCaseRetry {
 
     pub fn max_attempts(&self) -> u32 {
         self.max_attempts
+    }
+
+    pub fn is_flaky_failure(&self) -> bool {
+        self.flaky_failure
+    }
+
+    pub fn is_junit_flaky_failure(&self) -> bool {
+        self.junit_flaky_failure
     }
 }
 

--- a/crates/karva_metadata/src/lib.rs
+++ b/crates/karva_metadata/src/lib.rs
@@ -18,9 +18,9 @@ pub use options::{
 };
 pub use pyproject::{PyProject, PyProjectError};
 pub use settings::{
-    CovFailUnder, CoverageSettings, FailSlowSecs, JunitSettings, NoTestsMode, OverrideSettings,
-    ProjectSettings, RunIgnoredMode, RunTimeoutSecs, SlowTimeoutSecs, TerminationGracePeriodSecs,
-    TestTimeoutSecs,
+    CovFailUnder, CoverageSettings, FailSlowSecs, FlakyResult, JunitSettings, NoTestsMode,
+    OverrideSettings, ProjectSettings, RunIgnoredMode, RunTimeoutSecs, SlowTimeoutSecs,
+    TerminationGracePeriodSecs, TestTimeoutSecs,
 };
 
 use crate::options::KarvaTomlError;

--- a/crates/karva_metadata/src/lib.rs
+++ b/crates/karva_metadata/src/lib.rs
@@ -13,14 +13,14 @@ mod settings;
 pub use max_fail::MaxFail;
 pub use options::{
     Config, CovReport, CoverageOptions, DEFAULT_PROFILE, IncompatibleVersionError, JunitOptions,
-    Options, OutputFormat, OverrideOptions, ProjectOptionsOverrides, SrcOptions, TerminalOptions,
-    TestOptions, UnknownProfile,
+    Options, OutputFormat, OverrideJunitOptions, OverrideOptions, ProjectOptionsOverrides,
+    SrcOptions, TerminalOptions, TestOptions, UnknownProfile,
 };
 pub use pyproject::{PyProject, PyProjectError};
 pub use settings::{
-    CovFailUnder, CoverageSettings, FailSlowSecs, FlakyResult, JunitSettings, NoTestsMode,
-    OverrideSettings, ProjectSettings, RunIgnoredMode, RunTimeoutSecs, SlowTimeoutSecs,
-    TerminationGracePeriodSecs, TestTimeoutSecs,
+    CovFailUnder, CoverageSettings, FailSlowSecs, FlakyResult, JunitFlakyFailStatus, JunitSettings,
+    NoTestsMode, OverrideSettings, ProjectSettings, RunIgnoredMode, RunTimeoutSecs,
+    SlowTimeoutSecs, TerminationGracePeriodSecs, TestTimeoutSecs,
 };
 
 use crate::options::KarvaTomlError;

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -15,9 +15,9 @@ pub use overrides::ProjectOptionsOverrides;
 use crate::filter::{FiltersetSet, ValidatedFilter};
 use crate::max_fail::MaxFail;
 use crate::settings::{
-    CovFailUnder, CoverageSettings, FailSlowSecs, JunitSettings, NoTestsMode, OverrideSettings,
-    ProjectSettings, RunIgnoredMode, RunTimeoutSecs, SlowTimeoutSecs, SrcSettings,
-    TerminalSettings, TerminationGracePeriodSecs, TestSettings, TestTimeoutSecs,
+    CovFailUnder, CoverageSettings, FailSlowSecs, FlakyResult, JunitSettings, NoTestsMode,
+    OverrideSettings, ProjectSettings, RunIgnoredMode, RunTimeoutSecs, SlowTimeoutSecs,
+    SrcSettings, TerminalSettings, TerminationGracePeriodSecs, TestSettings, TestTimeoutSecs,
 };
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, OptionsMetadata)]
@@ -372,6 +372,17 @@ pub struct TestOptions {
     )]
     pub retry: Option<u32>,
 
+    /// Whether tests that pass only after a retry should fail the run.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"pass"#,
+        value_type = "pass | fail",
+        example = r#"
+            flaky-result = "fail"
+        "#
+    )]
+    pub flaky_result: Option<FlakyResult>,
+
     /// Configures behavior when no tests are found to run.
     ///
     /// `auto` (the default) fails when no filter expressions were given, and
@@ -502,6 +513,7 @@ impl TestOptions {
             max_fail,
             try_import_fixtures: self.try_import_fixtures.unwrap_or_default(),
             retry: self.retry.unwrap_or_default(),
+            flaky_result: self.flaky_result.unwrap_or_default(),
             filter: FiltersetSet::default(),
             run_ignored: RunIgnoredMode::default(),
             no_tests: self.no_tests.unwrap_or_default(),
@@ -897,7 +909,7 @@ nonsense = 42
           |
         4 | nonsense = 42
           | ^^^^^^^^
-        unknown field `nonsense`, expected one of `test-function-prefix`, `fail-fast`, `max-fail`, `try-import-fixtures`, `retry`, `no-tests`, `slow-timeout`, `timeout`, `fail-slow`, `run-timeout`, `termination-grace-period`
+        unknown field `nonsense`, expected one of `test-function-prefix`, `fail-fast`, `max-fail`, `try-import-fixtures`, `retry`, `flaky-result`, `no-tests`, `slow-timeout`, `timeout`, `fail-slow`, `run-timeout`, `termination-grace-period`
         "
         );
     }
@@ -994,6 +1006,7 @@ max-fail = 0
             retry: Some(
                 5,
             ),
+            flaky_result: None,
             no_tests: None,
             slow_timeout: None,
             timeout: None,
@@ -1026,6 +1039,7 @@ max-fail = 0
             retry: Some(
                 3,
             ),
+            flaky_result: None,
             no_tests: None,
             slow_timeout: None,
             timeout: None,
@@ -1091,6 +1105,7 @@ retry = 2
                 retry: Some(
                     2,
                 ),
+                flaky_result: None,
                 no_tests: None,
                 slow_timeout: None,
                 timeout: None,
@@ -1150,6 +1165,7 @@ retry = 5
                 retry: Some(
                     5,
                 ),
+                flaky_result: None,
                 no_tests: None,
                 slow_timeout: None,
                 timeout: None,

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -15,9 +15,10 @@ pub use overrides::ProjectOptionsOverrides;
 use crate::filter::{FiltersetSet, ValidatedFilter};
 use crate::max_fail::MaxFail;
 use crate::settings::{
-    CovFailUnder, CoverageSettings, FailSlowSecs, FlakyResult, JunitSettings, NoTestsMode,
-    OverrideSettings, ProjectSettings, RunIgnoredMode, RunTimeoutSecs, SlowTimeoutSecs,
-    SrcSettings, TerminalSettings, TerminationGracePeriodSecs, TestSettings, TestTimeoutSecs,
+    CovFailUnder, CoverageSettings, FailSlowSecs, FlakyResult, JunitFlakyFailStatus, JunitSettings,
+    NoTestsMode, OverrideSettings, ProjectSettings, RunIgnoredMode, RunTimeoutSecs,
+    SlowTimeoutSecs, SrcSettings, TerminalSettings, TerminationGracePeriodSecs, TestSettings,
+    TestTimeoutSecs,
 };
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, OptionsMetadata)]
@@ -115,6 +116,22 @@ pub struct OverrideOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retries: Option<u32>,
 
+    /// Whether matching flaky tests pass or fail the run.
+    #[option(
+        default = "null",
+        value_type = "pass | fail",
+        example = r#"
+            flaky-result = "pass"
+        "#
+    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flaky_result: Option<FlakyResult>,
+
+    /// `JUnit` behavior for matching flaky tests configured to fail.
+    #[option_group]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub junit: Option<OverrideJunitOptions>,
+
     /// Hard per-test timeout, in seconds, applied to matching tests.
     /// Mirrors the profile-level [`timeout`](#timeout) field. A value of
     /// `0` (or any non-positive value) disables the hard timeout for the
@@ -162,11 +179,33 @@ impl OverrideOptions {
         OverrideSettings {
             filter: self.filter.clone(),
             retries: self.retries,
+            flaky_result: self.flaky_result,
+            junit_flaky_fail_status: self
+                .junit
+                .as_ref()
+                .and_then(|junit| junit.flaky_fail_status),
             timeout: self.timeout,
             slow_timeout: self.slow_timeout,
             fail_slow: self.fail_slow,
         }
     }
+}
+
+#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize, OptionsMetadata)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct OverrideJunitOptions {
+    /// Whether matching flaky-fail tests appear as failures or successes in
+    /// `JUnit`, while preserving their flaky attempt details.
+    #[option(
+        default = "null",
+        value_type = "failure | success",
+        example = r#"
+            flaky-fail-status = "success"
+        "#
+    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flaky_fail_status: Option<JunitFlakyFailStatus>,
 }
 
 #[derive(
@@ -733,6 +772,17 @@ pub struct JunitOptions {
         "#
     )]
     pub store_failure_output: Option<bool>,
+
+    /// How flaky tests configured to fail are represented in `JUnit`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"failure"#,
+        value_type = r#"failure | success"#,
+        example = r#"
+            flaky-fail-status = "success"
+        "#
+    )]
+    pub flaky_fail_status: Option<JunitFlakyFailStatus>,
 }
 
 impl JunitOptions {
@@ -745,6 +795,7 @@ impl JunitOptions {
                 .unwrap_or_else(|| "karva-tests".to_string()),
             store_success_output: self.store_success_output.unwrap_or_default(),
             store_failure_output: self.store_failure_output.unwrap_or(true),
+            flaky_fail_status: self.flaky_fail_status.unwrap_or_default(),
         }
     }
 }
@@ -1349,6 +1400,7 @@ store-failure-output = false
                 store_failure_output: Some(
                     false,
                 ),
+                flaky_fail_status: None,
             },
         )
         "#);

--- a/crates/karva_metadata/src/options/overrides.rs
+++ b/crates/karva_metadata/src/options/overrides.rs
@@ -29,6 +29,17 @@ impl ProjectOptionsOverrides {
     /// overrides on top.
     pub fn apply_to(&self, config: Config) -> Result<Options, UnknownProfile> {
         let resolved = config.resolve_profile(self.profile.as_deref())?;
-        Ok(self.options.clone().combine(resolved))
+        let disable_flaky_result_overrides = self
+            .options
+            .test
+            .as_ref()
+            .is_some_and(|test| test.flaky_result.is_some());
+        let mut options = self.options.clone().combine(resolved);
+        if disable_flaky_result_overrides {
+            for override_options in &mut options.overrides {
+                override_options.flaky_result = None;
+            }
+        }
+        Ok(options)
     }
 }

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -57,6 +57,43 @@ pub enum FlakyResult {
     Fail,
 }
 
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum JunitFlakyFailStatus {
+    #[default]
+    Failure,
+    Success,
+}
+
+impl JunitFlakyFailStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Failure => "failure",
+            Self::Success => "success",
+        }
+    }
+}
+
+impl FlakyResult {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pass => "pass",
+            Self::Fail => "fail",
+        }
+    }
+}
+
+impl Combine for JunitFlakyFailStatus {
+    #[inline(always)]
+    fn combine_with(&mut self, _other: Self) {}
+
+    #[inline]
+    fn combine(self, _other: Self) -> Self {
+        self
+    }
+}
+
 impl Combine for FlakyResult {
     #[inline(always)]
     fn combine_with(&mut self, _other: Self) {}
@@ -294,6 +331,10 @@ pub struct OverrideSettings {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retries: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub flaky_result: Option<FlakyResult>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub junit_flaky_fail_status: Option<JunitFlakyFailStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout: Option<TestTimeoutSecs>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub slow_timeout: Option<SlowTimeoutSecs>,
@@ -355,6 +396,16 @@ impl ProjectSettings {
     pub fn retry_for(&self, ctx: &EvalContext<'_>) -> u32 {
         self.first_matching_override(ctx, |ovr| ovr.retries)
             .unwrap_or(self.test.retry)
+    }
+
+    pub fn flaky_result_for(&self, ctx: &EvalContext<'_>) -> FlakyResult {
+        self.first_matching_override(ctx, |ovr| ovr.flaky_result)
+            .unwrap_or(self.test.flaky_result)
+    }
+
+    pub fn junit_flaky_fail_status_for(&self, ctx: &EvalContext<'_>) -> JunitFlakyFailStatus {
+        self.first_matching_override(ctx, |ovr| ovr.junit_flaky_fail_status)
+            .unwrap_or(self.junit.flaky_fail_status)
     }
 
     /// Resolve the hard per-test timeout for a single test.
@@ -463,6 +514,7 @@ pub struct JunitSettings {
     #[serde(skip_serializing_if = "is_false")]
     pub store_success_output: bool,
     pub store_failure_output: bool,
+    pub flaky_fail_status: JunitFlakyFailStatus,
 }
 
 impl Default for JunitSettings {
@@ -472,6 +524,7 @@ impl Default for JunitSettings {
             report_name: "karva-tests".to_string(),
             store_success_output: false,
             store_failure_output: true,
+            flaky_fail_status: JunitFlakyFailStatus::default(),
         }
     }
 }

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -48,6 +48,25 @@ pub enum NoTestsMode {
     Fail,
 }
 
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum FlakyResult {
+    #[default]
+    Pass,
+    Fail,
+}
+
+impl Combine for FlakyResult {
+    #[inline(always)]
+    fn combine_with(&mut self, _other: Self) {}
+
+    #[inline]
+    fn combine(self, _other: Self) -> Self {
+        self
+    }
+}
+
 impl Combine for NoTestsMode {
     #[inline(always)]
     fn combine_with(&mut self, _other: Self) {}
@@ -475,6 +494,7 @@ pub struct TestSettings {
     pub max_fail: MaxFail,
     pub try_import_fixtures: bool,
     pub retry: u32,
+    pub flaky_result: FlakyResult,
     /// Runtime-only: filters are sourced from CLI flags, never config files.
     #[serde(skip)]
     pub filter: FiltersetSet,

--- a/crates/karva_runner/src/worker_args.rs
+++ b/crates/karva_runner/src/worker_args.rs
@@ -131,6 +131,18 @@ fn inner_cli_args(settings: &ProjectSettings, args: &SubTestCommand) -> Vec<Stri
         push_value_arg(&mut cli_args, "--retry", settings.test().retry);
     }
 
+    push_value_arg(
+        &mut cli_args,
+        "--flaky-result",
+        settings.test().flaky_result.as_str(),
+    );
+
+    push_value_arg(
+        &mut cli_args,
+        "--junit-flaky-fail-status",
+        settings.junit().flaky_fail_status.as_str(),
+    );
+
     if let Some(threshold) = settings.test().slow_timeout {
         push_value_arg(&mut cli_args, "--slow-timeout", threshold.as_secs_f64());
     }
@@ -167,6 +179,10 @@ fn inner_cli_args(settings: &ProjectSettings, args: &SubTestCommand) -> Vec<Stri
         let json = serde_json::json!({
             "filter": ovr.filter.as_str(),
             "retries": ovr.retries,
+            "flaky-result": ovr.flaky_result,
+            "junit": {
+                "flaky-fail-status": ovr.junit_flaky_fail_status,
+            },
             "timeout": ovr.timeout.map(|t| t.0),
             "slow-timeout": ovr.slow_timeout.map(|t| t.0),
             "fail-slow": ovr.fail_slow.map(|t| t.0),

--- a/crates/karva_static/src/lib.rs
+++ b/crates/karva_static/src/lib.rs
@@ -65,6 +65,10 @@ env_vars! {
         /// `--no-tests`.
         pub const KARVA_NO_TESTS: &'static str = "KARVA_NO_TESTS";
 
+        /// Whether flaky tests pass or fail the run, equivalent to
+        /// `--flaky-result`.
+        pub const KARVA_FLAKY_RESULT: &'static str = "KARVA_FLAKY_RESULT";
+
         /// Test result statuses to display during the run, equivalent to
         /// `--status-level`.
         pub const KARVA_STATUS_LEVEL: &'static str = "KARVA_STATUS_LEVEL";

--- a/crates/karva_test_semantic/src/context.rs
+++ b/crates/karva_test_semantic/src/context.rs
@@ -172,7 +172,7 @@ impl<'a> Context<'a> {
         captured_output: Option<CapturedTestOutput>,
         attempts: Vec<TestExecutionAttempt>,
     ) -> bool {
-        let passed = !outcome.is_non_success();
+        let passed = !outcome.is_non_success() && !retry.is_flaky_failure();
         self.result().register_retried_result(
             test_case_name,
             outcome,

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use karva_diagnostic::{CapturedTestOutput, TestCaseRetry, TestExecutionOutcome};
-use karva_metadata::RunIgnoredMode;
 use karva_metadata::filter::EvalContext;
+use karva_metadata::{FlakyResult, JunitFlakyFailStatus, RunIgnoredMode};
 use karva_python_semantic::QualifiedTestName;
 use pyo3::prelude::*;
 
@@ -253,6 +253,16 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             .settings()
             .retry_for(&evaluation_context)
             .saturating_add(1);
+        let flaky_result = self
+            .package_runner
+            .context
+            .settings()
+            .flaky_result_for(&evaluation_context);
+        let junit_flaky_fail_status = self
+            .package_runner
+            .context
+            .settings()
+            .junit_flaky_fail_status_for(&evaluation_context);
         let expect_fail_tag = self.tags.expect_fail_tag();
         let expect_fail = expect_fail_tag
             .as_ref()
@@ -287,6 +297,8 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             fail_slow_budget,
             slow_timeout,
             max_attempts,
+            flaky_result,
+            junit_flaky_fail_status,
         }
     }
 
@@ -340,6 +352,10 @@ impl<'runner, 'context, 'settings, 'test, 'py>
         } else {
             let final_attempt_number = final_attempt.attempt;
             let outcome = final_attempt.outcome.clone();
+            let flaky_failure = matches!(&outcome, TestExecutionOutcome::Passed)
+                && settings.flaky_result == FlakyResult::Fail;
+            let junit_flaky_failure =
+                flaky_failure && settings.junit_flaky_fail_status == JunitFlakyFailStatus::Failure;
             let mut execution_attempts = prior_attempts
                 .into_iter()
                 .map(TestLifecycleAttempt::into_execution_attempt)
@@ -349,7 +365,8 @@ impl<'runner, 'context, 'settings, 'test, 'py>
                 &settings.qualified_test_name,
                 outcome,
                 total_duration,
-                TestCaseRetry::new(final_attempt_number, settings.max_attempts),
+                TestCaseRetry::new(final_attempt_number, settings.max_attempts)
+                    .with_failure_policy(flaky_failure, junit_flaky_failure),
                 captured_output,
                 execution_attempts,
             )
@@ -452,6 +469,10 @@ struct VariantSettings {
     slow_timeout: Option<Duration>,
     /// Total attempts, including the initial call.
     max_attempts: u32,
+    /// Whether a pass after retry fails the run.
+    flaky_result: FlakyResult,
+    /// How a flaky failure appears in `JUnit`.
+    junit_flaky_fail_status: JunitFlakyFailStatus,
 }
 
 /// Finishes best-effort Python output capture.

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -440,6 +440,23 @@ fail-slow = 0.25
 
 ---
 
+### `flaky-result`
+
+Whether tests that pass only after a retry should fail the run.
+
+**Default value**: `pass`
+
+**Type**: `pass | fail`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.karva.profile.default.test]
+flaky-result = "fail"
+```
+
+---
+
 ### `max-fail`
 
 Stop scheduling new tests once this many tests have failed.

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -182,6 +182,23 @@ sources = ["src"]
 
 ## `junit`
 
+### `flaky-fail-status`
+
+How flaky tests configured to fail are represented in `JUnit`.
+
+**Default value**: `failure`
+
+**Type**: `failure | success`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.karva.profile.default.junit]
+flaky-fail-status = "success"
+```
+
+---
+
 ### `path`
 
 Output path for the `JUnit` XML report.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -89,6 +89,11 @@ karva test [OPTIONS] [PATH]...
 <li><code>pass</code>:  Always display the summary line and diagnostics (default)</li>
 <li><code>skip</code>:  Same as <code>pass</code> until skip-specific summary lines are emitted</li>
 <li><code>all</code>:  Always display every summary status</li>
+</ul></dd><dt id="karva-test--flaky-result"><a href="#karva-test--flaky-result"><code>--flaky-result</code></a> <i>action</i></dt><dd><p>Whether tests that pass only after a retry should pass or fail the run</p>
+<p>May also be set with the <code>KARVA_FLAKY_RESULT</code> environment variable.</p><p>Possible values:</p>
+<ul>
+<li><code>pass</code></li>
+<li><code>fail</code></li>
 </ul></dd><dt id="karva-test--help"><a href="#karva-test--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Print help (see a summary with '-h')</p>
 </dd><dt id="karva-test--last-failed"><a href="#karva-test--last-failed"><code>--last-failed</code></a>, <code>--lf</code></dt><dd><p>Re-run only the tests that failed in the previous run</p>
 </dd><dt id="karva-test--max-fail"><a href="#karva-test--max-fail"><code>--max-fail</code></a> <i>n</i></dt><dd><p>Stop scheduling new tests after this many failures.</p>

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -29,6 +29,11 @@ Configuration profile to use, equivalent to `--profile`.
 Behavior when no tests are found to run, equivalent to
 `--no-tests`.
 
+### `KARVA_FLAKY_RESULT`
+
+Whether flaky tests pass or fail the run, equivalent to
+`--flaky-result`.
+
 ### `KARVA_STATUS_LEVEL`
 
 Test result statuses to display during the run, equivalent to

--- a/docs/usage/failure-handling/retries.md
+++ b/docs/usage/failure-handling/retries.md
@@ -17,6 +17,25 @@ retry = 3
 
 A test that passes on any attempt is treated as a pass. The first failed attempt is reported as `TRY 1 FAIL`; the test is only marked as failing once every attempt has been exhausted.
 
+Set `flaky-result = "fail"` when retries should expose flaky tests without allowing them to pass the run:
+
+```toml
+[tool.karva.profile.default.test]
+retry = 2
+flaky-result = "pass"
+
+[tool.karva.profile.ci.test]
+flaky-result = "fail"
+```
+
+The equivalent command-line override is:
+
+```bash
+uv run karva test --retry 2 --flaky-result fail
+```
+
+`pass` remains the default. With `fail`, Karva keeps the test's `FLAKY` status and attempt history but exits non-zero and marks JSON, JSONL, and JUnit reports as failed. `--flaky-result` does not enable retries by itself. `KARVA_FLAKY_RESULT` provides the same override through the environment.
+
 To see the per-attempt lines in the run output, raise the status level:
 
 ```bash

--- a/docs/usage/failure-handling/retries.md
+++ b/docs/usage/failure-handling/retries.md
@@ -34,7 +34,7 @@ The equivalent command-line override is:
 uv run karva test --retry 2 --flaky-result fail
 ```
 
-`pass` remains the default. With `fail`, Karva keeps the test's `FLAKY` status and attempt history but exits non-zero and marks JSON, JSONL, and JUnit reports as failed. `--flaky-result` does not enable retries by itself. `KARVA_FLAKY_RESULT` provides the same override through the environment.
+`pass` remains the default. With `fail`, Karva keeps the test's `FLAKY` status and attempt history but exits non-zero, marks JSON and JSONL reports as failed, and adds a JUnit failure by default. `--flaky-result` does not enable retries by itself. `KARVA_FLAKY_RESULT` provides the same override through the environment.
 
 To see the per-attempt lines in the run output, raise the status level:
 
@@ -62,6 +62,19 @@ retries = 0
 ```
 
 In this example tests tagged `network` retry up to five times, tests tagged `unit` never retry, and everything else falls back to `retry = 1`. Overrides defined in a named profile (`[[profile.ci.overrides]]`) take precedence over those defined under `default`.
+
+Overrides can also set `flaky-result` per test:
+
+```toml
+[profile.default.test]
+flaky-result = "pass"
+
+[[profile.default.overrides]]
+filter = "tag(strict)"
+flaky-result = "fail"
+```
+
+An explicit `--flaky-result` or `KARVA_FLAKY_RESULT` value disables all per-test `flaky-result` overrides, matching nextest's global override behavior.
 
 The same `[[profile.<name>.overrides]]` block also supports `timeout`, `slow-timeout`, and `fail-slow` fields, mirroring the [profile-level timeout](../../configuration/configuration.md), slow-test threshold, and [fail-slow budget](fail-slow.md). A matching override with a non-positive value disables the corresponding limit for that test, even when the profile sets one.
 

--- a/docs/usage/running-tests/reports.md
+++ b/docs/usage/running-tests/reports.md
@@ -14,6 +14,7 @@ path = "reports/test-results.xml"
 report-name = "karva-tests"
 store-failure-output = true
 store-success-output = false
+flaky-fail-status = "failure"
 ```
 
 ```bash
@@ -25,6 +26,19 @@ fixture and collection errors use `<error>`, and skipped tests use `<skipped>`.
 Retry history is preserved with `flakyFailure` and `rerunFailure` elements.
 Captured stdout and stderr are included according to the two `store-*-output`
 settings.
+
+When `flaky-result = "fail"`, `flaky-fail-status = "failure"` adds a regular
+`failure` element as well as preserving `flakyFailure`. Set it to `success` to
+keep the JUnit testcase successful while Karva still exits non-zero. It can be
+overridden for matching tests:
+
+```toml
+[[tool.karva.profile.ci.overrides]]
+filter = "tag(strict)"
+
+[tool.karva.profile.ci.overrides.junit]
+flaky-fail-status = "failure"
+```
 
 ## JSON
 

--- a/karva.schema.json
+++ b/karva.schema.json
@@ -178,6 +178,13 @@
         }
       ]
     },
+    "FlakyResult": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "fail"
+      ]
+    },
     "JunitOptions": {
       "type": "object",
       "properties": {
@@ -496,6 +503,17 @@
           "anyOf": [
             {
               "$ref": "#/definitions/FailSlowSecs"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "flaky-result": {
+          "description": "Whether tests that pass only after a retry should fail the run.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FlakyResult"
             },
             {
               "type": "null"

--- a/karva.schema.json
+++ b/karva.schema.json
@@ -185,9 +185,27 @@
         "fail"
       ]
     },
+    "JunitFlakyFailStatus": {
+      "type": "string",
+      "enum": [
+        "failure",
+        "success"
+      ]
+    },
     "JunitOptions": {
       "type": "object",
       "properties": {
+        "flaky-fail-status": {
+          "description": "How flaky tests configured to fail are represented in `JUnit`.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/JunitFlakyFailStatus"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "path": {
           "description": "Output path for the `JUnit` XML report.\n\nWhen unset, no `JUnit` report is written.",
           "type": [
@@ -308,6 +326,23 @@
         "concise"
       ]
     },
+    "OverrideJunitOptions": {
+      "type": "object",
+      "properties": {
+        "flaky-fail-status": {
+          "description": "Whether matching flaky-fail tests appear as failures or successes in\n`JUnit`, while preserving their flaky attempt details.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/JunitFlakyFailStatus"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "OverrideOptions": {
       "description": "A single per-test override entry.\n\nMirrors `[[profile.<name>.overrides]]` in `karva.toml`. Each override\npairs a filter expression with one or more option fields to apply when\nthe filter matches a given test.",
       "type": "object",
@@ -326,6 +361,28 @@
         "filter": {
           "description": "A filter expression evaluated against each test. Tests whose name\nor tags match the expression pick up this override's settings.",
           "type": "string"
+        },
+        "flaky-result": {
+          "description": "Whether matching flaky tests pass or fail the run.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FlakyResult"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "junit": {
+          "description": "`JUnit` behavior for matching flaky tests configured to fail.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OverrideJunitOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "retries": {
           "description": "Number of times to retry a matching test before giving up. Mirrors\nthe profile-level [`retry`](#retry) field.",


### PR DESCRIPTION
## Summary

Add nextest-compatible flaky-result policy globally and per test, including CLI and environment override precedence. Preserve flaky retry history while failing terminal, JSON, and JSONL results, with configurable global and per-test JUnit failure representation. Closes #962.

## Test Plan

Focused integration tests, workspace Clippy, and `uvx prek run -a` pass.