### PR TITLE
Write inline snapshot updates atomically

### DIFF
--- a/crates/karva_snapshot/src/inline.rs
+++ b/crates/karva_snapshot/src/inline.rs
@@ -1,5 +1,6 @@
 use std::io;
 
+use camino::Utf8Path;
 use fs_err as fs;
 
 /// Location of an inline snapshot string literal in source code.
@@ -388,7 +389,7 @@ pub fn rewrite_inline_snapshot(
     let new_literal = generate_inline_literal(new_value, location.indent);
     let new_source = apply_edit(&source, location.start, location.end, &new_literal);
 
-    fs::write(source_path, new_source)
+    crate::storage::write_file_atomically(Utf8Path::new(source_path), new_source.as_bytes())
 }
 
 #[cfg(test)]

--- a/crates/karva_snapshot/src/storage.rs
+++ b/crates/karva_snapshot/src/storage.rs
@@ -68,6 +68,12 @@ pub fn write_pending_snapshot(snap_path: &Utf8Path, snapshot: &SnapshotFile) -> 
 }
 
 fn write_snapshot_file(path: &Utf8Path, snapshot: &SnapshotFile) -> io::Result<()> {
+    let content = snapshot.serialize();
+    write_file_atomically(path, content.as_bytes())
+}
+
+/// Replaces a file only after its complete contents have been written beside it.
+pub(crate) fn write_file_atomically(path: &Utf8Path, content: &[u8]) -> io::Result<()> {
     let parent = path
         .parent()
         .filter(|parent| !parent.as_str().is_empty())
@@ -75,7 +81,7 @@ fn write_snapshot_file(path: &Utf8Path, snapshot: &SnapshotFile) -> io::Result<(
     fs::create_dir_all(parent)?;
 
     let mut temp = NamedTempFile::new_in(parent)?;
-    temp.write_all(snapshot.serialize().as_bytes())?;
+    temp.write_all(content)?;
     temp.flush()?;
     temp.persist(path.as_std_path()).map_err(|err| err.error)?;
     Ok(())


### PR DESCRIPTION
## Summary

Inline snapshot source rewrites now use same-directory atomic replacement, preventing partial writes when an update is interrupted.

## Test Plan

cargo test -p karva_snapshot; uvx prek run -a