### PR TITLE
Share fixture source identity end to end

### DIFF
--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -260,8 +260,8 @@ fn report_dependency_chain(
             format!("Fixture `{}` requires `{next_name}`", entry.name),
         );
 
-        let span =
-            Span::from(entry.source_file.clone()).with_range(entry.stmt_function_def.name.range);
+        let span = Span::from(entry.definition.source_file().clone())
+            .with_range(entry.definition.statement().name.range);
 
         sub.annotate(Annotation::primary(span));
         diagnostic.sub(sub);
@@ -359,8 +359,7 @@ pub fn fixture_failure_diagnostic(
     let FixtureCallError {
         fixture_name,
         error,
-        stmt_function_def,
-        source_file,
+        definition,
         arguments,
         dependency_chain,
     } = error;
@@ -372,8 +371,8 @@ pub fn fixture_failure_diagnostic(
     handle_failed_function_call(
         &mut diagnostic,
         py,
-        &source_file,
-        &stmt_function_def,
+        definition.source_file(),
+        definition.statement(),
         &arguments,
         FailedFunctionCallOptions {
             function_kind: FunctionKind::Fixture,
@@ -398,12 +397,11 @@ pub fn fixture_resolution_diagnostic(error: FixtureResolutionError) -> Diagnosti
             rejected_fixtures,
         } => fixture_missing_fixtures_diagnostic(&fixture, &missing_fixtures, &rejected_fixtures),
         FixtureResolutionError::MissingTestFixtures {
-            stmt_function_def,
-            source_file,
+            definition,
             missing_fixtures,
         } => missing_fixtures_diagnostic(
-            source_file,
-            &stmt_function_def,
+            definition.source_file().clone(),
+            definition.statement(),
             &missing_fixtures,
             FunctionKind::Test,
         ),
@@ -416,8 +414,8 @@ fn fixture_cycle_diagnostic(cycle: &[FixtureResolutionEntry]) -> Diagnostic {
     if let Some(first_fixture) = cycle.first() {
         annotate_function_name(
             &mut diagnostic,
-            first_fixture.source_file.clone(),
-            &first_fixture.stmt_function_def,
+            first_fixture.definition.source_file().clone(),
+            first_fixture.definition.statement(),
         );
     }
 
@@ -429,8 +427,8 @@ fn fixture_cycle_diagnostic(cycle: &[FixtureResolutionEntry]) -> Diagnostic {
             SubDiagnosticSeverity::Info,
             format!("Fixture `{}` requires `{}`", fixture.name, dependency.name),
         );
-        let span = Span::from(fixture.source_file.clone())
-            .with_range(fixture.stmt_function_def.name.range);
+        let span = Span::from(fixture.definition.source_file().clone())
+            .with_range(fixture.definition.statement().name.range);
         sub.annotate(Annotation::primary(span));
         diagnostic.sub(sub);
     }
@@ -460,8 +458,8 @@ fn fixture_scope_mismatch_diagnostic(
 
     annotate_function_name(
         &mut diagnostic,
-        fixture.source_file.clone(),
-        &fixture.stmt_function_def,
+        fixture.definition.source_file().clone(),
+        fixture.definition.statement(),
     );
 
     for (index, path_fixture) in dependency_path.iter().enumerate() {
@@ -473,8 +471,8 @@ fn fixture_scope_mismatch_diagnostic(
                 path_fixture.name, next_fixture.name
             ),
         );
-        let span = Span::from(path_fixture.source_file.clone())
-            .with_range(path_fixture.stmt_function_def.name.range);
+        let span = Span::from(path_fixture.definition.source_file().clone())
+            .with_range(path_fixture.definition.statement().name.range);
         sub.annotate(Annotation::primary(span));
         diagnostic.sub(sub);
     }
@@ -487,8 +485,8 @@ fn fixture_scope_mismatch_diagnostic(
             dependency.scope.name()
         ),
     );
-    let span = Span::from(dependency.source_file.clone())
-        .with_range(dependency.stmt_function_def.name.range);
+    let span = Span::from(dependency.definition.source_file().clone())
+        .with_range(dependency.definition.statement().name.range);
     dependency_sub.annotate(Annotation::primary(span));
     diagnostic.sub(dependency_sub);
     diagnostic
@@ -500,8 +498,8 @@ fn fixture_missing_fixtures_diagnostic(
     rejected_fixtures: &[RejectedFixture],
 ) -> Diagnostic {
     let mut diagnostic = missing_fixtures_diagnostic(
-        fixture.source_file.clone(),
-        &fixture.stmt_function_def,
+        fixture.definition.source_file().clone(),
+        fixture.definition.statement(),
         missing_fixtures,
         FunctionKind::Fixture,
     );

--- a/crates/karva_test_semantic/src/extensions/fixtures/finalizer.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/finalizer.rs
@@ -3,8 +3,6 @@ use std::rc::Rc;
 use camino::Utf8PathBuf;
 use pyo3::prelude::*;
 use pyo3::types::PyIterator;
-use ruff_python_ast::StmtFunctionDef;
-use ruff_source_file::SourceFile;
 use thiserror::Error;
 
 use ruff_db::diagnostic::Diagnostic;
@@ -51,11 +49,8 @@ pub struct Finalizer {
     /// Defining package for package-scoped teardown.
     pub(crate) package_owner: Utf8PathBuf,
 
-    /// AST definition used to locate teardown errors.
-    pub(crate) stmt_function_def: Rc<StmtFunctionDef>,
-
-    /// Source code containing the fixture definition.
-    pub(crate) source_file: SourceFile,
+    /// Immutable fixture identity, syntax, and source.
+    pub(crate) definition: Rc<FunctionDefinition>,
 }
 
 impl Finalizer {
@@ -69,8 +64,8 @@ impl Finalizer {
 
         result.map_err(|error| {
             invalid_fixture_finalizer_diagnostic(
-                self.source_file,
-                &self.stmt_function_def,
+                self.definition.source_file().clone(),
+                self.definition.statement(),
                 &error.to_string(),
             )
         })
@@ -110,3 +105,4 @@ impl Finalizer {
         }
     }
 }
+use crate::discovery::models::definition::FunctionDefinition;

--- a/crates/karva_test_semantic/src/extensions/fixtures/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/mod.rs
@@ -129,6 +129,10 @@ impl DiscoveredFixture {
         self.definition.name()
     }
 
+    pub(crate) fn definition(&self) -> &Rc<FunctionDefinition> {
+        &self.definition
+    }
+
     pub(crate) fn scope(&self) -> FixtureScope {
         self.scope
     }
@@ -147,10 +151,6 @@ impl DiscoveredFixture {
 
     pub(crate) fn stmt_function_def(&self) -> &Rc<StmtFunctionDef> {
         self.definition.statement_rc()
-    }
-
-    pub(crate) fn source_file(&self) -> &SourceFile {
-        self.definition.source_file()
     }
 
     pub(crate) fn try_from_function(

--- a/crates/karva_test_semantic/src/extensions/fixtures/normalized_fixture.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/normalized_fixture.rs
@@ -4,8 +4,8 @@ use camino::{Utf8Path, Utf8PathBuf};
 use karva_python_semantic::QualifiedFunctionName;
 use pyo3::prelude::*;
 use ruff_python_ast::StmtFunctionDef;
-use ruff_source_file::SourceFile;
 
+use crate::discovery::models::definition::FunctionDefinition;
 use crate::extensions::fixtures::FixtureScope;
 use crate::runner::FixtureArguments;
 use crate::utils::run_coroutine;
@@ -43,8 +43,8 @@ impl FixturePlan {
 /// and normalized the same way as user-defined ones.
 #[derive(Debug)]
 pub struct NormalizedFixture {
-    /// Fully qualified name including module path and function name.
-    pub(crate) name: QualifiedFunctionName,
+    /// Immutable fixture identity, syntax, and source.
+    pub(crate) definition: Rc<FunctionDefinition>,
 
     /// Resolved fixture dependencies this fixture requires.
     pub(crate) dependencies: Vec<FixtureId>,
@@ -60,18 +60,20 @@ pub struct NormalizedFixture {
 
     /// Reference to the Python callable that produces the fixture value.
     pub(crate) py_function: Py<PyAny>,
-
-    /// AST representation of the fixture function definition.
-    pub(crate) stmt_function_def: Rc<StmtFunctionDef>,
-
-    /// Source code captured during discovery for diagnostic reporting.
-    pub(crate) source_file: SourceFile,
 }
 
 impl NormalizedFixture {
     /// Returns the fixture's unqualified function name.
     pub(crate) fn function_name(&self) -> &str {
-        self.name.function_name()
+        self.definition.name().function_name()
+    }
+
+    pub(crate) fn name(&self) -> &QualifiedFunctionName {
+        self.definition.name()
+    }
+
+    pub(crate) fn statement(&self) -> &StmtFunctionDef {
+        self.definition.statement()
     }
 
     /// Returns the fixture dependencies.
@@ -102,7 +104,7 @@ impl NormalizedFixture {
             self.py_function.call(py, (), Some(&kwargs_dict))
         };
 
-        if self.stmt_function_def.is_async && !self.is_generator {
+        if self.statement().is_async && !self.is_generator {
             result.and_then(|coroutine| run_coroutine(py, coroutine))
         } else {
             result

--- a/crates/karva_test_semantic/src/runner/fixture_resolver.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_resolver.rs
@@ -5,9 +5,8 @@ use std::rc::Rc;
 
 use camino::Utf8Path;
 use pyo3::prelude::*;
-use ruff_python_ast::StmtFunctionDef;
-use ruff_source_file::SourceFile;
 
+use crate::discovery::models::definition::FunctionDefinition;
 use crate::discovery::{DiscoveredPackage, DiscoveredTestFunction};
 use crate::extensions::fixtures::{
     DiscoveredFixture, FixtureId, FixturePlan, FixtureScope, HasFixtures, NormalizedFixture,
@@ -42,10 +41,8 @@ pub struct FixtureResolutionEntry {
     pub(crate) name: String,
     /// Declared lifetime scope.
     pub(crate) scope: FixtureScope,
-    /// Fixture definition used to locate the diagnostic.
-    pub(crate) stmt_function_def: Rc<StmtFunctionDef>,
-    /// Source containing the fixture definition.
-    pub(crate) source_file: SourceFile,
+    /// Immutable fixture identity, syntax, and source.
+    pub(crate) definition: Rc<FunctionDefinition>,
 }
 
 /// Structural failure discovered while resolving a fixture graph.
@@ -75,10 +72,8 @@ pub enum FixtureResolutionError {
     },
     /// Test requires names that cannot be resolved.
     MissingTestFixtures {
-        /// Test definition used to locate the diagnostic.
-        stmt_function_def: Rc<StmtFunctionDef>,
-        /// Source containing the test definition.
-        source_file: SourceFile,
+        /// Immutable test identity, syntax, and source.
+        definition: Rc<FunctionDefinition>,
         /// Unresolved fixture names.
         missing_fixtures: Vec<String>,
     },
@@ -92,8 +87,7 @@ impl FixtureResolutionEntry {
         Self {
             name: fixture.name().function_name().to_string(),
             scope: fixture.scope(),
-            stmt_function_def: Rc::clone(fixture.stmt_function_def()),
-            source_file: fixture.source_file().clone(),
+            definition: Rc::clone(fixture.definition()),
         }
     }
 }
@@ -224,14 +218,12 @@ impl<'a> FixturePlanCompiler<'a> {
         })?;
 
         let result = NormalizedFixture {
-            name: fixture.name().clone(),
+            definition: Rc::clone(fixture.definition()),
             dependencies: dependent_fixtures,
             scope: fixture.scope(),
             package_owner: self.package_owner(fixture).to_path_buf(),
             is_generator: fixture.is_generator(),
             py_function: fixture.function().clone_ref(py),
-            stmt_function_def: Rc::clone(fixture.stmt_function_def()),
-            source_file: fixture.source_file().clone(),
         };
 
         let fixture_id = FixtureId::new(self.fixtures.len());
@@ -285,8 +277,7 @@ impl<'a> FixturePlanCompiler<'a> {
 
         if !missing_fixtures.is_empty() {
             return Err(FixtureResolutionError::MissingTestFixtures {
-                stmt_function_def: Rc::clone(test.definition().statement_rc()),
-                source_file: test.source_file().clone(),
+                definition: Rc::clone(test.definition()),
                 missing_fixtures,
             });
         }

--- a/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
@@ -9,10 +9,9 @@ use karva_diagnostic::{FixtureFailure, FixtureUsage};
 use pyo3::prelude::*;
 use pyo3::types::PyIterator;
 use ruff_db::diagnostic::Diagnostic;
-use ruff_python_ast::StmtFunctionDef;
-use ruff_source_file::SourceFile;
 
 use crate::diagnostic::fixture_resolution_diagnostic;
+use crate::discovery::models::definition::FunctionDefinition;
 use crate::extensions::fixtures::{
     Finalizer, FixtureId, FixturePlan, FixtureScope, HasFixtures, NormalizedFixture,
 };
@@ -346,10 +345,8 @@ pub struct FixtureCallError {
     pub(crate) fixture_name: String,
     /// Python exception raised by fixture setup.
     pub(crate) error: PyErr,
-    /// Fixture definition used to locate the failure.
-    pub(crate) stmt_function_def: Rc<StmtFunctionDef>,
-    /// Source containing the failing fixture.
-    pub(crate) source_file: SourceFile,
+    /// Immutable fixture identity, syntax, and source.
+    pub(crate) definition: Rc<FunctionDefinition>,
     /// Arguments already prepared for the failing fixture.
     pub(crate) arguments: FixtureArguments,
     /// Intermediate fixtures between the requested fixture and failing fixture.
@@ -362,10 +359,8 @@ pub struct FixtureCallError {
 pub struct FixtureChainEntry {
     /// Fixture name shown in dependency diagnostics.
     pub(crate) name: String,
-    /// Source containing this intermediate fixture.
-    pub(crate) source_file: SourceFile,
-    /// Fixture definition used to locate this dependency step.
-    pub(crate) stmt_function_def: Rc<StmtFunctionDef>,
+    /// Immutable fixture identity, syntax, and source.
+    pub(crate) definition: Rc<FunctionDefinition>,
 }
 
 impl FixtureCallError {
@@ -373,8 +368,7 @@ impl FixtureCallError {
         Self {
             fixture_name: fixture.function_name().to_string(),
             error,
-            stmt_function_def: Rc::clone(&fixture.stmt_function_def),
-            source_file: fixture.source_file.clone(),
+            definition: Rc::clone(&fixture.definition),
             arguments,
             dependency_chain: Vec::new(),
         }
@@ -384,8 +378,7 @@ impl FixtureCallError {
     fn with_dependent(mut self, fixture: &NormalizedFixture) -> Self {
         self.dependency_chain.push(FixtureChainEntry {
             name: fixture.function_name().to_string(),
-            source_file: fixture.source_file.clone(),
-            stmt_function_def: Rc::clone(&fixture.stmt_function_def),
+            definition: Rc::clone(&fixture.definition),
         });
         self
     }
@@ -397,7 +390,7 @@ fn get_value_and_finalizer(
     fixture: &NormalizedFixture,
     fixture_call_result: Py<PyAny>,
 ) -> PyResult<(Py<PyAny>, Option<Finalizer>)> {
-    if fixture.is_generator && fixture.stmt_function_def.is_async {
+    if fixture.is_generator && fixture.statement().is_async {
         let bound = fixture_call_result.bind(py);
         let anext_coroutine = bound.call_method0("__anext__")?;
         let value = run_coroutine(py, anext_coroutine.unbind())?;
@@ -407,8 +400,7 @@ fn get_value_and_finalizer(
             is_async: true,
             scope: fixture.scope(),
             package_owner: fixture.package_owner().to_path_buf(),
-            stmt_function_def: Rc::clone(&fixture.stmt_function_def),
-            source_file: fixture.source_file.clone(),
+            definition: Rc::clone(&fixture.definition),
         };
 
         Ok((value, Some(finalizer)))
@@ -429,8 +421,7 @@ fn get_value_and_finalizer(
                     is_async: false,
                     scope: fixture.scope(),
                     package_owner: fixture.package_owner().to_path_buf(),
-                    stmt_function_def: Rc::clone(&fixture.stmt_function_def),
-                    source_file: fixture.source_file.clone(),
+                    definition: Rc::clone(&fixture.definition),
                 };
 
                 Ok((value.unbind(), Some(finalizer)))

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
@@ -209,7 +209,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             .fixture_dependencies
             .iter()
             .map(|fixture_id| self.fixture_plan.fixture(*fixture_id))
-            .filter(|fixture| fixture.name.module_path().module_name() == "karva._builtins")
+            .filter(|fixture| fixture.name().module_path().module_name() == "karva._builtins")
             .map(NormalizedFixture::function_name)
             .collect::<Vec<_>>();
         let full_name = if let Some(id) = &self.id {


### PR DESCRIPTION
## Summary

Compiled fixtures, finalizers, setup failures, and resolution diagnostics now share the immutable `FunctionDefinition` created during discovery. This removes repeated qualified names, AST handles, and source-file snapshots from the fixture lifecycle.

## Test plan

Semantic unit tests, crate Clippy, generator-fixture integrations, and scope-mismatch integrations.