### PR TITLE
Make module path construction allocation-light

### DIFF
--- a/crates/karva_collector/src/lib.rs
+++ b/crates/karva_collector/src/lib.rs
@@ -54,7 +54,7 @@ pub fn collect_file(
     settings: &CollectionSettings,
     function_names: &[String],
 ) -> Result<Option<CollectedModule>, CollectionError> {
-    let Some(module_path) = ModulePath::new(path, &cwd.to_path_buf()) else {
+    let Some(module_path) = ModulePath::new(path, cwd) else {
         return Ok(None);
     };
 

--- a/crates/karva_python_semantic/src/lib.rs
+++ b/crates/karva_python_semantic/src/lib.rs
@@ -1,6 +1,6 @@
 //! Shared Python semantic types independent of Karva's test runner.
 
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::Utf8Path;
 
 mod function_kind;
 mod name;
@@ -35,15 +35,27 @@ pub fn is_fixture(expr: &Expr) -> bool {
 /// Converts a Python file below `cwd` into its dotted import path.
 ///
 /// Returns `None` when `path` lies outside `cwd`.
-pub fn module_name(cwd: &Utf8PathBuf, path: &Utf8Path) -> Option<String> {
+pub fn module_name(cwd: &Utf8Path, path: &Utf8Path) -> Option<String> {
     let relative_path = path.strip_prefix(cwd).ok()?;
+    let mut components = relative_path.components().peekable();
+    let mut name = String::with_capacity(relative_path.as_str().len());
 
-    let components: Vec<_> = relative_path
-        .components()
-        .map(|c| c.as_os_str().to_string_lossy().into_owned())
-        .collect();
+    while let Some(component) = components.next() {
+        if !name.is_empty() {
+            name.push('.');
+        }
 
-    Some(components.join(".").trim_end_matches(".py").to_string())
+        let component = component.as_str();
+        if components.peek().is_none()
+            && let Some(stem) = component.strip_suffix(".py")
+        {
+            name.push_str(stem);
+        } else {
+            name.push_str(component);
+        }
+    }
+
+    Some(name)
 }
 
 /// Retrieves the current Python interpreter version.
@@ -83,6 +95,15 @@ mod tests {
                 &Utf8PathBuf::from("/test_dir/test.py")
             ),
             Some("test_dir.test".to_string())
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_module_name_removes_only_the_file_extension() {
+        assert_eq!(
+            module_name(Utf8Path::new("/"), Utf8Path::new("/test_suffix.py.py")),
+            Some("test_suffix.py".to_string())
         );
     }
 

--- a/crates/karva_python_semantic/src/name.rs
+++ b/crates/karva_python_semantic/src/name.rs
@@ -1,4 +1,4 @@
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 use serde::{Serialize, Serializer};
 
 use crate::module_name;
@@ -98,7 +98,7 @@ pub struct ModulePath {
 
 impl ModulePath {
     /// Create a new module path by computing the dotted module name relative to `cwd`.
-    pub fn new<P: Into<Utf8PathBuf>>(path: P, cwd: &Utf8PathBuf) -> Option<Self> {
+    pub fn new<P: Into<Utf8PathBuf>>(path: P, cwd: &Utf8Path) -> Option<Self> {
         let path = path.into();
         let module_name = module_name(cwd, path.as_ref())?;
         Some(Self { path, module_name })

--- a/crates/karva_test_semantic/src/discovery/visitor.rs
+++ b/crates/karva_test_semantic/src/discovery/visitor.rs
@@ -230,7 +230,7 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
             .extract::<String>()
             .ok()?;
         let utf8_file_name = Utf8Path::from_path(Path::new(&file_name))?;
-        let module_path = ModulePath::new(utf8_file_name, &self.context.cwd().to_path_buf())?;
+        let module_path = ModulePath::new(utf8_file_name, self.context.cwd())?;
 
         // Use the function's own __name__ to find its definition in the source, since the
         // conftest symbol name may differ when the fixture is imported under an alias.


### PR DESCRIPTION
## Summary

Module path construction now borrows the project root and builds dotted names in one allocation. It also removes only the final Python extension, preserving earlier `.py` suffixes.

## Test plan

Python semantic and collector crate tests; cross-crate Clippy.