### PR TITLE
Serialize qualified names without allocation

### DIFF
--- a/crates/karva_python_semantic/src/name.rs
+++ b/crates/karva_python_semantic/src/name.rs
@@ -46,7 +46,7 @@ impl Serialize for QualifiedFunctionName {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        serializer.collect_str(self)
     }
 }
 


### PR DESCRIPTION
## Summary

Qualified function names now serialize through their Display implementation without allocating an intermediate String.

## Test Plan

uvx prek run -a