### PR TITLE
Make semantic run state explicitly owned

### DIFF
--- a/crates/karva_test_semantic/src/context.rs
+++ b/crates/karva_test_semantic/src/context.rs
@@ -1,5 +1,3 @@
-use std::cell::RefCell;
-
 use camino::Utf8Path;
 use karva_collector::CollectionSettings;
 use karva_diagnostic::{
@@ -11,10 +9,7 @@ use karva_python_semantic::{ModulePath, QualifiedFunctionName, QualifiedTestName
 use ruff_db::diagnostic::Diagnostic;
 use ruff_python_ast::PythonVersion;
 
-/// Central context object that holds shared state for a test run.
-///
-/// Provides access to system operations, project settings, and test result
-/// accumulation throughout the test discovery and execution phases.
+/// Immutable configuration and reporting services shared by one test run.
 pub struct Context<'a> {
     /// Current working directory.
     cwd: &'a Utf8Path,
@@ -25,14 +20,17 @@ pub struct Context<'a> {
     /// The Python version being used for this test run.
     python_version: PythonVersion,
 
-    /// Accumulated test results, wrapped in `RefCell` for interior mutability.
-    result: RefCell<TestRunResult>,
-
     /// Reporter for outputting test progress and results.
     reporter: &'a dyn Reporter,
 
     /// Whether diagnostics should include the full Python call chain.
     verbose: bool,
+}
+
+/// Mutable result state owned by the active execution path.
+#[derive(Default)]
+pub struct RunState {
+    result: TestRunResult,
 }
 
 impl<'a> Context<'a> {
@@ -47,7 +45,6 @@ impl<'a> Context<'a> {
             cwd,
             settings,
             python_version,
-            result: RefCell::new(TestRunResult::default()),
             reporter,
             verbose,
         }
@@ -74,14 +71,6 @@ impl<'a> Context<'a> {
         }
     }
 
-    pub(crate) fn result(&self) -> std::cell::RefMut<'_, TestRunResult> {
-        self.result.borrow_mut()
-    }
-
-    pub(crate) fn into_result(self) -> TestRunResult {
-        self.result.into_inner().into_sorted()
-    }
-
     /// Record the start of a test execution. Forwarded to the reporter
     /// so cancellation logic can render per-test `SIGINT` lines naming
     /// the in-flight test.
@@ -95,11 +84,23 @@ impl<'a> Context<'a> {
         self.reporter.report_test_finished(test_case_name);
     }
 
+    /// Returns the parser target matching the embedded interpreter.
+    pub fn python_version(&self) -> PythonVersion {
+        self.python_version
+    }
+}
+
+impl RunState {
+    pub(crate) fn into_result(self) -> TestRunResult {
+        self.result.into_sorted()
+    }
+
     /// Stores and reports a final non-retried test outcome.
     ///
     /// Returns whether the outcome counts as successful for failure-budget accounting.
     pub fn register_test_case_result(
-        &self,
+        &mut self,
+        context: &Context<'_>,
         test_case_name: &QualifiedTestName,
         outcome: TestExecutionOutcome,
         duration: std::time::Duration,
@@ -107,23 +108,29 @@ impl<'a> Context<'a> {
     ) -> bool {
         let passed = !outcome.is_non_success();
 
-        self.result().register_test_case_result(
+        self.result.register_test_case_result(
             test_case_name,
             outcome,
             duration,
             captured_output,
-            Some(self.reporter),
+            Some(context.reporter),
         );
 
         passed
     }
 
-    pub(crate) fn register_module_skip(&self, module_path: &ModulePath, reason: Option<String>) {
+    pub(crate) fn register_module_skip(
+        &mut self,
+        context: &Context<'_>,
+        module_path: &ModulePath,
+        reason: Option<String>,
+    ) {
         let name = QualifiedTestName::new(
             QualifiedFunctionName::new("<module>".to_string(), module_path.clone()),
             None,
         );
         self.register_test_case_result(
+            context,
             &name,
             TestExecutionOutcome::Skipped { reason },
             std::time::Duration::ZERO,
@@ -136,17 +143,18 @@ impl<'a> Context<'a> {
     /// via [`Self::register_retried_result`].
     pub fn report_test_attempt(
         &self,
+        context: &Context<'_>,
         test_case_name: &QualifiedTestName,
         attempt: u32,
         result: IndividualTestResultKind,
         duration: std::time::Duration,
     ) {
-        self.result().report_test_attempt(
+        self.result.report_test_attempt(
             test_case_name,
             attempt,
             result,
             duration,
-            Some(self.reporter),
+            Some(context.reporter),
         );
     }
 
@@ -154,12 +162,13 @@ impl<'a> Context<'a> {
     /// `SLOW` reporter line. Called once per test variant whose total
     /// runtime exceeded the configured `slow-timeout`.
     pub fn register_slow_test(
-        &self,
+        &mut self,
+        context: &Context<'_>,
         test_case_name: &QualifiedTestName,
         duration: std::time::Duration,
     ) {
-        self.result()
-            .register_slow_test(test_case_name, duration, Some(self.reporter));
+        self.result
+            .register_slow_test(test_case_name, duration, Some(context.reporter));
     }
 
     /// Register the final outcome of a retried test. Updates summary stats
@@ -167,7 +176,7 @@ impl<'a> Context<'a> {
     /// emitting a duplicate result line — the per-attempt `TRY N STATUS`
     /// lines already showed every attempt.
     pub fn register_retried_result(
-        &self,
+        &mut self,
         test_case_name: &QualifiedTestName,
         outcome: TestExecutionOutcome,
         duration: std::time::Duration,
@@ -176,7 +185,7 @@ impl<'a> Context<'a> {
         attempts: Vec<TestExecutionAttempt>,
     ) -> bool {
         let passed = !outcome.is_non_success() && !retry.is_flaky_failure();
-        self.result().register_retried_result(
+        self.result.register_retried_result(
             test_case_name,
             outcome,
             duration,
@@ -187,12 +196,7 @@ impl<'a> Context<'a> {
         passed
     }
 
-    pub(crate) fn add_run_diagnostic(&self, diagnostic: Diagnostic) {
-        self.result().add_run_diagnostic(diagnostic);
-    }
-
-    /// Returns the parser target matching the embedded interpreter.
-    pub fn python_version(&self) -> PythonVersion {
-        self.python_version
+    pub(crate) fn add_run_diagnostic(&mut self, diagnostic: Diagnostic) {
+        self.result.add_run_diagnostic(diagnostic);
     }
 }

--- a/crates/karva_test_semantic/src/lib.rs
+++ b/crates/karva_test_semantic/src/lib.rs
@@ -11,7 +11,7 @@ mod python;
 mod runner;
 pub mod utils;
 
-pub(crate) use context::Context;
+pub(crate) use context::{Context, RunState};
 pub use karva_coverage::CoverageConfig;
 pub use python::init_module;
 
@@ -39,6 +39,7 @@ pub fn run_tests(
     verbose: bool,
 ) -> TestRunResult {
     let context = Context::new(cwd, settings, python_version, reporter, verbose);
+    let mut state = RunState::default();
 
     attach_with_output(settings.terminal().show_python_output, |py| {
         let cov_session = coverage.and_then(|cfg| match CoverageSession::start(py, cwd, cfg) {
@@ -54,16 +55,17 @@ pub fn run_tests(
         for issue in discovery.issues {
             match issue {
                 DiscoveryIssue::Error(error) => {
-                    context.add_run_diagnostic(error.into_diagnostic());
+                    state.add_run_diagnostic(error.into_diagnostic());
                 }
                 DiscoveryIssue::SkippedModule {
                     module_path,
                     reason,
-                } => context.register_module_skip(&module_path, reason),
+                } => state.register_module_skip(&context, &module_path, reason),
             }
         }
 
-        PackageRunner::new(&context, cov_session.as_ref()).execute(py, &discovery.package);
+        PackageRunner::new(&context, &mut state, cov_session.as_ref())
+            .execute(py, &discovery.package);
 
         if let Some(cov_session) = cov_session
             && let Err(err) = cov_session.stop_and_save(py)
@@ -71,6 +73,6 @@ pub fn run_tests(
             tracing::error!("Failed to save coverage data: {err}");
         }
 
-        context.into_result()
+        state.into_result()
     })
 }

--- a/crates/karva_test_semantic/src/runner/finalizer_cache.rs
+++ b/crates/karva_test_semantic/src/runner/finalizer_cache.rs
@@ -18,7 +18,7 @@ pub(super) struct FinalizerCache {
 
 impl FinalizerCache {
     /// Adds a finalizer to its declared scope's LIFO stack.
-    pub(super) fn add_finalizer(&self, finalizer: Finalizer) {
+    pub(super) fn add_finalizer(&mut self, finalizer: Finalizer) {
         let package_owner = finalizer.package_owner.clone();
         let scope = match finalizer.scope {
             FixtureScope::Session => ScopeKey::Session,
@@ -33,7 +33,7 @@ impl FinalizerCache {
 
     /// Drains one scope and returns diagnostics raised during teardown.
     pub(super) fn run_and_clear_scope(
-        &self,
+        &mut self,
         py: Python<'_>,
         scope: ScopeKey<'_>,
     ) -> Vec<Diagnostic> {

--- a/crates/karva_test_semantic/src/runner/fixture_cache.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_cache.rs
@@ -27,14 +27,14 @@ impl FixtureCache {
     }
 
     /// Caches a fixture value until its declared scope completes.
-    pub(super) fn insert(&self, name: String, value: Py<PyAny>, scope: ScopeKey<'_>) {
+    pub(super) fn insert(&mut self, name: String, value: Py<PyAny>, scope: ScopeKey<'_>) {
         self.storage.with_mut(scope, |values| {
             values.insert(name, value);
         });
     }
 
     /// Drops every cached value owned by one completed scope.
-    pub(super) fn clear_scope(&self, scope: ScopeKey<'_>) {
+    pub(super) fn clear_scope(&mut self, scope: ScopeKey<'_>) {
         drop(self.storage.take(scope));
     }
 }

--- a/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
@@ -31,7 +31,7 @@ impl PackageRunner<'_, '_> {
     /// a test module, or a package. Resolution failures
     /// trigger cleanup for the partially initialized scope before returning.
     pub(super) fn run_auto_use_fixtures<'a>(
-        &self,
+        &mut self,
         py: Python<'_>,
         parents: &'a [&'a crate::discovery::DiscoveredPackage],
         current: &'a (dyn HasFixtures<'a> + 'a),
@@ -62,7 +62,7 @@ impl PackageRunner<'_, '_> {
 
     /// Runs function-scoped finalizers and clears their cached fixture values.
     pub(super) fn clean_up_test_attempt(
-        &self,
+        &mut self,
         py: Python<'_>,
         finalizers: Vec<Finalizer>,
     ) -> Vec<Diagnostic> {
@@ -76,16 +76,20 @@ impl PackageRunner<'_, '_> {
     }
 
     /// Clears cached fixture values and runs finalizers for one completed scope.
-    pub(super) fn clean_up_scope(&self, py: Python<'_>, scope: ScopeKey<'_>) -> Vec<Diagnostic> {
+    pub(super) fn clean_up_scope(
+        &mut self,
+        py: Python<'_>,
+        scope: ScopeKey<'_>,
+    ) -> Vec<Diagnostic> {
         let diagnostics = self.finalizer_cache.run_and_clear_scope(py, scope);
         self.fixture_cache.clear_scope(scope);
         diagnostics
     }
 
     /// Cleans one scope and promotes teardown failures to run diagnostics.
-    pub(super) fn report_scope_cleanup(&self, py: Python<'_>, scope: ScopeKey<'_>) {
+    pub(super) fn report_scope_cleanup(&mut self, py: Python<'_>, scope: ScopeKey<'_>) {
         for diagnostic in self.clean_up_scope(py, scope) {
-            self.context.add_run_diagnostic(diagnostic);
+            self.state.add_run_diagnostic(diagnostic);
         }
     }
 
@@ -94,7 +98,7 @@ impl PackageRunner<'_, '_> {
     /// Returned finalizers belong directly to the test attempt. Broader-scoped
     /// finalizers are retained in the runner cache until their scope ends.
     pub(super) fn prepare_test_fixtures(
-        &self,
+        &mut self,
         py: Python<'_>,
         fixture_plan: &FixturePlan,
         fixture_dependencies: &[FixtureId],
@@ -154,7 +158,7 @@ impl PackageRunner<'_, '_> {
     /// Runs one fixture, recursively preparing dependencies first.
     #[expect(clippy::result_large_err)]
     fn run_fixture(
-        &self,
+        &mut self,
         py: Python<'_>,
         fixture_plan: &FixturePlan,
         fixture_id: FixtureId,
@@ -210,7 +214,7 @@ impl PackageRunner<'_, '_> {
 
     /// Runs fixtures whose values are not passed to the test call.
     fn run_fixtures(
-        &self,
+        &mut self,
         py: Python<'_>,
         fixture_plan: &FixturePlan,
         fixture_ids: &[FixtureId],

--- a/crates/karva_test_semantic/src/runner/package_runner/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/mod.rs
@@ -1,13 +1,11 @@
 //! Package-tree orchestration and run-wide execution state.
 
-use std::cell::Cell;
 use std::collections::HashMap;
 
 use karva_coverage::CoverageSession;
 use karva_python_semantic::QualifiedTestName;
 use pyo3::prelude::*;
 
-use crate::Context;
 use crate::diagnostic::{fixture_resolution_diagnostic, invalid_parametrize_diagnostic};
 use crate::discovery::{DiscoveredModule, DiscoveredPackage, DiscoveredTestFunction};
 use crate::extensions::fixtures::FixtureScope;
@@ -15,6 +13,7 @@ use crate::runner::fixture_resolver::{FixturePlanCompiler, FixtureResolutionErro
 use crate::runner::scoped_storage::ScopeKey;
 use crate::runner::test_iterator::{CompiledTestPlan, TestVariantIterator};
 use crate::runner::{FinalizerCache, FixtureCache};
+use crate::{Context, RunState};
 
 mod failure;
 mod fixture;
@@ -33,8 +32,10 @@ type CompiledTestPlans = HashMap<String, Result<CompiledTestPlan, FixtureResolut
 /// failure-budget accounting. Package traversal stays in this module; fixture
 /// lifecycle and individual test-variant lifecycle live in child modules.
 pub struct PackageRunner<'context, 'settings> {
-    /// Shared settings, reporter, and result accumulator for this test run.
+    /// Shared immutable settings and reporting services for this test run.
     context: &'context Context<'settings>,
+    /// Result accumulator exclusively owned by this runner during execution.
+    state: &'context mut RunState,
     /// Fixture values retained until their declared scope completes.
     fixture_cache: FixtureCache,
     /// Fixture finalizers retained until their declared scope completes.
@@ -42,21 +43,23 @@ pub struct PackageRunner<'context, 'settings> {
     /// Active coverage session for this worker, when coverage is enabled.
     coverage: Option<&'context CoverageSession>,
     /// Failed variants observed so far, used to enforce `max-fail`.
-    failed_count: Cell<u32>,
+    failed_count: u32,
 }
 
 impl<'context, 'settings> PackageRunner<'context, 'settings> {
     /// Creates an empty runner for one discovered package tree.
     pub(crate) fn new(
         context: &'context Context<'settings>,
+        state: &'context mut RunState,
         coverage: Option<&'context CoverageSession>,
     ) -> Self {
         Self {
             context,
+            state,
             fixture_cache: FixtureCache::default(),
             finalizer_cache: FinalizerCache::default(),
             coverage,
-            failed_count: Cell::new(0),
+            failed_count: 0,
         }
     }
 
@@ -66,20 +69,20 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
             .settings()
             .test()
             .max_fail
-            .is_exceeded_by(self.failed_count.get())
+            .is_exceeded_by(self.failed_count)
     }
 
     /// Adds one failed variant to `max-fail` accounting.
-    fn record_outcome(&self, passed: bool) {
+    fn record_outcome(&mut self, passed: bool) {
         if !passed {
-            self.failed_count
-                .set(self.failed_count.get().saturating_add(1));
+            self.failed_count = self.failed_count.saturating_add(1);
         }
     }
 
     /// Registers a discovery or setup error against one test.
-    fn register_error_test(&self, test: &DiscoveredTestFunction, error: TestError) {
-        self.context.register_test_case_result(
+    fn register_error_test(&mut self, test: &DiscoveredTestFunction, error: TestError) {
+        self.state.register_test_case_result(
+            self.context,
             &QualifiedTestName::new(test.name().clone(), None),
             error.into_outcome(),
             std::time::Duration::ZERO,
@@ -89,7 +92,7 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
     }
 
     /// Registers one shared module error against tests not blocked by `max-fail`.
-    fn register_error_module_tests(&self, module: &DiscoveredModule, error: &TestError) {
+    fn register_error_module_tests(&mut self, module: &DiscoveredModule, error: &TestError) {
         for test in module.test_functions() {
             self.register_error_test(test, error.clone());
             if self.max_fail_reached() {
@@ -99,7 +102,7 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
     }
 
     /// Registers one shared package error throughout its remaining test tree.
-    fn register_error_package_tests(&self, package: &DiscoveredPackage, error: &TestError) {
+    fn register_error_package_tests(&mut self, package: &DiscoveredPackage, error: &TestError) {
         for module in package.modules().values() {
             self.register_error_module_tests(module, error);
             if self.max_fail_reached() {
@@ -118,7 +121,7 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
     ///
     /// Validation is deliberately a separate tree pass: once session setup
     /// begins, invalid parametrization must not leave partially run fixtures.
-    fn validate_parametrization(&self, package: &DiscoveredPackage) -> bool {
+    fn validate_parametrization(&mut self, package: &DiscoveredPackage) -> bool {
         let mut valid = true;
 
         for module in package.modules().values() {
@@ -172,7 +175,7 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
     }
 
     /// Executes all discovered tests and session-scoped fixture teardown.
-    pub(crate) fn execute(&self, py: Python<'_>, session: &DiscoveredPackage) {
+    pub(crate) fn execute(&mut self, py: Python<'_>, session: &DiscoveredPackage) {
         if !self.validate_parametrization(session) {
             return;
         }
@@ -193,7 +196,7 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
 
     /// Executes module auto-use fixtures, variants, and module teardown.
     fn execute_module(
-        &self,
+        &mut self,
         py: Python<'_>,
         module: &DiscoveredModule,
         parents: &[&DiscoveredPackage],
@@ -252,7 +255,7 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
 
     /// Recursively executes package modules, child packages, and teardown.
     fn execute_package(
-        &self,
+        &mut self,
         py: Python<'_>,
         package: &DiscoveredPackage,
         parents: &[&DiscoveredPackage],

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/attempt.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/attempt.rs
@@ -19,7 +19,7 @@ use crate::runner::package_runner::outcome::{
 impl VariantRunner<'_, '_, '_, '_, '_> {
     /// Runs one setup/call/teardown lifecycle and decides retry eligibility.
     pub(super) fn execute_attempt(
-        &self,
+        &mut self,
         settings: &VariantSettings,
         function: &Py<PyAny>,
         test_name_env_result: &PyResult<()>,

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
@@ -30,7 +30,11 @@ use attempt::{PreparedTestAttempt, TestLifecycleAttempt};
 
 impl PackageRunner<'_, '_> {
     /// Runs one concrete parameter and fixture combination.
-    pub(super) fn execute_test_variant(&self, py: Python<'_>, variant: TestVariant<'_>) -> bool {
+    pub(super) fn execute_test_variant(
+        &mut self,
+        py: Python<'_>,
+        variant: TestVariant<'_>,
+    ) -> bool {
         VariantRunner::new(self, py, variant).execute()
     }
 }
@@ -42,7 +46,7 @@ impl PackageRunner<'_, '_> {
 /// fixture selections, tags, and identity stay here.
 struct VariantRunner<'runner, 'context, 'settings, 'test, 'py> {
     /// Run-wide owner for fixtures, reporting, settings, and coverage.
-    package_runner: &'runner PackageRunner<'context, 'settings>,
+    package_runner: &'runner mut PackageRunner<'context, 'settings>,
     /// Attached Python interpreter used by every attempt.
     py: Python<'py>,
     /// Discovered test definition shared by every variant.
@@ -70,7 +74,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
 {
     /// Captures raw variant inputs before any fixture setup begins.
     fn new(
-        package_runner: &'runner PackageRunner<'context, 'settings>,
+        package_runner: &'runner mut PackageRunner<'context, 'settings>,
         py: Python<'py>,
         variant: TestVariant<'test>,
     ) -> Self {
@@ -141,7 +145,8 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             );
 
             if attempt.retryable && attempt_number < settings.max_attempts {
-                self.package_runner.context.report_test_attempt(
+                self.package_runner.state.report_test_attempt(
+                    self.package_runner.context,
                     &settings.qualified_test_name,
                     attempt_number,
                     attempt.lifecycle.outcome.result_kind(),
@@ -160,7 +165,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
 
     /// Prepares fixture values and records setup duration for one attempt.
     fn prepare_attempt(
-        &self,
+        &mut self,
         params: HashMap<String, Arc<Py<PyAny>>>,
         output_capture: Option<PythonOutputCapture>,
     ) -> PreparedTestAttempt {
@@ -182,7 +187,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
 
     /// Prepares a retry while ensuring coverage excludes fixture setup.
     fn prepare_retry(
-        &self,
+        &mut self,
         params: HashMap<String, Arc<Py<PyAny>>>,
         settings: &VariantSettings,
     ) -> PreparedTestAttempt {
@@ -304,7 +309,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
 
     /// Registers final outcome after all retries and returns pass/fail status.
     fn finish(
-        &self,
+        &mut self,
         settings: &VariantSettings,
         prior_attempts: Vec<TestLifecycleAttempt>,
         final_attempt: TestLifecycleAttempt,
@@ -323,7 +328,8 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             .saturating_add(final_attempt.duration);
 
         if !prior_attempts.is_empty() {
-            self.package_runner.context.report_test_attempt(
+            self.package_runner.state.report_test_attempt(
+                self.package_runner.context,
                 &settings.qualified_test_name,
                 final_attempt.attempt,
                 final_attempt.outcome.result_kind(),
@@ -334,16 +340,19 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             .slow_timeout
             .is_some_and(|threshold| total_duration > threshold)
         {
-            self.package_runner
-                .context
-                .register_slow_test(&settings.qualified_test_name, total_duration);
+            self.package_runner.state.register_slow_test(
+                self.package_runner.context,
+                &settings.qualified_test_name,
+                total_duration,
+            );
         }
         self.package_runner
             .context
             .report_test_finished(&settings.qualified_test_name);
 
         if prior_attempts.is_empty() {
-            self.package_runner.context.register_test_case_result(
+            self.package_runner.state.register_test_case_result(
+                self.package_runner.context,
                 &settings.qualified_test_name,
                 final_attempt.outcome,
                 total_duration,
@@ -361,7 +370,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
                 .map(TestLifecycleAttempt::into_execution_attempt)
                 .collect::<Vec<_>>();
             execution_attempts.push(final_attempt.into_execution_attempt());
-            self.package_runner.context.register_retried_result(
+            self.package_runner.state.register_retried_result(
                 &settings.qualified_test_name,
                 outcome,
                 total_duration,
@@ -374,7 +383,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
     }
 
     /// Returns a registered skip result when filters or skip policy exclude this variant.
-    fn should_skip(&self) -> Option<bool> {
+    fn should_skip(&mut self) -> Option<bool> {
         let filter = &self.package_runner.context.settings().test().filter;
         let run_ignored = self.package_runner.context.settings().test().run_ignored;
 
@@ -387,7 +396,8 @@ impl<'runner, 'context, 'settings, 'test, 'py>
                 tags: &custom_names,
             };
             if !filter.matches(&context) {
-                return Some(self.package_runner.context.register_test_case_result(
+                return Some(self.package_runner.state.register_test_case_result(
+                    self.package_runner.context,
                     &qualified,
                     TestExecutionOutcome::Skipped { reason: None },
                     Duration::ZERO,
@@ -408,7 +418,8 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             return None;
         };
         let qualified = QualifiedTestName::new(self.test.name().clone(), None);
-        Some(self.package_runner.context.register_test_case_result(
+        Some(self.package_runner.state.register_test_case_result(
+            self.package_runner.context,
             &qualified,
             TestExecutionOutcome::Skipped { reason },
             Duration::ZERO,

--- a/crates/karva_test_semantic/src/runner/scoped_storage.rs
+++ b/crates/karva_test_semantic/src/runner/scoped_storage.rs
@@ -1,6 +1,5 @@
 //! Shared storage primitive for state isolated by fixture lifetime.
 
-use std::cell::RefCell;
 use std::collections::HashMap;
 
 use camino::{Utf8Path, Utf8PathBuf};
@@ -20,45 +19,40 @@ pub(super) enum ScopeKey<'a> {
 /// cannot clear values owned by an ancestor package.
 #[derive(Debug, Default)]
 pub(super) struct ScopedStorage<T: Default> {
-    session: RefCell<T>,
-    packages: RefCell<HashMap<Utf8PathBuf, T>>,
-    module: RefCell<T>,
-    function: RefCell<T>,
+    session: T,
+    packages: HashMap<Utf8PathBuf, T>,
+    module: T,
+    function: T,
 }
 
 impl<T: Default> ScopedStorage<T> {
     /// Reads state when it exists. Package keys are absent until first use.
     pub(super) fn with<R>(&self, key: ScopeKey<'_>, read: impl FnOnce(&T) -> R) -> Option<R> {
         match key {
-            ScopeKey::Session => Some(read(&self.session.borrow())),
-            ScopeKey::Package(path) => self.packages.borrow().get(path).map(read),
-            ScopeKey::Module => Some(read(&self.module.borrow())),
-            ScopeKey::Function => Some(read(&self.function.borrow())),
+            ScopeKey::Session => Some(read(&self.session)),
+            ScopeKey::Package(path) => self.packages.get(path).map(read),
+            ScopeKey::Module => Some(read(&self.module)),
+            ScopeKey::Function => Some(read(&self.function)),
         }
     }
 
     /// Mutates state, creating package-owned state on first use.
-    pub(super) fn with_mut<R>(&self, key: ScopeKey<'_>, update: impl FnOnce(&mut T) -> R) -> R {
+    pub(super) fn with_mut<R>(&mut self, key: ScopeKey<'_>, update: impl FnOnce(&mut T) -> R) -> R {
         match key {
-            ScopeKey::Session => update(&mut self.session.borrow_mut()),
-            ScopeKey::Package(path) => update(
-                self.packages
-                    .borrow_mut()
-                    .entry(path.to_path_buf())
-                    .or_default(),
-            ),
-            ScopeKey::Module => update(&mut self.module.borrow_mut()),
-            ScopeKey::Function => update(&mut self.function.borrow_mut()),
+            ScopeKey::Session => update(&mut self.session),
+            ScopeKey::Package(path) => update(self.packages.entry(path.to_path_buf()).or_default()),
+            ScopeKey::Module => update(&mut self.module),
+            ScopeKey::Function => update(&mut self.function),
         }
     }
 
     /// Takes all state owned by a completed lifetime.
-    pub(super) fn take(&self, key: ScopeKey<'_>) -> T {
+    pub(super) fn take(&mut self, key: ScopeKey<'_>) -> T {
         match key {
-            ScopeKey::Session => std::mem::take(&mut self.session.borrow_mut()),
-            ScopeKey::Package(path) => self.packages.borrow_mut().remove(path).unwrap_or_default(),
-            ScopeKey::Module => std::mem::take(&mut self.module.borrow_mut()),
-            ScopeKey::Function => std::mem::take(&mut self.function.borrow_mut()),
+            ScopeKey::Session => std::mem::take(&mut self.session),
+            ScopeKey::Package(path) => self.packages.remove(path).unwrap_or_default(),
+            ScopeKey::Module => std::mem::take(&mut self.module),
+            ScopeKey::Function => std::mem::take(&mut self.function),
         }
     }
 }


### PR DESCRIPTION
## Summary

Immutable run configuration is separated from exclusively owned mutable result state. Runner failure accounting and fixture scope storage now use ordinary mutable ownership instead of `Cell` and `RefCell`.

## Test plan

Semantic unit tests, crate Clippy, and retry integrations.