### PR TITLE
Compile fixture dependency plans

### DIFF
--- a/crates/karva_test_semantic/src/extensions/fixtures/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/mod.rs
@@ -16,7 +16,7 @@ mod traits;
 mod utils;
 
 pub use finalizer::Finalizer;
-pub use normalized_fixture::NormalizedFixture;
+pub use normalized_fixture::{FixtureId, FixturePlan, NormalizedFixture};
 pub use scope::FixtureScope;
 pub use traits::{HasFixtures, RequiresFixtures};
 pub use utils::missing_arguments_from_error;

--- a/crates/karva_test_semantic/src/extensions/fixtures/normalized_fixture.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/normalized_fixture.rs
@@ -1,27 +1,50 @@
-use std::rc::Rc;
-
 use karva_python_semantic::QualifiedFunctionName;
 use pyo3::prelude::*;
 use ruff_python_ast::StmtFunctionDef;
 use ruff_source_file::SourceFile;
 
 use crate::extensions::fixtures::FixtureScope;
-use crate::extensions::tags::Tags;
 use crate::runner::FixtureArguments;
 use crate::utils::run_coroutine;
+
+/// Stable index into one compiled [`FixturePlan`].
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct FixtureId(usize);
+
+impl FixtureId {
+    pub(crate) fn new(index: usize) -> Self {
+        Self(index)
+    }
+}
+
+/// Arena containing every fixture definition needed by one resolution context.
+#[derive(Debug)]
+pub struct FixturePlan {
+    fixtures: Vec<NormalizedFixture>,
+}
+
+impl FixturePlan {
+    pub(crate) fn new(fixtures: Vec<NormalizedFixture>) -> Self {
+        Self { fixtures }
+    }
+
+    pub(crate) fn fixture(&self, id: FixtureId) -> &NormalizedFixture {
+        &self.fixtures[id.0]
+    }
+}
 
 /// A normalized fixture represents a concrete instance of a fixture ready for execution.
 ///
 /// All fixtures — both user-defined and framework-provided — share this single
 /// representation. Framework fixtures (from `karva._builtins`) are discovered
 /// and normalized the same way as user-defined ones.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct NormalizedFixture {
     /// Fully qualified name including module path and function name.
     pub(crate) name: QualifiedFunctionName,
 
     /// Resolved fixture dependencies this fixture requires.
-    pub(crate) dependencies: Vec<Rc<Self>>,
+    pub(crate) dependencies: Vec<FixtureId>,
 
     /// The scope at which this fixture's value is cached.
     pub(crate) scope: FixtureScope,
@@ -30,10 +53,7 @@ pub struct NormalizedFixture {
     pub(crate) is_generator: bool,
 
     /// Reference to the Python callable that produces the fixture value.
-    /// Wrapped in ``Rc`` so ``NormalizedFixture`` stays cheaply ``Clone``
-    /// without needing a Python token (``Py<T>`` only supports
-    /// ``clone_ref(py)``).
-    pub(crate) py_function: Rc<Py<PyAny>>,
+    pub(crate) py_function: Py<PyAny>,
 
     /// AST representation of the fixture function definition.
     pub(crate) stmt_function_def: Rc<StmtFunctionDef>,
@@ -49,24 +69,13 @@ impl NormalizedFixture {
     }
 
     /// Returns the fixture dependencies.
-    pub(crate) fn dependencies(&self) -> &Vec<Rc<Self>> {
+    pub(crate) fn dependencies(&self) -> &[FixtureId] {
         &self.dependencies
     }
 
     /// Returns the fixture scope.
     pub(crate) fn scope(&self) -> FixtureScope {
         self.scope
-    }
-
-    /// Combines tags inherited through the fixture dependency graph.
-    pub(crate) fn resolved_tags(&self) -> Tags {
-        let mut tags = Tags::default();
-
-        for dependency in self.dependencies() {
-            tags.extend(&dependency.resolved_tags());
-        }
-
-        tags
     }
 
     /// Call this fixture with the already-resolved arguments and return the result.
@@ -89,3 +98,4 @@ impl NormalizedFixture {
         }
     }
 }
+use std::rc::Rc;

--- a/crates/karva_test_semantic/src/runner/fixture_resolver.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_resolver.rs
@@ -9,11 +9,11 @@ use ruff_source_file::SourceFile;
 
 use crate::discovery::{DiscoveredPackage, DiscoveredTestFunction};
 use crate::extensions::fixtures::{
-    DiscoveredFixture, FixtureScope, HasFixtures, NormalizedFixture, RejectedFixture,
-    RequiresFixtures, get_auto_use_fixtures,
+    DiscoveredFixture, FixtureId, FixturePlan, FixtureScope, HasFixtures, NormalizedFixture,
+    RejectedFixture, RequiresFixtures, get_auto_use_fixtures,
 };
 
-/// Resolves fixtures at runtime during test execution.
+/// Compiles fixture lookup results into an arena for one request context.
 ///
 /// Unlike pre-normalization, this resolver finds and normalizes fixtures
 /// on-demand when tests need them. `current` is typed as a trait object so
@@ -21,13 +21,16 @@ use crate::extensions::fixtures::{
 /// resolution), a package (package-autouse resolution), or the session package
 /// itself (session-autouse resolution). Package providers expose both user and
 /// framework fixtures through their `HasFixtures` implementation.
-pub(super) struct RuntimeFixtureResolver<'a> {
+pub(super) struct FixturePlanCompiler<'a> {
     /// Package chain searched from session root toward the current module.
     parents: &'a [&'a DiscoveredPackage],
     /// Fixture provider at the active package, module, or session scope.
     current: &'a (dyn HasFixtures<'a> + 'a),
-    /// Normalized non-function fixtures reused within this resolution pass.
-    fixture_cache: HashMap<String, Rc<NormalizedFixture>>,
+    /// Definition IDs reused within this compilation pass.
+    fixture_ids: HashMap<String, FixtureId>,
+
+    /// Arena under construction.
+    fixtures: Vec<NormalizedFixture>,
 }
 
 /// Source-backed fixture metadata retained for resolution diagnostics.
@@ -154,7 +157,7 @@ impl<'a> FixturePath<'a> {
     }
 }
 
-impl<'a> RuntimeFixtureResolver<'a> {
+impl<'a> FixturePlanCompiler<'a> {
     /// Creates a resolver for one current fixture provider and package chain.
     pub(super) fn new(
         parents: &'a [&'a DiscoveredPackage],
@@ -163,28 +166,30 @@ impl<'a> RuntimeFixtureResolver<'a> {
         Self {
             parents,
             current,
-            fixture_cache: HashMap::new(),
+            fixture_ids: HashMap::new(),
+            fixtures: Vec::new(),
         }
+    }
+
+    /// Finishes the immutable arena after all requested root groups are compiled.
+    pub(super) fn finish(self) -> FixturePlan {
+        FixturePlan::new(self.fixtures)
     }
 
     /// Normalizes a fixture and its dependencies recursively.
     ///
-    /// Function-scoped fixtures are NOT cached because their built-in dependencies
-    /// (e.g. `tmp_path`) must be fresh for each test invocation. Broader-scoped
-    /// fixtures are cached so they are shared across tests within the appropriate
-    /// scope.
+    /// A definition is stored once per request context. Runtime scope caches still
+    /// decide when its Python value is reused.
     fn normalize_fixture(
         &mut self,
         py: Python,
         fixture: &'a DiscoveredFixture,
         path: &mut FixturePath<'a>,
-    ) -> FixtureResolutionResult<Rc<NormalizedFixture>> {
+    ) -> FixtureResolutionResult<FixtureId> {
         let cache_key = fixture.name().to_string();
 
-        if fixture.scope() != FixtureScope::Function {
-            if let Some(cached) = self.fixture_cache.get(&cache_key) {
-                return Ok(Rc::clone(cached));
-            }
+        if let Some(cached) = self.fixture_ids.get(&cache_key) {
+            return Ok(*cached);
         }
 
         let dependent_fixtures = path.enter(fixture, |path| {
@@ -192,21 +197,21 @@ impl<'a> RuntimeFixtureResolver<'a> {
             self.get_dependent_fixtures(py, Some(fixture), &required_fixtures, path)
         })?;
 
-        let result = Rc::new(NormalizedFixture {
+        let result = NormalizedFixture {
             name: fixture.name().clone(),
             dependencies: dependent_fixtures,
             scope: fixture.scope(),
             is_generator: fixture.is_generator(),
-            py_function: Rc::new(fixture.function().clone_ref(py)),
+            py_function: fixture.function().clone_ref(py),
             stmt_function_def: Rc::clone(fixture.stmt_function_def()),
             source_file: fixture.source_file().clone(),
-        });
+        };
 
-        if fixture.scope() != FixtureScope::Function {
-            self.fixture_cache.insert(cache_key, Rc::clone(&result));
-        }
+        let fixture_id = FixtureId::new(self.fixtures.len());
+        self.fixtures.push(result);
+        self.fixture_ids.insert(cache_key, fixture_id);
 
-        Ok(result)
+        Ok(fixture_id)
     }
 
     /// Returns normalized auto-use fixtures for a given scope.
@@ -214,7 +219,7 @@ impl<'a> RuntimeFixtureResolver<'a> {
         &mut self,
         py: Python,
         scope: FixtureScope,
-    ) -> FixtureResolutionResult<Vec<Rc<NormalizedFixture>>> {
+    ) -> FixtureResolutionResult<Vec<FixtureId>> {
         let auto_use_fixtures = get_auto_use_fixtures(self.parents, self.current, scope);
         let mut path = FixturePath::default();
 
@@ -230,7 +235,7 @@ impl<'a> RuntimeFixtureResolver<'a> {
         py: Python,
         test: &DiscoveredTestFunction,
         parametrize_param_names: &HashSet<&str>,
-    ) -> FixtureResolutionResult<Vec<Rc<NormalizedFixture>>> {
+    ) -> FixtureResolutionResult<Vec<FixtureId>> {
         let fixture_names = test.statement().required_fixtures(py);
         let regular_fixture_names: Vec<String> = fixture_names
             .iter()
@@ -268,7 +273,7 @@ impl<'a> RuntimeFixtureResolver<'a> {
         &mut self,
         py: Python,
         fixture_names: &[String],
-    ) -> FixtureResolutionResult<Vec<Rc<NormalizedFixture>>> {
+    ) -> FixtureResolutionResult<Vec<FixtureId>> {
         let mut path = FixturePath::default();
         self.get_dependent_fixtures(py, None, fixture_names, &mut path)
     }
@@ -280,7 +285,7 @@ impl<'a> RuntimeFixtureResolver<'a> {
         current_fixture: Option<&'a DiscoveredFixture>,
         fixture_names: &[String],
         path: &mut FixturePath<'a>,
-    ) -> FixtureResolutionResult<Vec<Rc<NormalizedFixture>>> {
+    ) -> FixtureResolutionResult<Vec<FixtureId>> {
         let mut normalized_fixtures = Vec::with_capacity(fixture_names.len());
         let mut missing_fixtures = Vec::new();
         let mut rejected_fixtures = Vec::new();

--- a/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
@@ -1,7 +1,6 @@
 //! Fixture setup, caching, and teardown for package-runner scopes.
 
 use std::collections::HashMap;
-use std::ops::Deref;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -13,9 +12,11 @@ use ruff_python_ast::StmtFunctionDef;
 use ruff_source_file::SourceFile;
 
 use crate::diagnostic::fixture_resolution_diagnostic;
-use crate::extensions::fixtures::{Finalizer, FixtureScope, HasFixtures, NormalizedFixture};
+use crate::extensions::fixtures::{
+    Finalizer, FixtureId, FixturePlan, FixtureScope, HasFixtures, NormalizedFixture,
+};
 use crate::runner::FixtureArguments;
-use crate::runner::fixture_resolver::RuntimeFixtureResolver;
+use crate::runner::fixture_resolver::FixturePlanCompiler;
 use crate::utils::run_coroutine;
 
 use super::PackageRunner;
@@ -34,16 +35,18 @@ impl PackageRunner<'_, '_> {
         current: &'a (dyn HasFixtures<'a> + 'a),
         scope: FixtureScope,
     ) -> Result<(), TestError> {
-        let mut resolver = RuntimeFixtureResolver::new(parents, current);
-        let auto_use_fixtures = match resolver.get_normalized_auto_use_fixtures(py, scope) {
+        let mut compiler = FixturePlanCompiler::new(parents, current);
+        let auto_use_fixtures = match compiler.get_normalized_auto_use_fixtures(py, scope) {
             Ok(fixtures) => fixtures,
             Err(error) => {
                 return Err(TestError::new(fixture_resolution_diagnostic(error))
                     .with_related(self.clean_up_scope(py, scope)));
             }
         };
+        let fixture_plan = compiler.finish();
 
-        let failures = self.run_fixtures(py, &auto_use_fixtures, FixtureUsage::AutoUse);
+        let failures =
+            self.run_fixtures(py, &fixture_plan, &auto_use_fixtures, FixtureUsage::AutoUse);
         let Some(failures) = FixtureSetupError::from_vec(failures) else {
             return Ok(());
         };
@@ -89,18 +92,24 @@ impl PackageRunner<'_, '_> {
     pub(super) fn prepare_test_fixtures(
         &self,
         py: Python<'_>,
-        fixture_dependencies: &[Rc<NormalizedFixture>],
-        use_fixture_dependencies: &[Rc<NormalizedFixture>],
-        auto_use_fixtures: &[Rc<NormalizedFixture>],
+        fixture_plan: &FixturePlan,
+        fixture_dependencies: &[FixtureId],
+        use_fixture_dependencies: &[FixtureId],
+        auto_use_fixtures: &[FixtureId],
         params: HashMap<String, Arc<Py<PyAny>>>,
     ) -> PreparedFixtures {
         let mut test_finalizers = Vec::new();
-        let mut fixture_call_errors =
-            self.run_fixtures(py, use_fixture_dependencies, FixtureUsage::UseFixtures);
+        let mut fixture_call_errors = self.run_fixtures(
+            py,
+            fixture_plan,
+            use_fixture_dependencies,
+            FixtureUsage::UseFixtures,
+        );
         let mut function_arguments = FixtureArguments::default();
 
-        for fixture in fixture_dependencies {
-            match self.run_fixture(py, fixture) {
+        for fixture_id in fixture_dependencies {
+            let fixture = fixture_plan.fixture(*fixture_id);
+            match self.run_fixture(py, fixture_plan, *fixture_id) {
                 Ok((value, finalizer)) => {
                     function_arguments
                         .insert(fixture.function_name().to_string(), value.clone_ref(py));
@@ -117,7 +126,12 @@ impl PackageRunner<'_, '_> {
             }
         }
 
-        fixture_call_errors.extend(self.run_fixtures(py, auto_use_fixtures, FixtureUsage::AutoUse));
+        fixture_call_errors.extend(self.run_fixtures(
+            py,
+            fixture_plan,
+            auto_use_fixtures,
+            FixtureUsage::AutoUse,
+        ));
 
         for (key, value) in params {
             function_arguments.insert(
@@ -138,8 +152,10 @@ impl PackageRunner<'_, '_> {
     fn run_fixture(
         &self,
         py: Python<'_>,
-        fixture: &NormalizedFixture,
+        fixture_plan: &FixturePlan,
+        fixture_id: FixtureId,
     ) -> Result<(Py<PyAny>, Option<Finalizer>), FixtureCallError> {
+        let fixture = fixture_plan.fixture(fixture_id);
         if let Some(cached) = self
             .fixture_cache
             .get(py, fixture.function_name(), fixture.scope())
@@ -149,8 +165,9 @@ impl PackageRunner<'_, '_> {
 
         let mut function_arguments = FixtureArguments::default();
 
-        for dependency in fixture.dependencies() {
-            match self.run_fixture(py, dependency) {
+        for dependency_id in fixture.dependencies() {
+            let dependency = fixture_plan.fixture(*dependency_id);
+            match self.run_fixture(py, fixture_plan, *dependency_id) {
                 Ok((value, finalizer)) => {
                     function_arguments
                         .insert(dependency.function_name().to_string(), value.clone_ref(py));
@@ -190,15 +207,17 @@ impl PackageRunner<'_, '_> {
     }
 
     /// Runs fixtures whose values are not passed to the test call.
-    fn run_fixtures<P: Deref<Target = NormalizedFixture>>(
+    fn run_fixtures(
         &self,
         py: Python<'_>,
-        fixtures: &[P],
+        fixture_plan: &FixturePlan,
+        fixture_ids: &[FixtureId],
         usage: FixtureUsage,
     ) -> Vec<PreparedFixtureFailure> {
         let mut errors = Vec::new();
-        for fixture in fixtures {
-            match self.run_fixture(py, fixture) {
+        for fixture_id in fixture_ids {
+            let fixture = fixture_plan.fixture(*fixture_id);
+            match self.run_fixture(py, fixture_plan, *fixture_id) {
                 Ok((_, Some(finalizer))) => self.finalizer_cache.add_finalizer(finalizer),
                 Ok((_, None)) => {}
                 Err(error) => errors.push(PreparedFixtureFailure::new(

--- a/crates/karva_test_semantic/src/runner/package_runner/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/mod.rs
@@ -1,6 +1,7 @@
 //! Package-tree orchestration and run-wide execution state.
 
 use std::cell::Cell;
+use std::collections::HashMap;
 
 use karva_coverage::CoverageSession;
 use karva_python_semantic::QualifiedTestName;
@@ -10,8 +11,8 @@ use crate::Context;
 use crate::diagnostic::{fixture_resolution_diagnostic, invalid_parametrize_diagnostic};
 use crate::discovery::{DiscoveredModule, DiscoveredPackage, DiscoveredTestFunction};
 use crate::extensions::fixtures::FixtureScope;
-use crate::runner::fixture_resolver::RuntimeFixtureResolver;
-use crate::runner::test_iterator::TestVariantIterator;
+use crate::runner::fixture_resolver::{FixturePlanCompiler, FixtureResolutionError};
+use crate::runner::test_iterator::{CompiledTestPlan, TestVariantIterator};
 use crate::runner::{FinalizerCache, FixtureCache};
 
 mod failure;
@@ -22,6 +23,8 @@ mod variant;
 pub use fixture::{FixtureCallError, FixtureChainEntry};
 
 use failure::TestError;
+
+type CompiledTestPlans = HashMap<String, Result<CompiledTestPlan, FixtureResolutionError>>;
 
 /// Executes one discovered package tree inside an attached Python interpreter.
 ///
@@ -144,18 +147,44 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
         valid
     }
 
+    /// Compiles every test fixture graph before any fixture code executes.
+    fn compile_test_plans(
+        py: Python<'_>,
+        package: &DiscoveredPackage,
+        parents: &[&DiscoveredPackage],
+        plans: &mut CompiledTestPlans,
+    ) {
+        let mut child_parents = parents.to_vec();
+        child_parents.push(package);
+
+        for module in package.modules().values() {
+            for test in module.test_functions() {
+                let compiler = FixturePlanCompiler::new(&child_parents, module);
+                let plan = CompiledTestPlan::compile(py, test, compiler);
+                plans.insert(test.name().to_string(), plan);
+            }
+        }
+
+        for child_package in package.packages().values() {
+            Self::compile_test_plans(py, child_package, &child_parents, plans);
+        }
+    }
+
     /// Executes all discovered tests and session-scoped fixture teardown.
     pub(crate) fn execute(&self, py: Python<'_>, session: &DiscoveredPackage) {
         if !self.validate_parametrization(session) {
             return;
         }
 
+        let mut test_plans = HashMap::new();
+        Self::compile_test_plans(py, session, &[], &mut test_plans);
+
         if let Err(error) = self.run_auto_use_fixtures(py, &[], session, FixtureScope::Session) {
             self.register_error_package_tests(session, &error);
             return;
         }
 
-        self.execute_package(py, session, &[]);
+        self.execute_package(py, session, &[], &mut test_plans);
         self.report_scope_cleanup(py, FixtureScope::Session);
     }
 
@@ -165,6 +194,7 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
         py: Python<'_>,
         module: &DiscoveredModule,
         parents: &[&DiscoveredPackage],
+        test_plans: &mut CompiledTestPlans,
     ) -> bool {
         if let Err(error) = self.run_auto_use_fixtures(py, parents, module, FixtureScope::Module) {
             self.register_error_module_tests(module, &error);
@@ -173,9 +203,12 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
 
         let mut passed = true;
         for test in module.test_functions() {
-            let mut resolver = RuntimeFixtureResolver::new(parents, module);
-            let variants = match TestVariantIterator::new(py, test, &mut resolver) {
-                Ok(variants) => variants,
+            let Some(test_plan) = test_plans.remove(&test.name().to_string()) else {
+                passed = false;
+                continue;
+            };
+            let test_plan = match test_plan {
+                Ok(plan) => plan,
                 Err(error) => {
                     self.register_error_test(
                         test,
@@ -188,6 +221,7 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
                     continue;
                 }
             };
+            let variants = TestVariantIterator::new(test, test_plan);
 
             for variant in variants {
                 let variant_passed = self.execute_test_variant(py, variant);
@@ -214,6 +248,7 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
         py: Python<'_>,
         package: &DiscoveredPackage,
         parents: &[&DiscoveredPackage],
+        test_plans: &mut CompiledTestPlans,
     ) -> bool {
         let mut child_parents = parents.to_vec();
         child_parents.push(package);
@@ -228,7 +263,7 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
 
         let mut passed = true;
         for module in package.modules().values() {
-            passed &= self.execute_module(py, module, &child_parents);
+            passed &= self.execute_module(py, module, &child_parents, test_plans);
             if self.max_fail_reached() {
                 break;
             }
@@ -236,7 +271,7 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
 
         if !self.max_fail_reached() {
             for child_package in package.packages().values() {
-                passed &= self.execute_package(py, child_package, &child_parents);
+                passed &= self.execute_package(py, child_package, &child_parents, test_plans);
                 if self.max_fail_reached() {
                     break;
                 }

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
@@ -11,7 +11,7 @@ use karva_metadata::{FlakyResult, JunitFlakyFailStatus, RunIgnoredMode};
 use karva_python_semantic::QualifiedTestName;
 use pyo3::prelude::*;
 
-use crate::extensions::fixtures::NormalizedFixture;
+use crate::extensions::fixtures::{FixtureId, FixturePlan, NormalizedFixture};
 use crate::extensions::functions::snapshot::SnapshotContext;
 use crate::extensions::tags::Tags;
 use crate::extensions::tags::expect_fail::ExpectFailTag;
@@ -51,12 +51,14 @@ struct VariantRunner<'runner, 'context, 'settings, 'test, 'py> {
     params: HashMap<String, Arc<Py<PyAny>>>,
     /// User-defined parameter ID used in the displayed test name.
     id: Option<String>,
+    /// Compiled fixture arena for this test.
+    fixture_plan: Rc<FixturePlan>,
     /// Fixtures passed as Python keyword arguments.
-    fixture_dependencies: Rc<[Rc<NormalizedFixture>]>,
+    fixture_dependencies: Rc<[FixtureId]>,
     /// Fixtures run for side effects but omitted from test arguments.
-    use_fixture_dependencies: Rc<[Rc<NormalizedFixture>]>,
+    use_fixture_dependencies: Rc<[FixtureId]>,
     /// Function-scoped auto-use fixtures.
-    auto_use_fixtures: Rc<[Rc<NormalizedFixture>]>,
+    auto_use_fixtures: Rc<[FixtureId]>,
     /// Test, parameter, and fixture tags resolved for this variant.
     tags: Tags,
     /// Module path used to build stable snapshot identity.
@@ -78,6 +80,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             test,
             params,
             id,
+            fixture_plan,
             fixture_dependencies,
             use_fixture_dependencies,
             auto_use_fixtures,
@@ -90,6 +93,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             test,
             params,
             id,
+            fixture_plan,
             fixture_dependencies,
             use_fixture_dependencies,
             auto_use_fixtures,
@@ -164,6 +168,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
         let setup_start = Instant::now();
         let fixtures = self.package_runner.prepare_test_fixtures(
             self.py,
+            &self.fixture_plan,
             &self.fixture_dependencies,
             &self.use_fixture_dependencies,
             &self.auto_use_fixtures,
@@ -194,13 +199,14 @@ impl<'runner, 'context, 'settings, 'test, 'py>
         let fixture_names = self
             .fixture_dependencies
             .iter()
-            .map(|fixture| fixture.function_name())
+            .map(|fixture_id| self.fixture_plan.fixture(*fixture_id).function_name())
             .collect::<Vec<_>>();
         let framework_fixture_names = self
             .fixture_dependencies
             .iter()
+            .map(|fixture_id| self.fixture_plan.fixture(*fixture_id))
             .filter(|fixture| fixture.name.module_path().module_name() == "karva._builtins")
-            .map(|fixture| fixture.function_name())
+            .map(NormalizedFixture::function_name)
             .collect::<Vec<_>>();
         let full_name = if let Some(id) = &self.id {
             format!("{name}({id})")

--- a/crates/karva_test_semantic/src/runner/test_iterator.rs
+++ b/crates/karva_test_semantic/src/runner/test_iterator.rs
@@ -7,10 +7,10 @@ use std::sync::Arc;
 use pyo3::prelude::*;
 
 use crate::discovery::DiscoveredTestFunction;
-use crate::extensions::fixtures::NormalizedFixture;
+use crate::extensions::fixtures::{FixtureId, FixturePlan};
 use crate::extensions::tags::Tags;
 use crate::extensions::tags::parametrize::ParametrizationArgs;
-use crate::runner::fixture_resolver::{FixtureResolutionResult, RuntimeFixtureResolver};
+use crate::runner::fixture_resolver::{FixturePlanCompiler, FixtureResolutionResult};
 
 /// A single variant of a test to be executed.
 ///
@@ -34,14 +34,17 @@ pub(super) struct TestVariant<'a> {
 
     pub id: Option<String>,
 
+    /// Arena shared by all fixture root groups for this test.
+    pub(super) fixture_plan: Rc<FixturePlan>,
+
     /// Fixtures to be passed as arguments to the test function.
-    pub(super) fixture_dependencies: Rc<[Rc<NormalizedFixture>]>,
+    pub(super) fixture_dependencies: Rc<[FixtureId]>,
 
     /// Fixtures from @usefixtures (run for side effects, not passed as args).
-    pub(super) use_fixture_dependencies: Rc<[Rc<NormalizedFixture>]>,
+    pub(super) use_fixture_dependencies: Rc<[FixtureId]>,
 
     /// Auto-use fixtures that run automatically before this test.
-    pub(super) auto_use_fixtures: Rc<[Rc<NormalizedFixture>]>,
+    pub(super) auto_use_fixtures: Rc<[FixtureId]>,
 
     /// Combined tags from the test and its parameter set.
     pub(super) tags: Tags,
@@ -55,21 +58,7 @@ impl TestVariant<'_> {
 
     /// Get the resolved tags including those from fixture dependencies.
     pub(super) fn resolved_tags(&self) -> Tags {
-        let mut tags = self.tags.clone();
-
-        for dependency in self.fixture_dependencies.iter() {
-            tags.extend(&dependency.resolved_tags());
-        }
-
-        for dependency in self.use_fixture_dependencies.iter() {
-            tags.extend(&dependency.resolved_tags());
-        }
-
-        for dependency in self.auto_use_fixtures.iter() {
-            tags.extend(&dependency.resolved_tags());
-        }
-
-        tags
+        self.tags.clone()
     }
 }
 
@@ -86,34 +75,42 @@ pub(super) struct TestVariantIterator<'a> {
     /// `ParametrizationArgs` are moved into the emitted variant (not cloned).
     param_args: std::vec::IntoIter<ParametrizationArgs>,
     /// Resolved fixtures passed as test arguments.
-    fixture_dependencies: Rc<[Rc<NormalizedFixture>]>,
+    fixture_plan: Rc<FixturePlan>,
+    fixture_dependencies: Rc<[FixtureId]>,
     /// Resolved side-effect-only fixtures.
-    use_fixture_dependencies: Rc<[Rc<NormalizedFixture>]>,
+    use_fixture_dependencies: Rc<[FixtureId]>,
     /// Resolved function-scoped auto-use fixtures.
-    auto_use_fixtures: Rc<[Rc<NormalizedFixture>]>,
+    auto_use_fixtures: Rc<[FixtureId]>,
 }
 
-impl<'a> TestVariantIterator<'a> {
-    /// Creates an iterator for one discovered test function.
-    ///
-    /// Resolves fixtures and computes all parametrize variants.
-    pub(super) fn new(
+/// Fixture roots and parameter cases compiled before any test fixture executes.
+pub(super) struct CompiledTestPlan {
+    fixture_plan: Rc<FixturePlan>,
+    fixture_dependencies: Rc<[FixtureId]>,
+    use_fixture_dependencies: Rc<[FixtureId]>,
+    auto_use_fixtures: Rc<[FixtureId]>,
+    param_args: Vec<ParametrizationArgs>,
+}
+
+impl CompiledTestPlan {
+    /// Resolves all fixture roots for one test without executing fixture code.
+    pub(super) fn compile(
         py: Python,
-        test: &'a DiscoveredTestFunction,
-        resolver: &mut RuntimeFixtureResolver,
+        test: &DiscoveredTestFunction,
+        mut compiler: FixturePlanCompiler<'_>,
     ) -> FixtureResolutionResult<Self> {
         let parametrize_param_names = test.tags.parametrize_names();
 
-        let auto_use_fixtures = resolver.get_normalized_auto_use_fixtures(
+        let auto_use_fixtures = compiler.get_normalized_auto_use_fixtures(
             py,
             crate::extensions::fixtures::FixtureScope::Function,
         )?;
 
         let fixture_dependencies =
-            resolver.resolve_test_fixtures(py, test, &parametrize_param_names)?;
+            compiler.resolve_test_fixtures(py, test, &parametrize_param_names)?;
 
         let use_fixture_names = test.tags.required_fixtures_names();
-        let use_fixture_dependencies = resolver.resolve_use_fixtures(py, &use_fixture_names)?;
+        let use_fixture_dependencies = compiler.resolve_use_fixtures(py, &use_fixture_names)?;
 
         let test_params = test.tags.parametrize_args();
         let param_args = if test_params.is_empty() {
@@ -123,12 +120,26 @@ impl<'a> TestVariantIterator<'a> {
         };
 
         Ok(Self {
-            test,
-            param_args: param_args.into_iter(),
+            fixture_plan: Rc::new(compiler.finish()),
             fixture_dependencies: Rc::from(fixture_dependencies),
             use_fixture_dependencies: Rc::from(use_fixture_dependencies),
             auto_use_fixtures: Rc::from(auto_use_fixtures),
+            param_args,
         })
+    }
+}
+
+impl<'a> TestVariantIterator<'a> {
+    /// Consumes one compiled plan into concrete test variants.
+    pub(super) fn new(test: &'a DiscoveredTestFunction, plan: CompiledTestPlan) -> Self {
+        Self {
+            test,
+            param_args: plan.param_args.into_iter(),
+            fixture_plan: plan.fixture_plan,
+            fixture_dependencies: plan.fixture_dependencies,
+            use_fixture_dependencies: plan.use_fixture_dependencies,
+            auto_use_fixtures: plan.auto_use_fixtures,
+        }
     }
 }
 
@@ -145,6 +156,7 @@ impl<'a> Iterator for TestVariantIterator<'a> {
             test: self.test,
             id: param_args.id().map(str::to_string),
             params: param_args.values,
+            fixture_plan: Rc::clone(&self.fixture_plan),
             fixture_dependencies: Rc::clone(&self.fixture_dependencies),
             use_fixture_dependencies: Rc::clone(&self.use_fixture_dependencies),
             auto_use_fixtures: Rc::clone(&self.auto_use_fixtures),


### PR DESCRIPTION
## Summary

Fixture dependencies are compiled before fixture execution into typed IDs backed by one arena per request context. This removes recursive `Rc<NormalizedFixture>` graphs while preserving request-aware fixture binding and diagnostic order.

## Test plan

Focused semantic tests, crate Clippy, and the fixture integration suite.