### PR TITLE
Isolate nested package fixture state

### DIFF
--- a/crates/karva/tests/it/extensions/fixtures/basic.rs
+++ b/crates/karva/tests/it/extensions/fixtures/basic.rs
@@ -106,6 +106,69 @@ def test_fixture_with_name_parameter(fixture_name):
 }
 
 #[test]
+fn test_parent_package_fixture_lives_through_descendant_packages() {
+    let context = TestContext::with_files([
+        (
+            "parent/conftest.py",
+            r#"
+from pathlib import Path
+
+import karva
+
+LOG = Path("lifecycle.log")
+LOG.write_text("")
+
+@karva.fixture(scope="package")
+def parent_fixture():
+    with LOG.open("a") as stream:
+        stream.write("setup\n")
+    yield "parent"
+    with LOG.open("a") as stream:
+        stream.write("teardown\n")
+"#,
+        ),
+        (
+            "parent/first/test_first.py",
+            r#"
+from pathlib import Path
+
+def test_first(parent_fixture):
+    assert parent_fixture == "parent"
+    assert Path("lifecycle.log").read_text() == "setup\n"
+"#,
+        ),
+        (
+            "parent/second/test_second.py",
+            r#"
+from pathlib import Path
+
+def test_second(parent_fixture):
+    assert parent_fixture == "parent"
+    assert Path("lifecycle.log").read_text() == "setup\n"
+"#,
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            PASS [TIME] parent.first.test_first::test_first(parent_fixture='parent')
+            PASS [TIME] parent.second.test_second::test_second(parent_fixture='parent')
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+    assert_eq!(
+        std::fs::read_to_string(context.root().join("lifecycle.log"))
+            .expect("read fixture lifecycle log"),
+        "setup\nteardown\n"
+    );
+}
+
+#[test]
 fn test_fixture_is_different_in_different_functions() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva/tests/it/extensions/fixtures/basic.rs
+++ b/crates/karva/tests/it/extensions/fixtures/basic.rs
@@ -161,11 +161,9 @@ def test_second(parent_fixture):
 
     ----- stderr -----
     ");
-    assert_eq!(
-        std::fs::read_to_string(context.root().join("lifecycle.log"))
-            .expect("read fixture lifecycle log"),
-        "setup\nteardown\n"
-    );
+    let lifecycle = std::fs::read_to_string(context.root().join("lifecycle.log"))
+        .expect("read fixture lifecycle log");
+    assert_eq!(lifecycle.lines().collect::<Vec<_>>(), ["setup", "teardown"]);
 }
 
 #[test]

--- a/crates/karva_test_semantic/src/extensions/fixtures/finalizer.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/finalizer.rs
@@ -1,5 +1,6 @@
 use std::rc::Rc;
 
+use camino::Utf8PathBuf;
 use pyo3::prelude::*;
 use pyo3::types::PyIterator;
 use ruff_python_ast::StmtFunctionDef;
@@ -46,6 +47,9 @@ pub struct Finalizer {
 
     /// The scope determines when this finalizer runs.
     pub(crate) scope: FixtureScope,
+
+    /// Defining package for package-scoped teardown.
+    pub(crate) package_owner: Utf8PathBuf,
 
     /// AST definition used to locate teardown errors.
     pub(crate) stmt_function_def: Rc<StmtFunctionDef>,

--- a/crates/karva_test_semantic/src/extensions/fixtures/normalized_fixture.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/normalized_fixture.rs
@@ -1,3 +1,6 @@
+use std::rc::Rc;
+
+use camino::{Utf8Path, Utf8PathBuf};
 use karva_python_semantic::QualifiedFunctionName;
 use pyo3::prelude::*;
 use ruff_python_ast::StmtFunctionDef;
@@ -49,6 +52,9 @@ pub struct NormalizedFixture {
     /// The scope at which this fixture's value is cached.
     pub(crate) scope: FixtureScope,
 
+    /// Package whose lifetime owns package-scoped values and finalizers.
+    pub(crate) package_owner: Utf8PathBuf,
+
     /// Whether this fixture uses yield for teardown logic.
     pub(crate) is_generator: bool,
 
@@ -78,6 +84,11 @@ impl NormalizedFixture {
         self.scope
     }
 
+    /// Returns the package that owns this fixture's package-scoped state.
+    pub(crate) fn package_owner(&self) -> &Utf8Path {
+        &self.package_owner
+    }
+
     /// Call this fixture with the already-resolved arguments and return the result.
     pub(crate) fn call(
         &self,
@@ -98,4 +109,3 @@ impl NormalizedFixture {
         }
     }
 }
-use std::rc::Rc;

--- a/crates/karva_test_semantic/src/runner/finalizer_cache.rs
+++ b/crates/karva_test_semantic/src/runner/finalizer_cache.rs
@@ -4,7 +4,7 @@ use pyo3::prelude::*;
 use ruff_db::diagnostic::Diagnostic;
 
 use crate::extensions::fixtures::{Finalizer, FixtureScope};
-use crate::runner::scoped_storage::ScopedStorage;
+use crate::runner::scoped_storage::{ScopeKey, ScopedStorage};
 
 /// Manages fixture teardown callbacks at different scope levels.
 ///
@@ -19,22 +19,27 @@ pub(super) struct FinalizerCache {
 impl FinalizerCache {
     /// Adds a finalizer to its declared scope's LIFO stack.
     pub(super) fn add_finalizer(&self, finalizer: Finalizer) {
-        self.storage
-            .get(finalizer.scope)
-            .borrow_mut()
-            .push(finalizer);
+        let package_owner = finalizer.package_owner.clone();
+        let scope = match finalizer.scope {
+            FixtureScope::Session => ScopeKey::Session,
+            FixtureScope::Package => ScopeKey::Package(&package_owner),
+            FixtureScope::Module => ScopeKey::Module,
+            FixtureScope::Function => ScopeKey::Function,
+        };
+        self.storage.with_mut(scope, |finalizers| {
+            finalizers.push(finalizer);
+        });
     }
 
     /// Drains one scope and returns diagnostics raised during teardown.
     pub(super) fn run_and_clear_scope(
         &self,
         py: Python<'_>,
-        scope: FixtureScope,
+        scope: ScopeKey<'_>,
     ) -> Vec<Diagnostic> {
         self.storage
-            .get(scope)
-            .borrow_mut()
-            .drain(..)
+            .take(scope)
+            .into_iter()
             .rev()
             .filter_map(|finalizer| finalizer.run(py).err())
             .collect()

--- a/crates/karva_test_semantic/src/runner/fixture_cache.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_cache.rs
@@ -4,8 +4,7 @@ use std::collections::HashMap;
 
 use pyo3::prelude::*;
 
-use crate::extensions::fixtures::FixtureScope;
-use crate::runner::scoped_storage::ScopedStorage;
+use crate::runner::scoped_storage::{ScopeKey, ScopedStorage};
 
 /// Caches fixture values at different scope levels.
 ///
@@ -19,21 +18,23 @@ pub(super) struct FixtureCache {
 
 impl FixtureCache {
     /// Returns a new Python reference to a cached fixture value.
-    pub(super) fn get(&self, py: Python<'_>, name: &str, scope: FixtureScope) -> Option<Py<PyAny>> {
+    pub(super) fn get(&self, py: Python<'_>, name: &str, scope: ScopeKey<'_>) -> Option<Py<PyAny>> {
         self.storage
-            .get(scope)
-            .borrow()
-            .get(name)
-            .map(|value| value.clone_ref(py))
+            .with(scope, |values| {
+                values.get(name).map(|value| value.clone_ref(py))
+            })
+            .flatten()
     }
 
     /// Caches a fixture value until its declared scope completes.
-    pub(super) fn insert(&self, name: String, value: Py<PyAny>, scope: FixtureScope) {
-        self.storage.get(scope).borrow_mut().insert(name, value);
+    pub(super) fn insert(&self, name: String, value: Py<PyAny>, scope: ScopeKey<'_>) {
+        self.storage.with_mut(scope, |values| {
+            values.insert(name, value);
+        });
     }
 
     /// Drops every cached value owned by one completed scope.
-    pub(super) fn clear_scope(&self, scope: FixtureScope) {
-        self.storage.get(scope).borrow_mut().clear();
+    pub(super) fn clear_scope(&self, scope: ScopeKey<'_>) {
+        drop(self.storage.take(scope));
     }
 }

--- a/crates/karva_test_semantic/src/runner/fixture_resolver.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_resolver.rs
@@ -3,6 +3,7 @@
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
+use camino::Utf8Path;
 use pyo3::prelude::*;
 use ruff_python_ast::StmtFunctionDef;
 use ruff_source_file::SourceFile;
@@ -26,6 +27,8 @@ pub(super) struct FixturePlanCompiler<'a> {
     parents: &'a [&'a DiscoveredPackage],
     /// Fixture provider at the active package, module, or session scope.
     current: &'a (dyn HasFixtures<'a> + 'a),
+    /// Package owning fixtures provided by `current`.
+    current_package: &'a Utf8Path,
     /// Definition IDs reused within this compilation pass.
     fixture_ids: HashMap<String, FixtureId>,
 
@@ -162,13 +165,36 @@ impl<'a> FixturePlanCompiler<'a> {
     pub(super) fn new(
         parents: &'a [&'a DiscoveredPackage],
         current: &'a (dyn HasFixtures<'a> + 'a),
+        current_package: &'a Utf8Path,
     ) -> Self {
         Self {
             parents,
             current,
+            current_package,
             fixture_ids: HashMap::new(),
             fixtures: Vec::new(),
         }
+    }
+
+    /// Finds the package whose provider contributed `fixture`.
+    fn package_owner(&self, fixture: &DiscoveredFixture) -> &Utf8Path {
+        let name = fixture.name().function_name();
+        if self
+            .current
+            .get_fixture(name)
+            .is_some_and(|candidate| std::ptr::eq(candidate, fixture))
+        {
+            return self.current_package;
+        }
+
+        self.parents
+            .iter()
+            .find(|package| {
+                package
+                    .get_fixture(name)
+                    .is_some_and(|candidate| std::ptr::eq(candidate, fixture))
+            })
+            .map_or(self.current_package, |package| package.path())
     }
 
     /// Finishes the immutable arena after all requested root groups are compiled.
@@ -201,6 +227,7 @@ impl<'a> FixturePlanCompiler<'a> {
             name: fixture.name().clone(),
             dependencies: dependent_fixtures,
             scope: fixture.scope(),
+            package_owner: self.package_owner(fixture).to_path_buf(),
             is_generator: fixture.is_generator(),
             py_function: fixture.function().clone_ref(py),
             stmt_function_def: Rc::clone(fixture.stmt_function_def()),

--- a/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
 
+use camino::Utf8Path;
 use karva_diagnostic::{FixtureFailure, FixtureUsage};
 use pyo3::prelude::*;
 use pyo3::types::PyIterator;
@@ -17,6 +18,7 @@ use crate::extensions::fixtures::{
 };
 use crate::runner::FixtureArguments;
 use crate::runner::fixture_resolver::FixturePlanCompiler;
+use crate::runner::scoped_storage::ScopeKey;
 use crate::utils::run_coroutine;
 
 use super::PackageRunner;
@@ -33,14 +35,16 @@ impl PackageRunner<'_, '_> {
         py: Python<'_>,
         parents: &'a [&'a crate::discovery::DiscoveredPackage],
         current: &'a (dyn HasFixtures<'a> + 'a),
+        current_package: &'a Utf8Path,
         scope: FixtureScope,
     ) -> Result<(), TestError> {
-        let mut compiler = FixturePlanCompiler::new(parents, current);
+        let scope_key = scope_key(scope, current_package);
+        let mut compiler = FixturePlanCompiler::new(parents, current, current_package);
         let auto_use_fixtures = match compiler.get_normalized_auto_use_fixtures(py, scope) {
             Ok(fixtures) => fixtures,
             Err(error) => {
                 return Err(TestError::new(fixture_resolution_diagnostic(error))
-                    .with_related(self.clean_up_scope(py, scope)));
+                    .with_related(self.clean_up_scope(py, scope_key)));
             }
         };
         let fixture_plan = compiler.finish();
@@ -53,7 +57,7 @@ impl PackageRunner<'_, '_> {
 
         Err(failures
             .into_test_error(py, self.context.is_verbose())
-            .with_related(self.clean_up_scope(py, scope)))
+            .with_related(self.clean_up_scope(py, scope_key)))
     }
 
     /// Runs function-scoped finalizers and clears their cached fixture values.
@@ -67,19 +71,19 @@ impl PackageRunner<'_, '_> {
             .rev()
             .filter_map(|finalizer| finalizer.run(py).err())
             .collect::<Vec<_>>();
-        diagnostics.extend(self.clean_up_scope(py, FixtureScope::Function));
+        diagnostics.extend(self.clean_up_scope(py, ScopeKey::Function));
         diagnostics
     }
 
     /// Clears cached fixture values and runs finalizers for one completed scope.
-    pub(super) fn clean_up_scope(&self, py: Python<'_>, scope: FixtureScope) -> Vec<Diagnostic> {
+    pub(super) fn clean_up_scope(&self, py: Python<'_>, scope: ScopeKey<'_>) -> Vec<Diagnostic> {
         let diagnostics = self.finalizer_cache.run_and_clear_scope(py, scope);
         self.fixture_cache.clear_scope(scope);
         diagnostics
     }
 
     /// Cleans one scope and promotes teardown failures to run diagnostics.
-    pub(super) fn report_scope_cleanup(&self, py: Python<'_>, scope: FixtureScope) {
+    pub(super) fn report_scope_cleanup(&self, py: Python<'_>, scope: ScopeKey<'_>) {
         for diagnostic in self.clean_up_scope(py, scope) {
             self.context.add_run_diagnostic(diagnostic);
         }
@@ -156,10 +160,8 @@ impl PackageRunner<'_, '_> {
         fixture_id: FixtureId,
     ) -> Result<(Py<PyAny>, Option<Finalizer>), FixtureCallError> {
         let fixture = fixture_plan.fixture(fixture_id);
-        if let Some(cached) = self
-            .fixture_cache
-            .get(py, fixture.function_name(), fixture.scope())
-        {
+        let scope = scope_key(fixture.scope(), fixture.package_owner());
+        if let Some(cached) = self.fixture_cache.get(py, fixture.function_name(), scope) {
             return Ok((cached, None));
         }
 
@@ -191,7 +193,7 @@ impl PackageRunner<'_, '_> {
         self.fixture_cache.insert(
             fixture.function_name().to_string(),
             value.clone_ref(py),
-            fixture.scope(),
+            scope,
         );
 
         let function_finalizer = finalizer.and_then(|finalizer| {
@@ -228,6 +230,15 @@ impl PackageRunner<'_, '_> {
             }
         }
         errors
+    }
+}
+
+fn scope_key(scope: FixtureScope, package_owner: &Utf8Path) -> ScopeKey<'_> {
+    match scope {
+        FixtureScope::Session => ScopeKey::Session,
+        FixtureScope::Package => ScopeKey::Package(package_owner),
+        FixtureScope::Module => ScopeKey::Module,
+        FixtureScope::Function => ScopeKey::Function,
     }
 }
 
@@ -391,6 +402,7 @@ fn get_value_and_finalizer(
             fixture_return: fixture_call_result,
             is_async: true,
             scope: fixture.scope(),
+            package_owner: fixture.package_owner().to_path_buf(),
             stmt_function_def: Rc::clone(&fixture.stmt_function_def),
             source_file: fixture.source_file.clone(),
         };
@@ -412,6 +424,7 @@ fn get_value_and_finalizer(
                     fixture_return: bound_iterator.clone().unbind().into_any(),
                     is_async: false,
                     scope: fixture.scope(),
+                    package_owner: fixture.package_owner().to_path_buf(),
                     stmt_function_def: Rc::clone(&fixture.stmt_function_def),
                     source_file: fixture.source_file.clone(),
                 };

--- a/crates/karva_test_semantic/src/runner/package_runner/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/mod.rs
@@ -12,6 +12,7 @@ use crate::diagnostic::{fixture_resolution_diagnostic, invalid_parametrize_diagn
 use crate::discovery::{DiscoveredModule, DiscoveredPackage, DiscoveredTestFunction};
 use crate::extensions::fixtures::FixtureScope;
 use crate::runner::fixture_resolver::{FixturePlanCompiler, FixtureResolutionError};
+use crate::runner::scoped_storage::ScopeKey;
 use crate::runner::test_iterator::{CompiledTestPlan, TestVariantIterator};
 use crate::runner::{FinalizerCache, FixtureCache};
 
@@ -159,7 +160,7 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
 
         for module in package.modules().values() {
             for test in module.test_functions() {
-                let compiler = FixturePlanCompiler::new(&child_parents, module);
+                let compiler = FixturePlanCompiler::new(&child_parents, module, package.path());
                 let plan = CompiledTestPlan::compile(py, test, compiler);
                 plans.insert(test.name().to_string(), plan);
             }
@@ -179,13 +180,15 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
         let mut test_plans = HashMap::new();
         Self::compile_test_plans(py, session, &[], &mut test_plans);
 
-        if let Err(error) = self.run_auto_use_fixtures(py, &[], session, FixtureScope::Session) {
+        if let Err(error) =
+            self.run_auto_use_fixtures(py, &[], session, session.path(), FixtureScope::Session)
+        {
             self.register_error_package_tests(session, &error);
             return;
         }
 
         self.execute_package(py, session, &[], &mut test_plans);
-        self.report_scope_cleanup(py, FixtureScope::Session);
+        self.report_scope_cleanup(py, ScopeKey::Session);
     }
 
     /// Executes module auto-use fixtures, variants, and module teardown.
@@ -196,7 +199,12 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
         parents: &[&DiscoveredPackage],
         test_plans: &mut CompiledTestPlans,
     ) -> bool {
-        if let Err(error) = self.run_auto_use_fixtures(py, parents, module, FixtureScope::Module) {
+        let package_path = parents
+            .last()
+            .map_or_else(|| module.path(), |package| package.path());
+        if let Err(error) =
+            self.run_auto_use_fixtures(py, parents, module, package_path, FixtureScope::Module)
+        {
             self.register_error_module_tests(module, &error);
             return false;
         }
@@ -238,7 +246,7 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
             }
         }
 
-        self.report_scope_cleanup(py, FixtureScope::Module);
+        self.report_scope_cleanup(py, ScopeKey::Module);
         passed
     }
 
@@ -254,8 +262,13 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
         child_parents.push(package);
 
         if package.configuration_module_impl().is_some()
-            && let Err(error) =
-                self.run_auto_use_fixtures(py, parents, package, FixtureScope::Package)
+            && let Err(error) = self.run_auto_use_fixtures(
+                py,
+                parents,
+                package,
+                package.path(),
+                FixtureScope::Package,
+            )
         {
             self.register_error_package_tests(package, &error);
             return false;
@@ -278,7 +291,7 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
             }
         }
 
-        self.report_scope_cleanup(py, FixtureScope::Package);
+        self.report_scope_cleanup(py, ScopeKey::Package(package.path()));
         passed
     }
 }

--- a/crates/karva_test_semantic/src/runner/scoped_storage.rs
+++ b/crates/karva_test_semantic/src/runner/scoped_storage.rs
@@ -1,33 +1,64 @@
-//! Shared storage primitive for state isolated by fixture scope.
+//! Shared storage primitive for state isolated by fixture lifetime.
 
 use std::cell::RefCell;
+use std::collections::HashMap;
 
-use crate::extensions::fixtures::FixtureScope;
+use camino::{Utf8Path, Utf8PathBuf};
 
-/// A per-scope storage container that maps each `FixtureScope` to its own `RefCell<T>`.
+/// Exact runtime lifetime owning a fixture value or finalizer.
+#[derive(Clone, Copy, Debug)]
+pub(super) enum ScopeKey<'a> {
+    Session,
+    Package(&'a Utf8Path),
+    Module,
+    Function,
+}
+
+/// Storage for session, package, module, and function fixture state.
 ///
-/// Used by both `FixtureCache` and `FinalizerCache` to avoid duplicating the same
-/// four-field struct and `match`-based accessor.
+/// Package state is keyed by defining package. Nested package cleanup therefore
+/// cannot clear values owned by an ancestor package.
 #[derive(Debug, Default)]
 pub(super) struct ScopedStorage<T: Default> {
-    /// Values retained for the complete worker session.
     session: RefCell<T>,
-    /// Values retained while one discovered package executes.
-    package: RefCell<T>,
-    /// Values retained while one test module executes.
+    packages: RefCell<HashMap<Utf8PathBuf, T>>,
     module: RefCell<T>,
-    /// Values retained for one concrete test attempt.
     function: RefCell<T>,
 }
 
 impl<T: Default> ScopedStorage<T> {
-    /// Returns interior-mutable storage belonging to `scope`.
-    pub(super) fn get(&self, scope: FixtureScope) -> &RefCell<T> {
-        match scope {
-            FixtureScope::Session => &self.session,
-            FixtureScope::Package => &self.package,
-            FixtureScope::Module => &self.module,
-            FixtureScope::Function => &self.function,
+    /// Reads state when it exists. Package keys are absent until first use.
+    pub(super) fn with<R>(&self, key: ScopeKey<'_>, read: impl FnOnce(&T) -> R) -> Option<R> {
+        match key {
+            ScopeKey::Session => Some(read(&self.session.borrow())),
+            ScopeKey::Package(path) => self.packages.borrow().get(path).map(read),
+            ScopeKey::Module => Some(read(&self.module.borrow())),
+            ScopeKey::Function => Some(read(&self.function.borrow())),
+        }
+    }
+
+    /// Mutates state, creating package-owned state on first use.
+    pub(super) fn with_mut<R>(&self, key: ScopeKey<'_>, update: impl FnOnce(&mut T) -> R) -> R {
+        match key {
+            ScopeKey::Session => update(&mut self.session.borrow_mut()),
+            ScopeKey::Package(path) => update(
+                self.packages
+                    .borrow_mut()
+                    .entry(path.to_path_buf())
+                    .or_default(),
+            ),
+            ScopeKey::Module => update(&mut self.module.borrow_mut()),
+            ScopeKey::Function => update(&mut self.function.borrow_mut()),
+        }
+    }
+
+    /// Takes all state owned by a completed lifetime.
+    pub(super) fn take(&self, key: ScopeKey<'_>) -> T {
+        match key {
+            ScopeKey::Session => std::mem::take(&mut self.session.borrow_mut()),
+            ScopeKey::Package(path) => self.packages.borrow_mut().remove(path).unwrap_or_default(),
+            ScopeKey::Module => std::mem::take(&mut self.module.borrow_mut()),
+            ScopeKey::Function => std::mem::take(&mut self.function.borrow_mut()),
         }
     }
 }


### PR DESCRIPTION
## Summary

Package-scoped fixture values and finalizers are keyed by their defining package. Nested package cleanup can no longer tear down ancestor-owned fixtures before sibling descendants finish.

## Test plan

Package-scope integrations, crate Clippy, and a regression covering sibling descendant packages.