### PR TITLE
Persist native coverage data

### DIFF
--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -5,6 +5,7 @@ mod result_report;
 mod watch;
 
 use std::collections::HashMap;
+use std::io::ErrorKind;
 use std::io::Write;
 use std::time::{Duration, Instant};
 
@@ -106,6 +107,7 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
 
     print_test_output(printer, start_time, &result, durations)?;
     junit::write_junit_report(project.settings().junit(), &result, project.cwd())?;
+    let coverage_data_file = persist_coverage(&project, &coverage_files)?;
     let write_result_report = |exit_status| {
         result_report::write_result_report(
             result_output.as_deref(),
@@ -124,12 +126,11 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
         return Ok(exit_status);
     }
 
-    let coverage_total = if coverage_files.is_empty() {
-        None
-    } else {
+    let coverage_total = if let Some(data_file) = coverage_data_file {
         let coverage = project.settings().coverage();
         let coverage_filters =
-            karva_coverage::CoverageFilters::new(&coverage.include, &coverage.omit)?;
+            karva_coverage::CoverageFilters::new(&coverage.include, &coverage.omit)?
+                .with_contexts(&coverage.contexts)?;
         if coverage.report_path.is_some()
             && matches!(coverage.report, CovReport::Term | CovReport::TermMissing)
         {
@@ -140,56 +141,48 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
                 coverage.report.as_str()
             )?;
         }
-        let coverage_result = match coverage.report {
-            CovReport::Term => karva_coverage::combine_and_report(
+        let coverage_result = (|| -> Result<Option<f64>> {
+            let Some(analysis) = karva_coverage::CoverageAnalysis::load_native(
                 project.cwd(),
-                &coverage_files,
-                false,
+                std::slice::from_ref(&data_file),
                 &coverage_filters,
-            ),
-            CovReport::TermMissing => karva_coverage::combine_and_report(
-                project.cwd(),
-                &coverage_files,
-                true,
-                &coverage_filters,
-            ),
-            CovReport::Xml => {
-                let output = coverage_report_path(
-                    coverage.report_path.as_deref(),
-                    "coverage.xml",
-                    project.cwd(),
-                );
-                karva_coverage::write_cobertura_xml(
-                    project.cwd(),
-                    &coverage_files,
-                    &output,
-                    &coverage_filters,
-                )
-            }
-            CovReport::Json => {
-                let output = coverage_report_path(
-                    coverage.report_path.as_deref(),
-                    "coverage.json",
-                    project.cwd(),
-                );
-                karva_coverage::write_json_report(
-                    project.cwd(),
-                    &coverage_files,
-                    &output,
-                    &coverage_filters,
-                )
-            }
-            CovReport::Html => {
-                let output =
-                    coverage_report_path(coverage.report_path.as_deref(), "htmlcov", project.cwd());
-                karva_coverage::write_html_report(
-                    project.cwd(),
-                    &coverage_files,
-                    &output,
-                    &coverage_filters,
-                )
-            }
-        };
+            )?
+            else {
+                return Ok(None);
+            };
+            let total = match coverage.report {
+                CovReport::None => analysis.total_percent(),
+                CovReport::Term => analysis.report_with_precision(false, coverage.precision.0)?,
+                CovReport::TermMissing => {
+                    analysis.report_with_precision(true, coverage.precision.0)?
+                }
+                CovReport::Xml => {
+                    let output = coverage_report_path(
+                        coverage.report_path.as_deref(),
+                        "coverage.xml",
+                        project.cwd(),
+                    );
+                    analysis.write_cobertura_xml(&output)?
+                }
+                CovReport::Json => {
+                    let output = coverage_report_path(
+                        coverage.report_path.as_deref(),
+                        "coverage.json",
+                        project.cwd(),
+                    );
+                    analysis.write_json(&output)?
+                }
+                CovReport::Html => {
+                    let output = coverage_report_path(
+                        coverage.report_path.as_deref(),
+                        "htmlcov",
+                        project.cwd(),
+                    );
+                    analysis.write_html(&output)?
+                }
+            };
+            Ok(Some(total))
+        })();
         match coverage_result {
             Ok(total) => total,
             Err(err) => {
@@ -197,6 +190,8 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
                 None
             }
         }
+    } else {
+        None
     };
 
     let coverage_below_threshold = if let Some(total) = coverage_total
@@ -242,6 +237,49 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
     };
     write_result_report(exit_status)?;
     Ok(exit_status)
+}
+
+fn persist_coverage(
+    project: &Project,
+    worker_files: &[Utf8PathBuf],
+) -> Result<Option<Utf8PathBuf>> {
+    if worker_files.is_empty() {
+        return Ok(None);
+    }
+
+    let settings = project.settings().coverage();
+    let mode = if settings.branch {
+        karva_coverage::native::CoverageMode::Branch
+    } else {
+        karva_coverage::native::CoverageMode::Line
+    };
+    let current = karva_coverage::native::NativeCoverage::from_worker_files(
+        project.cwd(),
+        &settings.sources,
+        mode,
+        worker_files,
+    )?;
+    let data_file = absolute(&settings.data_file, project.cwd());
+    let artifact = if settings.append {
+        match std::fs::metadata(&data_file) {
+            Ok(_) => {
+                let mut previous = karva_coverage::native::NativeCoverage::read(&data_file)?;
+                previous.merge(current).with_context(|| {
+                    format!("failed to append native coverage data `{data_file}`")
+                })?;
+                previous
+            }
+            Err(error) if error.kind() == ErrorKind::NotFound => current,
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("failed to inspect coverage data `{data_file}`"));
+            }
+        }
+    } else {
+        current
+    };
+    artifact.write(&data_file)?;
+    Ok(Some(data_file))
 }
 
 fn coverage_report_path(

--- a/crates/karva/tests/it/coverage_command.rs
+++ b/crates/karva/tests/it/coverage_command.rs
@@ -150,3 +150,169 @@ fn report_fail_under_returns_failure() {
     ----- stderr -----
     ");
 }
+
+#[test]
+fn test_run_persists_native_data_without_rendering() {
+    let context = TestContext::with_file(
+        "test_native.py",
+        r"
+def test_native():
+    assert True
+",
+    );
+
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .args(["--cov", "--cov-report=", "--status-level=none", "test_native.py"]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+
+    assert_cmd_snapshot!(context.coverage("report"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    Name             Stmts   Miss   Cover
+    [LONG-LINE]
+    test_native.py       2      0    100%
+    [LONG-LINE]
+    TOTAL                2      0    100%
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn failing_test_still_persists_native_data() {
+    let context = TestContext::with_file(
+        "test_failure.py",
+        r"
+def test_failure():
+    assert False
+",
+    );
+
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .args(["--cov", "--cov-report=", "--status-level=none", "test_failure.py"]),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    failures:
+
+    test_failure::test_failure:
+
+    error[test-failure]: Test `test_failure` failed
+     --> test_failure.py:2:5
+      |
+    2 | def test_failure():
+      |     ^^^^^^^^^^^^
+      |
+    info: Test failed here
+     --> test_failure.py:3:5
+      |
+    3 |     assert False
+      |     ^^^^^^^^^^^^
+      |
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+
+    assert!(context.root().join(".karva/coverage/data.json").is_file());
+}
+
+#[test]
+fn cov_append_unions_runs_and_default_replaces_them() {
+    let context = TestContext::with_file(
+        "test_append.py",
+        r"
+def first():
+    return 1
+
+def second():
+    return 2
+
+def test_alpha():
+    assert first() == 1
+
+def test_beta():
+    assert second() == 2
+",
+    );
+    let run = |filter: &str, append: bool| {
+        let mut command = context.command_no_parallel();
+        command.args([
+            "--cov",
+            "--cov-report=",
+            "--status-level=none",
+            "-E",
+            filter,
+            "test_append.py",
+        ]);
+        if append {
+            command.arg("--cov-append");
+        }
+        command
+    };
+
+    assert_cmd_snapshot!(run("test(~alpha)", false), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 2 tests run: 1 passed, 1 skipped
+
+    ----- stderr -----
+    ");
+    assert_cmd_snapshot!(run("test(~beta)", true), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 2 tests run: 1 passed, 1 skipped
+
+    ----- stderr -----
+    ");
+
+    let path = context.root().join(".karva/coverage/data.json");
+    let appended = NativeCoverage::read(&path).expect("read appended data");
+    let appended_file = appended
+        .files
+        .get(Utf8Path::new("test_append.py"))
+        .expect("appended source");
+    assert!(appended_file.executed.contains(&3));
+    assert!(appended_file.executed.contains(&6));
+
+    assert_cmd_snapshot!(run("test(~alpha)", false), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 2 tests run: 1 passed, 1 skipped
+
+    ----- stderr -----
+    ");
+    let replaced = NativeCoverage::read(&path).expect("read replaced data");
+    let replaced_file = replaced
+        .files
+        .get(Utf8Path::new("test_append.py"))
+        .expect("replaced source");
+    assert!(replaced_file.executed.contains(&3));
+    assert!(!replaced_file.executed.contains(&6));
+}

--- a/crates/karva/tests/it/show_config.rs
+++ b/crates/karva/tests/it/show_config.rs
@@ -204,6 +204,7 @@ fail-under = 90
     omit = ["**/generated.py"]
     contexts = []
     precision = 0
+    append = false
     report = "term-missing"
     fail-under = 90.0
 

--- a/crates/karva/tests/it/show_config.rs
+++ b/crates/karva/tests/it/show_config.rs
@@ -34,6 +34,7 @@ fn show_config_default_profile() {
     omit = []
     contexts = []
     precision = 0
+    append = false
     report = "term"
 
     [junit]
@@ -88,6 +89,7 @@ output-format = "concise"
     omit = []
     contexts = []
     precision = 0
+    append = false
     report = "term"
 
     [junit]
@@ -143,6 +145,7 @@ output-format = "concise"
     omit = []
     contexts = []
     precision = 0
+    append = false
     report = "term"
 
     [junit]
@@ -261,6 +264,7 @@ slow-timeout = 0.5
     omit = []
     contexts = []
     precision = 0
+    append = false
     report = "term"
 
     [junit]

--- a/crates/karva_cli/src/coverage.rs
+++ b/crates/karva_cli/src/coverage.rs
@@ -84,6 +84,7 @@ impl CoverageCommand {
                 omit: (!self.omit.is_empty()).then(|| self.omit.clone()),
                 contexts: (!self.contexts.is_empty()).then(|| self.contexts.clone()),
                 precision: self.precision,
+                append: None,
                 fail_under: self.fail_under.map(CovFailUnder),
                 ..CoverageOptions::default()
             }),

--- a/crates/karva_cli/src/enums.rs
+++ b/crates/karva_cli/src/enums.rs
@@ -11,6 +11,9 @@ use karva_metadata::{
 /// Coverage report selection parsed from `--cov-report`.
 #[derive(Clone, Hash, Debug, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum CovReport {
+    /// Persist native data without rendering a report.
+    None,
+
     /// Compact terminal table (default).
     #[default]
     Term,
@@ -34,6 +37,7 @@ impl FromStr for CovReport {
     fn from_str(raw: &str) -> Result<Self, Self::Err> {
         match raw.split_once(':') {
             None => match raw {
+                "" => Ok(Self::None),
                 "term" => Ok(Self::Term),
                 "term-missing" => Ok(Self::TermMissing),
                 "xml" => Ok(Self::Xml { path: None }),
@@ -109,6 +113,7 @@ impl From<OutputFormat> for karva_metadata::OutputFormat {
 impl From<CovReport> for karva_metadata::CovReport {
     fn from(value: CovReport) -> Self {
         match value {
+            CovReport::None => Self::None,
             CovReport::Term => Self::Term,
             CovReport::TermMissing => Self::TermMissing,
             CovReport::Xml { .. } => Self::Xml,

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -246,6 +246,10 @@ pub struct SubTestCommand {
     #[clap(long = "cov-branch", action = clap::ArgAction::SetTrue, help_heading = "Coverage options")]
     pub cov_branch: bool,
 
+    /// Add this run to compatible native coverage data instead of replacing it.
+    #[clap(long = "cov-append", default_missing_value = "true", require_equals = true, num_args = 0..=1, help_heading = "Coverage options")]
+    pub cov_append: Option<bool>,
+
     /// Disable coverage measurement for this run.
     ///
     /// Overrides any `--cov` flag and any `[coverage] sources` configured in
@@ -265,6 +269,7 @@ pub struct SubTestCommand {
     /// `term-missing` extends it with a `Missing` column listing the
     /// uncovered line numbers per file.
     /// `xml[:PATH]`, `json[:PATH]`, and `html[:DIR]` write reports to disk.
+    /// Pass an empty value (`--cov-report=`) to persist native data only.
     #[clap(
         long = "cov-report",
         value_name = "TYPE",
@@ -460,7 +465,7 @@ impl SubTestCommand {
             CovReport::Xml { path } | CovReport::Json { path } | CovReport::Html { path } => {
                 path.as_ref().map(ToString::to_string)
             }
-            CovReport::Term | CovReport::TermMissing => None,
+            CovReport::None | CovReport::Term | CovReport::TermMissing => None,
         });
 
         Options {
@@ -499,6 +504,7 @@ impl SubTestCommand {
                 omit: (!self.cov_omit.is_empty()).then_some(self.cov_omit),
                 contexts: None,
                 precision: None,
+                append: self.cov_append,
                 report: self.cov_report.map(Into::into),
                 report_path: coverage_report_path,
                 branch: self.cov_branch.then_some(true),
@@ -635,6 +641,11 @@ mod tests {
     #[test]
     fn parse_html_cov_report_without_path() {
         assert_eq!(parse_cov_report("html"), Ok(CovReport::Html { path: None }));
+    }
+
+    #[test]
+    fn empty_cov_report_disables_rendering() {
+        assert_eq!(parse_cov_report(""), Ok(CovReport::None));
     }
 
     #[test]

--- a/crates/karva_coverage/src/native.rs
+++ b/crates/karva_coverage/src/native.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 use siphasher::sip128::{Hasher128, SipHasher13};
 use tempfile::NamedTempFile;
 
-use crate::data::BranchArc;
+use crate::data::{BranchArc, WorkerFile};
 
 /// Current native coverage schema version.
 pub const FORMAT_VERSION: u32 = 1;
@@ -117,6 +117,191 @@ impl NativeCoverage {
         }
         Ok(())
     }
+
+    /// Builds one durable artifact by unioning transient worker payloads.
+    pub fn from_worker_files(
+        project_root: &Utf8Path,
+        source_roots: &[String],
+        mode: CoverageMode,
+        files: &[impl AsRef<Utf8Path>],
+    ) -> Result<Self> {
+        let canonical_root = dunce::canonicalize(project_root)
+            .with_context(|| format!("failed to resolve coverage project root `{project_root}`"))?;
+        let canonical_root = Utf8PathBuf::from_path_buf(canonical_root).map_err(|path| {
+            anyhow::anyhow!(
+                "coverage project root contains non-Unicode characters: `{}`",
+                path.display()
+            )
+        })?;
+        let mut native_files = BTreeMap::new();
+
+        for worker_path in files {
+            let worker_path = worker_path.as_ref();
+            let bytes = fs::read(worker_path)
+                .with_context(|| format!("failed to read coverage file `{worker_path}`"))?;
+            let worker: WorkerFile = serde_json::from_slice(&bytes)
+                .with_context(|| format!("failed to parse coverage file `{worker_path}`"))?;
+            for (source, file) in worker.files {
+                merge_worker_file(
+                    &canonical_root,
+                    worker_path,
+                    &source,
+                    file,
+                    mode,
+                    &mut native_files,
+                )?;
+            }
+        }
+
+        Ok(Self::new(
+            mode,
+            canonical_root,
+            source_roots.iter().map(Utf8PathBuf::from).collect(),
+            None,
+            native_files,
+        ))
+    }
+
+    /// Unions compatible observations into this artifact.
+    pub fn merge(&mut self, other: Self) -> Result<()> {
+        if self.mode != other.mode {
+            bail!(
+                "cannot append coverage collected in {:?} mode to coverage collected in {:?} mode",
+                other.mode,
+                self.mode
+            );
+        }
+        if self.project_root != other.project_root {
+            bail!(
+                "cannot append coverage from project root `{}` to coverage from `{}`",
+                other.project_root,
+                self.project_root
+            );
+        }
+        if self.source_roots != other.source_roots {
+            bail!("cannot append coverage collected from different source roots");
+        }
+        if self.run_context != other.run_context {
+            bail!("cannot append coverage collected with different run contexts");
+        }
+
+        for (path, incoming) in other.files {
+            if let Some(current) = self.files.get_mut(&path) {
+                merge_native_file(&path, current, incoming)?;
+            } else {
+                self.files.insert(path, incoming);
+            }
+        }
+        Ok(())
+    }
+}
+
+fn merge_worker_file(
+    project_root: &Utf8Path,
+    worker_path: &Utf8Path,
+    source: &str,
+    file: crate::data::FileEntry,
+    mode: CoverageMode,
+    files: &mut BTreeMap<Utf8PathBuf, NativeFileCoverage>,
+) -> Result<()> {
+    let source_path = dunce::canonicalize(source).with_context(|| {
+        format!("coverage worker artifact `{worker_path}` references unreadable source `{source}`")
+    })?;
+    let source_path = Utf8PathBuf::from_path_buf(source_path).map_err(|path| {
+        anyhow::anyhow!(
+            "coverage source contains non-Unicode characters: `{}`",
+            path.display()
+        )
+    })?;
+    let stored_path = source_path
+        .strip_prefix(project_root)
+        .unwrap_or(&source_path)
+        .to_path_buf();
+    let source_bytes = fs::read(&source_path).with_context(|| {
+        format!("coverage worker artifact `{worker_path}` references unreadable source `{source}`")
+    })?;
+    let fingerprint = SourceFingerprint::from_bytes(&source_bytes);
+    let incoming = NativeFileCoverage {
+        source_fingerprint: fingerprint,
+        executable: file.executable.into_iter().collect(),
+        excluded: BTreeSet::new(),
+        executed: file.executed.into_iter().collect(),
+        line_contexts: file.contexts,
+        branches: match (mode, file.branches) {
+            (CoverageMode::Line, None) => None,
+            (CoverageMode::Line, Some(_)) => {
+                bail!(
+                    "coverage worker artifact `{worker_path}` contains branch data for line-only collection"
+                )
+            }
+            (CoverageMode::Branch, None) => {
+                bail!("coverage worker artifact `{worker_path}` lacks branch data for `{source}`")
+            }
+            (CoverageMode::Branch, Some(branches)) => Some(NativeBranchCoverage {
+                possible: branches.possible.into_iter().collect(),
+                executed: branches.executed.into_iter().collect(),
+                contexts: branches
+                    .contexts
+                    .into_iter()
+                    .map(|entry| NativeArcContexts {
+                        arc: entry.arc,
+                        contexts: entry.contexts,
+                    })
+                    .collect(),
+            }),
+        },
+    };
+
+    if let Some(current) = files.get_mut(&stored_path) {
+        merge_native_file(&stored_path, current, incoming)
+    } else {
+        files.insert(stored_path, incoming);
+        Ok(())
+    }
+}
+
+fn merge_native_file(
+    path: &Utf8Path,
+    current: &mut NativeFileCoverage,
+    incoming: NativeFileCoverage,
+) -> Result<()> {
+    if current.source_fingerprint != incoming.source_fingerprint {
+        bail!("cannot merge coverage for changed source `{path}`");
+    }
+    current.executable.extend(incoming.executable);
+    current.excluded.extend(incoming.excluded);
+    current.executed.extend(incoming.executed);
+    for (line, contexts) in incoming.line_contexts {
+        current
+            .line_contexts
+            .entry(line)
+            .or_default()
+            .extend(contexts);
+    }
+    match (&mut current.branches, incoming.branches) {
+        (None, None) => {}
+        (Some(current), Some(incoming)) => {
+            current.possible.extend(incoming.possible);
+            current.executed.extend(incoming.executed);
+            for entry in incoming.contexts {
+                merge_arc_contexts(&mut current.contexts, entry);
+            }
+        }
+        _ => bail!("cannot merge line and branch coverage for `{path}`"),
+    }
+    Ok(())
+}
+
+fn merge_arc_contexts(current: &mut BTreeSet<NativeArcContexts>, mut incoming: NativeArcContexts) {
+    if let Some(existing) = current
+        .iter()
+        .find(|entry| entry.arc == incoming.arc)
+        .cloned()
+    {
+        current.remove(&existing);
+        incoming.contexts.extend(existing.contexts);
+    }
+    current.insert(incoming);
 }
 
 /// Coverage opportunities captured by an artifact.
@@ -320,6 +505,65 @@ mod tests {
             error
                 .to_string()
                 .contains("source changed since collection")
+        );
+    }
+
+    #[test]
+    fn worker_artifacts_and_appended_runs_union_observations() {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let project_root =
+            Utf8PathBuf::from_path_buf(directory.path().to_path_buf()).expect("UTF-8 temp path");
+        let source = project_root.join("app.py");
+        fs::write(&source, "first = 1\nsecond = 2\n").expect("write source");
+        let first_worker = project_root.join("first-worker.json");
+        let second_worker = project_root.join("second-worker.json");
+        let worker = |executed, context: &str| WorkerFile {
+            files: BTreeMap::from([(
+                source.to_string(),
+                crate::data::FileEntry {
+                    executable: vec![1, 2],
+                    executed: vec![executed],
+                    contexts: BTreeMap::from([(executed, BTreeSet::from([context.to_owned()]))]),
+                    branches: None,
+                },
+            )]),
+        };
+        fs::write(
+            &first_worker,
+            serde_json::to_vec(&worker(1, "first")).expect("serialize worker"),
+        )
+        .expect("write first worker");
+        fs::write(
+            &second_worker,
+            serde_json::to_vec(&worker(2, "second")).expect("serialize worker"),
+        )
+        .expect("write second worker");
+
+        let mut first = NativeCoverage::from_worker_files(
+            &project_root,
+            &["app.py".to_owned()],
+            CoverageMode::Line,
+            &[first_worker],
+        )
+        .expect("build first artifact");
+        let second = NativeCoverage::from_worker_files(
+            &project_root,
+            &["app.py".to_owned()],
+            CoverageMode::Line,
+            &[second_worker],
+        )
+        .expect("build second artifact");
+
+        first.merge(second).expect("append compatible artifact");
+
+        let file = first.files.get(Utf8Path::new("app.py")).expect("app data");
+        assert_eq!(file.executed, BTreeSet::from([1, 2]));
+        assert_eq!(
+            file.line_contexts,
+            BTreeMap::from([
+                (1, BTreeSet::from(["first".to_owned()])),
+                (2, BTreeSet::from(["second".to_owned()])),
+            ])
         );
     }
 }

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -671,15 +671,26 @@ pub struct CoverageOptions {
     )]
     pub precision: Option<CoveragePrecision>,
 
+    /// Add a test run to compatible native data instead of replacing it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"false"#,
+        value_type = r#"true | false"#,
+        example = r#"
+            append = true
+        "#
+    )]
+    pub append: Option<bool>,
+
     /// Coverage report type.
     ///
     /// `term` (default) prints a compact terminal table.
     /// `term-missing` extends it with a `Missing` column listing the
-    /// uncovered line numbers per file.
+    /// uncovered line numbers per file. `none` persists native data only.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[option(
         default = r#"term"#,
-        value_type = r#"term | term-missing | xml | json | html"#,
+        value_type = r#"none | term | term-missing | xml | json | html"#,
         example = r#"
             report = "term-missing"
         "#
@@ -748,6 +759,7 @@ impl Combine for CoverageOptions {
         self.omit = self.omit.take().combine(other.omit);
         self.contexts = self.contexts.take().combine(other.contexts);
         self.precision = self.precision.combine(other.precision);
+        self.append = self.append.combine(other.append);
         self.report = self.report.combine(other.report);
         self.report_path = if report_overridden && self.report_path.is_none() {
             None
@@ -778,6 +790,7 @@ impl CoverageOptions {
             omit: self.omit.clone().unwrap_or_default(),
             contexts: self.contexts.clone().unwrap_or_default(),
             precision: self.precision.unwrap_or_default(),
+            append: self.append.unwrap_or_default(),
             report: self.report.unwrap_or_default(),
             report_path: self.report_path.clone(),
             branch: self.branch.unwrap_or_default(),
@@ -872,6 +885,9 @@ impl JunitOptions {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub enum CovReport {
+    /// Persist native data without rendering a report.
+    None,
+
     /// Compact terminal table (default).
     #[default]
     Term,
@@ -903,6 +919,7 @@ impl CovReport {
     /// Returns canonical configuration spelling.
     pub fn as_str(self) -> &'static str {
         match self {
+            Self::None => "none",
             Self::Term => "term",
             Self::TermMissing => "term-missing",
             Self::Xml => "xml",
@@ -1445,6 +1462,7 @@ report-path = "build/coverage.xml"
                         2,
                     ),
                 ),
+                append: None,
                 report: Some(
                     TermMissing,
                 ),
@@ -1531,6 +1549,7 @@ store-failure-output = false
             omit: None,
             contexts: None,
             precision: None,
+            append: None,
             report: Some(
                 TermMissing,
             ),
@@ -1573,6 +1592,7 @@ store-failure-output = false
             ),
             contexts: None,
             precision: None,
+            append: None,
             report: None,
             report_path: None,
             branch: None,
@@ -1636,6 +1656,7 @@ store-failure-output = false
             omit: None,
             contexts: None,
             precision: None,
+            append: None,
             report: Some(
                 Json,
             ),
@@ -1696,7 +1717,7 @@ nonsense = 1
           |
         4 | nonsense = 1
           | ^^^^^^^^
-        unknown field `nonsense`, expected one of `data-file`, `sources`, `include`, `omit`, `contexts`, `precision`, `report`, `report-path`, `branch`, `fail-under`
+        unknown field `nonsense`, expected one of `data-file`, `sources`, `include`, `omit`, `contexts`, `precision`, `append`, `report`, `report-path`, `branch`, `fail-under`
         "
         );
     }

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -1698,7 +1698,7 @@ disabled = true
           |
         3 | disabled = true
           | ^^^^^^^^
-        unknown field `disabled`, expected one of `data-file`, `sources`, `include`, `omit`, `contexts`, `precision`, `report`, `report-path`, `branch`, `fail-under`
+        unknown field `disabled`, expected one of `data-file`, `sources`, `include`, `omit`, `contexts`, `precision`, `append`, `report`, `report-path`, `branch`, `fail-under`
         "
         );
     }

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -628,6 +628,9 @@ pub struct CoverageSettings {
     /// Decimal places shown in coverage percentages.
     pub precision: CoveragePrecision,
 
+    /// Whether a test run unions observations with an existing native artifact.
+    pub append: bool,
+
     /// Selected report backend.
     pub report: CovReport,
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -39,6 +39,23 @@ Configuration groups combined across defaults, profiles, environment, and CLI.
 
 Controls measured Python sources and coverage report generation.
 
+### `append`
+
+Add a test run to compatible native data instead of replacing it.
+
+**Default value**: `false`
+
+**Type**: `true | false`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.karva.profile.default.coverage]
+append = true
+```
+
+---
+
 ### `branch`
 
 Whether to measure branch coverage in addition to line coverage.
@@ -179,11 +196,11 @@ Coverage report type.
 
 `term` (default) prints a compact terminal table.
 `term-missing` extends it with a `Missing` column listing the
-uncovered line numbers per file.
+uncovered line numbers per file. `none` persists native data only.
 
 **Default value**: `term`
 
-**Type**: `term | term-missing | xml | json | html`
+**Type**: `none | term | term-missing | xml | json | html`
 
 **Example usage** (`pyproject.toml`):
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -50,7 +50,12 @@ karva test [OPTIONS] [PATH]...
 <p>While karva configuration can be included in a <code>pyproject.toml</code> file, it is not allowed in this context.</p>
 <p>May also be set with the <code>KARVA_CONFIG_FILE</code> environment variable.</p></dd><dt id="karva-test--cov"><a href="#karva-test--cov"><code>--cov</code></a> <i>source</i></dt><dd><p>Measure code coverage for the given source path.</p>
 <p>May be passed multiple times to measure several sources. Pass without a value (<code>--cov</code>) to measure the current working directory.</p>
-</dd><dt id="karva-test--cov-branch"><a href="#karva-test--cov-branch"><code>--cov-branch</code></a></dt><dd><p>Measure branch coverage in addition to line coverage</p>
+</dd><dt id="karva-test--cov-append"><a href="#karva-test--cov-append"><code>--cov-append</code></a> <i>cov-append</i></dt><dd><p>Add this run to compatible native coverage data instead of replacing it</p>
+<p>Possible values:</p>
+<ul>
+<li><code>true</code></li>
+<li><code>false</code></li>
+</ul></dd><dt id="karva-test--cov-branch"><a href="#karva-test--cov-branch"><code>--cov-branch</code></a></dt><dd><p>Measure branch coverage in addition to line coverage</p>
 </dd><dt id="karva-test--cov-context"><a href="#karva-test--cov-context"><code>--cov-context</code></a> <i>context</i></dt><dd><p>Record per-test coverage contexts.</p>
 <p>Currently supports <code>test</code>, which records the qualified test name for each line executed while that test is running. Contexts are emitted in JSON coverage reports.</p>
 <p>Possible values:</p>
@@ -63,7 +68,7 @@ karva test [OPTIONS] [PATH]...
 </dd><dt id="karva-test--cov-omit"><a href="#karva-test--cov-omit"><code>--cov-omit</code></a> <i>glob</i></dt><dd><p>Exclude coverage report files whose project-relative path matches this glob.</p>
 <p>May be passed multiple times.</p>
 </dd><dt id="karva-test--cov-report"><a href="#karva-test--cov-report"><code>--cov-report</code></a> <i>type</i></dt><dd><p>Coverage report type.</p>
-<p><code>term</code> (default) prints a compact terminal table. <code>term-missing</code> extends it with a <code>Missing</code> column listing the uncovered line numbers per file. <code>xml&#91;:PATH&#93;</code>, <code>json&#91;:PATH&#93;</code>, and <code>html&#91;:DIR&#93;</code> write reports to disk.</p>
+<p><code>term</code> (default) prints a compact terminal table. <code>term-missing</code> extends it with a <code>Missing</code> column listing the uncovered line numbers per file. <code>xml&#91;:PATH&#93;</code>, <code>json&#91;:PATH&#93;</code>, and <code>html&#91;:DIR&#93;</code> write reports to disk. Pass an empty value (<code>--cov-report=</code>) to persist native data only.</p>
 </dd><dt id="karva-test--durations"><a href="#karva-test--durations"><code>--durations</code></a> <i>n</i></dt><dd><p>Show the N slowest tests after the run completes</p>
 </dd><dt id="karva-test--fail-fast"><a href="#karva-test--fail-fast"><code>--fail-fast</code></a> <i>fail-fast</i></dt><dd><p>Stop scheduling new tests after the first failure.</p>
 <p>Equivalent to <code>--max-fail=1</code>. Use <code>--no-fail-fast</code> to keep running after failures.</p>

--- a/karva.schema.json
+++ b/karva.schema.json
@@ -36,6 +36,11 @@
       "description": "Coverage report type.",
       "oneOf": [
         {
+          "description": "Persist native data without rendering a report.",
+          "type": "string",
+          "const": "none"
+        },
+        {
           "description": "Compact terminal table (default).",
           "type": "string",
           "const": "term"
@@ -66,6 +71,13 @@
       "description": "Controls measured Python sources and coverage report generation.",
       "type": "object",
       "properties": {
+        "append": {
+          "description": "Add a test run to compatible native data instead of replacing it.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "branch": {
           "description": "Whether to measure branch coverage in addition to line coverage.",
           "type": [
@@ -133,7 +145,7 @@
           ]
         },
         "report": {
-          "description": "Coverage report type.\n\n`term` (default) prints a compact terminal table.\n`term-missing` extends it with a `Missing` column listing the\nuncovered line numbers per file.",
+          "description": "Coverage report type.\n\n`term` (default) prints a compact terminal table.\n`term-missing` extends it with a `Missing` column listing the\nuncovered line numbers per file. `none` persists native data only.",
           "anyOf": [
             {
               "$ref": "#/definitions/CovReport"


### PR DESCRIPTION
## Summary

Persists worker coverage as one atomic native artifact, supports explicit append and raw-data-only runs, and renders test-run reports from that artifact. Closes #1152.

## Test Plan

Full coverage integration tests, workspace clippy, and `uvx prek run -a`.