### PR TITLE
Expand parameter matrices lazily

### DIFF
--- a/crates/karva_test_semantic/src/extensions/tags/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/mod.rs
@@ -21,7 +21,7 @@ mod use_fixtures;
 use custom::CustomTag;
 use expect_fail::ExpectFailTag;
 use fail_slow::FailSlowTag;
-use parametrize::{InvalidParametrizeError, ParametrizationArgs, ParametrizeTag};
+use parametrize::{InvalidParametrizeError, ParameterPlan, ParametrizeTag};
 use skip::SkipTag;
 use timeout::TimeoutTag;
 use use_fixtures::UseFixturesTag;
@@ -229,6 +229,121 @@ pub struct Tags {
     inner: Vec<Tag>,
 }
 
+/// Runtime tag policy compiled from decorators and parameter-specific marks.
+#[derive(Clone, Debug, Default)]
+pub struct RuntimeTags {
+    skip: SkipPolicy,
+    expect_fail: Option<ExpectFailTag>,
+    timeout: Option<TimeoutTag>,
+    fail_slow: Option<FailSlowTag>,
+    custom_names: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default)]
+enum SkipPolicy {
+    #[default]
+    Run,
+    Skip(Option<String>),
+}
+
+impl RuntimeTags {
+    fn from_tags(tags: &Tags) -> Self {
+        let mut runtime = Self::default();
+        runtime.extend(tags);
+        runtime
+    }
+
+    pub(crate) fn extend(&mut self, tags: &Tags) {
+        for tag in &tags.inner {
+            match tag {
+                Tag::Skip(skip) if matches!(self.skip, SkipPolicy::Run) && skip.should_skip() => {
+                    self.skip = SkipPolicy::Skip(skip.reason());
+                }
+                Tag::ExpectFail(expect_fail) if self.expect_fail.is_none() => {
+                    self.expect_fail = Some(expect_fail.clone());
+                }
+                Tag::Timeout(timeout) if self.timeout.is_none() => self.timeout = Some(*timeout),
+                Tag::FailSlow(fail_slow) if self.fail_slow.is_none() => {
+                    self.fail_slow = Some(*fail_slow);
+                }
+                Tag::Custom(custom) => self.custom_names.push(custom.name().to_string()),
+                _ => {}
+            }
+        }
+    }
+
+    pub(crate) fn should_skip(&self) -> (bool, Option<String>) {
+        match &self.skip {
+            SkipPolicy::Run => (false, None),
+            SkipPolicy::Skip(reason) => (true, reason.clone()),
+        }
+    }
+
+    pub(crate) fn custom_tag_names(&self) -> Vec<&str> {
+        self.custom_names.iter().map(String::as_str).collect()
+    }
+
+    pub(crate) fn expect_fail_tag(&self) -> Option<ExpectFailTag> {
+        self.expect_fail.clone()
+    }
+
+    pub(crate) fn timeout_tag(&self) -> Option<TimeoutTag> {
+        self.timeout
+    }
+
+    pub(crate) fn fail_slow_tag(&self) -> Option<FailSlowTag> {
+        self.fail_slow
+    }
+}
+
+/// Static tag metadata and lazy parameter matrix compiled for one test.
+pub struct CompiledTags {
+    parameter_names: HashSet<String>,
+    required_fixtures: Vec<String>,
+    parameters: ParameterPlan,
+    runtime: RuntimeTags,
+}
+
+impl CompiledTags {
+    pub(crate) fn new(tags: &Tags) -> Self {
+        let mut parameter_names = HashSet::new();
+        let mut required_fixtures = Vec::new();
+        let mut dimensions = Vec::new();
+
+        for tag in &tags.inner {
+            match tag {
+                Tag::Parametrize(parametrize) => {
+                    parameter_names.extend(parametrize.names().iter().cloned());
+                    dimensions.push(parametrize.each_arg_value());
+                }
+                Tag::UseFixtures(use_fixtures) => {
+                    required_fixtures.extend(use_fixtures.fixture_names().iter().cloned());
+                }
+                _ => {}
+            }
+        }
+
+        Self {
+            parameter_names,
+            required_fixtures,
+            parameters: ParameterPlan::new(dimensions),
+            runtime: RuntimeTags::from_tags(tags),
+        }
+    }
+
+    pub(crate) fn parameter_names(&self) -> HashSet<&str> {
+        self.parameter_names.iter().map(String::as_str).collect()
+    }
+
+    pub(crate) fn required_fixtures(&self) -> &[String] {
+        &self.required_fixtures
+    }
+
+    pub(crate) fn into_runtime(self) -> (ParameterPlan, RuntimeTags) {
+        (self.parameters, self.runtime)
+    }
+}
+
 impl Tags {
     pub(crate) fn new(tags: Vec<Tag>) -> Self {
         Self { inner: tags }
@@ -303,44 +418,6 @@ impl Tags {
         Ok(Some(Self { inner: tags }))
     }
 
-    /// Return all parametrizations
-    ///
-    /// This function ensures that if we have multiple parametrize tags, we combine them together.
-    pub(crate) fn parametrize_args(&self) -> Vec<ParametrizationArgs> {
-        let mut param_args: Vec<ParametrizationArgs> = vec![ParametrizationArgs::default()];
-
-        for tag in &self.inner {
-            if let Tag::Parametrize(parametrize_tag) = tag {
-                let current_values = parametrize_tag.each_arg_value();
-
-                let mut new_param_args =
-                    Vec::with_capacity(param_args.len() * current_values.len());
-
-                for existing_params in &param_args {
-                    for new_params in &current_values {
-                        let mut combined_params = existing_params.clone();
-                        combined_params.extend(new_params.clone());
-                        new_param_args.push(combined_params);
-                    }
-                }
-                param_args = new_param_args;
-            }
-        }
-        param_args
-    }
-
-    pub(crate) fn parametrize_names(&self) -> HashSet<&str> {
-        self.inner
-            .iter()
-            .filter_map(|tag| match tag {
-                Tag::Parametrize(parametrize) => Some(parametrize.names()),
-                _ => None,
-            })
-            .flatten()
-            .map(String::as_str)
-            .collect()
-    }
-
     pub(crate) fn validate_parametrize(
         &self,
         function: &StmtFunctionDef,
@@ -358,83 +435,16 @@ impl Tags {
             }
         }
 
-        for params in self.parametrize_args() {
-            let Some(id) = params.id() else {
-                continue;
-            };
-            if id.is_empty() {
-                return Err(InvalidParametrizeError::EmptyId);
+        for tag in &self.inner {
+            if let Tag::Parametrize(parametrize) = tag {
+                for params in parametrize.each_arg_value() {
+                    if params.id().is_some_and(str::is_empty) {
+                        return Err(InvalidParametrizeError::EmptyId);
+                    }
+                }
             }
         }
 
         Ok(())
-    }
-
-    /// Get all required fixture names for the given test.
-    pub(crate) fn required_fixtures_names(&self) -> Vec<String> {
-        self.inner
-            .iter()
-            .filter_map(|tag| match tag {
-                Tag::UseFixtures(use_fixtures_tag) => Some(use_fixtures_tag.fixture_names()),
-                _ => None,
-            })
-            .flat_map(|names| names.iter().cloned())
-            .collect()
-    }
-
-    /// Returns true if any skip tag should be skipped.
-    pub(crate) fn should_skip(&self) -> (bool, Option<String>) {
-        for tag in &self.inner {
-            if let Tag::Skip(skip_tag) = tag {
-                if skip_tag.should_skip() {
-                    return (true, skip_tag.reason());
-                }
-            }
-        }
-        (false, None)
-    }
-
-    /// Return the names of all custom tags.
-    pub(crate) fn custom_tag_names(&self) -> Vec<&str> {
-        self.inner
-            .iter()
-            .filter_map(|tag| {
-                if let Tag::Custom(custom) = tag {
-                    Some(custom.name())
-                } else {
-                    None
-                }
-            })
-            .collect()
-    }
-
-    /// Return the `ExpectFailTag` if it exists.
-    pub(crate) fn expect_fail_tag(&self) -> Option<ExpectFailTag> {
-        for tag in &self.inner {
-            if let Tag::ExpectFail(expect_fail_tag) = tag {
-                return Some(expect_fail_tag.clone());
-            }
-        }
-        None
-    }
-
-    /// Return the `TimeoutTag` if it exists.
-    pub(crate) fn timeout_tag(&self) -> Option<TimeoutTag> {
-        for tag in &self.inner {
-            if let Tag::Timeout(timeout_tag) = tag {
-                return Some(*timeout_tag);
-            }
-        }
-        None
-    }
-
-    /// Return the `FailSlowTag` if it exists.
-    pub(crate) fn fail_slow_tag(&self) -> Option<FailSlowTag> {
-        for tag in &self.inner {
-            if let Tag::FailSlow(fail_slow_tag) = tag {
-                return Some(*fail_slow_tag);
-            }
-        }
-        None
     }
 }

--- a/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
@@ -426,6 +426,76 @@ impl ParametrizationArgs {
     }
 }
 
+/// Lazily expanded Cartesian product of stacked parametrization decorators.
+#[derive(Debug)]
+pub struct ParameterPlan {
+    dimensions: Vec<Vec<ParametrizationArgs>>,
+}
+
+impl ParameterPlan {
+    pub(crate) fn new(dimensions: Vec<Vec<ParametrizationArgs>>) -> Self {
+        Self { dimensions }
+    }
+}
+
+impl IntoIterator for ParameterPlan {
+    type Item = ParametrizationArgs;
+    type IntoIter = ParameterPlanIterator;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let complete = self.dimensions.iter().any(Vec::is_empty);
+        let indices = vec![0; self.dimensions.len()];
+        ParameterPlanIterator {
+            dimensions: self.dimensions,
+            indices,
+            complete,
+        }
+    }
+}
+
+/// Mixed-radix iterator that materializes only the next parameter combination.
+pub struct ParameterPlanIterator {
+    dimensions: Vec<Vec<ParametrizationArgs>>,
+    indices: Vec<usize>,
+    complete: bool,
+}
+
+impl Iterator for ParameterPlanIterator {
+    type Item = ParametrizationArgs;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.complete {
+            return None;
+        }
+
+        if self.dimensions.is_empty() {
+            self.complete = true;
+            return Some(ParametrizationArgs::default());
+        }
+
+        let mut combination = ParametrizationArgs::default();
+        for (dimension, index) in self.dimensions.iter().zip(&self.indices) {
+            combination.extend(dimension[*index].clone());
+        }
+
+        self.advance();
+        Some(combination)
+    }
+}
+
+impl ParameterPlanIterator {
+    fn advance(&mut self) {
+        for dimension_index in (0..self.indices.len()).rev() {
+            self.indices[dimension_index] += 1;
+            if self.indices[dimension_index] < self.dimensions[dimension_index].len() {
+                return;
+            }
+            self.indices[dimension_index] = 0;
+        }
+        self.complete = true;
+    }
+}
+
 fn make_unique_parametrize_ids(parametrizations: &mut [ParametrizationArgs]) {
     let mut id_counts = HashMap::new();
     for parametrization in &*parametrizations {
@@ -838,5 +908,44 @@ pub(super) fn handle_custom_parametrize_param(
         })
     } else {
         Ok(default_parametrization())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ParameterPlan, ParametrizationArgs};
+
+    fn args(id: &str) -> ParametrizationArgs {
+        ParametrizationArgs {
+            id: id.to_string(),
+            has_explicit_id: true,
+            ..ParametrizationArgs::default()
+        }
+    }
+
+    #[test]
+    fn parameter_plan_preserves_stacked_decorator_order() {
+        let combinations = ParameterPlan::new(vec![
+            vec![args("a0"), args("a1")],
+            vec![args("b0"), args("b1"), args("b2")],
+        ])
+        .into_iter()
+        .filter_map(|arguments| arguments.id().map(str::to_string))
+        .collect::<Vec<_>>();
+
+        assert_eq!(
+            combinations,
+            ["a0-b0", "a0-b1", "a0-b2", "a1-b0", "a1-b1", "a1-b2"]
+        );
+    }
+
+    #[test]
+    fn parameter_plan_emits_one_case_without_parametrization() {
+        let combinations = ParameterPlan::new(Vec::new())
+            .into_iter()
+            .collect::<Vec<_>>();
+
+        assert_eq!(combinations.len(), 1);
+        assert_eq!(combinations[0].id(), None);
     }
 }

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
@@ -13,7 +13,7 @@ use pyo3::prelude::*;
 
 use crate::extensions::fixtures::{FixtureId, FixturePlan, NormalizedFixture};
 use crate::extensions::functions::snapshot::SnapshotContext;
-use crate::extensions::tags::Tags;
+use crate::extensions::tags::RuntimeTags;
 use crate::extensions::tags::expect_fail::ExpectFailTag;
 use crate::extensions::tags::fail_slow::FailSlowTag;
 use crate::extensions::tags::timeout::TimeoutTag;
@@ -60,7 +60,7 @@ struct VariantRunner<'runner, 'context, 'settings, 'test, 'py> {
     /// Function-scoped auto-use fixtures.
     auto_use_fixtures: Rc<[FixtureId]>,
     /// Test, parameter, and fixture tags resolved for this variant.
-    tags: Tags,
+    tags: RuntimeTags,
     /// Module path used to build stable snapshot identity.
     module_path: camino::Utf8PathBuf,
 }
@@ -74,7 +74,6 @@ impl<'runner, 'context, 'settings, 'test, 'py>
         py: Python<'py>,
         variant: TestVariant<'test>,
     ) -> Self {
-        let tags = variant.resolved_tags();
         let module_path = variant.module_path().clone();
         let TestVariant {
             test,
@@ -84,7 +83,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             fixture_dependencies,
             use_fixture_dependencies,
             auto_use_fixtures,
-            tags: _,
+            tags,
         } = variant;
 
         Self {

--- a/crates/karva_test_semantic/src/runner/test_iterator.rs
+++ b/crates/karva_test_semantic/src/runner/test_iterator.rs
@@ -8,8 +8,8 @@ use pyo3::prelude::*;
 
 use crate::discovery::DiscoveredTestFunction;
 use crate::extensions::fixtures::{FixtureId, FixturePlan};
-use crate::extensions::tags::Tags;
-use crate::extensions::tags::parametrize::ParametrizationArgs;
+use crate::extensions::tags::parametrize::{ParameterPlan, ParameterPlanIterator};
+use crate::extensions::tags::{CompiledTags, RuntimeTags};
 use crate::runner::fixture_resolver::{FixturePlanCompiler, FixtureResolutionResult};
 
 /// A single variant of a test to be executed.
@@ -47,18 +47,13 @@ pub(super) struct TestVariant<'a> {
     pub(super) auto_use_fixtures: Rc<[FixtureId]>,
 
     /// Combined tags from the test and its parameter set.
-    pub(super) tags: Tags,
+    pub(super) tags: RuntimeTags,
 }
 
 impl TestVariant<'_> {
     /// Get the module path for diagnostics.
     pub(super) fn module_path(&self) -> &camino::Utf8PathBuf {
         self.test.name().module_path().path()
-    }
-
-    /// Get the resolved tags including those from fixture dependencies.
-    pub(super) fn resolved_tags(&self) -> Tags {
-        self.tags.clone()
     }
 }
 
@@ -73,7 +68,9 @@ pub(super) struct TestVariantIterator<'a> {
     test: &'a DiscoveredTestFunction,
     /// Consumed as we iterate, so `values` and `tags` on each
     /// `ParametrizationArgs` are moved into the emitted variant (not cloned).
-    param_args: std::vec::IntoIter<ParametrizationArgs>,
+    param_args: ParameterPlanIterator,
+    /// Runtime policy shared by every parameter variant.
+    runtime_tags: RuntimeTags,
     /// Resolved fixtures passed as test arguments.
     fixture_plan: Rc<FixturePlan>,
     fixture_dependencies: Rc<[FixtureId]>,
@@ -89,7 +86,8 @@ pub(super) struct CompiledTestPlan {
     fixture_dependencies: Rc<[FixtureId]>,
     use_fixture_dependencies: Rc<[FixtureId]>,
     auto_use_fixtures: Rc<[FixtureId]>,
-    param_args: Vec<ParametrizationArgs>,
+    parameters: ParameterPlan,
+    runtime_tags: RuntimeTags,
 }
 
 impl CompiledTestPlan {
@@ -99,7 +97,8 @@ impl CompiledTestPlan {
         test: &DiscoveredTestFunction,
         mut compiler: FixturePlanCompiler<'_>,
     ) -> FixtureResolutionResult<Self> {
-        let parametrize_param_names = test.tags.parametrize_names();
+        let tags = CompiledTags::new(&test.tags);
+        let parametrize_param_names = tags.parameter_names();
 
         let auto_use_fixtures = compiler.get_normalized_auto_use_fixtures(
             py,
@@ -109,22 +108,17 @@ impl CompiledTestPlan {
         let fixture_dependencies =
             compiler.resolve_test_fixtures(py, test, &parametrize_param_names)?;
 
-        let use_fixture_names = test.tags.required_fixtures_names();
-        let use_fixture_dependencies = compiler.resolve_use_fixtures(py, &use_fixture_names)?;
-
-        let test_params = test.tags.parametrize_args();
-        let param_args = if test_params.is_empty() {
-            vec![ParametrizationArgs::default()]
-        } else {
-            test_params
-        };
+        let use_fixture_dependencies =
+            compiler.resolve_use_fixtures(py, tags.required_fixtures())?;
+        let (parameters, runtime_tags) = tags.into_runtime();
 
         Ok(Self {
             fixture_plan: Rc::new(compiler.finish()),
             fixture_dependencies: Rc::from(fixture_dependencies),
             use_fixture_dependencies: Rc::from(use_fixture_dependencies),
             auto_use_fixtures: Rc::from(auto_use_fixtures),
-            param_args,
+            parameters,
+            runtime_tags,
         })
     }
 }
@@ -134,7 +128,8 @@ impl<'a> TestVariantIterator<'a> {
     pub(super) fn new(test: &'a DiscoveredTestFunction, plan: CompiledTestPlan) -> Self {
         Self {
             test,
-            param_args: plan.param_args.into_iter(),
+            param_args: plan.parameters.into_iter(),
+            runtime_tags: plan.runtime_tags,
             fixture_plan: plan.fixture_plan,
             fixture_dependencies: plan.fixture_dependencies,
             use_fixture_dependencies: plan.use_fixture_dependencies,
@@ -149,7 +144,7 @@ impl<'a> Iterator for TestVariantIterator<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         let param_args = self.param_args.next()?;
 
-        let mut tags = self.test.tags.clone();
+        let mut tags = self.runtime_tags.clone();
         tags.extend(&param_args.tags);
 
         Some(TestVariant {
@@ -168,5 +163,3 @@ impl<'a> Iterator for TestVariantIterator<'a> {
         self.param_args.size_hint()
     }
 }
-
-impl ExactSizeIterator for TestVariantIterator<'_> {}


### PR DESCRIPTION
## Summary

Stacked parametrization now uses a mixed-radix iterator that materializes one case at a time instead of building the full Cartesian product. Runtime tag policy is compiled once, so variants avoid repeated raw tag scans and fixture metadata extraction.

## Test plan

Semantic unit tests, crate Clippy, and parametrization integrations.