### PR TITLE
Refactor semantic runner error lifecycle

### DIFF
--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -1002,6 +1002,61 @@ fn test_fixture_generator_fail_in_teardown() {
 }
 
 #[test]
+fn test_fixture_generator_setup_failure_reports_arguments() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+        import karva
+
+        @karva.fixture
+        def dependency():
+            return "prepared"
+
+        @karva.fixture
+        def broken_generator(dependency):
+            raise RuntimeError("setup failed")
+            yield
+
+        def test_blocked(broken_generator):
+            raise AssertionError("test body ran")
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command(), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+           ERROR [TIME] test::test_blocked
+
+    failures:
+
+    test::test_blocked (requires fixture `broken_generator`):
+
+    error[fixture-failure]: Fixture `broken_generator` failed
+     --> test.py:9:5
+      |
+    9 | def broken_generator(dependency):
+      |     ^^^^^^^^^^^^^^^^
+      |
+    info: Fixture ran with arguments:
+    info: `dependency`: `prepared`
+    info: Fixture failed here
+      --> test.py:10:5
+       |
+    10 |     raise RuntimeError("setup failed")
+       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       |
+    info: setup failed
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
+
+    ----- stderr -----
+    "#);
+}
+
+#[test]
 fn test_invalid_fixture() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva_test_semantic/src/extensions/fixtures/finalizer.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/finalizer.rs
@@ -4,12 +4,25 @@ use pyo3::prelude::*;
 use pyo3::types::PyIterator;
 use ruff_python_ast::StmtFunctionDef;
 use ruff_source_file::SourceFile;
+use thiserror::Error;
 
 use ruff_db::diagnostic::Diagnostic;
 
 use crate::diagnostic::invalid_fixture_finalizer_diagnostic;
 use crate::extensions::fixtures::FixtureScope;
 use crate::utils::run_coroutine;
+
+/// Invalid state observed while resuming a generator fixture for teardown.
+#[derive(Debug, Error)]
+enum FinalizerError {
+    /// Generator produced another value instead of completing.
+    #[error("Fixture had more than one yield statement")]
+    MultipleYields,
+
+    /// Generator could not be resumed or raised during teardown.
+    #[error("Failed to reset fixture: {0}")]
+    ResetFailed(String),
+}
 
 /// Represents the teardown portion of a generator fixture.
 ///
@@ -34,69 +47,62 @@ pub struct Finalizer {
     /// The scope determines when this finalizer runs.
     pub(crate) scope: FixtureScope,
 
-    /// Optional AST definition for error reporting.
-    pub(crate) stmt_function_def: Option<Rc<StmtFunctionDef>>,
+    /// AST definition used to locate teardown errors.
+    pub(crate) stmt_function_def: Rc<StmtFunctionDef>,
 
-    /// Optional source code for error reporting.
-    pub(crate) source_file: Option<SourceFile>,
+    /// Source code containing the fixture definition.
+    pub(crate) source_file: SourceFile,
 }
 
 impl Finalizer {
-    /// Resumes teardown once and returns a diagnostic for invalid generator behavior.
-    pub(crate) fn run(self, py: Python<'_>) -> Option<Diagnostic> {
-        let invalid_finalizer_reason = if self.is_async {
+    /// Resumes teardown once and reports invalid generator behavior.
+    pub(crate) fn run(self, py: Python<'_>) -> Result<(), Diagnostic> {
+        let result = if self.is_async {
             self.run_async_teardown(py)
         } else {
             self.run_sync_teardown(py)
         };
 
-        if let Some(reason) = invalid_finalizer_reason
-            && let Some(stmt_function_def) = self.stmt_function_def
-            && let Some(source_file) = self.source_file
-        {
-            return Some(invalid_fixture_finalizer_diagnostic(
-                source_file,
-                &stmt_function_def,
-                &reason,
-            ));
-        }
-        None
+        result.map_err(|error| {
+            invalid_fixture_finalizer_diagnostic(
+                self.source_file,
+                &self.stmt_function_def,
+                &error.to_string(),
+            )
+        })
     }
 
     /// Runs teardown for a sync generator fixture.
-    fn run_sync_teardown(&self, py: Python<'_>) -> Option<String> {
-        let Ok(mut generator) = self
+    fn run_sync_teardown(&self, py: Python<'_>) -> Result<(), FinalizerError> {
+        let mut generator = self
             .fixture_return
             .clone_ref(py)
             .into_bound(py)
             .cast_into::<PyIterator>()
-        else {
-            return None;
-        };
-        let generator_next_result = generator.next()?;
-        let reason = match generator_next_result {
-            Ok(_) => "Fixture had more than one yield statement".to_string(),
-            Err(err) => format!("Failed to reset fixture: {}", err.value(py)),
-        };
-        Some(reason)
+            .map_err(|error| FinalizerError::ResetFailed(error.to_string()))?;
+        match generator.next() {
+            None => Ok(()),
+            Some(Ok(_)) => Err(FinalizerError::MultipleYields),
+            Some(Err(error)) => Err(FinalizerError::ResetFailed(error.value(py).to_string())),
+        }
     }
 
     /// Runs teardown for an async generator fixture.
-    fn run_async_teardown(&self, py: Python<'_>) -> Option<String> {
-        let bound = self.fixture_return.bind(py);
-        let anext_result = match bound.call_method0("__anext__") {
-            Ok(coroutine) => run_coroutine(py, coroutine.unbind()),
-            Err(_) => return None,
-        };
-        let reason = match anext_result {
-            Ok(_) => "Fixture had more than one yield statement".to_string(),
-            Err(err) => {
-                if err.is_instance_of::<pyo3::exceptions::PyStopAsyncIteration>(py) {
-                    return None;
+    fn run_async_teardown(&self, py: Python<'_>) -> Result<(), FinalizerError> {
+        let coroutine = self
+            .fixture_return
+            .bind(py)
+            .call_method0("__anext__")
+            .map_err(|error| FinalizerError::ResetFailed(error.value(py).to_string()))?;
+        match run_coroutine(py, coroutine.unbind()) {
+            Ok(_) => Err(FinalizerError::MultipleYields),
+            Err(error) => {
+                if error.is_instance_of::<pyo3::exceptions::PyStopAsyncIteration>(py) {
+                    Ok(())
+                } else {
+                    Err(FinalizerError::ResetFailed(error.value(py).to_string()))
                 }
-                format!("Failed to reset fixture: {}", err.value(py))
             }
-        };
-        Some(reason)
+        }
     }
 }

--- a/crates/karva_test_semantic/src/runner/finalizer_cache.rs
+++ b/crates/karva_test_semantic/src/runner/finalizer_cache.rs
@@ -36,7 +36,7 @@ impl FinalizerCache {
             .borrow_mut()
             .drain(..)
             .rev()
-            .filter_map(|finalizer| finalizer.run(py))
+            .filter_map(|finalizer| finalizer.run(py).err())
             .collect()
     }
 }

--- a/crates/karva_test_semantic/src/runner/package_runner/failure.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/failure.rs
@@ -1,0 +1,63 @@
+//! Test-owned execution errors shared across runner lifecycle boundaries.
+
+use karva_diagnostic::{FixtureFailure, TestExecutionOutcome};
+use ruff_db::diagnostic::Diagnostic;
+
+/// Primary test error plus related diagnostics and fixture causality.
+///
+/// Keeping these fields together prevents package, module, and attempt paths
+/// from independently splitting and rebuilding the same error state.
+#[derive(Clone)]
+pub(super) struct TestError {
+    /// Primary diagnostic displayed for every affected test.
+    diagnostic: Diagnostic,
+
+    /// Diagnostics caused by the same failure after the primary error.
+    related: Vec<Diagnostic>,
+
+    /// Fixture relationships through which this error reached the test.
+    fixture_failures: Vec<FixtureFailure>,
+}
+
+impl TestError {
+    /// Creates an error with no related diagnostics or fixture causality.
+    pub(super) fn new(diagnostic: Diagnostic) -> Self {
+        Self {
+            diagnostic,
+            related: Vec::new(),
+            fixture_failures: Vec::new(),
+        }
+    }
+
+    /// Creates an error caused by one or more fixture setup failures.
+    pub(super) fn from_fixture_failures(
+        diagnostic: Diagnostic,
+        related: Vec<Diagnostic>,
+        fixture_failures: Vec<FixtureFailure>,
+    ) -> Self {
+        Self {
+            diagnostic,
+            related,
+            fixture_failures,
+        }
+    }
+
+    /// Appends diagnostics produced after the primary error, such as teardown failures.
+    #[must_use]
+    pub(super) fn with_related(
+        mut self,
+        diagnostics: impl IntoIterator<Item = Diagnostic>,
+    ) -> Self {
+        self.related.extend(diagnostics);
+        self
+    }
+
+    /// Converts this error into an owned test outcome.
+    pub(super) fn into_outcome(self) -> TestExecutionOutcome {
+        TestExecutionOutcome::error_with_fixture_failures(
+            self.diagnostic,
+            self.related,
+            self.fixture_failures,
+        )
+    }
+}

--- a/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
@@ -12,13 +12,14 @@ use ruff_db::diagnostic::Diagnostic;
 use ruff_python_ast::StmtFunctionDef;
 use ruff_source_file::SourceFile;
 
-use crate::diagnostic::{fixture_failure_diagnostic, fixture_resolution_diagnostic};
+use crate::diagnostic::fixture_resolution_diagnostic;
 use crate::extensions::fixtures::{Finalizer, FixtureScope, HasFixtures, NormalizedFixture};
 use crate::runner::FixtureArguments;
 use crate::runner::fixture_resolver::RuntimeFixtureResolver;
 use crate::utils::run_coroutine;
 
 use super::PackageRunner;
+use super::failure::TestError;
 
 impl PackageRunner<'_, '_> {
     /// Resolves and runs auto-use fixtures at the start of one scope.
@@ -32,31 +33,52 @@ impl PackageRunner<'_, '_> {
         parents: &'a [&'a crate::discovery::DiscoveredPackage],
         current: &'a (dyn HasFixtures<'a> + 'a),
         scope: FixtureScope,
-    ) -> Result<(), FixtureSetupFailures> {
+    ) -> Result<(), TestError> {
         let mut resolver = RuntimeFixtureResolver::new(parents, current);
         let auto_use_fixtures = match resolver.get_normalized_auto_use_fixtures(py, scope) {
             Ok(fixtures) => fixtures,
             Err(error) => {
-                let mut diagnostics = vec![fixture_resolution_diagnostic(error)];
-                diagnostics.extend(self.clean_up_scope(py, scope));
-                return Err(FixtureSetupFailures {
-                    diagnostics,
-                    fixture_failures: Vec::new(),
-                });
+                return Err(TestError::new(fixture_resolution_diagnostic(error))
+                    .with_related(self.clean_up_scope(py, scope)));
             }
         };
 
-        let auto_use_errors = self.run_fixtures(py, &auto_use_fixtures, FixtureUsage::AutoUse);
-        if auto_use_errors.is_empty() {
-            Ok(())
-        } else {
-            let (mut diagnostics, fixture_failures) =
-                fixture_failure_diagnostics(py, auto_use_errors, self.context.is_verbose());
-            diagnostics.extend(self.clean_up_scope(py, scope));
-            Err(FixtureSetupFailures {
-                diagnostics,
-                fixture_failures,
-            })
+        let failures = self.run_fixtures(py, &auto_use_fixtures, FixtureUsage::AutoUse);
+        let Some(failures) = FixtureSetupError::from_vec(failures) else {
+            return Ok(());
+        };
+
+        Err(failures
+            .into_test_error(py, self.context.is_verbose())
+            .with_related(self.clean_up_scope(py, scope)))
+    }
+
+    /// Runs function-scoped finalizers and clears their cached fixture values.
+    pub(super) fn clean_up_test_attempt(
+        &self,
+        py: Python<'_>,
+        finalizers: Vec<Finalizer>,
+    ) -> Vec<Diagnostic> {
+        let mut diagnostics = finalizers
+            .into_iter()
+            .rev()
+            .filter_map(|finalizer| finalizer.run(py).err())
+            .collect::<Vec<_>>();
+        diagnostics.extend(self.clean_up_scope(py, FixtureScope::Function));
+        diagnostics
+    }
+
+    /// Clears cached fixture values and runs finalizers for one completed scope.
+    pub(super) fn clean_up_scope(&self, py: Python<'_>, scope: FixtureScope) -> Vec<Diagnostic> {
+        let diagnostics = self.finalizer_cache.run_and_clear_scope(py, scope);
+        self.fixture_cache.clear_scope(scope);
+        diagnostics
+    }
+
+    /// Cleans one scope and promotes teardown failures to run diagnostics.
+    pub(super) fn report_scope_cleanup(&self, py: Python<'_>, scope: FixtureScope) {
+        for diagnostic in self.clean_up_scope(py, scope) {
+            self.context.add_run_diagnostic(diagnostic);
         }
     }
 
@@ -106,7 +128,7 @@ impl PackageRunner<'_, '_> {
 
         PreparedFixtures {
             function_arguments,
-            fixture_call_errors,
+            setup_result: FixtureSetupError::from_vec(fixture_call_errors).map_or(Ok(()), Err),
             test_finalizers,
         }
     }
@@ -137,38 +159,17 @@ impl PackageRunner<'_, '_> {
                         self.finalizer_cache.add_finalizer(finalizer);
                     }
                 }
-                Err(mut error) => {
-                    error.dependency_chain.push(FixtureChainEntry {
-                        name: fixture.name.function_name().to_string(),
-                        source_file: fixture.source_file.clone(),
-                        stmt_function_def: Rc::clone(&fixture.stmt_function_def),
-                    });
-                    return Err(error);
-                }
+                Err(error) => return Err(error.with_dependent(fixture)),
             }
         }
 
-        let fixture_call_result =
-            fixture
-                .call(py, &function_arguments)
-                .map_err(|error| FixtureCallError {
-                    fixture_name: fixture.name.function_name().to_string(),
-                    error,
-                    stmt_function_def: Rc::clone(&fixture.stmt_function_def),
-                    source_file: fixture.source_file.clone(),
-                    arguments: function_arguments,
-                    dependency_chain: Vec::new(),
-                })?;
+        let fixture_call_result = match fixture.call(py, &function_arguments) {
+            Ok(result) => result,
+            Err(error) => return Err(FixtureCallError::new(fixture, error, function_arguments)),
+        };
 
         let (value, finalizer) = get_value_and_finalizer(py, fixture, fixture_call_result)
-            .map_err(|error| FixtureCallError {
-                fixture_name: fixture.name.function_name().to_string(),
-                error,
-                stmt_function_def: Rc::clone(&fixture.stmt_function_def),
-                source_file: fixture.source_file.clone(),
-                arguments: FixtureArguments::default(),
-                dependency_chain: Vec::new(),
-            })?;
+            .map_err(|error| FixtureCallError::new(fixture, error, function_arguments))?;
 
         self.fixture_cache.insert(
             fixture.function_name().to_string(),
@@ -186,20 +187,6 @@ impl PackageRunner<'_, '_> {
         });
 
         Ok((value, function_finalizer))
-    }
-
-    /// Clears cached fixture values and runs finalizers for one completed scope.
-    pub(super) fn clean_up_scope(&self, py: Python<'_>, scope: FixtureScope) -> Vec<Diagnostic> {
-        let diagnostics = self.finalizer_cache.run_and_clear_scope(py, scope);
-        self.fixture_cache.clear_scope(scope);
-        diagnostics
-    }
-
-    /// Cleans one scope and promotes teardown failures to run diagnostics.
-    pub(super) fn report_scope_cleanup(&self, py: Python<'_>, scope: FixtureScope) {
-        for diagnostic in self.clean_up_scope(py, scope) {
-            self.context.add_run_diagnostic(diagnostic);
-        }
     }
 
     /// Runs fixtures whose values are not passed to the test call.
@@ -229,20 +216,55 @@ impl PackageRunner<'_, '_> {
 pub(super) struct PreparedFixtures {
     /// Keyword arguments passed to the Python test function.
     pub(super) function_arguments: FixtureArguments,
-    /// Fixture setup failures that prevent the test call.
-    pub(super) fixture_call_errors: Vec<PreparedFixtureFailure>,
+    /// Whether fixture setup completed or blocked the test call.
+    pub(super) setup_result: Result<(), FixtureSetupError>,
     /// Function-scoped finalizers run after this attempt.
     pub(super) test_finalizers: Vec<Finalizer>,
 }
 
-pub(super) struct FixtureSetupFailures {
-    pub(super) diagnostics: Vec<Diagnostic>,
-    pub(super) fixture_failures: Vec<FixtureFailure>,
+/// Raw fixture call error paired with its relationship to the blocked test.
+struct PreparedFixtureFailure {
+    /// Python call failure and source context for diagnostic rendering.
+    error: FixtureCallError,
+
+    /// Requested fixture and dependency chain exposed to result consumers.
+    fixture_failure: FixtureFailure,
 }
 
-pub(super) struct PreparedFixtureFailure {
-    pub(super) error: FixtureCallError,
-    pub(super) fixture_failure: FixtureFailure,
+/// One or more fixture failures from a single setup phase.
+///
+/// Splitting the first failure from the remainder makes the primary diagnostic
+/// invariant explicit and removes unchecked indexing from error reporting.
+pub(super) struct FixtureSetupError {
+    /// Failure promoted to the primary diagnostic.
+    first: PreparedFixtureFailure,
+
+    /// Additional failures produced during the same setup phase.
+    related: Vec<PreparedFixtureFailure>,
+}
+
+impl FixtureSetupError {
+    fn from_vec(failures: Vec<PreparedFixtureFailure>) -> Option<Self> {
+        let mut failures = failures.into_iter();
+        Some(Self {
+            first: failures.next()?,
+            related: failures.collect(),
+        })
+    }
+
+    /// Renders raw Python failures into one test-owned execution error.
+    pub(super) fn into_test_error(self, py: Python<'_>, verbose: bool) -> TestError {
+        let (diagnostic, fixture_failure) = render_fixture_failure(py, self.first, verbose);
+        let mut related = Vec::with_capacity(self.related.len());
+        let mut fixture_failures = Vec::with_capacity(self.related.len() + 1);
+        fixture_failures.push(fixture_failure);
+        for failure in self.related {
+            let (diagnostic, fixture_failure) = render_fixture_failure(py, failure, verbose);
+            related.push(diagnostic);
+            fixture_failures.push(fixture_failure);
+        }
+        TestError::from_fixture_failures(diagnostic, related, fixture_failures)
+    }
 }
 
 impl PreparedFixtureFailure {
@@ -273,20 +295,15 @@ impl PreparedFixtureFailure {
     }
 }
 
-pub(super) fn fixture_failure_diagnostics(
+fn render_fixture_failure(
     py: Python<'_>,
-    failures: Vec<PreparedFixtureFailure>,
+    failure: PreparedFixtureFailure,
     verbose: bool,
-) -> (Vec<Diagnostic>, Vec<FixtureFailure>) {
-    failures
-        .into_iter()
-        .map(|failure| {
-            (
-                fixture_failure_diagnostic(py, failure.error, verbose),
-                failure.fixture_failure,
-            )
-        })
-        .unzip()
+) -> (Diagnostic, FixtureFailure) {
+    (
+        crate::diagnostic::fixture_failure_diagnostic(py, failure.error, verbose),
+        failure.fixture_failure,
+    )
 }
 
 /// Failure raised while preparing or calling a fixture.
@@ -317,6 +334,29 @@ pub struct FixtureChainEntry {
     pub(crate) stmt_function_def: Rc<StmtFunctionDef>,
 }
 
+impl FixtureCallError {
+    fn new(fixture: &NormalizedFixture, error: PyErr, arguments: FixtureArguments) -> Self {
+        Self {
+            fixture_name: fixture.function_name().to_string(),
+            error,
+            stmt_function_def: Rc::clone(&fixture.stmt_function_def),
+            source_file: fixture.source_file.clone(),
+            arguments,
+            dependency_chain: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    fn with_dependent(mut self, fixture: &NormalizedFixture) -> Self {
+        self.dependency_chain.push(FixtureChainEntry {
+            name: fixture.function_name().to_string(),
+            source_file: fixture.source_file.clone(),
+            stmt_function_def: Rc::clone(&fixture.stmt_function_def),
+        });
+        self
+    }
+}
+
 /// Extracts the value and teardown finalizer produced by a fixture call.
 fn get_value_and_finalizer(
     py: Python<'_>,
@@ -332,25 +372,29 @@ fn get_value_and_finalizer(
             fixture_return: fixture_call_result,
             is_async: true,
             scope: fixture.scope(),
-            stmt_function_def: Some(Rc::clone(&fixture.stmt_function_def)),
-            source_file: Some(fixture.source_file.clone()),
+            stmt_function_def: Rc::clone(&fixture.stmt_function_def),
+            source_file: fixture.source_file.clone(),
         };
 
         Ok((value, Some(finalizer)))
-    } else if fixture.is_generator
-        && let Ok(mut bound_iterator) = fixture_call_result
-            .clone_ref(py)
+    } else if fixture.is_generator {
+        let mut bound_iterator = fixture_call_result
             .into_bound(py)
             .cast_into::<PyIterator>()
-    {
+            .map_err(|_| {
+                pyo3::exceptions::PyTypeError::new_err(format!(
+                    "Generator fixture `{}` did not return an iterator",
+                    fixture.function_name()
+                ))
+            })?;
         match bound_iterator.next() {
             Some(Ok(value)) => {
                 let finalizer = Finalizer {
                     fixture_return: bound_iterator.clone().unbind().into_any(),
                     is_async: false,
                     scope: fixture.scope(),
-                    stmt_function_def: Some(Rc::clone(&fixture.stmt_function_def)),
-                    source_file: Some(fixture.source_file.clone()),
+                    stmt_function_def: Rc::clone(&fixture.stmt_function_def),
+                    source_file: fixture.source_file.clone(),
                 };
 
                 Ok((value.unbind(), Some(finalizer)))

--- a/crates/karva_test_semantic/src/runner/package_runner/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/mod.rs
@@ -3,10 +3,8 @@
 use std::cell::Cell;
 
 use karva_coverage::CoverageSession;
-use karva_diagnostic::{FixtureFailure, TestExecutionOutcome};
 use karva_python_semantic::QualifiedTestName;
 use pyo3::prelude::*;
-use ruff_db::diagnostic::Diagnostic;
 
 use crate::Context;
 use crate::diagnostic::{fixture_resolution_diagnostic, invalid_parametrize_diagnostic};
@@ -16,11 +14,14 @@ use crate::runner::fixture_resolver::RuntimeFixtureResolver;
 use crate::runner::test_iterator::TestVariantIterator;
 use crate::runner::{FinalizerCache, FixtureCache};
 
+mod failure;
 mod fixture;
 mod outcome;
 mod variant;
 
 pub use fixture::{FixtureCallError, FixtureChainEntry};
+
+use failure::TestError;
 
 /// Executes one discovered package tree inside an attached Python interpreter.
 ///
@@ -73,20 +74,10 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
     }
 
     /// Registers a discovery or setup error against one test.
-    fn register_error_test(
-        &self,
-        test: &DiscoveredTestFunction,
-        diagnostic: Diagnostic,
-        related: Vec<Diagnostic>,
-        fixture_failures: Vec<FixtureFailure>,
-    ) {
+    fn register_error_test(&self, test: &DiscoveredTestFunction, error: TestError) {
         self.context.register_test_case_result(
             &QualifiedTestName::new(test.name.clone(), None),
-            TestExecutionOutcome::error_with_fixture_failures(
-                diagnostic,
-                related,
-                fixture_failures,
-            ),
+            error.into_outcome(),
             std::time::Duration::ZERO,
             None,
         );
@@ -94,20 +85,9 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
     }
 
     /// Registers one shared module error against tests not blocked by `max-fail`.
-    fn register_error_module_tests(
-        &self,
-        module: &DiscoveredModule,
-        diagnostic: &Diagnostic,
-        related: &[Diagnostic],
-        fixture_failures: &[FixtureFailure],
-    ) {
+    fn register_error_module_tests(&self, module: &DiscoveredModule, error: &TestError) {
         for test in module.test_functions() {
-            self.register_error_test(
-                test,
-                diagnostic.clone(),
-                related.to_vec(),
-                fixture_failures.to_vec(),
-            );
+            self.register_error_test(test, error.clone());
             if self.max_fail_reached() {
                 return;
             }
@@ -115,21 +95,15 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
     }
 
     /// Registers one shared package error throughout its remaining test tree.
-    fn register_error_package_tests(
-        &self,
-        package: &DiscoveredPackage,
-        diagnostic: &Diagnostic,
-        related: &[Diagnostic],
-        fixture_failures: &[FixtureFailure],
-    ) {
+    fn register_error_package_tests(&self, package: &DiscoveredPackage, error: &TestError) {
         for module in package.modules().values() {
-            self.register_error_module_tests(module, diagnostic, related, fixture_failures);
+            self.register_error_module_tests(module, error);
             if self.max_fail_reached() {
                 return;
             }
         }
         for child_package in package.packages().values() {
-            self.register_error_package_tests(child_package, diagnostic, related, fixture_failures);
+            self.register_error_package_tests(child_package, error);
             if self.max_fail_reached() {
                 return;
             }
@@ -151,7 +125,7 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
                         &test.stmt_function_def,
                         &error,
                     );
-                    self.register_error_test(test, diagnostic, Vec::new(), Vec::new());
+                    self.register_error_test(test, TestError::new(diagnostic));
                     valid = false;
                     if self.max_fail_reached() {
                         return false;
@@ -176,16 +150,8 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
             return;
         }
 
-        if let Err(mut failure) =
-            self.run_auto_use_fixtures(py, &[], session, FixtureScope::Session)
-        {
-            let diagnostic = failure.diagnostics.remove(0);
-            self.register_error_package_tests(
-                session,
-                &diagnostic,
-                &failure.diagnostics,
-                &failure.fixture_failures,
-            );
+        if let Err(error) = self.run_auto_use_fixtures(py, &[], session, FixtureScope::Session) {
+            self.register_error_package_tests(session, &error);
             return;
         }
 
@@ -200,16 +166,8 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
         module: &DiscoveredModule,
         parents: &[&DiscoveredPackage],
     ) -> bool {
-        if let Err(mut failure) =
-            self.run_auto_use_fixtures(py, parents, module, FixtureScope::Module)
-        {
-            let diagnostic = failure.diagnostics.remove(0);
-            self.register_error_module_tests(
-                module,
-                &diagnostic,
-                &failure.diagnostics,
-                &failure.fixture_failures,
-            );
+        if let Err(error) = self.run_auto_use_fixtures(py, parents, module, FixtureScope::Module) {
+            self.register_error_module_tests(module, &error);
             return false;
         }
 
@@ -221,9 +179,7 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
                 Err(error) => {
                     self.register_error_test(
                         test,
-                        fixture_resolution_diagnostic(error),
-                        Vec::new(),
-                        Vec::new(),
+                        TestError::new(fixture_resolution_diagnostic(error)),
                     );
                     passed = false;
                     if self.max_fail_reached() {
@@ -263,16 +219,10 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
         child_parents.push(package);
 
         if package.configuration_module_impl().is_some()
-            && let Err(mut failure) =
+            && let Err(error) =
                 self.run_auto_use_fixtures(py, parents, package, FixtureScope::Package)
         {
-            let diagnostic = failure.diagnostics.remove(0);
-            self.register_error_package_tests(
-                package,
-                &diagnostic,
-                &failure.diagnostics,
-                &failure.fixture_failures,
-            );
+            self.register_error_package_tests(package, &error);
             return false;
         }
 

--- a/crates/karva_test_semantic/src/runner/package_runner/outcome.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/outcome.rs
@@ -38,9 +38,17 @@ pub(super) struct OutcomeContext<'a> {
     /// Fixture and parameter values supplied to the test.
     pub(super) function_arguments: &'a FixtureArguments,
     /// Active expected-failure policy, when configured.
-    pub(super) expect_fail_tag: Option<ExpectFailTag>,
+    pub(super) expect_fail_tag: Option<&'a ExpectFailTag>,
     /// Whether failure diagnostics should include every Python call frame.
     pub(super) verbose: bool,
+}
+
+/// Classified test-body outcome and whether retry policy may run it again.
+pub(super) struct ClassifiedTestResult {
+    /// User-visible semantic outcome.
+    pub(super) outcome: TestExecutionOutcome,
+    /// Whether another attempt could change this outcome.
+    pub(super) retryable: bool,
 }
 
 /// Durations for each phase of one complete test attempt.
@@ -83,41 +91,19 @@ pub(super) fn reject_non_none_return(py: Python<'_>, value: &Py<PyAny>) -> TestC
     }
 }
 
-/// Returns whether a call result qualifies for another attempt.
-pub(super) fn should_retry_result(
-    py: Python<'_>,
-    test_result: &PyResult<TestCallOutcome>,
-    expect_fail: bool,
-    test_name: &str,
-) -> bool {
-    if expect_fail {
-        return false;
-    }
-
-    match test_result {
-        Ok(TestCallOutcome::ReturnedNone) => false,
-        Ok(TestCallOutcome::ReturnedValue(_)) => true,
-        Err(error) => {
-            !is_skip_exception(py, error)
-                && missing_arguments_from_error(test_name, &error.to_string()).is_empty()
-        }
-    }
-}
-
-/// Classifies a Python call result and attaches source diagnostics.
+/// Classifies a Python call result and its retry eligibility together.
 pub(super) fn classify_test_result(
     py: Python<'_>,
     test_result: PyResult<TestCallOutcome>,
     context: &OutcomeContext<'_>,
-) -> TestExecutionOutcome {
+) -> ClassifiedTestResult {
     let expect_fail = context
         .expect_fail_tag
-        .as_ref()
         .is_some_and(ExpectFailTag::should_expect_fail);
 
     let error = match test_result {
         Ok(TestCallOutcome::ReturnedValue(_)) if expect_fail => {
-            return TestExecutionOutcome::Passed;
+            return ClassifiedTestResult::new(TestExecutionOutcome::Passed, false);
         }
         Ok(TestCallOutcome::ReturnedValue(value)) => {
             let diagnostic = test_returned_value_diagnostic(
@@ -125,32 +111,34 @@ pub(super) fn classify_test_result(
                 context.stmt_function_def,
                 &value,
             );
-            return TestExecutionOutcome::failed(diagnostic);
+            return ClassifiedTestResult::new(TestExecutionOutcome::failed(diagnostic), true);
         }
         Ok(TestCallOutcome::ReturnedNone) if expect_fail => {
-            let reason = context
-                .expect_fail_tag
-                .as_ref()
-                .and_then(ExpectFailTag::reason);
+            let reason = context.expect_fail_tag.and_then(ExpectFailTag::reason);
             let diagnostic = test_pass_on_expect_failure_diagnostic(
                 context.source_file.clone(),
                 context.stmt_function_def,
                 reason,
             );
-            return TestExecutionOutcome::failed(diagnostic);
+            return ClassifiedTestResult::new(TestExecutionOutcome::failed(diagnostic), false);
         }
-        Ok(TestCallOutcome::ReturnedNone) => return TestExecutionOutcome::Passed,
+        Ok(TestCallOutcome::ReturnedNone) => {
+            return ClassifiedTestResult::new(TestExecutionOutcome::Passed, false);
+        }
         Err(error) => error,
     };
 
     if is_skip_exception(py, &error) {
-        return TestExecutionOutcome::Skipped {
-            reason: extract_skip_reason(py, &error),
-        };
+        return ClassifiedTestResult::new(
+            TestExecutionOutcome::Skipped {
+                reason: extract_skip_reason(py, &error),
+            },
+            false,
+        );
     }
 
     if expect_fail {
-        return TestExecutionOutcome::Passed;
+        return ClassifiedTestResult::new(TestExecutionOutcome::Passed, false);
     }
 
     let missing_arguments =
@@ -164,7 +152,7 @@ pub(super) fn classify_test_result(
             &error,
             context.verbose,
         );
-        TestExecutionOutcome::failed(diagnostic)
+        ClassifiedTestResult::new(TestExecutionOutcome::failed(diagnostic), true)
     } else {
         let diagnostic = missing_fixtures_diagnostic(
             context.source_file.clone(),
@@ -172,25 +160,33 @@ pub(super) fn classify_test_result(
             &missing_arguments,
             karva_python_semantic::FunctionKind::Test,
         );
-        TestExecutionOutcome::error(diagnostic)
+        ClassifiedTestResult::new(TestExecutionOutcome::error(diagnostic), false)
     }
 }
 
-/// Attaches teardown failures while preserving an existing primary failure.
-pub(super) fn attach_finalizer_diagnostics(
-    outcome: TestExecutionOutcome,
-    mut diagnostics: Vec<Diagnostic>,
-) -> TestExecutionOutcome {
-    if diagnostics.is_empty() {
-        return outcome;
+impl ClassifiedTestResult {
+    fn new(outcome: TestExecutionOutcome, retryable: bool) -> Self {
+        Self { outcome, retryable }
     }
+}
+
+/// Attaches later diagnostics while preserving an existing primary failure.
+pub(super) fn attach_related_diagnostics(
+    outcome: TestExecutionOutcome,
+    diagnostics: Vec<Diagnostic>,
+) -> TestExecutionOutcome {
+    let mut diagnostics = diagnostics.into_iter();
+    let Some(first) = diagnostics.next() else {
+        return outcome;
+    };
 
     match outcome {
         TestExecutionOutcome::Failed {
             diagnostic,
             mut related,
         } => {
-            related.append(&mut diagnostics);
+            related.push(first);
+            related.extend(diagnostics);
             TestExecutionOutcome::Failed {
                 diagnostic,
                 related,
@@ -201,7 +197,8 @@ pub(super) fn attach_finalizer_diagnostics(
             mut related,
             fixture_failures,
         } => {
-            related.append(&mut diagnostics);
+            related.push(first);
+            related.extend(diagnostics);
             TestExecutionOutcome::Error {
                 diagnostic,
                 related,
@@ -209,8 +206,7 @@ pub(super) fn attach_finalizer_diagnostics(
             }
         }
         TestExecutionOutcome::Passed | TestExecutionOutcome::Skipped { .. } => {
-            let diagnostic = diagnostics.remove(0);
-            TestExecutionOutcome::error_with_related(diagnostic, diagnostics)
+            TestExecutionOutcome::error_with_related(first, diagnostics.collect())
         }
     }
 }
@@ -242,7 +238,7 @@ pub(super) fn apply_fail_slow_budget(
     match outcome {
         TestExecutionOutcome::Passed => TestExecutionOutcome::failed(diagnostic),
         TestExecutionOutcome::Skipped { reason } => TestExecutionOutcome::Skipped { reason },
-        other => attach_finalizer_diagnostics(other, vec![diagnostic]),
+        other => attach_related_diagnostics(other, vec![diagnostic]),
     }
 }
 

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/attempt.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/attempt.rs
@@ -5,16 +5,15 @@ use std::time::{Duration, Instant};
 use karva_diagnostic::{CapturedTestOutput, TestExecutionAttempt, TestExecutionOutcome};
 use pyo3::prelude::*;
 
-use crate::extensions::fixtures::FixtureScope;
 use crate::extensions::functions::snapshot::set_snapshot_context;
 use crate::utils::{run_coroutine, run_test_with_timeout};
 
 use super::{VariantRunner, VariantSettings, finish_output_capture};
 use crate::output_capture::PythonOutputCapture;
-use crate::runner::package_runner::fixture::{PreparedFixtures, fixture_failure_diagnostics};
+use crate::runner::package_runner::fixture::PreparedFixtures;
 use crate::runner::package_runner::outcome::{
-    OutcomeContext, PhaseDurations, apply_fail_slow_budget, attach_finalizer_diagnostics,
-    classify_test_result, reject_non_none_return, should_retry_result,
+    OutcomeContext, PhaseDurations, apply_fail_slow_budget, attach_related_diagnostics,
+    classify_test_result, reject_non_none_return,
 };
 
 impl VariantRunner<'_, '_, '_, '_, '_> {
@@ -32,152 +31,55 @@ impl VariantRunner<'_, '_, '_, '_, '_> {
             fixtures:
                 PreparedFixtures {
                     function_arguments,
-                    fixture_call_errors,
+                    setup_result,
                     test_finalizers,
                 },
             setup_duration,
             output_capture,
         } = prepared;
 
-        let (outcome, duration, retryable) = if fixture_call_errors.is_empty() {
-            set_snapshot_context(settings.snapshot_context.clone());
-            let prepared_call = attempt_env_result.and_then(|()| {
-                if let Err(error) = test_name_env_result {
-                    return Err(error.clone_ref(self.py));
-                }
-                if let Err(error) = &settings.async_patch_result {
-                    return Err(error.clone_ref(self.py));
-                }
-                if function_arguments.is_empty() || settings.timeout_seconds.is_some() {
-                    Ok(None)
-                } else {
-                    function_arguments.to_kwargs(self.py).map(Some)
-                }
-            });
-            let (test_result, call_duration) = match prepared_call {
-                Ok(keyword_arguments) => {
-                    let call_start = Instant::now();
-                    let result = if let Some(seconds) = settings.timeout_seconds {
-                        run_test_with_timeout(
-                            self.py,
-                            function,
-                            &function_arguments,
-                            settings.is_async,
-                            seconds,
-                            &settings.snapshot_context,
-                        )
-                    } else {
-                        let result = if let Some(keyword_arguments) = keyword_arguments {
-                            function.call(self.py, (), Some(&keyword_arguments))
-                        } else {
-                            function.call0(self.py)
-                        };
-                        if settings.is_async {
-                            result.and_then(|coroutine| run_coroutine(self.py, coroutine))
-                        } else {
-                            result
-                        }
-                    };
-                    (
-                        result.map(|value| reject_non_none_return(self.py, &value)),
-                        call_start.elapsed(),
-                    )
-                }
-                Err(error) => (Err(error), Duration::ZERO),
-            };
-            let retryable_result = should_retry_result(
-                self.py,
-                &test_result,
-                settings.expect_fail,
-                settings.qualified_test_name.function_name().function_name(),
-            );
-            let outcome = classify_test_result(
-                self.py,
-                test_result,
-                &OutcomeContext {
-                    name: &self.test.name,
-                    source_file: &self.test.source_file,
-                    stmt_function_def: &self.test.stmt_function_def,
-                    function_arguments: &function_arguments,
-                    expect_fail_tag: settings.expect_fail_tag.clone(),
-                    verbose: self.package_runner.context.is_verbose(),
-                },
-            );
-            let skipped = outcome.is_skipped();
-
-            let teardown_start = Instant::now();
-            let mut finalizer_diagnostics = test_finalizers
-                .into_iter()
-                .rev()
-                .filter_map(|finalizer| finalizer.run(self.py))
-                .collect::<Vec<_>>();
-            finalizer_diagnostics.extend(
-                self.package_runner
-                    .clean_up_scope(self.py, FixtureScope::Function),
-            );
-            let teardown_failed = !finalizer_diagnostics.is_empty();
-            let phases = PhaseDurations {
-                setup: setup_duration,
-                call: call_duration,
-                teardown: teardown_start.elapsed(),
-            };
-            let duration = phases.total();
-            let budget_exceeded = settings
-                .fail_slow_budget
-                .is_some_and(|budget| duration > budget);
-            let outcome = attach_finalizer_diagnostics(outcome, finalizer_diagnostics);
-            let outcome = apply_fail_slow_budget(
-                outcome,
-                duration,
-                phases,
-                settings.fail_slow_budget,
-                &self.test.source_file,
-                &self.test.stmt_function_def,
-            );
-            (
-                outcome,
-                duration,
-                retryable_result || teardown_failed || (budget_exceeded && !skipped),
-            )
-        } else {
-            let (mut diagnostics, fixture_failures) = fixture_failure_diagnostics(
-                self.py,
-                fixture_call_errors,
-                self.package_runner.context.is_verbose(),
-            );
-            let teardown_start = Instant::now();
-            diagnostics.extend(
-                test_finalizers
-                    .into_iter()
-                    .rev()
-                    .filter_map(|finalizer| finalizer.run(self.py)),
-            );
-            diagnostics.extend(
-                self.package_runner
-                    .clean_up_scope(self.py, FixtureScope::Function),
-            );
-            let phases = PhaseDurations {
-                setup: setup_duration,
-                call: Duration::ZERO,
-                teardown: teardown_start.elapsed(),
-            };
-            let duration = phases.total();
-            let diagnostic = diagnostics.remove(0);
-            let outcome = TestExecutionOutcome::error_with_fixture_failures(
-                diagnostic,
-                diagnostics,
-                fixture_failures,
-            );
-            let outcome = apply_fail_slow_budget(
-                outcome,
-                duration,
-                phases,
-                settings.fail_slow_budget,
-                &self.test.source_file,
-                &self.test.stmt_function_def,
-            );
-            (outcome, duration, true)
+        let body = match setup_result {
+            Ok(()) => self.execute_test_body(
+                settings,
+                function,
+                test_name_env_result,
+                attempt_env_result,
+                &function_arguments,
+            ),
+            Err(error) => AttemptBody {
+                outcome: error
+                    .into_test_error(self.py, self.package_runner.context.is_verbose())
+                    .into_outcome(),
+                call_duration: Duration::ZERO,
+                retryable: true,
+            },
         };
+
+        let skipped = body.outcome.is_skipped();
+        let teardown_start = Instant::now();
+        let finalizer_diagnostics = self
+            .package_runner
+            .clean_up_test_attempt(self.py, test_finalizers);
+        let teardown_failed = !finalizer_diagnostics.is_empty();
+        let phases = PhaseDurations {
+            setup: setup_duration,
+            call: body.call_duration,
+            teardown: teardown_start.elapsed(),
+        };
+        let duration = phases.total();
+        let budget_exceeded = settings
+            .fail_slow_budget
+            .is_some_and(|budget| duration > budget);
+        let outcome = attach_related_diagnostics(body.outcome, finalizer_diagnostics);
+        let outcome = apply_fail_slow_budget(
+            outcome,
+            duration,
+            phases,
+            settings.fail_slow_budget,
+            &self.test.source_file,
+            &self.test.stmt_function_def,
+        );
+        let retryable = body.retryable || teardown_failed || (budget_exceeded && !skipped);
 
         let captured_output = finish_output_capture(self.py, output_capture);
 
@@ -191,6 +93,92 @@ impl VariantRunner<'_, '_, '_, '_, '_> {
             retryable,
         }
     }
+
+    /// Executes and classifies the Python test body after successful setup.
+    fn execute_test_body(
+        &self,
+        settings: &VariantSettings,
+        function: &Py<PyAny>,
+        test_name_env_result: &PyResult<()>,
+        attempt_env_result: PyResult<()>,
+        function_arguments: &crate::runner::FixtureArguments,
+    ) -> AttemptBody {
+        set_snapshot_context(settings.snapshot_context.clone());
+        let prepared_call = attempt_env_result.and_then(|()| {
+            if let Err(error) = test_name_env_result {
+                return Err(error.clone_ref(self.py));
+            }
+            if let Err(error) = &settings.async_patch_result {
+                return Err(error.clone_ref(self.py));
+            }
+            if function_arguments.is_empty() || settings.timeout_seconds.is_some() {
+                Ok(None)
+            } else {
+                function_arguments.to_kwargs(self.py).map(Some)
+            }
+        });
+        let (test_result, call_duration) = match prepared_call {
+            Ok(keyword_arguments) => {
+                let call_start = Instant::now();
+                let result = if let Some(seconds) = settings.timeout_seconds {
+                    run_test_with_timeout(
+                        self.py,
+                        function,
+                        function_arguments,
+                        settings.is_async,
+                        seconds,
+                        &settings.snapshot_context,
+                    )
+                } else {
+                    let result = if let Some(keyword_arguments) = keyword_arguments {
+                        function.call(self.py, (), Some(&keyword_arguments))
+                    } else {
+                        function.call0(self.py)
+                    };
+                    if settings.is_async {
+                        result.and_then(|coroutine| run_coroutine(self.py, coroutine))
+                    } else {
+                        result
+                    }
+                };
+                (
+                    result.map(|value| reject_non_none_return(self.py, &value)),
+                    call_start.elapsed(),
+                )
+            }
+            Err(error) => (Err(error), Duration::ZERO),
+        };
+        let result = classify_test_result(
+            self.py,
+            test_result,
+            &OutcomeContext {
+                name: &self.test.name,
+                source_file: &self.test.source_file,
+                stmt_function_def: &self.test.stmt_function_def,
+                function_arguments,
+                expect_fail_tag: settings.expect_fail_tag.as_ref(),
+                verbose: self.package_runner.context.is_verbose(),
+            },
+        );
+
+        AttemptBody {
+            outcome: result.outcome,
+            call_duration,
+            retryable: result.retryable,
+        }
+    }
+}
+
+/// Test-body result before common teardown and duration policy are applied.
+struct AttemptBody {
+    /// Classified result before teardown diagnostics and budgets.
+    outcome: TestExecutionOutcome,
+
+    /// Time spent invoking the Python test function.
+    call_duration: Duration,
+
+    /// Whether test-body policy permits another attempt.
+    retryable: bool,
 }
 
 /// Fixture setup and timing captured before one test attempt.

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
@@ -264,9 +264,6 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             .settings()
             .junit_flaky_fail_status_for(&evaluation_context);
         let expect_fail_tag = self.tags.expect_fail_tag();
-        let expect_fail = expect_fail_tag
-            .as_ref()
-            .is_some_and(ExpectFailTag::should_expect_fail);
         let async_patch_result = if self.test.stmt_function_def.is_async {
             crate::utils::patch_async_test_function(self.py, &self.test.py_function)
         } else {
@@ -290,7 +287,6 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             qualified_name,
             snapshot_context,
             expect_fail_tag,
-            expect_fail,
             async_patch_result,
             is_async,
             timeout_seconds,
@@ -455,8 +451,6 @@ struct VariantSettings {
     snapshot_context: SnapshotContext,
     /// Expected-failure tag needed for result classification.
     expect_fail_tag: Option<ExpectFailTag>,
-    /// Cached expected-failure decision used by retry policy.
-    expect_fail: bool,
     /// Result of patching pytest-style async wrappers.
     async_patch_result: PyResult<bool>,
     /// Whether Karva must await the returned coroutine.


### PR DESCRIPTION
## Summary

Unify fixture and runner failures behind typed error state, centralize attempt teardown and retry classification, and preserve fixture arguments when generator setup fails. This removes duplicated lifecycle branches and unchecked primary-diagnostic extraction while keeping reporting behavior stable.

## Test Plan

Workspace tests, focused integration tests, Clippy, and `uvx prek run -a`.