### PR TITLE
Build native coverage analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1213,6 +1213,7 @@ dependencies = [
  "globset",
  "insta",
  "pyo3",
+ "regex",
  "ruff_python_ast",
  "ruff_python_parser",
  "ruff_source_file",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,6 +1219,7 @@ dependencies = [
  "ruff_text_size",
  "serde",
  "serde_json",
+ "siphasher",
  "tempfile",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ semver = { version = "1.0.28", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.150" }
 similar = { version = "3.1", features = ["inline"] }
+siphasher = { version = "1.0.2" }
 syn = { version = "3.0.3" }
 tempfile = "3.25"
 terminal_size = { version = "0.4" }

--- a/crates/karva_coverage/Cargo.toml
+++ b/crates/karva_coverage/Cargo.toml
@@ -19,6 +19,7 @@ dunce = { workspace = true }
 fs-err = { workspace = true }
 globset = { workspace = true }
 pyo3 = { workspace = true }
+regex = { workspace = true }
 ruff_python_ast = { workspace = true }
 ruff_python_parser = { workspace = true }
 ruff_source_file = { workspace = true }

--- a/crates/karva_coverage/Cargo.toml
+++ b/crates/karva_coverage/Cargo.toml
@@ -25,11 +25,12 @@ ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+siphasher = { workspace = true }
+tempfile = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
-tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/karva_coverage/src/lib.rs
+++ b/crates/karva_coverage/src/lib.rs
@@ -12,12 +12,16 @@
 //!
 //! The two halves communicate only through the JSON file format, defined
 //! in [`data`].
+//!
+//! [`native`] owns the versioned artifact retained after a run. Unlike the
+//! worker format, it is a stable boundary consumed by coverage commands.
 
 #![warn(unreachable_pub)]
 
 pub(crate) mod branches;
 pub mod data;
 pub mod executable;
+pub mod native;
 pub mod report;
 pub mod tracer;
 

--- a/crates/karva_coverage/src/lib.rs
+++ b/crates/karva_coverage/src/lib.rs
@@ -26,6 +26,7 @@ pub mod report;
 pub mod tracer;
 
 pub use report::{
-    CoverageFilters, combine_and_report, write_cobertura_xml, write_html_report, write_json_report,
+    CoverageAnalysis, CoverageFilters, combine_and_report, write_cobertura_xml, write_html_report,
+    write_json_report,
 };
 pub use tracer::{CoverageConfig, CoverageSession};

--- a/crates/karva_coverage/src/native.rs
+++ b/crates/karva_coverage/src/native.rs
@@ -1,0 +1,325 @@
+//! Versioned native coverage artifact.
+//!
+//! Worker payloads in [`crate::data`] are transient process communication.
+//! This module owns Karva's durable interchange format for later combination
+//! and reporting. It is deliberately unrelated to coverage.py's `SQLite` schema
+//! and to exported `coverage.json` reports.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::hash::Hasher;
+use std::io::Write;
+
+use anyhow::{Context, Result, bail};
+use camino::{Utf8Path, Utf8PathBuf};
+use fs_err as fs;
+use serde::{Deserialize, Serialize};
+use siphasher::sip128::{Hasher128, SipHasher13};
+use tempfile::NamedTempFile;
+
+use crate::data::BranchArc;
+
+/// Current native coverage schema version.
+pub const FORMAT_VERSION: u32 = 1;
+
+/// Karva coverage data retained after one or more test runs.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NativeCoverage {
+    /// Native artifact schema version.
+    pub format_version: u32,
+    /// Karva version that produced this artifact.
+    pub karva_version: String,
+    /// Whether collection measured statements alone or statements and branches.
+    pub mode: CoverageMode,
+    /// Normalized absolute project root used during collection.
+    pub project_root: Utf8PathBuf,
+    /// Normalized source roots measured during collection.
+    pub source_roots: BTreeSet<Utf8PathBuf>,
+    /// User-provided context attached to the whole run.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_context: Option<String>,
+    /// Coverage keyed by normalized project-relative source path.
+    pub files: BTreeMap<Utf8PathBuf, NativeFileCoverage>,
+}
+
+impl NativeCoverage {
+    /// Creates an artifact for the current schema and Karva version.
+    pub fn new(
+        mode: CoverageMode,
+        project_root: Utf8PathBuf,
+        source_roots: BTreeSet<Utf8PathBuf>,
+        run_context: Option<String>,
+        files: BTreeMap<Utf8PathBuf, NativeFileCoverage>,
+    ) -> Self {
+        Self {
+            format_version: FORMAT_VERSION,
+            karva_version: env!("CARGO_PKG_VERSION").to_owned(),
+            mode,
+            project_root,
+            source_roots,
+            run_context,
+            files,
+        }
+    }
+
+    /// Serializes this artifact deterministically and atomically replaces `path`.
+    pub fn write(&self, path: &Utf8Path) -> Result<()> {
+        let mut json = serde_json::to_vec_pretty(self)
+            .with_context(|| format!("failed to serialize native coverage artifact `{path}`"))?;
+        json.push(b'\n');
+
+        let parent = path
+            .parent()
+            .filter(|parent| !parent.as_str().is_empty())
+            .unwrap_or_else(|| Utf8Path::new("."));
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create native coverage directory `{parent}`"))?;
+
+        let mut temporary = NamedTempFile::new_in(parent)
+            .with_context(|| format!("failed to create native coverage artifact `{path}`"))?;
+        temporary
+            .write_all(&json)
+            .with_context(|| format!("failed to write native coverage artifact `{path}`"))?;
+        temporary
+            .flush()
+            .with_context(|| format!("failed to flush native coverage artifact `{path}`"))?;
+        temporary
+            .persist(path.as_std_path())
+            .map_err(|error| error.error)
+            .with_context(|| format!("failed to replace native coverage artifact `{path}`"))?;
+        Ok(())
+    }
+
+    /// Reads a supported native artifact, rejecting unknown schema versions.
+    pub fn read(path: &Utf8Path) -> Result<Self> {
+        let bytes = fs::read(path)
+            .with_context(|| format!("failed to read native coverage artifact `{path}`"))?;
+        let header: ArtifactHeader = serde_json::from_slice(&bytes)
+            .with_context(|| format!("failed to parse native coverage artifact `{path}`"))?;
+        if header.format_version != FORMAT_VERSION {
+            bail!(
+                "unsupported native coverage artifact `{path}`: found format version {}, supported version is {FORMAT_VERSION}",
+                header.format_version
+            );
+        }
+        serde_json::from_slice(&bytes)
+            .with_context(|| format!("failed to parse native coverage artifact `{path}`"))
+    }
+
+    /// Fails when any source differs from the bytes measured during collection.
+    pub fn verify_sources(&self) -> Result<()> {
+        for (source_path, coverage) in &self.files {
+            let path = self.project_root.join(source_path);
+            let source = fs::read(&path)
+                .with_context(|| format!("failed to verify coverage source `{path}`"))?;
+            if !coverage.source_fingerprint.matches(&source) {
+                bail!("coverage source changed since collection: `{path}`");
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Coverage opportunities captured by an artifact.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CoverageMode {
+    /// Statement coverage only.
+    Line,
+    /// Statement and branch coverage.
+    Branch,
+}
+
+/// Durable coverage for one Python source file.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NativeFileCoverage {
+    /// Fingerprint of the source bytes used to compute executable lines.
+    pub source_fingerprint: SourceFingerprint,
+    /// Executable source lines.
+    pub executable: BTreeSet<u32>,
+    /// Executable lines removed by exclusion rules.
+    pub excluded: BTreeSet<u32>,
+    /// Source lines observed at runtime.
+    pub executed: BTreeSet<u32>,
+    /// Contexts that executed each source line.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub line_contexts: BTreeMap<u32, BTreeSet<String>>,
+    /// Branch data, absent for statement-only collection.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branches: Option<NativeBranchCoverage>,
+}
+
+/// Durable branch coverage for one Python source file.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NativeBranchCoverage {
+    /// Statically discovered control-flow edges.
+    pub possible: BTreeSet<BranchArc>,
+    /// Control-flow edges observed at runtime.
+    pub executed: BTreeSet<BranchArc>,
+    /// Contexts grouped by executed edge, sorted by edge.
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub contexts: BTreeSet<NativeArcContexts>,
+}
+
+/// Contexts that traversed one branch edge.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub struct NativeArcContexts {
+    /// Executed control-flow edge.
+    pub arc: BranchArc,
+    /// Context names that traversed the edge.
+    pub contexts: BTreeSet<String>,
+}
+
+/// Stable 128-bit fingerprint of source content.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SourceFingerprint(String);
+
+impl SourceFingerprint {
+    /// Fingerprints source bytes with fixed-key SipHash-128.
+    pub fn from_bytes(source: &[u8]) -> Self {
+        let mut hasher = SipHasher13::new_with_keys(0, 0);
+        hasher.write(source);
+        let hash: u128 = hasher.finish128().into();
+        Self(format!("{hash:032x}"))
+    }
+
+    /// Returns the lowercase hexadecimal fingerprint.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Returns whether `source` has the content captured by this fingerprint.
+    pub fn matches(&self, source: &[u8]) -> bool {
+        *self == Self::from_bytes(source)
+    }
+}
+
+#[derive(Deserialize)]
+struct ArtifactHeader {
+    format_version: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn artifact() -> NativeCoverage {
+        NativeCoverage::new(
+            CoverageMode::Branch,
+            Utf8PathBuf::from("/project"),
+            BTreeSet::from([Utf8PathBuf::from("/project/src")]),
+            Some("linux-py313".to_owned()),
+            BTreeMap::from([(
+                Utf8PathBuf::from("src/package.py"),
+                NativeFileCoverage {
+                    source_fingerprint: SourceFingerprint::from_bytes(b"if ready:\n    run()\n"),
+                    executable: BTreeSet::from([1, 2]),
+                    excluded: BTreeSet::from([2]),
+                    executed: BTreeSet::from([1]),
+                    line_contexts: BTreeMap::from([(
+                        1,
+                        BTreeSet::from(["tests/test_package.py::test_ready".to_owned()]),
+                    )]),
+                    branches: Some(NativeBranchCoverage {
+                        possible: BTreeSet::from([
+                            BranchArc { from: 1, to: 2 },
+                            BranchArc { from: 1, to: 0 },
+                        ]),
+                        executed: BTreeSet::from([BranchArc { from: 1, to: 2 }]),
+                        contexts: BTreeSet::from([NativeArcContexts {
+                            arc: BranchArc { from: 1, to: 2 },
+                            contexts: BTreeSet::from([
+                                "tests/test_package.py::test_ready".to_owned()
+                            ]),
+                        }]),
+                    }),
+                },
+            )]),
+        )
+    }
+
+    #[test]
+    fn artifact_round_trips_without_loss() {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let path = Utf8PathBuf::from_path_buf(directory.path().join("coverage/data.json"))
+            .expect("UTF-8 temp path");
+        let expected = artifact();
+
+        expected.write(&path).expect("write artifact");
+        let actual = NativeCoverage::read(&path).expect("read artifact");
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn artifact_schema_snapshot() {
+        insta::assert_snapshot!(
+            serde_json::to_string_pretty(&artifact()).expect("serialize artifact")
+        );
+    }
+
+    #[test]
+    fn equivalent_artifacts_serialize_identically() {
+        let first = artifact();
+        let mut second = artifact();
+        let file = second
+            .files
+            .get_mut(Utf8Path::new("src/package.py"))
+            .expect("fixture file");
+        file.executable = [2, 1].into_iter().collect();
+        file.line_contexts = BTreeMap::from([(
+            1,
+            BTreeSet::from(["tests/test_package.py::test_ready".to_owned()]),
+        )]);
+
+        assert_eq!(
+            serde_json::to_vec_pretty(&first).expect("serialize first"),
+            serde_json::to_vec_pretty(&second).expect("serialize second")
+        );
+    }
+
+    #[test]
+    fn unsupported_version_names_path_and_versions() {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let path = Utf8PathBuf::from_path_buf(directory.path().join("data.json"))
+            .expect("UTF-8 temp path");
+        fs::write(&path, br#"{"format_version":2}"#).expect("write artifact");
+
+        let error = NativeCoverage::read(&path).expect_err("reject future version");
+        let message = error.to_string();
+
+        assert!(message.contains(path.as_str()));
+        assert!(message.contains("found format version 2"));
+        assert!(message.contains("supported version is 1"));
+    }
+
+    #[test]
+    fn source_fingerprint_detects_source_changes() {
+        let original = SourceFingerprint::from_bytes(b"value = 1\n");
+        let changed = SourceFingerprint::from_bytes(b"value = 2\n");
+
+        assert_ne!(original, changed);
+        assert_eq!(original.as_str().len(), 32);
+    }
+
+    #[test]
+    fn source_verification_rejects_drift() {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let project_root =
+            Utf8PathBuf::from_path_buf(directory.path().to_path_buf()).expect("UTF-8 temp path");
+        fs::create_dir(project_root.join("src")).expect("create source directory");
+        fs::write(project_root.join("src/package.py"), "value = 2\n").expect("write source");
+        let mut coverage = artifact();
+        coverage.project_root = project_root;
+
+        let error = coverage
+            .verify_sources()
+            .expect_err("reject changed source");
+
+        assert!(
+            error
+                .to_string()
+                .contains("source changed since collection")
+        );
+    }
+}

--- a/crates/karva_coverage/src/native.rs
+++ b/crates/karva_coverage/src/native.rs
@@ -207,7 +207,7 @@ mod tests {
         NativeCoverage::new(
             CoverageMode::Branch,
             Utf8PathBuf::from("/project"),
-            BTreeSet::from([Utf8PathBuf::from("/project/src")]),
+            BTreeSet::from([Utf8PathBuf::from("src")]),
             Some("linux-py313".to_owned()),
             BTreeMap::from([(
                 Utf8PathBuf::from("src/package.py"),

--- a/crates/karva_coverage/src/report/json.rs
+++ b/crates/karva_coverage/src/report/json.rs
@@ -91,7 +91,7 @@ pub(super) fn build_json_report(rows: &[FileRow]) -> Result<String> {
                     executed_lines: row.executed.clone(),
                     summary: json_summary(row),
                     missing_lines: missing_lines(row),
-                    excluded_lines: Vec::new(),
+                    excluded_lines: row.excluded.clone(),
                     contexts: row.contexts.clone(),
                     executed_branches: row
                         .branches_enabled
@@ -125,7 +125,7 @@ fn json_summary(row: &FileRow) -> JsonFileSummary {
         num_statements: row.stmts,
         percent_covered: row_percent(row),
         missing_lines: missing_lines(row),
-        excluded_lines: Vec::new(),
+        excluded_lines: row.excluded.clone(),
         num_branches: row.branches_enabled.then_some(row.branches),
         num_partial_branches: row.branches_enabled.then_some(row.branch_partial),
         covered_branches: row.branches_enabled.then_some(row.branch_hit),

--- a/crates/karva_coverage/src/report/mod.rs
+++ b/crates/karva_coverage/src/report/mod.rs
@@ -7,22 +7,24 @@ mod terminal;
 pub(crate) mod xml;
 
 use anyhow::Result;
-use camino::Utf8Path;
+use camino::{Utf8Path, Utf8PathBuf};
 use fs_err as fs;
 use globset::{Glob, GlobSet, GlobSetBuilder};
+use regex::RegexSet;
 
 pub use terminal::combine_and_report;
 pub use terminal::write_cobertura_xml;
 pub use terminal::write_html_report;
 pub use terminal::write_json_report;
 
-use self::shared::combine;
+use self::shared::{FileRow, combine, combine_native, total_percent, verify_combined_sources};
 
 #[derive(Debug, Default)]
-/// Include and omit globs applied to normalized coverage report paths.
+/// File globs and context regexes applied before coverage metrics are calculated.
 pub struct CoverageFilters {
     include: Option<GlobSet>,
     omit: Option<GlobSet>,
+    contexts: Option<RegexSet>,
 }
 
 impl CoverageFilters {
@@ -31,7 +33,14 @@ impl CoverageFilters {
         Ok(Self {
             include: compile_globs("include", include)?,
             omit: compile_globs("omit", omit)?,
+            contexts: None,
         })
+    }
+
+    /// Adds context patterns used to select executed lines and branches.
+    pub fn with_contexts(mut self, contexts: &[String]) -> Result<Self> {
+        self.contexts = compile_contexts(contexts)?;
+        Ok(self)
     }
 
     fn matches(&self, path: &str) -> bool {
@@ -39,6 +48,71 @@ impl CoverageFilters {
             .as_ref()
             .is_none_or(|include| include.is_match(path))
             && !self.omit.as_ref().is_some_and(|omit| omit.is_match(path))
+    }
+
+    fn has_contexts(&self) -> bool {
+        self.contexts.is_some()
+    }
+
+    fn matches_context(&self, context: &str) -> bool {
+        self.contexts
+            .as_ref()
+            .is_none_or(|contexts| contexts.is_match(context))
+    }
+}
+
+fn compile_contexts(patterns: &[String]) -> Result<Option<RegexSet>> {
+    if patterns.is_empty() {
+        return Ok(None);
+    }
+    RegexSet::new(patterns)
+        .map(Some)
+        .map_err(|error| anyhow::anyhow!("invalid coverage context pattern: {error}"))
+}
+
+/// Validated, filtered coverage metrics shared by every report renderer.
+#[derive(Debug)]
+pub struct CoverageAnalysis {
+    coverage_root: Utf8PathBuf,
+    cwd_real: std::path::PathBuf,
+    rows: Vec<FileRow>,
+}
+
+impl CoverageAnalysis {
+    /// Loads and analyzes durable native coverage artifacts.
+    pub fn load_native(
+        project_root: &Utf8Path,
+        files: &[impl AsRef<Utf8Path>],
+        filters: &CoverageFilters,
+    ) -> Result<Option<Self>> {
+        let Some(combined) = combine_native(files, filters)? else {
+            return Ok(None);
+        };
+        if combined.is_empty() {
+            return Ok(None);
+        }
+        verify_combined_sources(project_root, &combined)?;
+        let coverage_root = project_root.to_path_buf();
+        let cwd_real = canonical_root(&coverage_root);
+        let rows = shared::build_rows(&cwd_real, &combined, true)
+            .into_iter()
+            .filter(|row| filters.matches(&row.name))
+            .collect();
+        Ok(Some(Self {
+            coverage_root,
+            cwd_real,
+            rows,
+        }))
+    }
+
+    /// Returns the combined statement-and-branch coverage percentage.
+    pub fn total_percent(&self) -> f64 {
+        total_percent(&self.rows)
+    }
+
+    /// Returns the number of source files retained by the filters.
+    pub fn file_count(&self) -> usize {
+        self.rows.len()
     }
 }
 
@@ -61,27 +135,83 @@ fn compile_globs(kind: &str, patterns: &[String]) -> Result<Option<GlobSet>> {
 fn combined_rows(
     cwd: &Utf8Path,
     files: &[impl AsRef<Utf8Path>],
-    show_missing: bool,
     filters: &CoverageFilters,
-) -> Result<Option<(std::path::PathBuf, Vec<shared::FileRow>)>> {
+) -> Result<Option<CoverageAnalysis>> {
     let combined = combine(files)?;
     if combined.is_empty() {
         return Ok(None);
     }
 
-    let cwd_real = fs::canonicalize(cwd.as_std_path())
-        .map(|path| dunce::simplified(&path).to_path_buf())
-        .unwrap_or_else(|_| cwd.into());
-    let rows = shared::build_rows(&cwd_real, &combined, show_missing)
+    let cwd_real = canonical_root(cwd);
+    let rows = shared::build_rows(&cwd_real, &combined, true)
         .into_iter()
         .filter(|row| filters.matches(&row.name))
         .collect();
-    Ok(Some((cwd_real, rows)))
+    Ok(Some(CoverageAnalysis {
+        coverage_root: cwd.to_path_buf(),
+        cwd_real,
+        rows,
+    }))
+}
+
+fn canonical_root(cwd: &Utf8Path) -> std::path::PathBuf {
+    fs::canonicalize(cwd.as_std_path())
+        .map(|path| dunce::simplified(&path).to_path_buf())
+        .unwrap_or_else(|_| cwd.into())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::CoverageFilters;
+    use std::collections::{BTreeMap, BTreeSet};
+
+    use camino::{Utf8Path, Utf8PathBuf};
+    use fs_err as fs;
+
+    use super::{CoverageAnalysis, CoverageFilters};
+    use crate::data::BranchArc;
+    use crate::native::{
+        CoverageMode, NativeBranchCoverage, NativeCoverage, NativeFileCoverage, SourceFingerprint,
+    };
+
+    const SOURCE: &[u8] = b"first = 1\nsecond = 2\n";
+
+    fn write_artifact(
+        directory: &tempfile::TempDir,
+        name: &str,
+        mode: CoverageMode,
+        executed: BTreeSet<u32>,
+        contexts: BTreeMap<u32, BTreeSet<String>>,
+    ) -> Utf8PathBuf {
+        let project_root =
+            Utf8PathBuf::from_path_buf(directory.path().to_path_buf()).expect("UTF-8 temp path");
+        fs::create_dir_all(project_root.join("src")).expect("create source directory");
+        fs::write(project_root.join("src/app.py"), SOURCE).expect("write source");
+        let branches = (mode == CoverageMode::Branch).then(|| NativeBranchCoverage {
+            possible: BTreeSet::from([BranchArc { from: 1, to: 2 }, BranchArc { from: 1, to: 0 }]),
+            executed: BTreeSet::new(),
+            contexts: BTreeSet::new(),
+        });
+        let artifact = NativeCoverage::new(
+            mode,
+            project_root.clone(),
+            BTreeSet::from([Utf8PathBuf::from("src")]),
+            None,
+            BTreeMap::from([(
+                Utf8PathBuf::from("src/app.py"),
+                NativeFileCoverage {
+                    source_fingerprint: SourceFingerprint::from_bytes(SOURCE),
+                    executable: BTreeSet::from([1, 2]),
+                    excluded: BTreeSet::new(),
+                    executed,
+                    line_contexts: contexts,
+                    branches,
+                },
+            )]),
+        );
+        let path = project_root.join(name);
+        artifact.write(&path).expect("write native artifact");
+        path
+    }
 
     #[test]
     fn filters_apply_include_then_omit() {
@@ -104,5 +234,246 @@ mod tests {
                 .contains("invalid coverage include glob `[`"),
             "{err:?}"
         );
+    }
+
+    #[test]
+    fn filters_reject_invalid_context_patterns() {
+        let error = CoverageFilters::new(&[], &[])
+            .expect("empty file filters")
+            .with_contexts(&["[".to_owned()])
+            .expect_err("invalid context pattern");
+
+        assert!(
+            error
+                .to_string()
+                .contains("invalid coverage context pattern")
+        );
+    }
+
+    #[test]
+    fn context_filters_search_qualified_names() {
+        let filters = CoverageFilters::new(&[], &[])
+            .expect("empty file filters")
+            .with_contexts(&["test_example".to_owned()])
+            .expect("valid context filter");
+
+        assert!(filters.matches_context("tests/test_app.py::test_example[param]"));
+        assert!(!filters.matches_context("tests/test_app.py::test_other"));
+    }
+
+    #[test]
+    fn native_merge_order_does_not_change_analysis() {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let first = write_artifact(
+            &directory,
+            "first.json",
+            CoverageMode::Line,
+            BTreeSet::from([1]),
+            BTreeMap::from([(1, BTreeSet::from(["test_first".to_owned()]))]),
+        );
+        let second = write_artifact(
+            &directory,
+            "second.json",
+            CoverageMode::Line,
+            BTreeSet::from([2]),
+            BTreeMap::from([(2, BTreeSet::from(["test_second".to_owned()]))]),
+        );
+        let filters = CoverageFilters::new(&[], &[]).expect("empty filters");
+
+        let project_root = first.parent().expect("project root");
+        let forward = CoverageAnalysis::load_native(project_root, &[&first, &second], &filters)
+            .expect("analyze forward")
+            .expect("coverage data");
+        let reverse = CoverageAnalysis::load_native(project_root, &[&second, &first], &filters)
+            .expect("analyze reverse")
+            .expect("coverage data");
+
+        assert_eq!(forward.rows, reverse.rows);
+    }
+
+    #[test]
+    fn native_context_filter_recalculates_coverage() {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let path = write_artifact(
+            &directory,
+            "data.json",
+            CoverageMode::Line,
+            BTreeSet::from([1, 2]),
+            BTreeMap::from([
+                (1, BTreeSet::from(["python=3.14".to_owned()])),
+                (2, BTreeSet::from(["python=3.13".to_owned()])),
+            ]),
+        );
+        let filters = CoverageFilters::new(&[], &[])
+            .expect("empty file filters")
+            .with_contexts(&["python=3.14".to_owned()])
+            .expect("valid context filter");
+
+        let project_root = path.parent().expect("project root").to_path_buf();
+        let analysis = CoverageAnalysis::load_native(&project_root, &[path], &filters)
+            .expect("analyze coverage")
+            .expect("coverage data");
+
+        assert_eq!(analysis.rows[0].hit, 1);
+        assert_eq!(analysis.rows[0].stmts, 2);
+    }
+
+    #[test]
+    fn native_loader_uses_current_checkout_for_sources() {
+        let collected = tempfile::tempdir().expect("create collection directory");
+        let path = write_artifact(
+            &collected,
+            "data.json",
+            CoverageMode::Line,
+            BTreeSet::from([1]),
+            BTreeMap::new(),
+        );
+        let current = tempfile::tempdir().expect("create current checkout");
+        let current_root = Utf8PathBuf::from_path_buf(current.path().to_path_buf())
+            .expect("UTF-8 current checkout");
+        fs::create_dir(current_root.join("src")).expect("create current source directory");
+        fs::write(current_root.join("src/app.py"), SOURCE).expect("write current source");
+        let filters = CoverageFilters::new(&[], &[]).expect("empty filters");
+
+        let analysis = CoverageAnalysis::load_native(&current_root, &[path], &filters)
+            .expect("analyze in current checkout")
+            .expect("coverage data");
+
+        assert_eq!(analysis.file_count(), 1);
+    }
+
+    #[test]
+    fn native_analysis_removes_excluded_statements() {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let path = write_artifact(
+            &directory,
+            "data.json",
+            CoverageMode::Line,
+            BTreeSet::from([1, 2]),
+            BTreeMap::new(),
+        );
+        let mut artifact = NativeCoverage::read(&path).expect("read native artifact");
+        artifact
+            .files
+            .get_mut(Utf8Path::new("src/app.py"))
+            .expect("fixture file")
+            .excluded
+            .insert(2);
+        artifact.write(&path).expect("rewrite native artifact");
+        let filters = CoverageFilters::new(&[], &[]).expect("empty filters");
+        let project_root = path.parent().expect("project root").to_path_buf();
+
+        let analysis = CoverageAnalysis::load_native(&project_root, &[path], &filters)
+            .expect("analyze coverage")
+            .expect("coverage data");
+
+        assert_eq!(analysis.rows[0].stmts, 1);
+        assert_eq!(analysis.rows[0].hit, 1);
+        assert_eq!(analysis.rows[0].excluded, vec![2]);
+    }
+
+    #[test]
+    fn native_loader_rejects_mixed_collection_modes() {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let line = write_artifact(
+            &directory,
+            "line.json",
+            CoverageMode::Line,
+            BTreeSet::new(),
+            BTreeMap::new(),
+        );
+        let branch = write_artifact(
+            &directory,
+            "branch.json",
+            CoverageMode::Branch,
+            BTreeSet::new(),
+            BTreeMap::new(),
+        );
+        let filters = CoverageFilters::new(&[], &[]).expect("empty filters");
+
+        let project_root = line.parent().expect("project root");
+        let error =
+            CoverageAnalysis::load_native(project_root, &[line.clone(), branch.clone()], &filters)
+                .expect_err("reject mixed modes");
+
+        assert!(error.to_string().contains(branch.as_str()));
+        assert!(error.to_string().contains("expected collection mode Line"));
+        assert!(error.to_string().contains("found Branch"));
+    }
+
+    #[test]
+    fn native_loader_rejects_different_source_roots() {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let first = write_artifact(
+            &directory,
+            "first.json",
+            CoverageMode::Line,
+            BTreeSet::new(),
+            BTreeMap::new(),
+        );
+        let second = write_artifact(
+            &directory,
+            "second.json",
+            CoverageMode::Line,
+            BTreeSet::new(),
+            BTreeMap::new(),
+        );
+        let mut artifact = NativeCoverage::read(&second).expect("read second artifact");
+        artifact.source_roots = BTreeSet::from([Utf8PathBuf::from("lib")]);
+        artifact.write(&second).expect("rewrite second artifact");
+        let filters = CoverageFilters::new(&[], &[]).expect("empty filters");
+        let project_root = first.parent().expect("project root").to_path_buf();
+
+        let error =
+            CoverageAnalysis::load_native(&project_root, &[first, second.clone()], &filters)
+                .expect_err("reject different source roots");
+
+        assert!(error.to_string().contains(second.as_str()));
+        assert!(error.to_string().contains("source-root identity"));
+    }
+
+    #[test]
+    fn native_loader_reports_source_drift_with_input_path() {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let path = write_artifact(
+            &directory,
+            "data.json",
+            CoverageMode::Line,
+            BTreeSet::new(),
+            BTreeMap::new(),
+        );
+        fs::write(
+            path.parent().expect("project root").join("src/app.py"),
+            b"changed\n",
+        )
+        .expect("change source");
+        let filters = CoverageFilters::new(&[], &[]).expect("empty filters");
+
+        let project_root = path.parent().expect("project root");
+        let error =
+            CoverageAnalysis::load_native(project_root, std::slice::from_ref(&path), &filters)
+                .expect_err("reject source drift");
+        let message = format!("{error:#}");
+
+        assert!(message.contains(path.as_str()));
+        assert!(message.contains("expected unchanged source"));
+        assert!(message.contains("fingerprint"));
+    }
+
+    #[test]
+    fn native_loader_reports_corrupt_input_path() {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let project_root =
+            Utf8PathBuf::from_path_buf(directory.path().to_path_buf()).expect("UTF-8 temp path");
+        let path = project_root.join("corrupt.json");
+        fs::write(&path, "{}").expect("write corrupt artifact");
+        let filters = CoverageFilters::new(&[], &[]).expect("empty filters");
+
+        let error =
+            CoverageAnalysis::load_native(&project_root, std::slice::from_ref(&path), &filters)
+                .expect_err("reject corrupt artifact");
+
+        assert!(error.to_string().contains(path.as_str()));
+        assert!(error.to_string().contains("failed to parse"));
     }
 }

--- a/crates/karva_coverage/src/report/shared.rs
+++ b/crates/karva_coverage/src/report/shared.rs
@@ -1,23 +1,30 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{Context, Result};
-use camino::Utf8Path;
+use camino::{Utf8Path, Utf8PathBuf};
 use fs_err as fs;
 
 use crate::data::{BranchArc, WorkerFile};
+use crate::native::{CoverageMode, NativeCoverage, SourceFingerprint};
+use crate::report::CoverageFilters;
 
 #[derive(Debug, Default)]
 /// Union of raw coverage observations for one normalized source path.
 pub(super) struct CombinedFile {
+    source_fingerprint: Option<SourceFingerprint>,
+    fingerprint_artifact: Option<Utf8PathBuf>,
     executable: BTreeSet<u32>,
+    excluded: BTreeSet<u32>,
     executed: BTreeSet<u32>,
     contexts: BTreeMap<u32, BTreeSet<String>>,
     branches_enabled: bool,
     branch_possible: BTreeSet<BranchArc>,
     branch_executed: BTreeSet<BranchArc>,
+    arc_contexts: BTreeMap<BranchArc, BTreeSet<String>>,
 }
 
 /// Report-ready metrics and source data shared by every output format.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct FileRow {
     /// Display path, relative to the coverage root when possible.
     pub name: String,
@@ -30,6 +37,7 @@ pub(super) struct FileRow {
     pub miss: u32,
     pub missing: String,
     pub executable: Vec<u32>,
+    pub excluded: Vec<u32>,
     pub executed: Vec<u32>,
     pub contexts: BTreeMap<u32, BTreeSet<String>>,
 
@@ -43,6 +51,7 @@ pub(super) struct FileRow {
     pub branch_possible: Vec<BranchArc>,
     pub branch_executed: Vec<BranchArc>,
     pub branch_missing: Vec<BranchArc>,
+    pub arc_contexts: BTreeMap<BranchArc, BTreeSet<String>>,
 }
 
 /// Unions per-worker payloads so each source path has one coverage record.
@@ -67,11 +76,186 @@ pub(super) fn combine(files: &[impl AsRef<Utf8Path>]) -> Result<BTreeMap<String,
                 bucket.branches_enabled = true;
                 bucket.branch_possible.extend(branches.possible);
                 bucket.branch_executed.extend(branches.executed);
+                for entry in branches.contexts {
+                    bucket
+                        .arc_contexts
+                        .entry(entry.arc)
+                        .or_default()
+                        .extend(entry.contexts);
+                }
             }
         }
     }
 
     Ok(combined)
+}
+
+/// Loads, validates, and deterministically unions durable native artifacts.
+pub(super) fn combine_native(
+    files: &[impl AsRef<Utf8Path>],
+    filters: &CoverageFilters,
+) -> Result<Option<BTreeMap<String, CombinedFile>>> {
+    let Some(first_path) = files.first().map(AsRef::as_ref) else {
+        return Ok(None);
+    };
+    let first = NativeCoverage::read(first_path)?;
+    let mut combined = BTreeMap::new();
+    merge_native(&mut combined, first_path, &first, filters)?;
+
+    for path in &files[1..] {
+        let path = path.as_ref();
+        let artifact = NativeCoverage::read(path)?;
+        validate_identity(first_path, &first, path, &artifact)?;
+        merge_native(&mut combined, path, &artifact, filters)?;
+    }
+
+    Ok(Some(combined))
+}
+
+fn validate_identity(
+    expected_path: &Utf8Path,
+    expected: &NativeCoverage,
+    path: &Utf8Path,
+    artifact: &NativeCoverage,
+) -> Result<()> {
+    if artifact.mode != expected.mode {
+        anyhow::bail!(
+            "incompatible native coverage artifact `{path}`: expected collection mode {:?} from `{expected_path}`, found {:?}",
+            expected.mode,
+            artifact.mode
+        );
+    }
+    if artifact.source_roots != expected.source_roots {
+        anyhow::bail!(
+            "incompatible native coverage artifact `{path}`: expected source-root identity from `{expected_path}`"
+        );
+    }
+    Ok(())
+}
+
+fn merge_native(
+    combined: &mut BTreeMap<String, CombinedFile>,
+    path: &Utf8Path,
+    artifact: &NativeCoverage,
+    filters: &CoverageFilters,
+) -> Result<()> {
+    let run_context_matches = artifact
+        .run_context
+        .as_deref()
+        .is_some_and(|context| filters.matches_context(context));
+    for (source_path, file) in &artifact.files {
+        let bucket = combined.entry(source_path.to_string()).or_default();
+        if let Some(expected) = &bucket.source_fingerprint
+            && expected != &file.source_fingerprint
+        {
+            anyhow::bail!(
+                "incompatible native coverage artifact `{path}`: expected source fingerprint {} for `{source_path}`, found {}",
+                expected.as_str(),
+                file.source_fingerprint.as_str()
+            );
+        }
+        bucket.source_fingerprint = Some(file.source_fingerprint.clone());
+        bucket
+            .fingerprint_artifact
+            .get_or_insert_with(|| path.to_path_buf());
+        bucket.executable.extend(&file.executable);
+        bucket.excluded.extend(&file.excluded);
+        bucket.branches_enabled = artifact.mode == CoverageMode::Branch;
+        merge_line_observations(bucket, file, filters, run_context_matches);
+        if let Some(branches) = &file.branches {
+            bucket.branches_enabled = true;
+            bucket.branch_possible.extend(&branches.possible);
+            merge_branch_observations(bucket, branches, filters, run_context_matches);
+        }
+    }
+    Ok(())
+}
+
+/// Verifies combined source fingerprints against the current project checkout.
+pub(super) fn verify_combined_sources(
+    project_root: &Utf8Path,
+    combined: &BTreeMap<String, CombinedFile>,
+) -> Result<()> {
+    for (source_path, file) in combined {
+        let path = project_root.join(source_path);
+        let artifact = file
+            .fingerprint_artifact
+            .as_deref()
+            .unwrap_or_else(|| Utf8Path::new("<unknown>"));
+        let source = fs::read(&path).with_context(|| {
+            format!("native coverage artifact `{artifact}` expected source `{path}` to exist")
+        })?;
+        if let Some(fingerprint) = &file.source_fingerprint
+            && !fingerprint.matches(&source)
+        {
+            anyhow::bail!(
+                "native coverage artifact `{artifact}` expected unchanged source `{path}` with fingerprint {}",
+                fingerprint.as_str()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn merge_line_observations(
+    bucket: &mut CombinedFile,
+    file: &crate::native::NativeFileCoverage,
+    filters: &CoverageFilters,
+    run_context_matches: bool,
+) {
+    if !filters.has_contexts() || run_context_matches {
+        bucket.executed.extend(&file.executed);
+    }
+    for (line, contexts) in &file.line_contexts {
+        let matching: BTreeSet<String> = contexts
+            .iter()
+            .filter(|context| filters.matches_context(context))
+            .cloned()
+            .collect();
+        if !matching.is_empty() {
+            bucket.executed.insert(*line);
+            bucket.contexts.entry(*line).or_default().extend(matching);
+        } else if !filters.has_contexts() {
+            bucket
+                .contexts
+                .entry(*line)
+                .or_default()
+                .extend(contexts.iter().cloned());
+        }
+    }
+}
+
+fn merge_branch_observations(
+    bucket: &mut CombinedFile,
+    branches: &crate::native::NativeBranchCoverage,
+    filters: &CoverageFilters,
+    run_context_matches: bool,
+) {
+    if !filters.has_contexts() || run_context_matches {
+        bucket.branch_executed.extend(&branches.executed);
+    }
+    for entry in &branches.contexts {
+        let matching: BTreeSet<String> = entry
+            .contexts
+            .iter()
+            .filter(|context| filters.matches_context(context))
+            .cloned()
+            .collect();
+        if !matching.is_empty() {
+            bucket.branch_executed.insert(entry.arc);
+            bucket
+                .arc_contexts
+                .entry(entry.arc)
+                .or_default()
+                .extend(matching);
+        } else if !filters.has_contexts() {
+            bucket
+                .arc_contexts
+                .entry(entry.arc)
+                .or_default()
+                .extend(entry.contexts.iter().cloned());
+        }
+    }
 }
 
 /// Converts combined observations into normalized metrics consumed by report writers.
@@ -84,8 +268,19 @@ pub(super) fn build_rows(
         .iter()
         .map(|(filename, data)| {
             let absolute_name = simplify_path(filename);
-            let executable: Vec<u32> = data.executable.iter().copied().collect();
-            let executed: Vec<u32> = data.executed.iter().copied().collect();
+            let executable_set: BTreeSet<u32> = data
+                .executable
+                .difference(&data.excluded)
+                .copied()
+                .collect();
+            let executed_set: BTreeSet<u32> = data
+                .executed
+                .intersection(&executable_set)
+                .copied()
+                .collect();
+            let executable: Vec<u32> = executable_set.iter().copied().collect();
+            let excluded: Vec<u32> = data.excluded.iter().copied().collect();
+            let executed: Vec<u32> = executed_set.iter().copied().collect();
             let stmts = u32::try_from(executable.len()).unwrap_or(u32::MAX);
             let hit = u32::try_from(executed.len()).unwrap_or(u32::MAX);
             let miss = stmts.saturating_sub(hit);
@@ -104,11 +299,8 @@ pub(super) fn build_rows(
             let branch_miss = branches.saturating_sub(branch_hit);
             let branch_partial = partial_branch_count(&data.branch_possible, &branch_executed);
             let missing = if show_missing {
-                let uncovered: BTreeSet<u32> = data
-                    .executable
-                    .difference(&data.executed)
-                    .copied()
-                    .collect();
+                let uncovered: BTreeSet<u32> =
+                    executable_set.difference(&executed_set).copied().collect();
                 collapse_missing(&uncovered, &branch_missing)
             } else {
                 String::new()
@@ -121,6 +313,7 @@ pub(super) fn build_rows(
                 miss,
                 missing,
                 executable,
+                excluded,
                 executed,
                 contexts: data.contexts.clone(),
                 branches_enabled: data.branches_enabled,
@@ -131,6 +324,7 @@ pub(super) fn build_rows(
                 branch_possible: data.branch_possible.iter().copied().collect(),
                 branch_executed: branch_executed.iter().copied().collect(),
                 branch_missing: branch_missing.iter().copied().collect(),
+                arc_contexts: data.arc_contexts.clone(),
             }
         })
         .collect()
@@ -186,6 +380,7 @@ pub(super) fn totals_row(rows: &[FileRow]) -> FileRow {
         miss,
         missing: collapse_ranges(&missing.iter().copied().collect()),
         executable: Vec::new(),
+        excluded: Vec::new(),
         executed: Vec::new(),
         contexts: BTreeMap::new(),
         branches_enabled: rows.iter().any(|row| row.branches_enabled),
@@ -196,6 +391,7 @@ pub(super) fn totals_row(rows: &[FileRow]) -> FileRow {
         branch_possible: Vec::new(),
         branch_executed: Vec::new(),
         branch_missing: Vec::new(),
+        arc_contexts: BTreeMap::new(),
     }
 }
 
@@ -456,6 +652,7 @@ mod tests {
             miss: 0,
             missing: String::new(),
             executable: Vec::new(),
+            excluded: Vec::new(),
             executed: Vec::new(),
             contexts: BTreeMap::new(),
             branches_enabled: false,
@@ -466,6 +663,7 @@ mod tests {
             branch_possible: Vec::new(),
             branch_executed: Vec::new(),
             branch_missing: Vec::new(),
+            arc_contexts: BTreeMap::new(),
         };
 
         assert_eq!(

--- a/crates/karva_coverage/src/report/terminal.rs
+++ b/crates/karva_coverage/src/report/terminal.rs
@@ -5,12 +5,12 @@ use camino::Utf8Path;
 use colored::Colorize;
 use fs_err as fs;
 
-use super::CoverageFilters;
 use super::combined_rows;
 use super::html::build_html_report;
 use super::json::build_json_report;
 use super::shared::{FileRow, row_percent, total_percent, totals_row};
 use super::xml::build_cobertura_xml;
+use super::{CoverageAnalysis, CoverageFilters};
 
 /// Prints the terminal coverage table and returns its total percentage.
 ///
@@ -21,11 +21,10 @@ pub fn combine_and_report(
     show_missing: bool,
     filters: &CoverageFilters,
 ) -> Result<Option<f64>> {
-    let Some((_, rows)) = combined_rows(cwd, files, show_missing, filters)? else {
+    let Some(analysis) = combined_rows(cwd, files, filters)? else {
         return Ok(None);
     };
-    let total = print_report(&rows, show_missing, &mut std::io::stdout().lock())?;
-    Ok(Some(total))
+    analysis.report(show_missing).map(Some)
 }
 
 /// Writes a Cobertura-compatible XML report and returns its total percentage.
@@ -35,23 +34,10 @@ pub fn write_cobertura_xml(
     output: &Utf8Path,
     filters: &CoverageFilters,
 ) -> Result<Option<f64>> {
-    let Some((cwd_real, rows)) = combined_rows(cwd, files, false, filters)? else {
+    let Some(analysis) = combined_rows(cwd, files, filters)? else {
         return Ok(None);
     };
-    let total_pct = total_percent(&rows);
-
-    if let Some(parent) = output.parent()
-        && !parent.as_str().is_empty()
-    {
-        fs::create_dir_all(parent.as_std_path())
-            .with_context(|| format!("failed to create coverage output directory {parent}"))?;
-    }
-
-    let xml = build_cobertura_xml(cwd, &cwd_real, &rows)?;
-    fs::write(output.as_std_path(), xml)
-        .with_context(|| format!("failed to write coverage xml {output}"))?;
-
-    Ok(Some(total_pct))
+    analysis.write_cobertura_xml(output).map(Some)
 }
 
 /// Writes a coverage.py-compatible JSON report and returns its total percentage.
@@ -61,23 +47,10 @@ pub fn write_json_report(
     output: &Utf8Path,
     filters: &CoverageFilters,
 ) -> Result<Option<f64>> {
-    let Some((_, rows)) = combined_rows(cwd, files, false, filters)? else {
+    let Some(analysis) = combined_rows(cwd, files, filters)? else {
         return Ok(None);
     };
-    let total_pct = total_percent(&rows);
-
-    if let Some(parent) = output.parent()
-        && !parent.as_str().is_empty()
-    {
-        fs::create_dir_all(parent.as_std_path())
-            .with_context(|| format!("failed to create coverage output directory {parent}"))?;
-    }
-
-    let json = build_json_report(&rows)?;
-    fs::write(output.as_std_path(), json)
-        .with_context(|| format!("failed to write coverage json {output}"))?;
-
-    Ok(Some(total_pct))
+    analysis.write_json(output).map(Some)
 }
 
 /// Writes a standalone HTML coverage report and returns its total percentage.
@@ -87,20 +60,56 @@ pub fn write_html_report(
     output_dir: &Utf8Path,
     filters: &CoverageFilters,
 ) -> Result<Option<f64>> {
-    let Some((_, rows)) = combined_rows(cwd, files, true, filters)? else {
+    let Some(analysis) = combined_rows(cwd, files, filters)? else {
         return Ok(None);
     };
-    let total_pct = total_percent(&rows);
+    analysis.write_html(output_dir).map(Some)
+}
 
-    fs::create_dir_all(output_dir.as_std_path())
-        .with_context(|| format!("failed to create coverage html directory {output_dir}"))?;
+impl CoverageAnalysis {
+    /// Prints the compact terminal report and returns total coverage.
+    pub fn report(&self, show_missing: bool) -> Result<f64> {
+        print_report(&self.rows, show_missing, &mut std::io::stdout().lock())
+    }
 
-    let html = build_html_report(&rows);
-    let output_file = output_dir.join("index.html");
-    fs::write(output_file.as_std_path(), html)
-        .with_context(|| format!("failed to write coverage html {output_file}"))?;
+    /// Writes a Cobertura-compatible XML report and returns total coverage.
+    pub fn write_cobertura_xml(&self, output: &Utf8Path) -> Result<f64> {
+        create_output_parent(output)?;
+        let xml = build_cobertura_xml(&self.coverage_root, &self.cwd_real, &self.rows)?;
+        fs::write(output.as_std_path(), xml)
+            .with_context(|| format!("failed to write coverage xml {output}"))?;
+        Ok(self.total_percent())
+    }
 
-    Ok(Some(total_pct))
+    /// Writes a coverage.py-compatible JSON report and returns total coverage.
+    pub fn write_json(&self, output: &Utf8Path) -> Result<f64> {
+        create_output_parent(output)?;
+        let json = build_json_report(&self.rows)?;
+        fs::write(output.as_std_path(), json)
+            .with_context(|| format!("failed to write coverage json {output}"))?;
+        Ok(self.total_percent())
+    }
+
+    /// Writes a standalone HTML report and returns total coverage.
+    pub fn write_html(&self, output_dir: &Utf8Path) -> Result<f64> {
+        fs::create_dir_all(output_dir.as_std_path())
+            .with_context(|| format!("failed to create coverage html directory {output_dir}"))?;
+        let html = build_html_report(&self.rows);
+        let output_file = output_dir.join("index.html");
+        fs::write(output_file.as_std_path(), html)
+            .with_context(|| format!("failed to write coverage html {output_file}"))?;
+        Ok(self.total_percent())
+    }
+}
+
+fn create_output_parent(output: &Utf8Path) -> Result<()> {
+    if let Some(parent) = output.parent()
+        && !parent.as_str().is_empty()
+    {
+        fs::create_dir_all(parent.as_std_path())
+            .with_context(|| format!("failed to create coverage output directory {parent}"))?;
+    }
+    Ok(())
 }
 
 struct Row<'a> {
@@ -250,6 +259,7 @@ mod tests {
             miss,
             missing: missing.to_string(),
             executable: Vec::new(),
+            excluded: Vec::new(),
             executed: Vec::new(),
             contexts: BTreeMap::new(),
             branches_enabled: false,
@@ -260,6 +270,7 @@ mod tests {
             branch_possible: Vec::new(),
             branch_executed: Vec::new(),
             branch_missing: Vec::new(),
+            arc_contexts: BTreeMap::new(),
         }
     }
 

--- a/crates/karva_coverage/src/snapshots/karva_coverage__native__tests__artifact_schema_snapshot.snap
+++ b/crates/karva_coverage/src/snapshots/karva_coverage__native__tests__artifact_schema_snapshot.snap
@@ -8,7 +8,7 @@ expression: "serde_json::to_string_pretty(&artifact()).expect(\"serialize artifa
   "mode": "branch",
   "project_root": "/project",
   "source_roots": [
-    "/project/src"
+    "src"
   ],
   "run_context": "linux-py313",
   "files": {

--- a/crates/karva_coverage/src/snapshots/karva_coverage__native__tests__artifact_schema_snapshot.snap
+++ b/crates/karva_coverage/src/snapshots/karva_coverage__native__tests__artifact_schema_snapshot.snap
@@ -1,0 +1,63 @@
+---
+source: crates/karva_coverage/src/native.rs
+expression: "serde_json::to_string_pretty(&artifact()).expect(\"serialize artifact\")"
+---
+{
+  "format_version": 1,
+  "karva_version": "0.0.0",
+  "mode": "branch",
+  "project_root": "/project",
+  "source_roots": [
+    "/project/src"
+  ],
+  "run_context": "linux-py313",
+  "files": {
+    "src/package.py": {
+      "source_fingerprint": "8198f531bcf087563f2129915ed5fd21",
+      "executable": [
+        1,
+        2
+      ],
+      "excluded": [
+        2
+      ],
+      "executed": [
+        1
+      ],
+      "line_contexts": {
+        "1": [
+          "tests/test_package.py::test_ready"
+        ]
+      },
+      "branches": {
+        "possible": [
+          {
+            "from": 1,
+            "to": 0
+          },
+          {
+            "from": 1,
+            "to": 2
+          }
+        ],
+        "executed": [
+          {
+            "from": 1,
+            "to": 2
+          }
+        ],
+        "contexts": [
+          {
+            "arc": {
+              "from": 1,
+              "to": 2
+            },
+            "contexts": [
+              "tests/test_package.py::test_ready"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/docs/reference/native-coverage-format.md
+++ b/docs/reference/native-coverage-format.md
@@ -5,9 +5,12 @@ the internal interchange format used by collection, combination, and reporting.
 It is not coverage.py's SQLite format and it is not the exported
 `coverage.json` report.
 
-Version 1 records the producing Karva version, collection mode, project and
-source roots, an optional run context, and files keyed by normalized
-project-relative path. Each file records a stable source-content fingerprint,
+Version 1 records the producing Karva version, collection mode, original
+project root, project-relative source roots, an optional run context, and files
+keyed by normalized project-relative path. The original root is provenance, not
+portable project identity; combination uses source roots, paths, and content
+fingerprints so artifacts can move between CI machines. Each file records a
+stable source-content fingerprint,
 executable, excluded, and executed lines, line contexts, and optional possible
 and executed branch arcs with their contexts. The fingerprint is lowercase
 hexadecimal fixed-key SipHash-128/1-3 over the source bytes.

--- a/docs/reference/native-coverage-format.md
+++ b/docs/reference/native-coverage-format.md
@@ -1,0 +1,22 @@
+# Native coverage format
+
+Karva stores durable coverage data as deterministic, versioned JSON. This is
+the internal interchange format used by collection, combination, and reporting.
+It is not coverage.py's SQLite format and it is not the exported
+`coverage.json` report.
+
+Version 1 records the producing Karva version, collection mode, project and
+source roots, an optional run context, and files keyed by normalized
+project-relative path. Each file records a stable source-content fingerprint,
+executable, excluded, and executed lines, line contexts, and optional possible
+and executed branch arcs with their contexts. The fingerprint is lowercase
+hexadecimal fixed-key SipHash-128/1-3 over the source bytes.
+
+Objects use lexicographically sorted keys. Sets serialize as sorted arrays, so
+equivalent coverage data produces identical bytes. Writers replace artifacts
+atomically. Readers accept version 1 only and report the artifact path, found
+version, and supported version when the schema is incompatible.
+
+Before reporting, Karva compares each stored source fingerprint with the
+current source bytes. Changed or missing sources fail reporting instead of
+silently producing results from stale code.

--- a/zensical.toml
+++ b/zensical.toml
@@ -61,6 +61,7 @@ nav = [
     { "Reference" = [
         { "CLI" = "reference/cli.md"},
         { "Environment Variables" = "reference/env-vars.md"},
+        { "Native Coverage Format" = "reference/native-coverage-format.md"},
     ]},
 ]
 


### PR DESCRIPTION
## Summary

Load, validate, merge, and filter native coverage artifacts into one deterministic analysis shared by every report renderer. The analysis rejects incompatible modes and source identities, verifies current source content, preserves line and branch contexts, applies exclusions, and supports context regex filtering without changing immediate test-run reports.

Closes #1153

## Test plan

`cargo test -p karva_coverage`; `cargo clippy -p karva_coverage --all-targets --all-features -- -D warnings`; `just test -p karva coverage`; `uvx prek run -a`