### PR TITLE
Add native coverage command group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ wheels/
 *.profraw
 .coverage
 .coverage.*
+.karva/
 htmlcov/
 
 # Rust formatter backups

--- a/crates/karva/src/commands/coverage.rs
+++ b/crates/karva/src/commands/coverage.rs
@@ -1,0 +1,69 @@
+use std::io::{ErrorKind, Write};
+
+use anyhow::{Context, Result, bail};
+use karva_cli::{CoverageAction, CoverageCommand};
+use karva_logging::Printer;
+use karva_metadata::{ProjectMetadata, ProjectOptionsOverrides};
+use karva_project::Project;
+use karva_project::path::absolute;
+use karva_python_semantic::current_python_version;
+
+use crate::ExitStatus;
+use crate::utils::cwd;
+
+pub fn coverage(args: &CoverageCommand) -> Result<ExitStatus> {
+    let cwd = cwd()?;
+    let config_file = args.config_file.as_ref().map(|path| absolute(path, &cwd));
+    let mut metadata = if let Some(config_file) = &config_file {
+        ProjectMetadata::from_config_file(config_file, &cwd, current_python_version())?
+    } else {
+        ProjectMetadata::discover(&cwd, current_python_version())?
+    };
+    let overrides = ProjectOptionsOverrides::new(config_file, args.options())
+        .with_profile(args.profile.clone());
+    metadata
+        .apply_overrides(&overrides)
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+    let project = Project::from_metadata(metadata);
+    let settings = project.settings().coverage();
+    let data_file = absolute(&settings.data_file, project.cwd());
+
+    match std::fs::metadata(&data_file) {
+        Ok(_) => {}
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            bail!("no coverage data found at `{data_file}`; run `uv run karva test --cov` first");
+        }
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("failed to inspect coverage data `{data_file}`"));
+        }
+    }
+
+    let filters = karva_coverage::CoverageFilters::new(&settings.include, &settings.omit)?
+        .with_contexts(&settings.contexts)?;
+    let analysis = karva_coverage::CoverageAnalysis::load_native(
+        project.cwd(),
+        std::slice::from_ref(&data_file),
+        &filters,
+    )?
+    .with_context(|| format!("coverage data at `{data_file}` contains no source files"))?;
+
+    match &args.action {
+        CoverageAction::Report(_) => {
+            let total = analysis.report_with_precision(false, settings.precision.0)?;
+            if let Some(threshold) = settings.fail_under
+                && total < threshold
+            {
+                let mut stdout = Printer::default().stream_for_message().lock();
+                writeln!(
+                    stdout,
+                    "\ncoverage failure: required total coverage of {threshold}% not reached, total coverage was {:.*}%",
+                    settings.precision.0, total
+                )?;
+                return Ok(ExitStatus::Failure);
+            }
+        }
+    }
+
+    Ok(ExitStatus::Success)
+}

--- a/crates/karva/src/commands/mod.rs
+++ b/crates/karva/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod cache;
+pub mod coverage;
 pub mod show_config;
 pub mod snapshot;
 pub mod test;

--- a/crates/karva/src/lib.rs
+++ b/crates/karva/src/lib.rs
@@ -41,6 +41,7 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
     match args.command {
         Command::Test(test_args) => commands::test::test(*test_args),
         Command::Snapshot(snapshot_args) => commands::snapshot::snapshot(snapshot_args),
+        Command::Coverage(coverage_args) => commands::coverage::coverage(&coverage_args),
         Command::Cache(cache_args) => commands::cache::cache(&cache_args),
         Command::ShowConfig(show_config_args) => {
             commands::show_config::show_config(show_config_args)

--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -3356,6 +3356,7 @@ fn test_no_subcommand_prints_help() {
     Commands:
       test         Run tests
       snapshot     Manage snapshots created by `karva.assert_snapshot()`
+      coverage     Read and report native Karva coverage data
       cache        Manage the karva cache
       show-config  Print the resolved configuration karva would run with
       version      Display Karva's version

--- a/crates/karva/tests/it/common/mod.rs
+++ b/crates/karva/tests/it/common/mod.rs
@@ -192,6 +192,15 @@ impl TestContext {
         command
     }
 
+    pub fn coverage(&self, subcommand: &str) -> Command {
+        let mut command = self.karva_command();
+        command
+            .arg("coverage")
+            .arg(subcommand)
+            .current_dir(self.root());
+        command
+    }
+
     pub fn version(&self) -> Command {
         let mut command = self.karva_command();
         command.arg("version").current_dir(self.root());

--- a/crates/karva/tests/it/coverage_command.rs
+++ b/crates/karva/tests/it/coverage_command.rs
@@ -1,0 +1,152 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use camino::{Utf8Path, Utf8PathBuf};
+use insta_cmd::assert_cmd_snapshot;
+use karva_coverage::native::{CoverageMode, NativeCoverage, NativeFileCoverage, SourceFingerprint};
+
+use crate::common::TestContext;
+
+const SOURCE: &str = "first = 1\nsecond = 2\n";
+
+fn write_coverage(context: &TestContext, path: &Utf8Path) {
+    context.write_file("src/app.py", SOURCE);
+    let root = context.root();
+    let artifact = NativeCoverage::new(
+        CoverageMode::Line,
+        root.clone(),
+        BTreeSet::from([Utf8PathBuf::from("src")]),
+        None,
+        BTreeMap::from([(
+            Utf8PathBuf::from("src/app.py"),
+            NativeFileCoverage {
+                source_fingerprint: SourceFingerprint::from_bytes(SOURCE.as_bytes()),
+                executable: BTreeSet::from([1, 2]),
+                excluded: BTreeSet::new(),
+                executed: BTreeSet::from([1]),
+                line_contexts: BTreeMap::new(),
+                branches: None,
+            },
+        )]),
+    );
+    artifact
+        .write(&root.join(path))
+        .expect("write coverage data");
+}
+
+#[test]
+fn report_reads_default_native_data() {
+    let context = TestContext::new();
+    write_coverage(&context, Utf8Path::new(".karva/coverage/data.json"));
+
+    assert_cmd_snapshot!(context.coverage("report"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    Name         Stmts   Miss   Cover
+    [LONG-LINE]
+    src/app.py       2      1     50%
+    [LONG-LINE]
+    TOTAL            2      1     50%
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn report_discovers_project_from_subdirectory_and_honors_config() {
+    let context = TestContext::new();
+    context.write_file(
+        "karva.toml",
+        r#"
+[profile.default.coverage]
+data-file = "build/native.json"
+precision = 2
+"#,
+    );
+    context.write_file("nested/.gitkeep", "");
+    write_coverage(&context, Utf8Path::new("build/native.json"));
+    let mut command = context.karva_command_in(context.root().join("nested"));
+    command.args(["coverage", "report"]);
+
+    assert_cmd_snapshot!(command, @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    Name         Stmts   Miss   Cover
+    [LONG-LINE]
+    src/app.py       2      1   50.00%
+    [LONG-LINE]
+    TOTAL            2      1   50.00%
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn report_cli_data_file_overrides_config() {
+    let context = TestContext::new();
+    context.write_file(
+        "karva.toml",
+        r#"
+[profile.default.coverage]
+data-file = "missing.json"
+"#,
+    );
+    write_coverage(&context, Utf8Path::new("actual.json"));
+
+    assert_cmd_snapshot!(
+        context.coverage("report").args(["--data-file", "actual.json"]),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    Name         Stmts   Miss   Cover
+    [LONG-LINE]
+    src/app.py       2      1     50%
+    [LONG-LINE]
+    TOTAL            2      1     50%
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
+fn report_missing_data_names_default_and_remedy() {
+    let context = TestContext::new();
+
+    assert_cmd_snapshot!(context.coverage("report"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Karva failed
+      Cause: no coverage data found at `<temp_dir>/.karva/coverage/data.json`; run `uv run karva test --cov` first
+    ");
+}
+
+#[test]
+fn report_fail_under_returns_failure() {
+    let context = TestContext::new();
+    write_coverage(&context, Utf8Path::new(".karva/coverage/data.json"));
+
+    assert_cmd_snapshot!(context.coverage("report").arg("--fail-under=75"), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    Name         Stmts   Miss   Cover
+    [LONG-LINE]
+    src/app.py       2      1     50%
+    [LONG-LINE]
+    TOTAL            2      1     50%
+
+    coverage failure: required total coverage of 75% not reached, total coverage was 50%
+
+    ----- stderr -----
+    ");
+}

--- a/crates/karva/tests/it/main.rs
+++ b/crates/karva/tests/it/main.rs
@@ -6,6 +6,7 @@ mod cache;
 mod cancel;
 mod configuration;
 mod coverage;
+mod coverage_command;
 mod discovery;
 mod durations;
 mod extensions;

--- a/crates/karva/tests/it/show_config.rs
+++ b/crates/karva/tests/it/show_config.rs
@@ -28,9 +28,12 @@ fn show_config_default_profile() {
     no-tests = "auto"
 
     [coverage]
+    data-file = ".karva/coverage/data.json"
     sources = []
     include = []
     omit = []
+    contexts = []
+    precision = 0
     report = "term"
 
     [junit]
@@ -79,9 +82,12 @@ output-format = "concise"
     no-tests = "auto"
 
     [coverage]
+    data-file = ".karva/coverage/data.json"
     sources = []
     include = []
     omit = []
+    contexts = []
+    precision = 0
     report = "term"
 
     [junit]
@@ -131,9 +137,12 @@ output-format = "concise"
     no-tests = "auto"
 
     [coverage]
+    data-file = ".karva/coverage/data.json"
     sources = []
     include = []
     omit = []
+    contexts = []
+    precision = 0
     report = "term"
 
     [junit]
@@ -189,9 +198,12 @@ fail-under = 90
     termination-grace-period = 2.0
 
     [coverage]
+    data-file = ".karva/coverage/data.json"
     sources = ["src"]
     include = ["src/app/*"]
     omit = ["**/generated.py"]
+    contexts = []
+    precision = 0
     report = "term-missing"
     fail-under = 90.0
 
@@ -242,9 +254,12 @@ slow-timeout = 0.5
     no-tests = "auto"
 
     [coverage]
+    data-file = ".karva/coverage/data.json"
     sources = []
     include = []
     omit = []
+    contexts = []
+    precision = 0
     report = "term"
 
     [junit]

--- a/crates/karva_cli/src/coverage.rs
+++ b/crates/karva_cli/src/coverage.rs
@@ -1,0 +1,151 @@
+use camino::Utf8PathBuf;
+use clap::{Args, Parser};
+use karva_metadata::{CovFailUnder, CoverageOptions, CoveragePrecision, Options};
+use karva_static::EnvVars;
+
+use crate::test::parse_cov_fail_under;
+
+#[derive(Debug, Parser)]
+/// Read and report native Karva coverage data.
+pub struct CoverageCommand {
+    /// Coverage operation to execute.
+    #[command(subcommand)]
+    pub action: CoverageAction,
+
+    /// Native coverage artifact path, relative to the project root.
+    #[arg(
+        long,
+        global = true,
+        value_name = "PATH",
+        help_heading = "Coverage options"
+    )]
+    pub data_file: Option<Utf8PathBuf>,
+
+    /// Include only report paths matching this glob.
+    #[arg(long, global = true, value_name = "GLOB", action = clap::ArgAction::Append, help_heading = "Coverage options")]
+    pub include: Vec<String>,
+
+    /// Exclude report paths matching this glob after inclusion.
+    #[arg(long, global = true, value_name = "GLOB", action = clap::ArgAction::Append, help_heading = "Coverage options")]
+    pub omit: Vec<String>,
+
+    /// Include execution attributed to a matching context regular expression.
+    #[arg(long = "contexts", global = true, value_name = "REGEX", action = clap::ArgAction::Append, help_heading = "Coverage options")]
+    pub contexts: Vec<String>,
+
+    /// Decimal places shown in coverage percentages.
+    #[arg(
+        long,
+        global = true,
+        value_name = "N",
+        help_heading = "Coverage options"
+    )]
+    pub precision: Option<CoveragePrecision>,
+
+    /// Fail when total coverage is below this percentage.
+    #[arg(
+        long,
+        global = true,
+        value_name = "PERCENT",
+        value_parser = parse_cov_fail_under,
+        help_heading = "Coverage options"
+    )]
+    pub fail_under: Option<f64>,
+
+    /// The path to a `karva.toml` file to use for configuration.
+    #[arg(
+        long,
+        global = true,
+        env = EnvVars::KARVA_CONFIG_FILE,
+        value_name = "PATH",
+        help_heading = "Config options"
+    )]
+    pub config_file: Option<Utf8PathBuf>,
+
+    /// Configuration profile to resolve.
+    #[arg(
+        short = 'P',
+        long,
+        global = true,
+        env = EnvVars::KARVA_PROFILE,
+        value_name = "NAME",
+        help_heading = "Config options"
+    )]
+    pub profile: Option<String>,
+}
+
+impl CoverageCommand {
+    /// Converts command-line values into highest-precedence coverage options.
+    pub fn options(&self) -> Options {
+        Options {
+            coverage: Some(CoverageOptions {
+                data_file: self.data_file.as_ref().map(ToString::to_string),
+                include: (!self.include.is_empty()).then(|| self.include.clone()),
+                omit: (!self.omit.is_empty()).then(|| self.omit.clone()),
+                contexts: (!self.contexts.is_empty()).then(|| self.contexts.clone()),
+                precision: self.precision,
+                fail_under: self.fail_under.map(CovFailUnder),
+                ..CoverageOptions::default()
+            }),
+            ..Options::default()
+        }
+    }
+}
+
+#[derive(Debug, clap::Subcommand)]
+/// Native coverage operations.
+pub enum CoverageAction {
+    /// Print the compact terminal coverage report.
+    Report(CoverageReportCommand),
+}
+
+#[derive(Debug, Args)]
+/// Options specific to the terminal coverage report.
+pub struct CoverageReportCommand;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shared_options_parse_after_report() {
+        let command = CoverageCommand::try_parse_from([
+            "coverage",
+            "report",
+            "--data-file",
+            "build/data.json",
+            "--include",
+            "src/**",
+            "--contexts",
+            "test_checkout",
+            "--precision",
+            "2",
+            "--fail-under",
+            "90.5",
+        ])
+        .expect("parse coverage command");
+        let coverage = command.options().coverage.expect("coverage options");
+
+        assert_eq!(coverage.data_file.as_deref(), Some("build/data.json"));
+        assert_eq!(coverage.include, Some(vec!["src/**".to_owned()]));
+        assert_eq!(coverage.contexts, Some(vec!["test_checkout".to_owned()]));
+        assert_eq!(coverage.precision, Some(CoveragePrecision(2)));
+        assert_eq!(coverage.fail_under, Some(CovFailUnder(90.5)));
+    }
+
+    #[test]
+    fn precision_rejects_digits_f64_cannot_represent() {
+        let requested = CoveragePrecision::MAX + 1;
+        let error = CoverageCommand::try_parse_from([
+            "coverage",
+            "report",
+            "--precision",
+            &requested.to_string(),
+        ])
+        .expect_err("reject excessive precision");
+        let message = error.to_string();
+
+        assert!(message.contains(&requested.to_string()));
+        assert!(message.contains(&CoveragePrecision::MAX.to_string()));
+    }
+}

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -5,6 +5,7 @@ use clap::builder::Styles;
 use clap::builder::styling::{AnsiColor, Effects};
 
 mod cache;
+mod coverage;
 mod enums;
 mod exit_status;
 mod partition;
@@ -14,6 +15,7 @@ mod test;
 mod verbosity;
 
 pub use cache::{CacheAction, CacheCommand};
+pub use coverage::{CoverageAction, CoverageCommand, CoverageReportCommand};
 pub use enums::{
     CovContext, CovReport, FlakyResult, JunitFlakyFailStatus, NoTests, OutputFormat, ResultFormat,
     RunIgnored,
@@ -52,6 +54,9 @@ pub enum Command {
 
     /// Manage snapshots created by `karva.assert_snapshot()`.
     Snapshot(SnapshotCommand),
+
+    /// Read and report native Karva coverage data.
+    Coverage(CoverageCommand),
 
     /// Manage the karva cache.
     Cache(CacheCommand),

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -493,9 +493,12 @@ impl SubTestCommand {
                 termination_grace_period: None,
             }),
             coverage: Some(CoverageOptions {
+                data_file: None,
                 sources: (!self.cov.is_empty()).then_some(self.cov),
                 include: (!self.cov_include.is_empty()).then_some(self.cov_include),
                 omit: (!self.cov_omit.is_empty()).then_some(self.cov_omit),
+                contexts: None,
+                precision: None,
                 report: self.cov_report.map(Into::into),
                 report_path: coverage_report_path,
                 branch: self.cov_branch.then_some(true),
@@ -554,7 +557,7 @@ fn parse_fail_slow(raw: &str) -> Result<f64, String> {
 /// Parse and validate a `--cov-fail-under=N` argument.
 ///
 /// Accepts any finite percentage in `0..=100`.
-fn parse_cov_fail_under(raw: &str) -> Result<f64, String> {
+pub fn parse_cov_fail_under(raw: &str) -> Result<f64, String> {
     let value: f64 = raw
         .parse()
         .map_err(|err| format!("`{raw}` is not a valid number: {err}"))?;

--- a/crates/karva_coverage/src/report/terminal.rs
+++ b/crates/karva_coverage/src/report/terminal.rs
@@ -69,7 +69,17 @@ pub fn write_html_report(
 impl CoverageAnalysis {
     /// Prints the compact terminal report and returns total coverage.
     pub fn report(&self, show_missing: bool) -> Result<f64> {
-        print_report(&self.rows, show_missing, &mut std::io::stdout().lock())
+        self.report_with_precision(show_missing, 0)
+    }
+
+    /// Prints the compact terminal report using `precision` decimal places.
+    pub fn report_with_precision(&self, show_missing: bool, precision: usize) -> Result<f64> {
+        print_report(
+            &self.rows,
+            show_missing,
+            precision,
+            &mut std::io::stdout().lock(),
+        )
     }
 
     /// Writes a Cobertura-compatible XML report and returns total coverage.
@@ -122,7 +132,12 @@ struct Row<'a> {
     missing: &'a str,
 }
 
-fn print_report(rows: &[FileRow], show_missing: bool, out: &mut dyn Write) -> Result<f64> {
+fn print_report(
+    rows: &[FileRow],
+    show_missing: bool,
+    precision: usize,
+    out: &mut dyn Write,
+) -> Result<f64> {
     let show_branches = rows.iter().any(|row| row.branches_enabled);
     let name_width = rows
         .iter()
@@ -154,7 +169,7 @@ fn print_report(rows: &[FileRow], show_missing: bool, out: &mut dyn Write) -> Re
     writeln!(out, "{rule}")?;
 
     for row in rows {
-        let cover = format!("{:.0}%", row_percent(row));
+        let cover = format!("{:.*}%", precision, row_percent(row));
         let stmts_str = row.stmts.to_string();
         let miss_str = row.miss.to_string();
         let branches_str = row.branches.to_string();
@@ -182,7 +197,7 @@ fn print_report(rows: &[FileRow], show_missing: bool, out: &mut dyn Write) -> Re
     writeln!(out, "{rule}")?;
     let total_pct = total_percent(rows);
     let total = totals_row(rows);
-    let total_cover = format!("{:.0}%", row_percent(&total));
+    let total_cover = format!("{:.*}%", precision, row_percent(&total));
     let total_stmts_str = total.stmts.to_string();
     let total_miss_str = total.miss.to_string();
     let total_branches_str = total.branches.to_string();
@@ -279,7 +294,7 @@ mod tests {
         let rows = [row("a.py", 4, 2, 2, ""), row("b.py", 2, 2, 0, "")];
 
         let mut buf: Vec<u8> = Vec::new();
-        let total = print_report(&rows, false, &mut buf).unwrap();
+        let total = print_report(&rows, false, 0, &mut buf).unwrap();
         let out = String::from_utf8(buf).unwrap();
 
         assert!(out.contains("a.py"));
@@ -295,7 +310,7 @@ mod tests {
         let rows = [row("a.py", 9, 3, 6, "2-4, 6-8")];
 
         let mut buf: Vec<u8> = Vec::new();
-        print_report(&rows, true, &mut buf).unwrap();
+        print_report(&rows, true, 0, &mut buf).unwrap();
         let out = String::from_utf8(buf).unwrap();
 
         assert!(out.contains("Missing"));

--- a/crates/karva_metadata/src/lib.rs
+++ b/crates/karva_metadata/src/lib.rs
@@ -20,9 +20,10 @@ pub use options::{
 };
 pub use pyproject::{PyProject, PyProjectError};
 pub use settings::{
-    CovFailUnder, CoverageSettings, FailSlowSecs, FlakyResult, JunitFlakyFailStatus, JunitSettings,
-    NoTestsMode, OverrideSettings, ProjectSettings, RunIgnoredMode, RunTimeoutSecs,
-    SlowTimeoutSecs, TerminationGracePeriodSecs, TestTimeoutSecs,
+    CovFailUnder, CoveragePrecision, CoverageSettings, DEFAULT_COVERAGE_DATA_FILE, FailSlowSecs,
+    FlakyResult, JunitFlakyFailStatus, JunitSettings, NoTestsMode, OverrideSettings,
+    ProjectSettings, RunIgnoredMode, RunTimeoutSecs, SlowTimeoutSecs, TerminationGracePeriodSecs,
+    TestTimeoutSecs,
 };
 
 use crate::options::KarvaTomlError;

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -1672,12 +1672,12 @@ disabled = true
 ";
         assert_snapshot!(
             Config::from_toml_str(toml).expect_err("unknown field"),
-            @r"
+            @"
         TOML parse error at line 3, column 1
           |
         3 | disabled = true
           | ^^^^^^^^
-        unknown field `disabled`, expected one of `sources`, `include`, `omit`, `report`, `report-path`, `branch`, `fail-under`
+        unknown field `disabled`, expected one of `data-file`, `sources`, `include`, `omit`, `contexts`, `precision`, `report`, `report-path`, `branch`, `fail-under`
         "
         );
     }

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -17,10 +17,10 @@ pub use overrides::ProjectOptionsOverrides;
 use crate::filter::{FiltersetSet, ValidatedFilter};
 use crate::max_fail::MaxFail;
 use crate::settings::{
-    CovFailUnder, CoverageSettings, FailSlowSecs, FlakyResult, JunitFlakyFailStatus, JunitSettings,
-    NoTestsMode, OverrideSettings, ProjectSettings, RunIgnoredMode, RunTimeoutSecs,
-    SlowTimeoutSecs, SrcSettings, TerminalSettings, TerminationGracePeriodSecs, TestSettings,
-    TestTimeoutSecs,
+    CovFailUnder, CoveragePrecision, CoverageSettings, DEFAULT_COVERAGE_DATA_FILE, FailSlowSecs,
+    FlakyResult, JunitFlakyFailStatus, JunitSettings, NoTestsMode, OverrideSettings,
+    ProjectSettings, RunIgnoredMode, RunTimeoutSecs, SlowTimeoutSecs, SrcSettings,
+    TerminalSettings, TerminationGracePeriodSecs, TestSettings, TestTimeoutSecs,
 };
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, OptionsMetadata)]
@@ -591,6 +591,19 @@ impl TestOptions {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 /// Controls measured Python sources and coverage report generation.
 pub struct CoverageOptions {
+    /// Native coverage artifact read and written by coverage commands.
+    ///
+    /// Relative paths are resolved from the project root.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#".karva/coverage/data.json"#,
+        value_type = r#"path"#,
+        example = r#"
+            data-file = ".karva/coverage/data.json"
+        "#
+    )]
+    pub data_file: Option<String>,
+
     /// Source paths to measure coverage for.
     ///
     /// Equivalent to passing `--cov=<path>` on the command line; may be
@@ -635,6 +648,28 @@ pub struct CoverageOptions {
         "#
     )]
     pub omit: Option<Vec<String>>,
+
+    /// Include execution attributed to contexts matching these regular expressions.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"null"#,
+        value_type = r#"list[str]"#,
+        example = r#"
+            contexts = ["python=3\\.14", "test_checkout"]
+        "#
+    )]
+    pub contexts: Option<Vec<String>>,
+
+    /// Decimal places shown in coverage percentages.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"0"#,
+        value_type = r#"non-negative integer"#,
+        example = r#"
+            precision = 2
+        "#
+    )]
+    pub precision: Option<CoveragePrecision>,
 
     /// Coverage report type.
     ///
@@ -707,9 +742,12 @@ impl Combine for CoverageOptions {
     fn combine_with(&mut self, other: Self) {
         let report_overridden = self.report.is_some();
 
+        self.data_file = self.data_file.take().combine(other.data_file);
         self.sources = self.sources.take().combine(other.sources);
         self.include = self.include.take().combine(other.include);
         self.omit = self.omit.take().combine(other.omit);
+        self.contexts = self.contexts.take().combine(other.contexts);
+        self.precision = self.precision.combine(other.precision);
         self.report = self.report.combine(other.report);
         self.report_path = if report_overridden && self.report_path.is_none() {
             None
@@ -731,9 +769,15 @@ impl CoverageOptions {
             self.sources.clone().unwrap_or_default()
         };
         CoverageSettings {
+            data_file: self
+                .data_file
+                .clone()
+                .unwrap_or_else(|| DEFAULT_COVERAGE_DATA_FILE.to_owned()),
             sources,
             include: self.include.clone().unwrap_or_default(),
             omit: self.omit.clone().unwrap_or_default(),
+            contexts: self.contexts.clone().unwrap_or_default(),
+            precision: self.precision.unwrap_or_default(),
             report: self.report.unwrap_or_default(),
             report_path: self.report_path.clone(),
             branch: self.branch.unwrap_or_default(),
@@ -1356,9 +1400,12 @@ retry = 5
     fn parse_coverage_section() {
         let toml = r#"
 [profile.default.coverage]
+data-file = "build/coverage-data.json"
 sources = ["src", "tests"]
 include = ["src/**"]
 omit = ["**/generated.py"]
+contexts = ["python=3\\.14"]
+precision = 2
 report = "term-missing"
 report-path = "build/coverage.xml"
 "#;
@@ -1369,6 +1416,9 @@ report-path = "build/coverage.xml"
         assert_debug_snapshot!(resolved.coverage, @r#"
         Some(
             CoverageOptions {
+                data_file: Some(
+                    "build/coverage-data.json",
+                ),
                 sources: Some(
                     [
                         "src",
@@ -1385,6 +1435,16 @@ report-path = "build/coverage.xml"
                         "**/generated.py",
                     ],
                 ),
+                contexts: Some(
+                    [
+                        "python=3\\.14",
+                    ],
+                ),
+                precision: Some(
+                    CoveragePrecision(
+                        2,
+                    ),
+                ),
                 report: Some(
                     TermMissing,
                 ),
@@ -1397,6 +1457,18 @@ report-path = "build/coverage.xml"
             },
         )
         "#);
+    }
+
+    #[test]
+    fn coverage_precision_rejects_unrepresentable_digits() {
+        let requested = CoveragePrecision::MAX + 1;
+        let toml = format!("[profile.default.coverage]\nprecision = {requested}\n");
+
+        let error = Config::from_toml_str(&toml).expect_err("reject excessive precision");
+        let message = error.to_string();
+
+        assert!(message.contains(&requested.to_string()));
+        assert!(message.contains(&CoveragePrecision::MAX.to_string()));
     }
 
     #[test]
@@ -1448,6 +1520,7 @@ store-failure-output = false
         };
         assert_debug_snapshot!(cli.combine(file), @r#"
         CoverageOptions {
+            data_file: None,
             sources: Some(
                 [
                     "src",
@@ -1456,6 +1529,8 @@ store-failure-output = false
             ),
             include: None,
             omit: None,
+            contexts: None,
+            precision: None,
             report: Some(
                 TermMissing,
             ),
@@ -1482,6 +1557,7 @@ store-failure-output = false
         };
         assert_debug_snapshot!(cli.combine(file), @r#"
         CoverageOptions {
+            data_file: None,
             sources: None,
             include: Some(
                 [
@@ -1495,6 +1571,8 @@ store-failure-output = false
                     "**/generated.py",
                 ],
             ),
+            contexts: None,
+            precision: None,
             report: None,
             report_path: None,
             branch: None,
@@ -1550,11 +1628,14 @@ store-failure-output = false
             report_path: Some("build/coverage.xml".to_string()),
             ..CoverageOptions::default()
         };
-        assert_debug_snapshot!(cli.combine(file), @r#"
+        assert_debug_snapshot!(cli.combine(file), @"
         CoverageOptions {
+            data_file: None,
             sources: None,
             include: None,
             omit: None,
+            contexts: None,
+            precision: None,
             report: Some(
                 Json,
             ),
@@ -1563,7 +1644,7 @@ store-failure-output = false
             fail_under: None,
             disabled: None,
         }
-        "#);
+        ");
     }
 
     /// `--no-cov` (CLI sets `disabled = Some(true)`) overrides any sources
@@ -1610,12 +1691,12 @@ nonsense = 1
 "#;
         assert_snapshot!(
             Config::from_toml_str(toml).expect_err("unknown field"),
-            @r"
+            @"
         TOML parse error at line 4, column 1
           |
         4 | nonsense = 1
           | ^^^^^^^^
-        unknown field `nonsense`, expected one of `sources`, `include`, `omit`, `report`, `report-path`, `branch`, `fail-under`
+        unknown field `nonsense`, expected one of `data-file`, `sources`, `include`, `omit`, `contexts`, `precision`, `report`, `report-path`, `branch`, `fail-under`
         "
         );
     }

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -8,6 +8,9 @@ use crate::filter::{EvalContext, FiltersetSet, ValidatedFilter};
 use crate::max_fail::MaxFail;
 use crate::options::{CovReport, OutputFormat};
 
+/// Project-relative native coverage artifact used when no path is configured.
+pub const DEFAULT_COVERAGE_DATA_FILE: &str = ".karva/coverage/data.json";
+
 macro_rules! impl_duration_secs_deserialize {
     ($type:ident, $option:literal) => {
         impl<'de> Deserialize<'de> for $type {
@@ -334,6 +337,67 @@ impl Combine for CovFailUnder {
     }
 }
 
+/// Decimal places used for coverage percentages.
+///
+/// The maximum is [`f64::DIGITS`], the number of meaningful decimal digits
+/// available from the percentage representation.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(transparent)]
+pub struct CoveragePrecision(pub usize);
+
+impl CoveragePrecision {
+    /// Maximum meaningful precision for an `f64` percentage.
+    pub const MAX: usize = f64::DIGITS as usize;
+}
+
+impl TryFrom<usize> for CoveragePrecision {
+    type Error = String;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        if value <= Self::MAX {
+            Ok(Self(value))
+        } else {
+            Err(format!(
+                "precision must be at most {} because coverage percentages use f64, got `{value}`",
+                Self::MAX
+            ))
+        }
+    }
+}
+
+impl std::str::FromStr for CoveragePrecision {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        value
+            .parse::<usize>()
+            .map_err(|error| format!("`{value}` is not a non-negative integer: {error}"))?
+            .try_into()
+    }
+}
+
+impl<'de> Deserialize<'de> for CoveragePrecision {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        usize::deserialize(deserializer)?
+            .try_into()
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+impl Combine for CoveragePrecision {
+    #[inline(always)]
+    fn combine_with(&mut self, _other: Self) {}
+
+    #[inline]
+    fn combine(self, _other: Self) -> Self {
+        self
+    }
+}
+
 #[derive(Default, Debug, Clone, Serialize)]
 #[serde(rename_all = "kebab-case")]
 /// Fully resolved settings after configuration profiles and CLI overrides combine.
@@ -546,6 +610,9 @@ pub struct SrcSettings {
 #[serde(rename_all = "kebab-case")]
 /// Resolved coverage collection and reporting settings.
 pub struct CoverageSettings {
+    /// Native coverage artifact path, relative to the project root when not absolute.
+    pub data_file: String,
+
     /// Source roots measured by worker tracers.
     pub sources: Vec<String>,
 
@@ -554,6 +621,12 @@ pub struct CoverageSettings {
 
     /// Report-path globs excluded after inclusion.
     pub omit: Vec<String>,
+
+    /// Regular expressions selecting execution contexts for reports.
+    pub contexts: Vec<String>,
+
+    /// Decimal places shown in coverage percentages.
+    pub precision: CoveragePrecision,
 
     /// Selected report backend.
     pub report: CovReport,

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -56,6 +56,42 @@ branch = true
 
 ---
 
+### `contexts`
+
+Include execution attributed to contexts matching these regular expressions.
+
+**Default value**: `null`
+
+**Type**: `list[str]`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.karva.profile.default.coverage]
+contexts = ["python=3\\.14", "test_checkout"]
+```
+
+---
+
+### `data-file`
+
+Native coverage artifact read and written by coverage commands.
+
+Relative paths are resolved from the project root.
+
+**Default value**: `.karva/coverage/data.json`
+
+**Type**: `path`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.karva.profile.default.coverage]
+data-file = ".karva/coverage/data.json"
+```
+
+---
+
 ### `fail-under`
 
 Minimum total coverage percentage required for the run to succeed.
@@ -116,6 +152,23 @@ applied after include filters.
 ```toml
 [tool.karva.profile.default.coverage]
 omit = ["**/migrations/*"]
+```
+
+---
+
+### `precision`
+
+Decimal places shown in coverage percentages.
+
+**Default value**: `0`
+
+**Type**: `non-negative integer`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.karva.profile.default.coverage]
+precision = 2
 ```
 
 ---

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -16,6 +16,7 @@ karva <COMMAND>
 
 <dl class="cli-reference"><dt><a href="#karva-test"><code>karva test</code></a></dt><dd><p>Run tests</p></dd>
 <dt><a href="#karva-snapshot"><code>karva snapshot</code></a></dt><dd><p>Manage snapshots created by <code>karva.assert_snapshot()</code></p></dd>
+<dt><a href="#karva-coverage"><code>karva coverage</code></a></dt><dd><p>Read and report native Karva coverage data</p></dd>
 <dt><a href="#karva-cache"><code>karva cache</code></a></dt><dd><p>Manage the karva cache</p></dd>
 <dt><a href="#karva-show-config"><code>karva show-config</code></a></dt><dd><p>Print the resolved configuration karva would run with</p></dd>
 <dt><a href="#karva-version"><code>karva version</code></a></dt><dd><p>Display Karva's version</p></dd>
@@ -342,6 +343,55 @@ Print this message or the help of the given subcommand(s)
 
 ```
 karva snapshot help [COMMAND]
+```
+
+## karva coverage
+
+Read and report native Karva coverage data
+
+<h3 class="cli-reference">Usage</h3>
+
+```
+karva coverage [OPTIONS] <COMMAND>
+```
+
+<h3 class="cli-reference">Commands</h3>
+
+<dl class="cli-reference"><dt><a href="#karva-coverage-report"><code>karva coverage report</code></a></dt><dd><p>Print the compact terminal coverage report</p></dd>
+<dt><a href="#karva-coverage-help"><code>karva coverage help</code></a></dt><dd><p>Print this message or the help of the given subcommand(s)</p></dd>
+</dl>
+
+### karva coverage report
+
+Print the compact terminal coverage report
+
+<h3 class="cli-reference">Usage</h3>
+
+```
+karva coverage report [OPTIONS]
+```
+
+<h3 class="cli-reference">Options</h3>
+
+<dl class="cli-reference"><dt id="karva-coverage-report--config-file"><a href="#karva-coverage-report--config-file"><code>--config-file</code></a> <i>path</i></dt><dd><p>The path to a <code>karva.toml</code> file to use for configuration</p>
+<p>May also be set with the <code>KARVA_CONFIG_FILE</code> environment variable.</p></dd><dt id="karva-coverage-report--contexts"><a href="#karva-coverage-report--contexts"><code>--contexts</code></a> <i>regex</i></dt><dd><p>Include execution attributed to a matching context regular expression</p>
+</dd><dt id="karva-coverage-report--data-file"><a href="#karva-coverage-report--data-file"><code>--data-file</code></a> <i>path</i></dt><dd><p>Native coverage artifact path, relative to the project root</p>
+</dd><dt id="karva-coverage-report--fail-under"><a href="#karva-coverage-report--fail-under"><code>--fail-under</code></a> <i>percent</i></dt><dd><p>Fail when total coverage is below this percentage</p>
+</dd><dt id="karva-coverage-report--help"><a href="#karva-coverage-report--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Print help</p>
+</dd><dt id="karva-coverage-report--include"><a href="#karva-coverage-report--include"><code>--include</code></a> <i>glob</i></dt><dd><p>Include only report paths matching this glob</p>
+</dd><dt id="karva-coverage-report--omit"><a href="#karva-coverage-report--omit"><code>--omit</code></a> <i>glob</i></dt><dd><p>Exclude report paths matching this glob after inclusion</p>
+</dd><dt id="karva-coverage-report--precision"><a href="#karva-coverage-report--precision"><code>--precision</code></a> <i>n</i></dt><dd><p>Decimal places shown in coverage percentages</p>
+</dd><dt id="karva-coverage-report--profile"><a href="#karva-coverage-report--profile"><code>--profile</code></a>, <code>-P</code> <i>name</i></dt><dd><p>Configuration profile to resolve</p>
+<p>May also be set with the <code>KARVA_PROFILE</code> environment variable.</p></dd></dl>
+
+### karva coverage help
+
+Print this message or the help of the given subcommand(s)
+
+<h3 class="cli-reference">Usage</h3>
+
+```
+karva coverage help [COMMAND]
 ```
 
 ## karva cache

--- a/karva.schema.json
+++ b/karva.schema.json
@@ -73,6 +73,23 @@
             "null"
           ]
         },
+        "contexts": {
+          "description": "Include execution attributed to contexts matching these regular expressions.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "data-file": {
+          "description": "Native coverage artifact read and written by coverage commands.\n\nRelative paths are resolved from the project root.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "fail-under": {
           "description": "Minimum total coverage percentage required for the run to succeed.\n\nWhen set, the test command exits with a non-zero status if the\nreported `TOTAL` coverage is below this value, even when every test\npassed. Has no effect when tests already failed (the exit code is\nalready non-zero).",
           "anyOf": [
@@ -104,6 +121,17 @@
             "type": "string"
           }
         },
+        "precision": {
+          "description": "Decimal places shown in coverage percentages.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CoveragePrecision"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "report": {
           "description": "Coverage report type.\n\n`term` (default) prints a compact terminal table.\n`term-missing` extends it with a `Missing` column listing the\nuncovered line numbers per file.",
           "anyOf": [
@@ -134,6 +162,12 @@
         }
       },
       "additionalProperties": false
+    },
+    "CoveragePrecision": {
+      "description": "Decimal places used for coverage percentages.\n\nThe maximum is [`f64::DIGITS`], the number of meaningful decimal digits\navailable from the percentage representation.",
+      "type": "integer",
+      "format": "uint",
+      "minimum": 0
     },
     "FailSlowSecs": {
       "description": "A per-test duration budget expressed in seconds.\n\nWraps `f64` for the same reason as [`SlowTimeoutSecs`]. Unlike\n[`SlowTimeoutSecs`] (informational) or [`TestTimeoutSecs`] (kills the\ntest mid-flight), a test exceeding this budget is allowed to finish its\nfull lifecycle — including fixture teardown — and is then reported as a\nfailure (see `TestSettings::fail_slow`).",


### PR DESCRIPTION
## Summary

Adds the `karva coverage` command group, shared native-data settings, and the initial terminal report command. Closes #1167.

## Test Plan

Focused coverage integration tests, workspace clippy, and `uvx prek run -a`.