### PR TITLE
Store structured test parameters

### DIFF
--- a/crates/karva_diagnostic/src/reporter.rs
+++ b/crates/karva_diagnostic/src/reporter.rs
@@ -380,8 +380,8 @@ fn format_test_path(test_name: &QualifiedTestName) -> String {
     let module = test_name.function_name().module_path().module_name().cyan();
     let fn_name = test_name.function_name().function_name().blue().bold();
     let params = test_name
-        .params()
-        .map(|p| p.blue().bold().to_string())
+        .parameters()
+        .map(|parameters| format!("({parameters})").blue().bold().to_string())
         .unwrap_or_default();
     format!("{module}::{fn_name}{params}")
 }
@@ -442,13 +442,10 @@ mod tests {
     use super::*;
 
     fn qualified_test_name() -> QualifiedTestName {
-        QualifiedTestName::new(
-            QualifiedFunctionName::new(
-                "test_example".to_string(),
-                ModulePath::new_with_name("test_module.py", "test_module".to_string()),
-            ),
-            None,
-        )
+        QualifiedTestName::new(QualifiedFunctionName::new(
+            "test_example".to_string(),
+            ModulePath::new_with_name("test_module.py", "test_module".to_string()),
+        ))
     }
 
     fn wait_for_progress_snapshot(
@@ -510,13 +507,10 @@ mod tests {
             .with_progress_file(&path)
             .expect("progress file should open");
 
-        reporter.report_test_started(&QualifiedTestName::new(
-            QualifiedFunctionName::new(
-                "test_example_with_a_much_longer_name".to_string(),
-                ModulePath::new_with_name("test_module.py", "test_module".to_string()),
-            ),
-            None,
-        ));
+        reporter.report_test_started(&QualifiedTestName::new(QualifiedFunctionName::new(
+            "test_example_with_a_much_longer_name".to_string(),
+            ModulePath::new_with_name("test_module.py", "test_module".to_string()),
+        )));
         let progress = wait_for_progress_snapshot(&path, |progress| {
             progress["name"] == "test_module::test_example_with_a_much_longer_name"
         });

--- a/crates/karva_python_semantic/src/name.rs
+++ b/crates/karva_python_semantic/src/name.rs
@@ -54,15 +54,23 @@ impl Serialize for QualifiedFunctionName {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct QualifiedTestName {
     function_name: QualifiedFunctionName,
-    full_name: Option<String>,
+    parameters: Option<String>,
 }
 
 impl QualifiedTestName {
-    /// Creates an identity whose `full_name`, when present, must start with `function_name`.
-    pub fn new(function_name: QualifiedFunctionName, full_name: Option<String>) -> Self {
+    /// Creates an identity for an unparameterized test function.
+    pub fn new(function_name: QualifiedFunctionName) -> Self {
         Self {
             function_name,
-            full_name,
+            parameters: None,
+        }
+    }
+
+    /// Creates an identity with the rendered contents of its parameter list.
+    pub fn with_parameters(function_name: QualifiedFunctionName, parameters: String) -> Self {
+        Self {
+            function_name,
+            parameters: Some(parameters),
         }
     }
 
@@ -71,21 +79,19 @@ impl QualifiedTestName {
         &self.function_name
     }
 
-    /// Return the parameter portion of the test name (e.g., `"(a=1, b=2)"`), if any.
-    pub fn params(&self) -> Option<&str> {
-        let full_name = self.full_name.as_deref()?;
-        let base = self.function_name.to_string();
-        full_name.strip_prefix(&base)
+    /// Returns the rendered contents of the parameter list, without parentheses.
+    pub fn parameters(&self) -> Option<&str> {
+        self.parameters.as_deref()
     }
 }
 
 impl std::fmt::Display for QualifiedTestName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(full_name) = &self.full_name {
-            write!(f, "{full_name}")
-        } else {
-            write!(f, "{}", self.function_name)
+        write!(f, "{}", self.function_name)?;
+        if let Some(parameters) = &self.parameters {
+            write!(f, "({parameters})")?;
         }
+        Ok(())
     }
 }
 
@@ -123,5 +129,33 @@ impl ModulePath {
     /// Return the filesystem path of this module.
     pub fn path(&self) -> &Utf8PathBuf {
         &self.path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn function_name() -> QualifiedFunctionName {
+        QualifiedFunctionName::new(
+            "test_example".to_string(),
+            ModulePath::new_with_name("test.py", "tests.test".to_string()),
+        )
+    }
+
+    #[test]
+    fn unparameterized_test_name_uses_function_identity() {
+        let name = QualifiedTestName::new(function_name());
+
+        assert_eq!(name.to_string(), "tests.test::test_example");
+        assert_eq!(name.parameters(), None);
+    }
+
+    #[test]
+    fn parameterized_test_name_appends_rendered_parameters() {
+        let name = QualifiedTestName::with_parameters(function_name(), "value=1".to_string());
+
+        assert_eq!(name.to_string(), "tests.test::test_example(value=1)");
+        assert_eq!(name.parameters(), Some("value=1"));
     }
 }

--- a/crates/karva_test_semantic/src/context.rs
+++ b/crates/karva_test_semantic/src/context.rs
@@ -125,10 +125,10 @@ impl RunState {
         module_path: &ModulePath,
         reason: Option<String>,
     ) {
-        let name = QualifiedTestName::new(
-            QualifiedFunctionName::new("<module>".to_string(), module_path.clone()),
-            None,
-        );
+        let name = QualifiedTestName::new(QualifiedFunctionName::new(
+            "<module>".to_string(),
+            module_path.clone(),
+        ));
         self.register_test_case_result(
             context,
             &name,

--- a/crates/karva_test_semantic/src/runner/package_runner/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/mod.rs
@@ -83,7 +83,7 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
     fn register_error_test(&mut self, test: &DiscoveredTestFunction, error: TestError) {
         self.state.register_test_case_result(
             self.context,
-            &QualifiedTestName::new(test.name().clone(), None),
+            &QualifiedTestName::new(test.name().clone()),
             error.into_outcome(),
             std::time::Duration::ZERO,
             None,

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
@@ -20,7 +20,7 @@ use crate::extensions::tags::timeout::TimeoutTag;
 use crate::output_capture::PythonOutputCapture;
 use crate::runner::fixture_arguments::FixtureArguments;
 use crate::runner::test_iterator::TestVariant;
-use crate::utils::{full_test_name, set_attempt_env, set_test_name_env};
+use crate::utils::{set_attempt_env, set_test_name_env, test_parameters};
 
 use super::PackageRunner;
 
@@ -212,18 +212,21 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             .filter(|fixture| fixture.name().module_path().module_name() == "karva._builtins")
             .map(NormalizedFixture::function_name)
             .collect::<Vec<_>>();
-        let full_name = if let Some(id) = &self.id {
-            format!("{name}({id})")
+        let parameters = if let Some(id) = &self.id {
+            Some(id.clone())
         } else {
-            full_test_name(
+            test_parameters(
                 self.py,
-                name.to_string(),
                 function_arguments,
                 &self.test.statement().parameters,
                 &framework_fixture_names,
             )
         };
-        let qualified_test_name = QualifiedTestName::new(name.clone(), Some(full_name));
+        let qualified_test_name = if let Some(parameters) = parameters {
+            QualifiedTestName::with_parameters(name.clone(), parameters)
+        } else {
+            QualifiedTestName::new(name.clone())
+        };
         let qualified_name = qualified_test_name.to_string();
         let custom_tag_names = self.tags.custom_tag_names();
         let evaluation_context = EvalContext {
@@ -280,16 +283,19 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             Ok(false)
         };
         let is_async = self.test.statement().is_async && matches!(&async_patch_result, Ok(false));
-        let snapshot_context = SnapshotContext::new(
-            self.module_path.to_string(),
-            full_test_name(
-                self.py,
-                name.function_name().to_string(),
-                function_arguments,
-                &self.test.statement().parameters,
-                &fixture_names,
-            ),
-        );
+        let mut snapshot_test_name = name.function_name().to_string();
+        if let Some(parameters) = test_parameters(
+            self.py,
+            function_arguments,
+            &self.test.statement().parameters,
+            &fixture_names,
+        ) {
+            snapshot_test_name.push('(');
+            snapshot_test_name.push_str(&parameters);
+            snapshot_test_name.push(')');
+        }
+        let snapshot_context =
+            SnapshotContext::new(self.module_path.to_string(), snapshot_test_name);
 
         VariantSettings {
             qualified_test_name,
@@ -388,7 +394,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
         let run_ignored = self.package_runner.context.settings().test().run_ignored;
 
         if !filter.is_empty() {
-            let qualified = QualifiedTestName::new(self.test.name().clone(), None);
+            let qualified = QualifiedTestName::new(self.test.name().clone());
             let display_name = qualified.to_string();
             let custom_names = self.tags.custom_tag_names();
             let context = EvalContext {
@@ -417,7 +423,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
         let (true, reason) = skipped else {
             return None;
         };
-        let qualified = QualifiedTestName::new(self.test.name().clone(), None);
+        let qualified = QualifiedTestName::new(self.test.name().clone());
         Some(self.package_runner.state.register_test_case_result(
             self.package_runner.context,
             &qualified,

--- a/crates/karva_test_semantic/src/utils.rs
+++ b/crates/karva_test_semantic/src/utils.rs
@@ -265,32 +265,31 @@ pub(crate) fn add_to_sys_path(py: Python<'_>, path: &Utf8Path, index: isize) -> 
     Ok(())
 }
 
-/// Builds a variant name in Python signature order, omitting values for fixture-only names.
-pub(crate) fn full_test_name(
+/// Renders parameter-list contents in Python signature order.
+pub(crate) fn test_parameters(
     py: Python,
-    function: String,
     kwargs: &FixtureArguments,
     parameters: &Parameters,
     name_only_arguments: &[&str],
-) -> String {
+) -> Option<String> {
     if kwargs.is_empty() {
-        function
-    } else {
-        let mut args_str = String::new();
-        for (i, (key, value)) in kwargs.iter_in_signature_order(parameters).enumerate() {
-            if i > 0 {
-                args_str.push_str(", ");
-            }
-            let truncated_key = truncate_string(key);
-            if name_only_arguments.contains(&key.as_str()) {
-                let _ = write!(args_str, "{truncated_key}");
-            } else if let Ok(value) = value.cast_bound::<PyAny>(py) {
-                let trimmed_value_str = truncated_display_value(value);
-                let _ = write!(args_str, "{truncated_key}={trimmed_value_str}");
-            }
-        }
-        format!("{function}({args_str})")
+        return None;
     }
+
+    let mut rendered = String::new();
+    for (index, (key, value)) in kwargs.iter_in_signature_order(parameters).enumerate() {
+        if index > 0 {
+            rendered.push_str(", ");
+        }
+        let truncated_key = truncate_string(key);
+        if name_only_arguments.contains(&key.as_str()) {
+            let _ = write!(rendered, "{truncated_key}");
+        } else if let Ok(value) = value.cast_bound::<PyAny>(py) {
+            let trimmed_value = truncated_display_value(value);
+            let _ = write!(rendered, "{truncated_key}={trimmed_value}");
+        }
+    }
+    Some(rendered)
 }
 
 /// Maximum display length for parameter keys and values in test names.


### PR DESCRIPTION
## Summary

Qualified test names now store the function name and parameter body separately, removing duplicated rendered identity while preserving display behavior.

## Test Plan

cargo test -p karva_python_semantic -p karva_test_semantic; uvx prek run -a