### PR TITLE
Refactor semantic discovery output

### DIFF
--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -1,7 +1,6 @@
 //! Converts collection and execution failures into source-backed `ruff_db` diagnostics.
 //!
-//! `report_*` functions mutate run context during discovery. Other builders return a
-//! diagnostic for attachment to a specific test outcome.
+//! Discovery and execution failures are rendered here without mutating run state.
 
 use camino::Utf8Path;
 use karva_collector::CollectionError;
@@ -17,6 +16,7 @@ use ruff_source_file::SourceFile;
 
 mod metadata;
 
+use crate::declare_diagnostic_type;
 use crate::extensions::fixtures::RejectedFixture;
 use crate::extensions::tags::parametrize::InvalidParametrizeError;
 use crate::runner::{
@@ -24,7 +24,6 @@ use crate::runner::{
     FixtureResolutionError,
 };
 use crate::utils::truncate_string;
-use crate::{Context, declare_diagnostic_type};
 
 #[derive(Clone, Copy)]
 struct FailedFunctionCallOptions {
@@ -269,69 +268,60 @@ fn report_dependency_chain(
     }
 }
 
-pub fn report_collection_error(context: &Context, error: &CollectionError) {
-    context.add_run_diagnostic(
-        FAILED_TO_COLLECT_MODULE.diagnostic(format!("Failed to collect python module: {error}")),
-    );
+pub fn collection_error_diagnostic(error: &CollectionError) -> Diagnostic {
+    FAILED_TO_COLLECT_MODULE.diagnostic(format!("Failed to collect python module: {error}"))
 }
 
-pub fn report_failed_to_import_module(context: &Context, module_name: &str, error: &str) {
-    context.add_run_diagnostic(FAILED_TO_IMPORT_MODULE.diagnostic(format!(
+pub fn failed_to_import_module_diagnostic(module_name: &str, error: &str) -> Diagnostic {
+    FAILED_TO_IMPORT_MODULE.diagnostic(format!(
         "Failed to import python module `{module_name}`: {error}"
-    )));
+    ))
 }
 
-pub fn report_failed_to_discover_imported_fixture(
-    context: &Context,
+pub fn failed_to_discover_imported_fixture_diagnostic(
     fixture_name: &str,
     source_path: &Utf8Path,
     error: &std::io::Error,
-) {
-    let diagnostic = FAILED_TO_DISCOVER_IMPORTED_FIXTURE.diagnostic(format!(
+) -> Diagnostic {
+    FAILED_TO_DISCOVER_IMPORTED_FIXTURE.diagnostic(format!(
         "Failed to discover imported fixture `{fixture_name}` from `{source_path}`: {error}"
-    ));
-
-    context.add_run_diagnostic(diagnostic);
+    ))
 }
 
-pub fn report_duplicate_fixture(
-    context: &Context,
+pub fn duplicate_fixture_diagnostic(
     source_file: SourceFile,
     fixture_name: &str,
     first_definition: &StmtFunctionDef,
     duplicate_definition: &StmtFunctionDef,
-) {
+) -> Diagnostic {
     let mut diagnostic = DUPLICATE_FIXTURE.diagnostic(format!(
         "Fixture `{fixture_name}` is defined more than once"
     ));
 
     annotate_function_name(&mut diagnostic, source_file.clone(), duplicate_definition);
     annotate_first_definition(&mut diagnostic, source_file, fixture_name, first_definition);
-    context.add_run_diagnostic(diagnostic);
+    diagnostic
 }
 
-pub fn report_duplicate_test(
-    context: &Context,
+pub fn duplicate_test_diagnostic(
     source_file: SourceFile,
     test_name: &str,
     first_definition: &StmtFunctionDef,
     duplicate_definition: &StmtFunctionDef,
-) {
+) -> Diagnostic {
     let mut diagnostic =
         DUPLICATE_TEST.diagnostic(format!("Test `{test_name}` is defined more than once"));
 
     annotate_function_name(&mut diagnostic, source_file.clone(), duplicate_definition);
     annotate_first_definition(&mut diagnostic, source_file, test_name, first_definition);
-    context.add_run_diagnostic(diagnostic);
+    diagnostic
 }
 
-pub fn report_invalid_fixture(
-    context: &Context,
-    py: Python,
+pub fn invalid_fixture_diagnostic(
     source_file: SourceFile,
     stmt_function_def: &StmtFunctionDef,
-    error: &PyErr,
-) {
+    reason: &str,
+) -> Diagnostic {
     let mut diagnostic = INVALID_FIXTURE.diagnostic(format!(
         "Discovered an invalid fixture `{}`",
         stmt_function_def.name
@@ -339,12 +329,10 @@ pub fn report_invalid_fixture(
 
     annotate_function_name(&mut diagnostic, source_file, stmt_function_def);
 
-    let error_string = error.value(py).to_string();
-
-    if !error_string.is_empty() {
-        diagnostic.info(indent_continuation_lines(&error_string));
+    if !reason.is_empty() {
+        diagnostic.info(indent_continuation_lines(reason));
     }
-    context.add_run_diagnostic(diagnostic);
+    diagnostic
 }
 
 pub fn invalid_fixture_finalizer_diagnostic(
@@ -523,11 +511,12 @@ fn fixture_missing_fixtures_diagnostic(
             SubDiagnosticSeverity::Info,
             format!(
                 "Fixture `{}` was rejected during discovery: {}",
-                rejected_fixture.name, rejected_fixture.reason
+                rejected_fixture.name(),
+                rejected_fixture.reason()
             ),
         );
-        let span = Span::from(rejected_fixture.source_file.clone())
-            .with_range(rejected_fixture.stmt_function_def.name.range);
+        let span = Span::from(rejected_fixture.source_file().clone())
+            .with_range(rejected_fixture.statement().name.range);
         sub.annotate(Annotation::primary(span));
         diagnostic.sub(sub);
     }
@@ -610,11 +599,10 @@ pub fn test_failure_diagnostic(
     diagnostic
 }
 
-pub fn report_generator_test(
-    context: &Context,
+pub fn generator_test_diagnostic(
     source_file: SourceFile,
     stmt_function_def: &StmtFunctionDef,
-) {
+) -> Diagnostic {
     let mut diagnostic = INVALID_TEST.diagnostic(format!(
         "Generator test `{}` is not supported",
         stmt_function_def.name
@@ -622,7 +610,7 @@ pub fn report_generator_test(
 
     annotate_function_name(&mut diagnostic, source_file, stmt_function_def);
     diagnostic.info("Use `@karva.tags.parametrize` to define multiple test cases.");
-    context.add_run_diagnostic(diagnostic);
+    diagnostic
 }
 
 pub fn invalid_parametrize_diagnostic(

--- a/crates/karva_test_semantic/src/discovery/discoverer.rs
+++ b/crates/karva_test_semantic/src/discovery/discoverer.rs
@@ -12,9 +12,10 @@ use ruff_python_parser::{Mode, ParseOptions, parse_unchecked};
 
 use crate::Context;
 use crate::collection::TestFunctionCollector;
-use crate::diagnostic::report_collection_error;
 use crate::discovery::visitor::{discover, is_generator};
-use crate::discovery::{DiscoveredModule, DiscoveredPackage};
+use crate::discovery::{
+    DiscoveredModule, DiscoveredPackage, DiscoveryError, DiscoveryIssue, DiscoveryOutput,
+};
 use crate::extensions::fixtures::{DiscoveredFixture, RejectedFixture};
 use crate::utils::add_to_sys_path;
 
@@ -25,22 +26,31 @@ use crate::utils::add_to_sys_path;
 pub struct StandardDiscoverer<'ctx, 'a> {
     /// Reference to the test execution context.
     context: &'ctx Context<'a>,
+
+    /// Ordered issues produced across all modules in the package tree.
+    issues: Vec<DiscoveryIssue>,
 }
 
 impl<'ctx, 'a> StandardDiscoverer<'ctx, 'a> {
     pub fn new(context: &'ctx Context<'a>) -> Self {
-        Self { context }
+        Self {
+            context,
+            issues: Vec::new(),
+        }
     }
 
     pub(crate) fn discover_with_py(
-        self,
+        mut self,
         py: Python<'_>,
         test_paths: Vec<Result<TestPath, TestPathError>>,
-    ) -> DiscoveredPackage {
+    ) -> DiscoveryOutput {
         let cwd = self.context.cwd();
 
         if add_to_sys_path(py, cwd, 0).is_err() {
-            return DiscoveredPackage::new(cwd.to_path_buf());
+            return DiscoveryOutput {
+                package: DiscoveredPackage::new(cwd.to_path_buf()),
+                issues: self.issues,
+            };
         }
 
         let test_paths = test_paths
@@ -60,8 +70,12 @@ impl<'ctx, 'a> StandardDiscoverer<'ctx, 'a> {
         let collected_package = match collector.collect_all(test_paths) {
             Ok(package) => package,
             Err(error) => {
-                report_collection_error(self.context, &error);
-                return DiscoveredPackage::new(cwd.to_path_buf());
+                self.issues
+                    .push(DiscoveryIssue::Error(DiscoveryError::Collection(error)));
+                return DiscoveryOutput {
+                    package: DiscoveredPackage::new(cwd.to_path_buf()),
+                    issues: self.issues,
+                };
             }
         };
 
@@ -74,13 +88,16 @@ impl<'ctx, 'a> StandardDiscoverer<'ctx, 'a> {
             self.context.python_version(),
         ));
 
-        session_package
+        DiscoveryOutput {
+            package: session_package,
+            issues: self.issues,
+        }
     }
 
     /// Convert a collected package to a discovered package by importing Python modules
     /// and resolving test functions and fixtures.
     fn convert_package(
-        &self,
+        &mut self,
         py: Python,
         collected_package: CollectedPackage,
     ) -> DiscoveredPackage {
@@ -110,7 +127,11 @@ impl<'ctx, 'a> StandardDiscoverer<'ctx, 'a> {
         discovered_package
     }
 
-    fn convert_module(&self, py: Python, collected_module: CollectedModule) -> DiscoveredModule {
+    fn convert_module(
+        &mut self,
+        py: Python,
+        collected_module: CollectedModule,
+    ) -> DiscoveredModule {
         let CollectedModule {
             path,
             module_type: _,
@@ -121,13 +142,13 @@ impl<'ctx, 'a> StandardDiscoverer<'ctx, 'a> {
 
         let mut module = DiscoveredModule::new_with_source(path, source_text);
 
-        discover(
+        self.issues.extend(discover(
             self.context,
             py,
             &mut module,
             test_function_defs,
             fixture_function_defs,
-        );
+        ));
 
         module
     }
@@ -220,6 +241,7 @@ fn discover_framework_fixtures(
                     err.value(py).to_string(),
                     stmt_rc,
                     source_file,
+                    module_path.clone(),
                 ));
                 tracing::warn!(
                     "Failed to discover framework fixture `{fixture_name}` from `karva._builtins`: {err}"

--- a/crates/karva_test_semantic/src/discovery/error.rs
+++ b/crates/karva_test_semantic/src/discovery/error.rs
@@ -1,0 +1,114 @@
+use std::rc::Rc;
+
+use camino::Utf8PathBuf;
+use karva_collector::CollectionError;
+use karva_python_semantic::ModulePath;
+use ruff_db::diagnostic::Diagnostic;
+use ruff_python_ast::StmtFunctionDef;
+use ruff_source_file::SourceFile;
+
+use crate::diagnostic::{
+    collection_error_diagnostic, duplicate_fixture_diagnostic, duplicate_test_diagnostic,
+    failed_to_discover_imported_fixture_diagnostic, failed_to_import_module_diagnostic,
+    generator_test_diagnostic, invalid_fixture_diagnostic,
+};
+
+/// A failure found while binding collected Python definitions to runtime objects.
+pub enum DiscoveryError {
+    Collection(CollectionError),
+    Import {
+        module_name: String,
+        reason: String,
+    },
+    ImportedFixture {
+        fixture_name: String,
+        source_path: Utf8PathBuf,
+        error: std::io::Error,
+    },
+    DuplicateFixture {
+        source_file: SourceFile,
+        fixture_name: String,
+        first_definition: Rc<StmtFunctionDef>,
+        duplicate_definition: Rc<StmtFunctionDef>,
+    },
+    DuplicateTest {
+        source_file: SourceFile,
+        test_name: String,
+        first_definition: Rc<StmtFunctionDef>,
+        duplicate_definition: Rc<StmtFunctionDef>,
+    },
+    InvalidFixture {
+        source_file: SourceFile,
+        definition: Rc<StmtFunctionDef>,
+        reason: String,
+    },
+    GeneratorTest {
+        source_file: SourceFile,
+        definition: Rc<StmtFunctionDef>,
+    },
+}
+
+impl DiscoveryError {
+    pub(crate) fn into_diagnostic(self) -> Diagnostic {
+        match self {
+            Self::Collection(error) => collection_error_diagnostic(&error),
+            Self::Import {
+                module_name,
+                reason,
+            } => failed_to_import_module_diagnostic(&module_name, &reason),
+            Self::ImportedFixture {
+                fixture_name,
+                source_path,
+                error,
+            } => {
+                failed_to_discover_imported_fixture_diagnostic(&fixture_name, &source_path, &error)
+            }
+            Self::DuplicateFixture {
+                source_file,
+                fixture_name,
+                first_definition,
+                duplicate_definition,
+            } => duplicate_fixture_diagnostic(
+                source_file,
+                &fixture_name,
+                &first_definition,
+                &duplicate_definition,
+            ),
+            Self::DuplicateTest {
+                source_file,
+                test_name,
+                first_definition,
+                duplicate_definition,
+            } => duplicate_test_diagnostic(
+                source_file,
+                &test_name,
+                &first_definition,
+                &duplicate_definition,
+            ),
+            Self::InvalidFixture {
+                source_file,
+                definition,
+                reason,
+            } => invalid_fixture_diagnostic(source_file, &definition, &reason),
+            Self::GeneratorTest {
+                source_file,
+                definition,
+            } => generator_test_diagnostic(source_file, &definition),
+        }
+    }
+}
+
+/// Ordered discovery side effect, applied after discovery completes.
+pub enum DiscoveryIssue {
+    Error(DiscoveryError),
+    SkippedModule {
+        module_path: ModulePath,
+        reason: Option<String>,
+    },
+}
+
+/// Fully discovered test tree and the ordered issues produced while building it.
+pub struct DiscoveryOutput {
+    pub(crate) package: super::DiscoveredPackage,
+    pub(crate) issues: Vec<DiscoveryIssue>,
+}

--- a/crates/karva_test_semantic/src/discovery/mod.rs
+++ b/crates/karva_test_semantic/src/discovery/mod.rs
@@ -1,10 +1,12 @@
 //! Project traversal and import-aware discovery models.
 
 pub mod discoverer;
+mod error;
 pub mod models;
 pub mod visitor;
 
 pub use discoverer::StandardDiscoverer;
+pub use error::{DiscoveryError, DiscoveryIssue, DiscoveryOutput};
 pub use models::function::DiscoveredTestFunction;
 pub use models::module::DiscoveredModule;
 pub use models::package::DiscoveredPackage;

--- a/crates/karva_test_semantic/src/discovery/models/definition.rs
+++ b/crates/karva_test_semantic/src/discovery/models/definition.rs
@@ -1,0 +1,43 @@
+use std::rc::Rc;
+
+use karva_python_semantic::QualifiedFunctionName;
+use ruff_python_ast::StmtFunctionDef;
+use ruff_source_file::SourceFile;
+
+/// Immutable source identity shared by discovered tests, fixtures, and diagnostics.
+#[derive(Debug)]
+pub struct FunctionDefinition {
+    name: QualifiedFunctionName,
+    statement: Rc<StmtFunctionDef>,
+    source_file: SourceFile,
+}
+
+impl FunctionDefinition {
+    pub(crate) fn new(
+        name: QualifiedFunctionName,
+        statement: Rc<StmtFunctionDef>,
+        source_file: SourceFile,
+    ) -> Self {
+        Self {
+            name,
+            statement,
+            source_file,
+        }
+    }
+
+    pub(crate) fn name(&self) -> &QualifiedFunctionName {
+        &self.name
+    }
+
+    pub(crate) fn statement(&self) -> &StmtFunctionDef {
+        &self.statement
+    }
+
+    pub(crate) fn statement_rc(&self) -> &Rc<StmtFunctionDef> {
+        &self.statement
+    }
+
+    pub(crate) fn source_file(&self) -> &SourceFile {
+        &self.source_file
+    }
+}

--- a/crates/karva_test_semantic/src/discovery/models/function.rs
+++ b/crates/karva_test_semantic/src/discovery/models/function.rs
@@ -7,6 +7,7 @@ use ruff_python_ast::StmtFunctionDef;
 use ruff_source_file::SourceFile;
 
 use crate::discovery::DiscoveredModule;
+use crate::discovery::models::definition::FunctionDefinition;
 use crate::extensions::tags::Tags;
 
 /// Represents a single test function discovered from Python source code.
@@ -16,14 +17,8 @@ use crate::extensions::tags::Tags;
 /// any associated decorator tags.
 #[derive(Debug)]
 pub struct DiscoveredTestFunction {
-    /// Fully qualified name including module path and function name.
-    pub(crate) name: QualifiedFunctionName,
-
-    /// AST representation of the function definition.
-    pub(crate) stmt_function_def: Rc<StmtFunctionDef>,
-
-    /// Source code captured during discovery for diagnostic reporting.
-    pub(crate) source_file: SourceFile,
+    /// Immutable source identity and syntax.
+    definition: Rc<FunctionDefinition>,
 
     /// Reference to the actual Python callable object.
     pub(crate) py_function: Py<PyAny>,
@@ -54,11 +49,29 @@ impl DiscoveredTestFunction {
         }
 
         Ok(Self {
-            name,
-            stmt_function_def,
-            source_file: module.source_file(),
+            definition: Rc::new(FunctionDefinition::new(
+                name,
+                stmt_function_def,
+                module.source_file(),
+            )),
             py_function,
             tags,
         })
+    }
+
+    pub(crate) fn definition(&self) -> &Rc<FunctionDefinition> {
+        &self.definition
+    }
+
+    pub(crate) fn name(&self) -> &QualifiedFunctionName {
+        self.definition.name()
+    }
+
+    pub(crate) fn statement(&self) -> &StmtFunctionDef {
+        self.definition.statement()
+    }
+
+    pub(crate) fn source_file(&self) -> &SourceFile {
+        self.definition.source_file()
     }
 }

--- a/crates/karva_test_semantic/src/discovery/models/mod.rs
+++ b/crates/karva_test_semantic/src/discovery/models/mod.rs
@@ -1,3 +1,4 @@
+pub mod definition;
 pub mod function;
 pub mod module;
 pub mod package;

--- a/crates/karva_test_semantic/src/discovery/models/module.rs
+++ b/crates/karva_test_semantic/src/discovery/models/module.rs
@@ -70,7 +70,7 @@ impl DiscoveredModule {
     pub(crate) fn rejected_fixture(&self, name: &str) -> Option<&RejectedFixture> {
         self.rejected_fixtures
             .iter()
-            .find(|fixture| fixture.name == name)
+            .find(|fixture| fixture.name() == name)
     }
 
     pub(crate) fn add_rejected_fixture(&mut self, fixture: RejectedFixture) {
@@ -89,6 +89,6 @@ impl DiscoveredModule {
 
     pub(crate) fn shrink(&mut self) {
         self.test_functions
-            .sort_by_key(|function| function.stmt_function_def.range.start());
+            .sort_by_key(|function| function.statement().range.start());
     }
 }

--- a/crates/karva_test_semantic/src/discovery/visitor.rs
+++ b/crates/karva_test_semantic/src/discovery/visitor.rs
@@ -14,11 +14,7 @@ use ruff_source_file::SourceFileBuilder;
 use ruff_text_size::TextRange;
 
 use crate::Context;
-use crate::diagnostic::{
-    report_duplicate_fixture, report_duplicate_test, report_failed_to_discover_imported_fixture,
-    report_failed_to_import_module, report_generator_test, report_invalid_fixture,
-};
-use crate::discovery::{DiscoveredModule, DiscoveredTestFunction};
+use crate::discovery::{DiscoveredModule, DiscoveredTestFunction, DiscoveryError, DiscoveryIssue};
 use crate::extensions::fixtures::python::FixtureFunctionDefinition;
 use crate::extensions::fixtures::{DiscoveredFixture, RejectedFixture};
 use crate::extensions::tags::skip::{extract_skip_reason, is_skip_exception};
@@ -42,6 +38,9 @@ struct FunctionDefinitionVisitor<'ctx, 'py, 'a, 'b> {
 
     /// Flag to prevent multiple import attempts for the same module.
     tried_to_import_module: bool,
+
+    /// Issues produced while discovering this module, in source order.
+    issues: Vec<DiscoveryIssue>,
 }
 
 impl<'ctx, 'py, 'a, 'b> FunctionDefinitionVisitor<'ctx, 'py, 'a, 'b> {
@@ -52,6 +51,7 @@ impl<'ctx, 'py, 'a, 'b> FunctionDefinitionVisitor<'ctx, 'py, 'a, 'b> {
             py_module: None,
             py,
             tried_to_import_module: false,
+            issues: Vec::new(),
         }
     }
 
@@ -72,16 +72,16 @@ impl<'ctx, 'py, 'a, 'b> FunctionDefinitionVisitor<'ctx, 'py, 'a, 'b> {
             }
             Err(error) => {
                 if is_skip_exception(self.py, &error) {
-                    self.context.register_module_skip(
-                        self.module.module_path(),
-                        extract_skip_reason(self.py, &error),
-                    );
+                    self.issues.push(DiscoveryIssue::SkippedModule {
+                        module_path: self.module.module_path().clone(),
+                        reason: extract_skip_reason(self.py, &error),
+                    });
                 } else {
-                    report_failed_to_import_module(
-                        self.context,
-                        self.module.name(),
-                        &error.value(self.py).to_string(),
-                    );
+                    self.issues
+                        .push(DiscoveryIssue::Error(DiscoveryError::Import {
+                            module_name: self.module.name().to_string(),
+                            reason: error.value(self.py).to_string(),
+                        }));
                 }
             }
         }
@@ -117,14 +117,14 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
                     error.value(self.py).to_string(),
                     Rc::clone(&stmt_function_def),
                     source_file,
+                    self.module.module_path().clone(),
                 ));
-                report_invalid_fixture(
-                    self.context,
-                    self.py,
-                    self.module.source_file(),
-                    &stmt_function_def,
-                    &error,
-                );
+                self.issues
+                    .push(DiscoveryIssue::Error(DiscoveryError::InvalidFixture {
+                        source_file: self.module.source_file(),
+                        definition: stmt_function_def,
+                        reason: error.value(self.py).to_string(),
+                    }));
                 None
             }
         }
@@ -147,11 +147,11 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
             ) {
                 Ok(test_function) => self.module.add_test_function(test_function),
                 Err(error) => {
-                    report_failed_to_import_module(
-                        self.context,
-                        self.module.name(),
-                        &error.value(self.py).to_string(),
-                    );
+                    self.issues
+                        .push(DiscoveryIssue::Error(DiscoveryError::Import {
+                            module_name: self.module.name().to_string(),
+                            reason: error.value(self.py).to_string(),
+                        }));
                 }
             }
         }
@@ -206,7 +206,7 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
             .module
             .test_functions()
             .iter()
-            .any(|f| f.name.function_name() == name)
+            .any(|f| f.name().function_name() == name)
         {
             return None;
         }
@@ -243,12 +243,12 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
         let source_text = match fs::read_to_string(utf8_file_name) {
             Ok(source_text) => source_text,
             Err(err) => {
-                report_failed_to_discover_imported_fixture(
-                    self.context,
-                    name,
-                    utf8_file_name,
-                    &err,
-                );
+                self.issues
+                    .push(DiscoveryIssue::Error(DiscoveryError::ImportedFixture {
+                        fixture_name: name.to_string(),
+                        source_path: utf8_file_name.to_path_buf(),
+                        error: err,
+                    }));
                 return None;
             }
         };
@@ -274,14 +274,14 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
                     error.value(self.py).to_string(),
                     Rc::clone(&stmt_function_def),
                     source_file.clone(),
+                    module_path.clone(),
                 ));
-                report_invalid_fixture(
-                    self.context,
-                    self.py,
-                    source_file,
-                    stmt_function_def.as_ref(),
-                    &error,
-                );
+                self.issues
+                    .push(DiscoveryIssue::Error(DiscoveryError::InvalidFixture {
+                        source_file,
+                        definition: stmt_function_def,
+                        reason: error.value(self.py).to_string(),
+                    }));
             }
         }
 
@@ -299,7 +299,7 @@ pub fn discover(
     module: &mut DiscoveredModule,
     test_function_defs: Vec<StmtFunctionDef>,
     fixture_function_defs: Vec<StmtFunctionDef>,
-) {
+) -> Vec<DiscoveryIssue> {
     let is_conftest = module
         .path()
         .file_name()
@@ -312,13 +312,14 @@ pub fn discover(
         |test_function_def| test_function_def.name.to_string(),
         |test_function_def| test_function_def.range,
         |name, first_definition, duplicate_definition| {
-            report_duplicate_test(
-                context,
-                visitor.module.source_file(),
-                name,
-                first_definition,
-                duplicate_definition,
-            );
+            visitor
+                .issues
+                .push(DiscoveryIssue::Error(DiscoveryError::DuplicateTest {
+                    source_file: visitor.module.source_file(),
+                    test_name: name.to_string(),
+                    first_definition: Rc::new(first_definition.clone()),
+                    duplicate_definition: Rc::new(duplicate_definition.clone()),
+                }));
         },
     );
 
@@ -328,7 +329,12 @@ pub fn discover(
         }
 
         if is_generator(&test_function_def) {
-            report_generator_test(context, visitor.module.source_file(), &test_function_def);
+            visitor
+                .issues
+                .push(DiscoveryIssue::Error(DiscoveryError::GeneratorTest {
+                    source_file: visitor.module.source_file(),
+                    definition: Rc::new(test_function_def),
+                }));
             continue;
         }
 
@@ -347,13 +353,14 @@ pub fn discover(
         |fixture| fixture.name().function_name().to_string(),
         |fixture| fixture.stmt_function_def().range,
         |name, first_definition, duplicate_definition| {
-            report_duplicate_fixture(
-                context,
-                visitor.module.source_file(),
-                name,
-                first_definition.stmt_function_def(),
-                duplicate_definition.stmt_function_def(),
-            );
+            visitor
+                .issues
+                .push(DiscoveryIssue::Error(DiscoveryError::DuplicateFixture {
+                    source_file: visitor.module.source_file(),
+                    fixture_name: name.to_string(),
+                    first_definition: Rc::clone(first_definition.stmt_function_def()),
+                    duplicate_definition: Rc::clone(duplicate_definition.stmt_function_def()),
+                }));
         },
     );
 
@@ -368,6 +375,8 @@ pub fn discover(
     if is_conftest || context.settings().test().try_import_fixtures {
         visitor.find_extra_fixtures();
     }
+
+    visitor.issues
 }
 
 fn duplicate_definition_indices<T>(

--- a/crates/karva_test_semantic/src/extensions/fixtures/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/mod.rs
@@ -22,6 +22,7 @@ pub use traits::{HasFixtures, RequiresFixtures};
 pub use utils::missing_arguments_from_error;
 
 use crate::discovery::DiscoveredPackage;
+use crate::discovery::models::definition::FunctionDefinition;
 use crate::extensions::fixtures::python::InvalidFixtureError;
 use crate::extensions::fixtures::scope::fixture_scope;
 
@@ -32,14 +33,8 @@ use crate::extensions::fixtures::scope::fixture_scope;
 /// be auto-used without explicit declaration.
 #[derive(Clone, Debug)]
 pub struct DiscoveredFixture {
-    /// Fully qualified name including module path and function name.
-    name: QualifiedFunctionName,
-
-    /// AST representation of the fixture function definition.
-    stmt_function_def: Rc<StmtFunctionDef>,
-
-    /// Source code captured during discovery for diagnostic reporting.
-    source_file: SourceFile,
+    /// Immutable source identity and syntax.
+    definition: Rc<FunctionDefinition>,
 
     /// The scope at which this fixture's value is cached.
     scope: FixtureScope,
@@ -60,16 +55,13 @@ pub struct DiscoveredFixture {
 #[derive(Clone, Debug)]
 pub struct RejectedFixture {
     /// Unqualified fixture name used for later lookup failures.
-    pub(crate) name: String,
+    name: String,
 
     /// Discovery error retained for dependency diagnostics.
-    pub(crate) reason: String,
+    reason: String,
 
-    /// Definition used to underline the rejected fixture.
-    pub(crate) stmt_function_def: Rc<StmtFunctionDef>,
-
-    /// Source containing the rejected definition.
-    pub(crate) source_file: SourceFile,
+    /// Immutable source identity and syntax.
+    definition: Rc<FunctionDefinition>,
 }
 
 impl RejectedFixture {
@@ -78,13 +70,35 @@ impl RejectedFixture {
         reason: String,
         stmt_function_def: Rc<StmtFunctionDef>,
         source_file: SourceFile,
+        module_path: ModulePath,
     ) -> Self {
+        let qualified_name =
+            QualifiedFunctionName::new(stmt_function_def.name.to_string(), module_path);
         Self {
             name,
             reason,
-            stmt_function_def,
-            source_file,
+            definition: Rc::new(FunctionDefinition::new(
+                qualified_name,
+                stmt_function_def,
+                source_file,
+            )),
         }
+    }
+
+    pub(crate) fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub(crate) fn reason(&self) -> &str {
+        &self.reason
+    }
+
+    pub(crate) fn statement(&self) -> &StmtFunctionDef {
+        self.definition.statement()
+    }
+
+    pub(crate) fn source_file(&self) -> &SourceFile {
+        self.definition.source_file()
     }
 }
 
@@ -99,9 +113,11 @@ impl DiscoveredFixture {
         is_generator: bool,
     ) -> Self {
         Self {
-            name,
-            stmt_function_def,
-            source_file,
+            definition: Rc::new(FunctionDefinition::new(
+                name,
+                stmt_function_def,
+                source_file,
+            )),
             scope,
             auto_use,
             function: Rc::new(function),
@@ -110,7 +126,7 @@ impl DiscoveredFixture {
     }
 
     pub(crate) fn name(&self) -> &QualifiedFunctionName {
-        &self.name
+        self.definition.name()
     }
 
     pub(crate) fn scope(&self) -> FixtureScope {
@@ -130,11 +146,11 @@ impl DiscoveredFixture {
     }
 
     pub(crate) fn stmt_function_def(&self) -> &Rc<StmtFunctionDef> {
-        &self.stmt_function_def
+        self.definition.statement_rc()
     }
 
     pub(crate) fn source_file(&self) -> &SourceFile {
-        &self.source_file
+        self.definition.source_file()
     }
 
     pub(crate) fn try_from_function(

--- a/crates/karva_test_semantic/src/extensions/fixtures/traits.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/traits.rs
@@ -121,6 +121,6 @@ impl RequiresFixtures for StmtFunctionDef {
 
 impl RequiresFixtures for DiscoveredFixture {
     fn required_fixtures(&self, py: Python<'_>) -> Vec<String> {
-        self.stmt_function_def.required_fixtures(py)
+        self.stmt_function_def().required_fixtures(py)
     }
 }

--- a/crates/karva_test_semantic/src/lib.rs
+++ b/crates/karva_test_semantic/src/lib.rs
@@ -22,7 +22,7 @@ use karva_metadata::ProjectSettings;
 use karva_project::path::{TestPath, TestPathError};
 use ruff_python_ast::PythonVersion;
 
-use crate::discovery::StandardDiscoverer;
+use crate::discovery::{DiscoveryIssue, StandardDiscoverer};
 use crate::py_attach::attach_with_output;
 use crate::runner::PackageRunner;
 
@@ -49,9 +49,21 @@ pub fn run_tests(
             }
         });
 
-        let session = StandardDiscoverer::new(&context).discover_with_py(py, test_paths);
+        let discovery = StandardDiscoverer::new(&context).discover_with_py(py, test_paths);
 
-        PackageRunner::new(&context, cov_session.as_ref()).execute(py, &session);
+        for issue in discovery.issues {
+            match issue {
+                DiscoveryIssue::Error(error) => {
+                    context.add_run_diagnostic(error.into_diagnostic());
+                }
+                DiscoveryIssue::SkippedModule {
+                    module_path,
+                    reason,
+                } => context.register_module_skip(&module_path, reason),
+            }
+        }
+
+        PackageRunner::new(&context, cov_session.as_ref()).execute(py, &discovery.package);
 
         if let Some(cov_session) = cov_session
             && let Err(err) = cov_session.stop_and_save(py)

--- a/crates/karva_test_semantic/src/runner/fixture_resolver.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_resolver.rs
@@ -231,7 +231,7 @@ impl<'a> RuntimeFixtureResolver<'a> {
         test: &DiscoveredTestFunction,
         parametrize_param_names: &HashSet<&str>,
     ) -> FixtureResolutionResult<Vec<Rc<NormalizedFixture>>> {
-        let fixture_names = test.stmt_function_def.required_fixtures(py);
+        let fixture_names = test.statement().required_fixtures(py);
         let regular_fixture_names: Vec<String> = fixture_names
             .iter()
             .filter(|name| !parametrize_param_names.contains(name.as_str()))
@@ -253,8 +253,8 @@ impl<'a> RuntimeFixtureResolver<'a> {
 
         if !missing_fixtures.is_empty() {
             return Err(FixtureResolutionError::MissingTestFixtures {
-                stmt_function_def: Rc::clone(&test.stmt_function_def),
-                source_file: test.source_file.clone(),
+                stmt_function_def: Rc::clone(test.definition().statement_rc()),
+                source_file: test.source_file().clone(),
                 missing_fixtures,
             });
         }

--- a/crates/karva_test_semantic/src/runner/package_runner/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/mod.rs
@@ -76,7 +76,7 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
     /// Registers a discovery or setup error against one test.
     fn register_error_test(&self, test: &DiscoveredTestFunction, error: TestError) {
         self.context.register_test_case_result(
-            &QualifiedTestName::new(test.name.clone(), None),
+            &QualifiedTestName::new(test.name().clone(), None),
             error.into_outcome(),
             std::time::Duration::ZERO,
             None,
@@ -119,10 +119,10 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
 
         for module in package.modules().values() {
             for test in module.test_functions() {
-                if let Err(error) = test.tags.validate_parametrize(&test.stmt_function_def) {
+                if let Err(error) = test.tags.validate_parametrize(test.statement()) {
                     let diagnostic = invalid_parametrize_diagnostic(
-                        test.source_file.clone(),
-                        &test.stmt_function_def,
+                        test.source_file().clone(),
+                        test.statement(),
                         &error,
                     );
                     self.register_error_test(test, TestError::new(diagnostic));

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/attempt.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/attempt.rs
@@ -76,8 +76,8 @@ impl VariantRunner<'_, '_, '_, '_, '_> {
             duration,
             phases,
             settings.fail_slow_budget,
-            &self.test.source_file,
-            &self.test.stmt_function_def,
+            self.test.source_file(),
+            self.test.statement(),
         );
         let retryable = body.retryable || teardown_failed || (budget_exceeded && !skipped);
 
@@ -152,9 +152,9 @@ impl VariantRunner<'_, '_, '_, '_, '_> {
             self.py,
             test_result,
             &OutcomeContext {
-                name: &self.test.name,
-                source_file: &self.test.source_file,
-                stmt_function_def: &self.test.stmt_function_def,
+                name: self.test.name(),
+                source_file: self.test.source_file(),
+                stmt_function_def: self.test.statement(),
                 function_arguments,
                 expect_fail_tag: settings.expect_fail_tag.as_ref(),
                 verbose: self.package_runner.context.is_verbose(),

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
@@ -190,7 +190,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
 
     /// Derives identity and execution policy after first fixture setup.
     fn settings(&self, function_arguments: &FixtureArguments) -> VariantSettings {
-        let name = &self.test.name;
+        let name = self.test.name();
         let fixture_names = self
             .fixture_dependencies
             .iter()
@@ -209,7 +209,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
                 self.py,
                 name.to_string(),
                 function_arguments,
-                &self.test.stmt_function_def.parameters,
+                &self.test.statement().parameters,
                 &framework_fixture_names,
             )
         };
@@ -264,20 +264,19 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             .settings()
             .junit_flaky_fail_status_for(&evaluation_context);
         let expect_fail_tag = self.tags.expect_fail_tag();
-        let async_patch_result = if self.test.stmt_function_def.is_async {
+        let async_patch_result = if self.test.statement().is_async {
             crate::utils::patch_async_test_function(self.py, &self.test.py_function)
         } else {
             Ok(false)
         };
-        let is_async =
-            self.test.stmt_function_def.is_async && matches!(&async_patch_result, Ok(false));
+        let is_async = self.test.statement().is_async && matches!(&async_patch_result, Ok(false));
         let snapshot_context = SnapshotContext::new(
             self.module_path.to_string(),
             full_test_name(
                 self.py,
                 name.function_name().to_string(),
                 function_arguments,
-                &self.test.stmt_function_def.parameters,
+                &self.test.statement().parameters,
                 &fixture_names,
             ),
         );
@@ -375,7 +374,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
         let run_ignored = self.package_runner.context.settings().test().run_ignored;
 
         if !filter.is_empty() {
-            let qualified = QualifiedTestName::new(self.test.name.clone(), None);
+            let qualified = QualifiedTestName::new(self.test.name().clone(), None);
             let display_name = qualified.to_string();
             let custom_names = self.tags.custom_tag_names();
             let context = EvalContext {
@@ -403,7 +402,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
         let (true, reason) = skipped else {
             return None;
         };
-        let qualified = QualifiedTestName::new(self.test.name.clone(), None);
+        let qualified = QualifiedTestName::new(self.test.name().clone(), None);
         Some(self.package_runner.context.register_test_case_result(
             &qualified,
             TestExecutionOutcome::Skipped { reason },

--- a/crates/karva_test_semantic/src/runner/test_iterator.rs
+++ b/crates/karva_test_semantic/src/runner/test_iterator.rs
@@ -50,7 +50,7 @@ pub(super) struct TestVariant<'a> {
 impl TestVariant<'_> {
     /// Get the module path for diagnostics.
     pub(super) fn module_path(&self) -> &camino::Utf8PathBuf {
-        self.test.name.module_path().path()
+        self.test.name().module_path().path()
     }
 
     /// Get the resolved tags including those from fixture dependencies.


### PR DESCRIPTION
## Summary

Discovery now returns a discovered package plus typed, ordered issues instead of mutating run state while traversing Python definitions. Tests and fixtures share one immutable source definition for qualified identity, syntax, and diagnostics.

## Test plan

`just test -p karva_test_semantic` and crate Clippy.