### PR TITLE
Normalize native coverage paths

### DIFF
--- a/crates/karva/src/commands/coverage.rs
+++ b/crates/karva/src/commands/coverage.rs
@@ -40,7 +40,8 @@ pub fn coverage(args: &CoverageCommand) -> Result<ExitStatus> {
     }
 
     let filters = karva_coverage::CoverageFilters::new(&settings.include, &settings.omit)?
-        .with_contexts(&settings.contexts)?;
+        .with_contexts(&settings.contexts)?
+        .with_path_aliases(&settings.path_aliases)?;
     let analysis = karva_coverage::CoverageAnalysis::load_native(
         project.cwd(),
         std::slice::from_ref(&data_file),

--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -130,7 +130,8 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
         let coverage = project.settings().coverage();
         let coverage_filters =
             karva_coverage::CoverageFilters::new(&coverage.include, &coverage.omit)?
-                .with_contexts(&coverage.contexts)?;
+                .with_contexts(&coverage.contexts)?
+                .with_path_aliases(&coverage.path_aliases)?;
         if coverage.report_path.is_some()
             && matches!(coverage.report, CovReport::Term | CovReport::TermMissing)
         {

--- a/crates/karva/tests/it/coverage_command.rs
+++ b/crates/karva/tests/it/coverage_command.rs
@@ -13,7 +13,6 @@ fn write_coverage(context: &TestContext, path: &Utf8Path) {
     let root = context.root();
     let artifact = NativeCoverage::new(
         CoverageMode::Line,
-        root.clone(),
         BTreeSet::from([Utf8PathBuf::from("src")]),
         None,
         BTreeMap::from([(

--- a/crates/karva/tests/it/show_config.rs
+++ b/crates/karva/tests/it/show_config.rs
@@ -202,6 +202,7 @@ fail-under = 90
 
     [coverage]
     data-file = ".karva/coverage/data.json"
+    path-aliases = []
     sources = ["src"]
     include = ["src/app/*"]
     omit = ["**/generated.py"]

--- a/crates/karva/tests/it/show_config.rs
+++ b/crates/karva/tests/it/show_config.rs
@@ -202,7 +202,6 @@ fail-under = 90
 
     [coverage]
     data-file = ".karva/coverage/data.json"
-    path-aliases = []
     sources = ["src"]
     include = ["src/app/*"]
     omit = ["**/generated.py"]

--- a/crates/karva/tests/it/show_config.rs
+++ b/crates/karva/tests/it/show_config.rs
@@ -29,6 +29,7 @@ fn show_config_default_profile() {
 
     [coverage]
     data-file = ".karva/coverage/data.json"
+    path-aliases = []
     sources = []
     include = []
     omit = []
@@ -84,6 +85,7 @@ output-format = "concise"
 
     [coverage]
     data-file = ".karva/coverage/data.json"
+    path-aliases = []
     sources = []
     include = []
     omit = []
@@ -140,6 +142,7 @@ output-format = "concise"
 
     [coverage]
     data-file = ".karva/coverage/data.json"
+    path-aliases = []
     sources = []
     include = []
     omit = []
@@ -202,6 +205,7 @@ fail-under = 90
 
     [coverage]
     data-file = ".karva/coverage/data.json"
+    path-aliases = []
     sources = ["src"]
     include = ["src/app/*"]
     omit = ["**/generated.py"]
@@ -259,6 +263,7 @@ slow-timeout = 0.5
 
     [coverage]
     data-file = ".karva/coverage/data.json"
+    path-aliases = []
     sources = []
     include = []
     omit = []

--- a/crates/karva_cli/src/coverage.rs
+++ b/crates/karva_cli/src/coverage.rs
@@ -80,6 +80,7 @@ impl CoverageCommand {
         Options {
             coverage: Some(CoverageOptions {
                 data_file: self.data_file.as_ref().map(ToString::to_string),
+                path_aliases: None,
                 include: (!self.include.is_empty()).then(|| self.include.clone()),
                 omit: (!self.omit.is_empty()).then(|| self.omit.clone()),
                 contexts: (!self.contexts.is_empty()).then(|| self.contexts.clone()),

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -499,6 +499,7 @@ impl SubTestCommand {
             }),
             coverage: Some(CoverageOptions {
                 data_file: None,
+                path_aliases: None,
                 sources: (!self.cov.is_empty()).then_some(self.cov),
                 include: (!self.cov_include.is_empty()).then_some(self.cov_include),
                 omit: (!self.cov_omit.is_empty()).then_some(self.cov_omit),

--- a/crates/karva_coverage/src/native.rs
+++ b/crates/karva_coverage/src/native.rs
@@ -19,7 +19,7 @@ use tempfile::NamedTempFile;
 use crate::data::{BranchArc, WorkerFile};
 
 /// Current native coverage schema version.
-pub const FORMAT_VERSION: u32 = 1;
+pub const FORMAT_VERSION: u32 = 2;
 
 /// Karva coverage data retained after one or more test runs.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -30,14 +30,15 @@ pub struct NativeCoverage {
     pub karva_version: String,
     /// Whether collection measured statements alone or statements and branches.
     pub mode: CoverageMode,
-    /// Normalized absolute project root used during collection.
-    pub project_root: Utf8PathBuf,
-    /// Normalized source roots measured during collection.
+    /// Portable project-relative source roots, or absolute roots outside the project.
     pub source_roots: BTreeSet<Utf8PathBuf>,
     /// User-provided context attached to the whole run.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub run_context: Option<String>,
-    /// Coverage keyed by normalized project-relative source path.
+    /// Coverage keyed by `/`-separated project-relative paths.
+    ///
+    /// Sources outside the project retain normalized absolute paths and require
+    /// a report-time path alias when consumed from another machine.
     pub files: BTreeMap<Utf8PathBuf, NativeFileCoverage>,
 }
 
@@ -45,7 +46,6 @@ impl NativeCoverage {
     /// Creates an artifact for the current schema and Karva version.
     pub fn new(
         mode: CoverageMode,
-        project_root: Utf8PathBuf,
         source_roots: BTreeSet<Utf8PathBuf>,
         run_context: Option<String>,
         files: BTreeMap<Utf8PathBuf, NativeFileCoverage>,
@@ -54,7 +54,6 @@ impl NativeCoverage {
             format_version: FORMAT_VERSION,
             karva_version: env!("CARGO_PKG_VERSION").to_owned(),
             mode,
-            project_root,
             source_roots,
             run_context,
             files,
@@ -106,9 +105,9 @@ impl NativeCoverage {
     }
 
     /// Fails when any source differs from the bytes measured during collection.
-    pub fn verify_sources(&self) -> Result<()> {
+    pub fn verify_sources(&self, project_root: &Utf8Path) -> Result<()> {
         for (source_path, coverage) in &self.files {
-            let path = self.project_root.join(source_path);
+            let path = project_root.join(source_path);
             let source = fs::read(&path)
                 .with_context(|| format!("failed to verify coverage source `{path}`"))?;
             if !coverage.source_fingerprint.matches(&source) {
@@ -155,8 +154,7 @@ impl NativeCoverage {
 
         Ok(Self::new(
             mode,
-            canonical_root,
-            source_roots.iter().map(Utf8PathBuf::from).collect(),
+            normalize_source_roots(&canonical_root, source_roots)?,
             None,
             native_files,
         ))
@@ -169,13 +167,6 @@ impl NativeCoverage {
                 "cannot append coverage collected in {:?} mode to coverage collected in {:?} mode",
                 other.mode,
                 self.mode
-            );
-        }
-        if self.project_root != other.project_root {
-            bail!(
-                "cannot append coverage from project root `{}` to coverage from `{}`",
-                other.project_root,
-                self.project_root
             );
         }
         if self.source_roots != other.source_roots {
@@ -213,10 +204,11 @@ fn merge_worker_file(
             path.display()
         )
     })?;
-    let stored_path = source_path
-        .strip_prefix(project_root)
-        .unwrap_or(&source_path)
-        .to_path_buf();
+    let stored_path = portable_path(
+        source_path
+            .strip_prefix(project_root)
+            .unwrap_or(&source_path),
+    );
     let source_bytes = fs::read(&source_path).with_context(|| {
         format!("coverage worker artifact `{worker_path}` references unreadable source `{source}`")
     })?;
@@ -258,6 +250,39 @@ fn merge_worker_file(
         files.insert(stored_path, incoming);
         Ok(())
     }
+}
+
+fn normalize_source_roots(
+    project_root: &Utf8Path,
+    source_roots: &[String],
+) -> Result<BTreeSet<Utf8PathBuf>> {
+    source_roots
+        .iter()
+        .map(|source| {
+            let source = if source.is_empty() { "." } else { source };
+            let path = Utf8Path::new(source);
+            let path = if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                project_root.join(path)
+            };
+            let path = dunce::canonicalize(&path)
+                .with_context(|| format!("failed to resolve coverage source root `{source}`"))?;
+            let path = Utf8PathBuf::from_path_buf(path).map_err(|path| {
+                anyhow::anyhow!(
+                    "coverage source root contains non-Unicode characters: `{}`",
+                    path.display()
+                )
+            })?;
+            Ok(portable_path(
+                path.strip_prefix(project_root).unwrap_or(&path),
+            ))
+        })
+        .collect()
+}
+
+fn portable_path(path: &Utf8Path) -> Utf8PathBuf {
+    Utf8PathBuf::from(path.as_str().replace('\\', "/"))
 }
 
 fn merge_native_file(
@@ -391,7 +416,6 @@ mod tests {
     fn artifact() -> NativeCoverage {
         NativeCoverage::new(
             CoverageMode::Branch,
-            Utf8PathBuf::from("/project"),
             BTreeSet::from([Utf8PathBuf::from("src")]),
             Some("linux-py313".to_owned()),
             BTreeMap::from([(
@@ -468,14 +492,14 @@ mod tests {
         let directory = tempfile::tempdir().expect("create temp directory");
         let path = Utf8PathBuf::from_path_buf(directory.path().join("data.json"))
             .expect("UTF-8 temp path");
-        fs::write(&path, br#"{"format_version":2}"#).expect("write artifact");
+        fs::write(&path, br#"{"format_version":3}"#).expect("write artifact");
 
         let error = NativeCoverage::read(&path).expect_err("reject future version");
         let message = error.to_string();
 
         assert!(message.contains(path.as_str()));
-        assert!(message.contains("found format version 2"));
-        assert!(message.contains("supported version is 1"));
+        assert!(message.contains("found format version 3"));
+        assert!(message.contains("supported version is 2"));
     }
 
     #[test]
@@ -494,11 +518,10 @@ mod tests {
             Utf8PathBuf::from_path_buf(directory.path().to_path_buf()).expect("UTF-8 temp path");
         fs::create_dir(project_root.join("src")).expect("create source directory");
         fs::write(project_root.join("src/package.py"), "value = 2\n").expect("write source");
-        let mut coverage = artifact();
-        coverage.project_root = project_root;
+        let coverage = artifact();
 
         let error = coverage
-            .verify_sources()
+            .verify_sources(&project_root)
             .expect_err("reject changed source");
 
         assert!(

--- a/crates/karva_coverage/src/report/mod.rs
+++ b/crates/karva_coverage/src/report/mod.rs
@@ -25,6 +25,14 @@ pub struct CoverageFilters {
     include: Option<GlobSet>,
     omit: Option<GlobSet>,
     contexts: Option<RegexSet>,
+    path_aliases: Vec<PathAlias>,
+}
+
+#[derive(Debug)]
+struct PathAlias {
+    from: String,
+    to: String,
+    case_insensitive: bool,
 }
 
 impl CoverageFilters {
@@ -34,12 +42,19 @@ impl CoverageFilters {
             include: compile_globs("include", include)?,
             omit: compile_globs("omit", omit)?,
             contexts: None,
+            path_aliases: Vec::new(),
         })
     }
 
     /// Adds context patterns used to select executed lines and branches.
     pub fn with_contexts(mut self, contexts: &[String]) -> Result<Self> {
         self.contexts = compile_contexts(contexts)?;
+        Ok(self)
+    }
+
+    /// Adds ordered `FROM=TO` mappings for paths stored in native artifacts.
+    pub fn with_path_aliases(mut self, aliases: &[String]) -> Result<Self> {
+        self.path_aliases = compile_path_aliases(aliases)?;
         Ok(self)
     }
 
@@ -59,6 +74,118 @@ impl CoverageFilters {
             .as_ref()
             .is_none_or(|contexts| contexts.is_match(context))
     }
+
+    fn map_path(&self, path: &str) -> String {
+        let normalized = normalize_path(path);
+        for alias in &self.path_aliases {
+            if let Some(suffix) = strip_alias_prefix(&normalized, alias) {
+                let mapped = if suffix.is_empty() {
+                    alias.to.clone()
+                } else if alias.to == "." {
+                    suffix.to_owned()
+                } else {
+                    format!("{}/{suffix}", alias.to.trim_end_matches('/'))
+                };
+                return normalize_path(&mapped);
+            }
+        }
+        normalized
+    }
+}
+
+fn compile_path_aliases(aliases: &[String]) -> Result<Vec<PathAlias>> {
+    let mut compiled: Vec<PathAlias> = Vec::new();
+    for raw in aliases {
+        let (from, to) = raw.split_once('=').ok_or_else(|| {
+            anyhow::anyhow!("invalid coverage path alias `{raw}`: expected `FROM=TO`")
+        })?;
+        if from.is_empty() || to.is_empty() {
+            anyhow::bail!("invalid coverage path alias `{raw}`: both FROM and TO are required");
+        }
+        let from = normalize_path(from);
+        let to = normalize_path(to);
+        let case_insensitive = is_windows_absolute(&from) || from.starts_with("//");
+        if let Some(previous) = compiled.iter().find(|alias| {
+            alias.case_insensitive == case_insensitive
+                && if case_insensitive {
+                    alias.from.eq_ignore_ascii_case(&from)
+                } else {
+                    alias.from == from
+                }
+        }) {
+            if previous.to != to {
+                anyhow::bail!(
+                    "ambiguous coverage path aliases for `{from}`: `{}` and `{to}`",
+                    previous.to
+                );
+            }
+            continue;
+        }
+        compiled.push(PathAlias {
+            from,
+            to,
+            case_insensitive,
+        });
+    }
+    Ok(compiled)
+}
+
+fn strip_alias_prefix<'a>(path: &'a str, alias: &PathAlias) -> Option<&'a str> {
+    if alias.from == "." && !path.starts_with('/') && !is_windows_absolute(path) {
+        return Some(path.trim_start_matches("./"));
+    }
+    let matches = if alias.case_insensitive {
+        path.get(..alias.from.len())
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case(&alias.from))
+    } else {
+        path.starts_with(&alias.from)
+    };
+    if !matches {
+        return None;
+    }
+    let suffix = &path[alias.from.len()..];
+    (suffix.is_empty() || suffix.starts_with('/')).then(|| suffix.trim_start_matches('/'))
+}
+
+fn normalize_path(raw: &str) -> String {
+    let raw = raw.replace('\\', "/");
+    let unc = raw.starts_with("//");
+    let unix_absolute = raw.starts_with('/');
+    let drive = is_windows_absolute(&raw).then(|| &raw[..2]);
+    let mut components: Vec<&str> = Vec::new();
+    for component in raw.split('/').skip(usize::from(drive.is_some())) {
+        match component {
+            "" | "." => {}
+            ".." if components.last().is_some_and(|part| *part != "..") => {
+                components.pop();
+            }
+            ".." if !unix_absolute && drive.is_none() => components.push(component),
+            ".." => {}
+            _ => components.push(component),
+        }
+    }
+    let body = components.join("/");
+    if let Some(drive) = drive {
+        if body.is_empty() {
+            format!("{drive}/")
+        } else {
+            format!("{drive}/{body}")
+        }
+    } else if unc {
+        format!("//{body}")
+    } else if unix_absolute {
+        format!("/{body}")
+    } else if body.is_empty() {
+        ".".to_owned()
+    } else {
+        body
+    }
+}
+
+fn is_windows_absolute(path: &str) -> bool {
+    path.as_bytes().get(1) == Some(&b':')
+        && path.as_bytes().get(2) == Some(&b'/')
+        && path.as_bytes().first().is_some_and(u8::is_ascii_alphabetic)
 }
 
 fn compile_contexts(patterns: &[String]) -> Result<Option<RegexSet>> {
@@ -167,7 +294,7 @@ mod tests {
     use camino::{Utf8Path, Utf8PathBuf};
     use fs_err as fs;
 
-    use super::{CoverageAnalysis, CoverageFilters};
+    use super::{CoverageAnalysis, CoverageFilters, normalize_path};
     use crate::data::BranchArc;
     use crate::native::{
         CoverageMode, NativeBranchCoverage, NativeCoverage, NativeFileCoverage, SourceFingerprint,
@@ -193,7 +320,6 @@ mod tests {
         });
         let artifact = NativeCoverage::new(
             mode,
-            project_root.clone(),
             BTreeSet::from([Utf8PathBuf::from("src")]),
             None,
             BTreeMap::from([(
@@ -234,6 +360,70 @@ mod tests {
                 .contains("invalid coverage include glob `[`"),
             "{err:?}"
         );
+    }
+
+    #[test]
+    fn path_aliases_combine_windows_and_unix_artifacts() {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let project_root =
+            Utf8PathBuf::from_path_buf(directory.path().to_path_buf()).expect("UTF-8 temp path");
+        fs::create_dir_all(project_root.join("src")).expect("create source directory");
+        fs::write(project_root.join("src/app.py"), SOURCE).expect("write source");
+        let unix = write_artifact(
+            &directory,
+            "unix.json",
+            CoverageMode::Line,
+            BTreeSet::from([1]),
+            BTreeMap::new(),
+        );
+        let mut windows = NativeCoverage::read(&unix).expect("read unix artifact");
+        windows.source_roots = BTreeSet::from([Utf8PathBuf::from(r"C:\repo\src")]);
+        let file = windows
+            .files
+            .remove(Utf8Path::new("src/app.py"))
+            .expect("source coverage");
+        windows
+            .files
+            .insert(Utf8PathBuf::from(r"C:\repo\src\app.py"), file);
+        let windows_path = project_root.join("windows.json");
+        windows
+            .write(&windows_path)
+            .expect("write windows artifact");
+        let filters = CoverageFilters::new(&["src/**".to_owned()], &[])
+            .expect("filters")
+            .with_path_aliases(&[r"C:\repo=.".to_owned()])
+            .expect("path alias");
+
+        let analysis =
+            CoverageAnalysis::load_native(&project_root, &[unix, windows_path], &filters)
+                .expect("load artifacts")
+                .expect("coverage analysis");
+
+        assert_eq!(analysis.file_count(), 1);
+    }
+
+    #[test]
+    fn path_aliases_reject_ambiguous_sources() {
+        let error = CoverageFilters::new(&[], &[])
+            .expect("filters")
+            .with_path_aliases(&["/workspace=src".to_owned(), "/workspace=vendor".to_owned()])
+            .expect_err("reject ambiguity");
+
+        assert!(
+            error
+                .to_string()
+                .contains("ambiguous coverage path aliases")
+        );
+    }
+
+    #[test]
+    fn paths_normalize_platform_separators_and_components() {
+        assert_eq!(normalize_path(r"C:\repo\src\..\app.py"), "C:/repo/app.py");
+        assert_eq!(
+            normalize_path(r"\\server\share\src\app.py"),
+            "//server/share/src/app.py"
+        );
+        assert_eq!(normalize_path("src/./package/../app.py"), "src/app.py");
     }
 
     #[test]

--- a/crates/karva_coverage/src/report/shared.rs
+++ b/crates/karva_coverage/src/report/shared.rs
@@ -105,7 +105,7 @@ pub(super) fn combine_native(
     for path in &files[1..] {
         let path = path.as_ref();
         let artifact = NativeCoverage::read(path)?;
-        validate_identity(first_path, &first, path, &artifact)?;
+        validate_identity(first_path, &first, path, &artifact, filters)?;
         merge_native(&mut combined, path, &artifact, filters)?;
     }
 
@@ -117,6 +117,7 @@ fn validate_identity(
     expected: &NativeCoverage,
     path: &Utf8Path,
     artifact: &NativeCoverage,
+    filters: &CoverageFilters,
 ) -> Result<()> {
     if artifact.mode != expected.mode {
         anyhow::bail!(
@@ -125,7 +126,17 @@ fn validate_identity(
             artifact.mode
         );
     }
-    if artifact.source_roots != expected.source_roots {
+    let expected_roots: BTreeSet<String> = expected
+        .source_roots
+        .iter()
+        .map(|root| filters.map_path(root.as_str()))
+        .collect();
+    let artifact_roots: BTreeSet<String> = artifact
+        .source_roots
+        .iter()
+        .map(|root| filters.map_path(root.as_str()))
+        .collect();
+    if artifact_roots != expected_roots {
         anyhow::bail!(
             "incompatible native coverage artifact `{path}`: expected source-root identity from `{expected_path}`"
         );
@@ -144,14 +155,15 @@ fn merge_native(
         .as_deref()
         .is_some_and(|context| filters.matches_context(context));
     for (source_path, file) in &artifact.files {
-        let bucket = combined.entry(source_path.to_string()).or_default();
+        let mapped_path = filters.map_path(source_path.as_str());
+        let bucket = combined.entry(mapped_path.clone()).or_default();
         if let Some(expected) = &bucket.source_fingerprint
             && expected != &file.source_fingerprint
         {
             anyhow::bail!(
-                "incompatible native coverage artifact `{path}`: expected source fingerprint {} for `{source_path}`, found {}",
+                "coverage path collision in native artifact `{path}`: `{source_path}` maps to `{mapped_path}` with fingerprint {}, expected {}",
+                file.source_fingerprint.as_str(),
                 expected.as_str(),
-                file.source_fingerprint.as_str()
             );
         }
         bucket.source_fingerprint = Some(file.source_fingerprint.clone());

--- a/crates/karva_coverage/src/snapshots/karva_coverage__native__tests__artifact_schema_snapshot.snap
+++ b/crates/karva_coverage/src/snapshots/karva_coverage__native__tests__artifact_schema_snapshot.snap
@@ -3,10 +3,9 @@ source: crates/karva_coverage/src/native.rs
 expression: "serde_json::to_string_pretty(&artifact()).expect(\"serialize artifact\")"
 ---
 {
-  "format_version": 1,
+  "format_version": 2,
   "karva_version": "0.0.0",
   "mode": "branch",
-  "project_root": "/project",
   "source_roots": [
     "src"
   ],

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -604,6 +604,20 @@ pub struct CoverageOptions {
     )]
     pub data_file: Option<String>,
 
+    /// Ordered `FROM=TO` path mappings applied when native artifacts are read.
+    ///
+    /// Use aliases to relocate absolute sources collected outside the project
+    /// or artifacts produced under a different CI checkout layout.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"null"#,
+        value_type = r#"list[str]"#,
+        example = r#"
+            path-aliases = ["/workspace=.", "C:/repo=."]
+        "#
+    )]
+    pub path_aliases: Option<Vec<String>>,
+
     /// Source paths to measure coverage for.
     ///
     /// Equivalent to passing `--cov=<path>` on the command line; may be
@@ -754,6 +768,9 @@ impl Combine for CoverageOptions {
         let report_overridden = self.report.is_some();
 
         self.data_file = self.data_file.take().combine(other.data_file);
+        if self.path_aliases.is_none() {
+            self.path_aliases = other.path_aliases;
+        }
         self.sources = self.sources.take().combine(other.sources);
         self.include = self.include.take().combine(other.include);
         self.omit = self.omit.take().combine(other.omit);
@@ -785,6 +802,7 @@ impl CoverageOptions {
                 .data_file
                 .clone()
                 .unwrap_or_else(|| DEFAULT_COVERAGE_DATA_FILE.to_owned()),
+            path_aliases: self.path_aliases.clone().unwrap_or_default(),
             sources,
             include: self.include.clone().unwrap_or_default(),
             omit: self.omit.clone().unwrap_or_default(),
@@ -1418,6 +1436,7 @@ retry = 5
         let toml = r#"
 [profile.default.coverage]
 data-file = "build/coverage-data.json"
+path-aliases = ["/workspace=."]
 sources = ["src", "tests"]
 include = ["src/**"]
 omit = ["**/generated.py"]
@@ -1435,6 +1454,11 @@ report-path = "build/coverage.xml"
             CoverageOptions {
                 data_file: Some(
                     "build/coverage-data.json",
+                ),
+                path_aliases: Some(
+                    [
+                        "/workspace=.",
+                    ],
                 ),
                 sources: Some(
                     [
@@ -1539,6 +1563,7 @@ store-failure-output = false
         assert_debug_snapshot!(cli.combine(file), @r#"
         CoverageOptions {
             data_file: None,
+            path_aliases: None,
             sources: Some(
                 [
                     "src",
@@ -1577,6 +1602,7 @@ store-failure-output = false
         assert_debug_snapshot!(cli.combine(file), @r#"
         CoverageOptions {
             data_file: None,
+            path_aliases: None,
             sources: None,
             include: Some(
                 [
@@ -1651,6 +1677,7 @@ store-failure-output = false
         assert_debug_snapshot!(cli.combine(file), @"
         CoverageOptions {
             data_file: None,
+            path_aliases: None,
             sources: None,
             include: None,
             omit: None,
@@ -1717,7 +1744,7 @@ nonsense = 1
           |
         4 | nonsense = 1
           | ^^^^^^^^
-        unknown field `nonsense`, expected one of `data-file`, `sources`, `include`, `omit`, `contexts`, `precision`, `append`, `report`, `report-path`, `branch`, `fail-under`
+        unknown field `nonsense`, expected one of `data-file`, `path-aliases`, `sources`, `include`, `omit`, `contexts`, `precision`, `append`, `report`, `report-path`, `branch`, `fail-under`
         "
         );
     }

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -1725,7 +1725,7 @@ disabled = true
           |
         3 | disabled = true
           | ^^^^^^^^
-        unknown field `disabled`, expected one of `data-file`, `sources`, `include`, `omit`, `contexts`, `precision`, `append`, `report`, `report-path`, `branch`, `fail-under`
+        unknown field `disabled`, expected one of `data-file`, `path-aliases`, `sources`, `include`, `omit`, `contexts`, `precision`, `append`, `report`, `report-path`, `branch`, `fail-under`
         "
         );
     }

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -613,6 +613,9 @@ pub struct CoverageSettings {
     /// Native coverage artifact path, relative to the project root when not absolute.
     pub data_file: String,
 
+    /// Ordered `FROM=TO` mappings applied to paths loaded from native artifacts.
+    pub path_aliases: Vec<String>,
+
     /// Source roots measured by worker tracers.
     pub sources: Vec<String>,
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -173,6 +173,26 @@ omit = ["**/migrations/*"]
 
 ---
 
+### `path-aliases`
+
+Ordered `FROM=TO` path mappings applied when native artifacts are read.
+
+Use aliases to relocate absolute sources collected outside the project
+or artifacts produced under a different CI checkout layout.
+
+**Default value**: `null`
+
+**Type**: `list[str]`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.karva.profile.default.coverage]
+path-aliases = ["/workspace=.", "C:/repo=."]
+```
+
+---
+
 ### `precision`
 
 Decimal places shown in coverage percentages.

--- a/karva.schema.json
+++ b/karva.schema.json
@@ -133,6 +133,16 @@
             "type": "string"
           }
         },
+        "path-aliases": {
+          "description": "Ordered `FROM=TO` path mappings applied when native artifacts are read.\n\nUse aliases to relocate absolute sources collected outside the project\nor artifacts produced under a different CI checkout layout.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "precision": {
           "description": "Decimal places shown in coverage percentages.",
           "anyOf": [


### PR DESCRIPTION
## Summary

Stores normal coverage paths without machine-specific roots, normalizes cross-platform separators, and adds ordered path aliases with collision diagnostics for CI artifacts. Closes #1154.

## Test Plan

Full coverage integration tests, portability unit tests, workspace clippy, and `uvx prek run -a`.