### PR TITLE
Fix light-mode docs and deploy docs independently

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,15 +1,6 @@
 name: Deploy docs
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/deploy-docs.yml"
-      - "docs/**"
-      - "pyproject.toml"
-      - "uv.lock"
-      - "zensical.toml"
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,44 @@
+name: Deploy docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/deploy-docs.yml"
+      - "docs/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "zensical.toml"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  deploy:
+    name: Deploy documentation
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          python-version: "3.14"
+          enable-cache: false
+
+      - name: Build docs
+        run: uv run --isolated --only-group docs zensical build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: site
+          publish_branch: gh-pages
+          keep_files: false
+          force_orphan: true

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -34,6 +34,12 @@
   border-bottom: 1px solid color-mix(in srgb, var(--md-default-fg-color) 12%, transparent);
   background: var(--karva-nav);
   box-shadow: none;
+  color: var(--karva-pale);
+}
+
+.md-header .md-search__button {
+  background: color-mix(in srgb, var(--karva-pale) 12%, transparent);
+  color: inherit;
 }
 
 .md-grid {


### PR DESCRIPTION
## Summary

Fix light-mode header contrast and add an independent, manually dispatched docs deployment workflow. This lets documentation deploy without publishing a Karva release.

## Test Plan

Built the Zensical docs and ran `pinact run` and `uvx prek run -a`.