### PR TITLE
Complete terminal coverage reports

### DIFF
--- a/crates/karva/src/commands/coverage.rs
+++ b/crates/karva/src/commands/coverage.rs
@@ -1,8 +1,8 @@
+use std::fs::OpenOptions;
 use std::io::{ErrorKind, Write};
 
 use anyhow::{Context, Result, bail};
-use karva_cli::{CoverageAction, CoverageCommand};
-use karva_logging::Printer;
+use karva_cli::{CoverageAction, CoverageCommand, CoverageFormat, CoverageSort};
 use karva_metadata::{ProjectMetadata, ProjectOptionsOverrides};
 use karva_project::Project;
 use karva_project::path::absolute;
@@ -28,43 +28,128 @@ pub fn coverage(args: &CoverageCommand) -> Result<ExitStatus> {
     let settings = project.settings().coverage();
     let data_file = absolute(&settings.data_file, project.cwd());
 
-    match std::fs::metadata(&data_file) {
-        Ok(_) => {}
-        Err(error) if error.kind() == ErrorKind::NotFound => {
-            bail!("no coverage data found at `{data_file}`; run `uv run karva test --cov` first");
+    let data_files = coverage_data_files(&data_file)?;
+
+    let filters = karva_coverage::CoverageFilters::new(&settings.include, &settings.omit)?
+        .with_contexts(&settings.contexts)?
+        .with_path_aliases(&settings.path_aliases)?;
+    let analysis =
+        karva_coverage::CoverageAnalysis::load_native(project.cwd(), &data_files, &filters)?
+            .with_context(|| format!("coverage data at `{data_file}` contains no source files"))?;
+
+    match &args.action {
+        CoverageAction::Report(report) => {
+            if report.append == Some(true) && report.format != CoverageFormat::Markdown {
+                bail!("`--append` requires `--format markdown`");
+            }
+            let options = karva_coverage::CoverageReportOptions {
+                selectors: report.selectors.clone(),
+                show_missing: report.show_missing,
+                skip_covered: report.skip_covered,
+                skip_empty: report.skip_empty,
+                sort: match report.sort {
+                    CoverageSort::Name => karva_coverage::CoverageReportSort::Name,
+                    CoverageSort::Statements => karva_coverage::CoverageReportSort::Statements,
+                    CoverageSort::Misses => karva_coverage::CoverageReportSort::Misses,
+                    CoverageSort::Branches => karva_coverage::CoverageReportSort::Branches,
+                    CoverageSort::PartialBranches => {
+                        karva_coverage::CoverageReportSort::PartialBranches
+                    }
+                    CoverageSort::Coverage => karva_coverage::CoverageReportSort::Coverage,
+                },
+                precision: settings.precision.0,
+                format: match report.format {
+                    CoverageFormat::Text => karva_coverage::CoverageReportFormat::Text,
+                    CoverageFormat::Markdown => karva_coverage::CoverageReportFormat::Markdown,
+                    CoverageFormat::Total => karva_coverage::CoverageReportFormat::Total,
+                },
+            };
+            let total = if let Some(output) = &report.output {
+                let output = absolute(output, project.cwd());
+                if let Some(parent) = output.parent()
+                    && !parent.as_str().is_empty()
+                {
+                    std::fs::create_dir_all(parent).with_context(|| {
+                        format!("failed to create coverage report directory `{parent}`")
+                    })?;
+                }
+                let mut file = OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .append(report.append == Some(true))
+                    .truncate(report.append != Some(true))
+                    .open(&output)
+                    .with_context(|| format!("failed to open coverage report `{output}`"))?;
+                analysis.write_report(&options, &mut file)?
+            } else {
+                analysis.write_report(&options, &mut std::io::stdout().lock())?
+            };
+            if let Some(threshold) = settings.fail_under
+                && total < threshold
+            {
+                let mut stderr = std::io::stderr().lock();
+                writeln!(
+                    stderr,
+                    "coverage failure: required total coverage of {threshold}% not reached, total coverage was {:.*}%",
+                    settings.precision.0, total
+                )?;
+                return Ok(ExitStatus::Error);
+            }
         }
+    }
+
+    Ok(ExitStatus::Success)
+}
+
+fn coverage_data_files(data_file: &camino::Utf8Path) -> Result<Vec<camino::Utf8PathBuf>> {
+    let mut files = Vec::new();
+    match std::fs::metadata(data_file) {
+        Ok(metadata) if metadata.is_file() => files.push(data_file.to_path_buf()),
+        Ok(_) => bail!("coverage data path `{data_file}` is not a file"),
+        Err(error) if error.kind() == ErrorKind::NotFound => {}
         Err(error) => {
             return Err(error)
                 .with_context(|| format!("failed to inspect coverage data `{data_file}`"));
         }
     }
 
-    let filters = karva_coverage::CoverageFilters::new(&settings.include, &settings.omit)?
-        .with_contexts(&settings.contexts)?
-        .with_path_aliases(&settings.path_aliases)?;
-    let analysis = karva_coverage::CoverageAnalysis::load_native(
-        project.cwd(),
-        std::slice::from_ref(&data_file),
-        &filters,
-    )?
-    .with_context(|| format!("coverage data at `{data_file}` contains no source files"))?;
-
-    match &args.action {
-        CoverageAction::Report(_) => {
-            let total = analysis.report_with_precision(false, settings.precision.0)?;
-            if let Some(threshold) = settings.fail_under
-                && total < threshold
-            {
-                let mut stdout = Printer::default().stream_for_message().lock();
-                writeln!(
-                    stdout,
-                    "\ncoverage failure: required total coverage of {threshold}% not reached, total coverage was {:.*}%",
-                    settings.precision.0, total
-                )?;
-                return Ok(ExitStatus::Failure);
+    let pending = data_file
+        .parent()
+        .unwrap_or_else(|| camino::Utf8Path::new("."))
+        .join("pending");
+    match std::fs::read_dir(&pending) {
+        Ok(entries) => {
+            for entry in entries {
+                let entry = entry.with_context(|| {
+                    format!("failed to read pending coverage directory `{pending}`")
+                })?;
+                if !entry
+                    .file_type()
+                    .with_context(|| format!("failed to inspect `{}`", entry.path().display()))?
+                    .is_file()
+                {
+                    continue;
+                }
+                let path = camino::Utf8PathBuf::from_path_buf(entry.path()).map_err(|path| {
+                    anyhow::anyhow!(
+                        "pending coverage path contains non-Unicode characters: `{}`",
+                        path.display()
+                    )
+                })?;
+                if path.extension() == Some("json") {
+                    files.push(path);
+                }
             }
         }
+        Err(error) if error.kind() == ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("failed to read pending coverage directory `{pending}`"));
+        }
     }
-
-    Ok(ExitStatus::Success)
+    files.sort();
+    if files.is_empty() {
+        bail!("no coverage data found at `{data_file}`; run `uv run karva test --cov` first");
+    }
+    Ok(files)
 }

--- a/crates/karva/tests/it/coverage.rs
+++ b/crates/karva/tests/it/coverage.rs
@@ -111,7 +111,7 @@ def test_yes():
 
     Name             Stmts   Miss   Branch   BrPart   Cover   Missing
     [LONG-LINE]
-    test_branch.py       6      1        2        1     75%   5
+    test_branch.py       6      1        2        1     75%   5, 3->5
     [LONG-LINE]
     TOTAL                6      1        2        1     75%
 
@@ -254,7 +254,7 @@ def test_yes():
 
     Name                    Stmts   Miss   Branch   BrPart   Cover   Missing
     [LONG-LINE]
-    test_branch_config.py       6      1        2        1     75%   5
+    test_branch_config.py       6      1        2        1     75%   5, 3->5
     [LONG-LINE]
     TOTAL                       6      1        2        1     75%
 

--- a/crates/karva/tests/it/coverage_command.rs
+++ b/crates/karva/tests/it/coverage_command.rs
@@ -53,6 +53,29 @@ fn report_reads_default_native_data() {
 }
 
 #[test]
+fn report_auto_combines_pending_shards() {
+    let context = TestContext::new();
+    write_coverage(
+        &context,
+        Utf8Path::new(".karva/coverage/pending/shard-a.json"),
+    );
+
+    assert_cmd_snapshot!(context.coverage("report"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    Name         Stmts   Miss   Cover
+    [LONG-LINE]
+    src/app.py       2      1     50%
+    [LONG-LINE]
+    TOTAL            2      1     50%
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn report_discovers_project_from_subdirectory_and_honors_config() {
     let context = TestContext::new();
     context.write_file(
@@ -133,9 +156,9 @@ fn report_fail_under_returns_failure() {
     let context = TestContext::new();
     write_coverage(&context, Utf8Path::new(".karva/coverage/data.json"));
 
-    assert_cmd_snapshot!(context.coverage("report").arg("--fail-under=75"), @r"
+    assert_cmd_snapshot!(context.coverage("report").arg("--fail-under=75"), @"
     success: false
-    exit_code: 1
+    exit_code: 2
     ----- stdout -----
 
     Name         Stmts   Miss   Cover
@@ -144,9 +167,104 @@ fn report_fail_under_returns_failure() {
     [LONG-LINE]
     TOTAL            2      1     50%
 
+    ----- stderr -----
     coverage failure: required total coverage of 75% not reached, total coverage was 50%
+    ");
+}
+
+#[test]
+fn report_total_outputs_only_percentage() {
+    let context = TestContext::new();
+    write_coverage(&context, Utf8Path::new(".karva/coverage/data.json"));
+
+    assert_cmd_snapshot!(context.coverage("report").args(["--format", "total"]), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    50
 
     ----- stderr -----
+    ");
+}
+
+#[test]
+fn report_show_missing_lists_ranges() {
+    let context = TestContext::new();
+    write_coverage(&context, Utf8Path::new(".karva/coverage/data.json"));
+
+    assert_cmd_snapshot!(context.coverage("report").arg("--show-missing"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    Name         Stmts   Miss   Cover   Missing
+    [LONG-LINE]
+    src/app.py       2      1     50%   2
+    [LONG-LINE]
+    TOTAL            2      1     50%
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn report_rejects_unmatched_selector() {
+    let context = TestContext::new();
+    write_coverage(&context, Utf8Path::new(".karva/coverage/data.json"));
+
+    assert_cmd_snapshot!(context.coverage("report").arg("missing.module"), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Karva failed
+      Cause: coverage selector `missing.module` matched no source files
+    ");
+}
+
+#[test]
+fn report_writes_and_appends_markdown() {
+    let context = TestContext::new();
+    write_coverage(&context, Utf8Path::new(".karva/coverage/data.json"));
+
+    assert_cmd_snapshot!(
+        context
+            .coverage("report")
+            .args(["--format", "markdown", "--output", "summary.md"]),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    "
+    );
+    assert_cmd_snapshot!(
+        context.coverage("report").args([
+            "--format",
+            "markdown",
+            "--output",
+            "summary.md",
+            "--append",
+        ]),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    "
+    );
+    insta::assert_snapshot!(context.read_file("summary.md"), @r"
+    | Name | Stmts | Miss | Cover |
+    | --- | ---: | ---: | ---: |
+    | src/app.py | 2 | 1 | 50% |
+    | **TOTAL** | 2 | 1 | **50%** |
+    | Name | Stmts | Miss | Cover |
+    | --- | ---: | ---: | ---: |
+    | src/app.py | 2 | 1 | 50% |
+    | **TOTAL** | 2 | 1 | **50%** |
     ");
 }
 

--- a/crates/karva_cli/src/coverage.rs
+++ b/crates/karva_cli/src/coverage.rs
@@ -103,7 +103,69 @@ pub enum CoverageAction {
 
 #[derive(Debug, Args)]
 /// Options specific to the terminal coverage report.
-pub struct CoverageReportCommand;
+pub struct CoverageReportCommand {
+    /// File paths, directories, or dotted module names to include.
+    #[arg(value_name = "SELECTOR")]
+    pub selectors: Vec<String>,
+
+    /// Show missing line ranges and branch arcs.
+    #[arg(long)]
+    pub show_missing: bool,
+
+    /// Hide files with complete coverage without changing totals.
+    #[arg(long)]
+    pub skip_covered: bool,
+
+    /// Hide files with no statements or branches without changing totals.
+    #[arg(long)]
+    pub skip_empty: bool,
+
+    /// Column used to order displayed files.
+    #[arg(long, value_enum, default_value_t)]
+    pub sort: CoverageSort,
+
+    /// Report representation.
+    #[arg(long, value_enum, default_value_t)]
+    pub format: CoverageFormat,
+
+    /// Write the report to this path instead of stdout.
+    #[arg(long, value_name = "PATH")]
+    pub output: Option<Utf8PathBuf>,
+
+    /// Append to the output file instead of replacing it.
+    #[arg(long, requires = "output", default_missing_value = "true", require_equals = true, num_args = 0..=1)]
+    pub append: Option<bool>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, clap::ValueEnum)]
+/// Terminal coverage report representation.
+pub enum CoverageFormat {
+    /// Human-readable aligned table.
+    #[default]
+    Text,
+    /// GitHub-flavored Markdown table.
+    Markdown,
+    /// Numeric total percentage only.
+    Total,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, clap::ValueEnum)]
+/// Column used to order displayed coverage files.
+pub enum CoverageSort {
+    /// Source path.
+    #[default]
+    Name,
+    /// Statement count.
+    Statements,
+    /// Missing statement count.
+    Misses,
+    /// Branch count.
+    Branches,
+    /// Partial branch count.
+    PartialBranches,
+    /// Coverage percentage.
+    Coverage,
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -15,7 +15,9 @@ mod test;
 mod verbosity;
 
 pub use cache::{CacheAction, CacheCommand};
-pub use coverage::{CoverageAction, CoverageCommand, CoverageReportCommand};
+pub use coverage::{
+    CoverageAction, CoverageCommand, CoverageFormat, CoverageReportCommand, CoverageSort,
+};
 pub use enums::{
     CovContext, CovReport, FlakyResult, JunitFlakyFailStatus, NoTests, OutputFormat, ResultFormat,
     RunIgnored,

--- a/crates/karva_coverage/src/lib.rs
+++ b/crates/karva_coverage/src/lib.rs
@@ -26,7 +26,8 @@ pub mod report;
 pub mod tracer;
 
 pub use report::{
-    CoverageAnalysis, CoverageFilters, combine_and_report, write_cobertura_xml, write_html_report,
+    CoverageAnalysis, CoverageFilters, CoverageReportFormat, CoverageReportOptions,
+    CoverageReportSort, combine_and_report, write_cobertura_xml, write_html_report,
     write_json_report,
 };
 pub use tracer::{CoverageConfig, CoverageSession};

--- a/crates/karva_coverage/src/report/mod.rs
+++ b/crates/karva_coverage/src/report/mod.rs
@@ -16,6 +16,7 @@ pub use terminal::combine_and_report;
 pub use terminal::write_cobertura_xml;
 pub use terminal::write_html_report;
 pub use terminal::write_json_report;
+pub use terminal::{CoverageReportFormat, CoverageReportOptions, CoverageReportSort};
 
 use self::shared::{FileRow, combine, combine_native, total_percent, verify_combined_sources};
 

--- a/crates/karva_coverage/src/report/terminal.rs
+++ b/crates/karva_coverage/src/report/terminal.rs
@@ -12,6 +12,49 @@ use super::shared::{FileRow, row_percent, total_percent, totals_row};
 use super::xml::build_cobertura_xml;
 use super::{CoverageAnalysis, CoverageFilters};
 
+/// Terminal coverage report representation.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum CoverageReportFormat {
+    /// Human-readable aligned text table.
+    #[default]
+    Text,
+    /// GitHub-flavored Markdown table.
+    Markdown,
+    /// Numeric total percentage only.
+    Total,
+}
+
+/// Column used to order displayed coverage rows.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum CoverageReportSort {
+    #[default]
+    Name,
+    Statements,
+    Misses,
+    Branches,
+    PartialBranches,
+    Coverage,
+}
+
+/// Selection and presentation settings for a terminal coverage report.
+#[derive(Debug, Default)]
+pub struct CoverageReportOptions {
+    /// File paths, directories, or dotted module names to include.
+    pub selectors: Vec<String>,
+    /// Whether to show missing lines and branch arcs.
+    pub show_missing: bool,
+    /// Whether to hide fully covered rows without changing totals.
+    pub skip_covered: bool,
+    /// Whether to hide rows with no statements or branches without changing totals.
+    pub skip_empty: bool,
+    /// Column used to order displayed rows.
+    pub sort: CoverageReportSort,
+    /// Decimal places shown for percentages.
+    pub precision: usize,
+    /// Output representation.
+    pub format: CoverageReportFormat,
+}
+
 /// Prints the terminal coverage table and returns its total percentage.
 ///
 /// Returns `None` when no worker coverage artifacts contain source data.
@@ -74,12 +117,52 @@ impl CoverageAnalysis {
 
     /// Prints the compact terminal report using `precision` decimal places.
     pub fn report_with_precision(&self, show_missing: bool, precision: usize) -> Result<f64> {
-        print_report(
-            &self.rows,
-            show_missing,
-            precision,
+        self.write_report(
+            &CoverageReportOptions {
+                show_missing,
+                precision,
+                ..CoverageReportOptions::default()
+            },
             &mut std::io::stdout().lock(),
         )
+    }
+
+    /// Writes a selected and formatted terminal report and returns total coverage.
+    pub fn write_report(
+        &self,
+        options: &CoverageReportOptions,
+        out: &mut dyn Write,
+    ) -> Result<f64> {
+        let selected = select_rows(&self.rows, &options.selectors)?;
+        let mut displayed = selected.clone();
+        if options.skip_covered {
+            displayed.retain(|row| row_percent(row) < 100.0);
+        }
+        if options.skip_empty {
+            displayed.retain(|row| row.stmts > 0 || row.branches > 0);
+        }
+        sort_rows(&mut displayed, options.sort);
+        match options.format {
+            CoverageReportFormat::Text => print_report(
+                &displayed,
+                &selected,
+                options.show_missing,
+                options.precision,
+                out,
+            ),
+            CoverageReportFormat::Markdown => print_markdown_report(
+                &displayed,
+                &selected,
+                options.show_missing,
+                options.precision,
+                out,
+            ),
+            CoverageReportFormat::Total => {
+                let total = total_percent(&selected);
+                writeln!(out, "{:.*}", options.precision, total)?;
+                Ok(total)
+            }
+        }
     }
 
     /// Writes a Cobertura-compatible XML report and returns total coverage.
@@ -134,11 +217,12 @@ struct Row<'a> {
 
 fn print_report(
     rows: &[FileRow],
+    total_rows: &[FileRow],
     show_missing: bool,
     precision: usize,
     out: &mut dyn Write,
 ) -> Result<f64> {
-    let show_branches = rows.iter().any(|row| row.branches_enabled);
+    let show_branches = total_rows.iter().any(|row| row.branches_enabled);
     let name_width = rows
         .iter()
         .map(|row| row.name.len())
@@ -174,6 +258,7 @@ fn print_report(
         let miss_str = row.miss.to_string();
         let branches_str = row.branches.to_string();
         let branch_partial_str = row.branch_partial.to_string();
+        let missing = missing_display(row);
         writeln!(
             out,
             "{}",
@@ -188,15 +273,15 @@ fn print_report(
                     branches: &branches_str,
                     branch_partial: &branch_partial_str,
                     cover: &cover,
-                    missing: &row.missing,
+                    missing: &missing,
                 },
             )
         )?;
     }
 
     writeln!(out, "{rule}")?;
-    let total_pct = total_percent(rows);
-    let total = totals_row(rows);
+    let total_pct = total_percent(total_rows);
+    let total = totals_row(total_rows);
     let total_cover = format!("{:.*}%", precision, row_percent(&total));
     let total_stmts_str = total.stmts.to_string();
     let total_miss_str = total.miss.to_string();
@@ -222,6 +307,128 @@ fn print_report(
     )?;
 
     Ok(total_pct)
+}
+
+fn print_markdown_report(
+    rows: &[FileRow],
+    total_rows: &[FileRow],
+    show_missing: bool,
+    precision: usize,
+    out: &mut dyn Write,
+) -> Result<f64> {
+    let show_branches = total_rows.iter().any(|row| row.branches_enabled);
+    write!(out, "| Name | Stmts | Miss")?;
+    if show_branches {
+        write!(out, " | Branch | BrPart")?;
+    }
+    write!(out, " | Cover")?;
+    if show_missing {
+        write!(out, " | Missing")?;
+    }
+    writeln!(out, " |")?;
+    write!(out, "| --- | ---: | ---:")?;
+    if show_branches {
+        write!(out, " | ---: | ---:")?;
+    }
+    write!(out, " | ---:")?;
+    if show_missing {
+        write!(out, " | ---")?;
+    }
+    writeln!(out, " |")?;
+    for row in rows {
+        write!(out, "| {} | {} | {}", row.name, row.stmts, row.miss)?;
+        if show_branches {
+            write!(out, " | {} | {}", row.branches, row.branch_partial)?;
+        }
+        write!(out, " | {:.*}%", precision, row_percent(row))?;
+        if show_missing {
+            write!(out, " | {}", missing_display(row))?;
+        }
+        writeln!(out, " |")?;
+    }
+    let total = totals_row(total_rows);
+    write!(out, "| **TOTAL** | {} | {}", total.stmts, total.miss)?;
+    if show_branches {
+        write!(out, " | {} | {}", total.branches, total.branch_partial)?;
+    }
+    let total_percent = total_percent(total_rows);
+    write!(out, " | **{total_percent:.precision$}%**")?;
+    if show_missing {
+        write!(out, " | ")?;
+    }
+    writeln!(out, " |")?;
+    Ok(total_percent)
+}
+
+fn select_rows(rows: &[FileRow], selectors: &[String]) -> Result<Vec<FileRow>> {
+    if selectors.is_empty() {
+        return Ok(rows.to_vec());
+    }
+    let mut matched = vec![false; selectors.len()];
+    let selected = rows
+        .iter()
+        .filter(|row| {
+            let mut include = false;
+            for (index, selector) in selectors.iter().enumerate() {
+                if selector_matches(&row.name, selector) {
+                    matched[index] = true;
+                    include = true;
+                }
+            }
+            include
+        })
+        .cloned()
+        .collect();
+    if let Some((index, _)) = matched.iter().enumerate().find(|(_, matched)| !**matched) {
+        anyhow::bail!(
+            "coverage selector `{}` matched no source files",
+            selectors[index]
+        );
+    }
+    Ok(selected)
+}
+
+fn selector_matches(name: &str, selector: &str) -> bool {
+    let selector_path = selector.replace('.', "/");
+    name == selector
+        || name == format!("{selector_path}.py")
+        || name.starts_with(&format!("{}/", selector.trim_end_matches('/')))
+        || name.starts_with(&format!("{selector_path}/"))
+}
+
+fn sort_rows(rows: &mut [FileRow], sort: CoverageReportSort) {
+    rows.sort_by(|left, right| match sort {
+        CoverageReportSort::Name => left.name.cmp(&right.name),
+        CoverageReportSort::Statements => left
+            .stmts
+            .cmp(&right.stmts)
+            .then(left.name.cmp(&right.name)),
+        CoverageReportSort::Misses => left.miss.cmp(&right.miss).then(left.name.cmp(&right.name)),
+        CoverageReportSort::Branches => left
+            .branches
+            .cmp(&right.branches)
+            .then(left.name.cmp(&right.name)),
+        CoverageReportSort::PartialBranches => left
+            .branch_partial
+            .cmp(&right.branch_partial)
+            .then(left.name.cmp(&right.name)),
+        CoverageReportSort::Coverage => row_percent(left)
+            .total_cmp(&row_percent(right))
+            .then(left.name.cmp(&right.name)),
+    });
+}
+
+fn missing_display(row: &FileRow) -> String {
+    let mut missing = row.missing.clone();
+    for arc in &row.branch_missing {
+        if !missing.is_empty() {
+            missing.push_str(", ");
+        }
+        missing.push_str(&arc.from.to_string());
+        missing.push_str("->");
+        missing.push_str(&arc.to.to_string());
+    }
+    missing
 }
 
 fn format_row(name_width: usize, show_missing: bool, show_branches: bool, row: &Row<'_>) -> String {
@@ -294,7 +501,7 @@ mod tests {
         let rows = [row("a.py", 4, 2, 2, ""), row("b.py", 2, 2, 0, "")];
 
         let mut buf: Vec<u8> = Vec::new();
-        let total = print_report(&rows, false, 0, &mut buf).unwrap();
+        let total = print_report(&rows, &rows, false, 0, &mut buf).unwrap();
         let out = String::from_utf8(buf).unwrap();
 
         assert!(out.contains("a.py"));
@@ -310,10 +517,86 @@ mod tests {
         let rows = [row("a.py", 9, 3, 6, "2-4, 6-8")];
 
         let mut buf: Vec<u8> = Vec::new();
-        print_report(&rows, true, 0, &mut buf).unwrap();
+        print_report(&rows, &rows, true, 0, &mut buf).unwrap();
         let out = String::from_utf8(buf).unwrap();
 
         assert!(out.contains("Missing"));
         assert!(out.contains("2-4, 6-8"));
+    }
+
+    #[test]
+    fn skip_covered_hides_row_without_changing_total() {
+        let analysis = CoverageAnalysis {
+            coverage_root: camino::Utf8PathBuf::from("/proj"),
+            cwd_real: std::path::PathBuf::from("/proj"),
+            rows: vec![
+                row("empty.py", 0, 0, 0, ""),
+                row("covered.py", 2, 2, 0, ""),
+                row("partial.py", 2, 1, 1, "2"),
+            ],
+        };
+        let mut output = Vec::new();
+
+        let total = analysis
+            .write_report(
+                &CoverageReportOptions {
+                    skip_covered: true,
+                    skip_empty: true,
+                    format: CoverageReportFormat::Markdown,
+                    ..CoverageReportOptions::default()
+                },
+                &mut output,
+            )
+            .expect("write report");
+
+        insta::assert_snapshot!(String::from_utf8(output).expect("UTF-8 report"), @r"
+        | Name | Stmts | Miss | Cover |
+        | --- | ---: | ---: | ---: |
+        | partial.py | 2 | 1 | 50% |
+        | **TOTAL** | 4 | 1 | **75%** |
+        ");
+        assert!((total - 75.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn missing_display_includes_branch_arcs() {
+        let mut branch_row = row("branch.py", 2, 1, 1, "2");
+        branch_row.branch_missing = vec![
+            crate::data::BranchArc { from: 1, to: 2 },
+            crate::data::BranchArc { from: 1, to: 3 },
+        ];
+
+        assert_eq!(missing_display(&branch_row), "2, 1->2, 1->3");
+    }
+
+    #[test]
+    fn selectors_accept_dotted_modules_and_name_failures() {
+        let rows = vec![row("src/package/module.py", 1, 1, 0, "")];
+
+        assert_eq!(
+            select_rows(&rows, &["src.package.module".to_owned()])
+                .expect("select module")
+                .len(),
+            1
+        );
+        let error = select_rows(&rows, &["missing.module".to_owned()])
+            .expect_err("reject unmatched selector");
+        assert!(error.to_string().contains("missing.module"));
+    }
+
+    #[test]
+    fn rows_sort_by_requested_metric_then_name() {
+        let mut rows = vec![
+            row("b.py", 4, 3, 1, "4"),
+            row("a.py", 2, 1, 1, "2"),
+            row("c.py", 2, 2, 0, ""),
+        ];
+
+        sort_rows(&mut rows, CoverageReportSort::Coverage);
+
+        assert_eq!(
+            rows.iter().map(|row| row.name.as_str()).collect::<Vec<_>>(),
+            ["a.py", "b.py", "c.py"]
+        );
     }
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -373,21 +373,50 @@ Print the compact terminal coverage report
 <h3 class="cli-reference">Usage</h3>
 
 ```
-karva coverage report [OPTIONS]
+karva coverage report [OPTIONS] [SELECTOR]...
 ```
+
+<h3 class="cli-reference">Arguments</h3>
+
+<dl class="cli-reference"><dt id="karva-coverage-report--selectors"><a href="#karva-coverage-report--selectors"><code>SELECTORS</code></a></dt><dd><p>File paths, directories, or dotted module names to include</p>
+</dd></dl>
 
 <h3 class="cli-reference">Options</h3>
 
-<dl class="cli-reference"><dt id="karva-coverage-report--config-file"><a href="#karva-coverage-report--config-file"><code>--config-file</code></a> <i>path</i></dt><dd><p>The path to a <code>karva.toml</code> file to use for configuration</p>
+<dl class="cli-reference"><dt id="karva-coverage-report--append"><a href="#karva-coverage-report--append"><code>--append</code></a> <i>append</i></dt><dd><p>Append to the output file instead of replacing it</p>
+<p>Possible values:</p>
+<ul>
+<li><code>true</code></li>
+<li><code>false</code></li>
+</ul></dd><dt id="karva-coverage-report--config-file"><a href="#karva-coverage-report--config-file"><code>--config-file</code></a> <i>path</i></dt><dd><p>The path to a <code>karva.toml</code> file to use for configuration</p>
 <p>May also be set with the <code>KARVA_CONFIG_FILE</code> environment variable.</p></dd><dt id="karva-coverage-report--contexts"><a href="#karva-coverage-report--contexts"><code>--contexts</code></a> <i>regex</i></dt><dd><p>Include execution attributed to a matching context regular expression</p>
 </dd><dt id="karva-coverage-report--data-file"><a href="#karva-coverage-report--data-file"><code>--data-file</code></a> <i>path</i></dt><dd><p>Native coverage artifact path, relative to the project root</p>
 </dd><dt id="karva-coverage-report--fail-under"><a href="#karva-coverage-report--fail-under"><code>--fail-under</code></a> <i>percent</i></dt><dd><p>Fail when total coverage is below this percentage</p>
-</dd><dt id="karva-coverage-report--help"><a href="#karva-coverage-report--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Print help</p>
+</dd><dt id="karva-coverage-report--format"><a href="#karva-coverage-report--format"><code>--format</code></a> <i>format</i></dt><dd><p>Report representation</p>
+<p>&#91;default: text&#93;</p><p>Possible values:</p>
+<ul>
+<li><code>text</code>:  Human-readable aligned table</li>
+<li><code>markdown</code>:  GitHub-flavored Markdown table</li>
+<li><code>total</code>:  Numeric total percentage only</li>
+</ul></dd><dt id="karva-coverage-report--help"><a href="#karva-coverage-report--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Print help (see a summary with '-h')</p>
 </dd><dt id="karva-coverage-report--include"><a href="#karva-coverage-report--include"><code>--include</code></a> <i>glob</i></dt><dd><p>Include only report paths matching this glob</p>
 </dd><dt id="karva-coverage-report--omit"><a href="#karva-coverage-report--omit"><code>--omit</code></a> <i>glob</i></dt><dd><p>Exclude report paths matching this glob after inclusion</p>
+</dd><dt id="karva-coverage-report--output"><a href="#karva-coverage-report--output"><code>--output</code></a> <i>path</i></dt><dd><p>Write the report to this path instead of stdout</p>
 </dd><dt id="karva-coverage-report--precision"><a href="#karva-coverage-report--precision"><code>--precision</code></a> <i>n</i></dt><dd><p>Decimal places shown in coverage percentages</p>
 </dd><dt id="karva-coverage-report--profile"><a href="#karva-coverage-report--profile"><code>--profile</code></a>, <code>-P</code> <i>name</i></dt><dd><p>Configuration profile to resolve</p>
-<p>May also be set with the <code>KARVA_PROFILE</code> environment variable.</p></dd></dl>
+<p>May also be set with the <code>KARVA_PROFILE</code> environment variable.</p></dd><dt id="karva-coverage-report--show-missing"><a href="#karva-coverage-report--show-missing"><code>--show-missing</code></a></dt><dd><p>Show missing line ranges and branch arcs</p>
+</dd><dt id="karva-coverage-report--skip-covered"><a href="#karva-coverage-report--skip-covered"><code>--skip-covered</code></a></dt><dd><p>Hide files with complete coverage without changing totals</p>
+</dd><dt id="karva-coverage-report--skip-empty"><a href="#karva-coverage-report--skip-empty"><code>--skip-empty</code></a></dt><dd><p>Hide files with no statements or branches without changing totals</p>
+</dd><dt id="karva-coverage-report--sort"><a href="#karva-coverage-report--sort"><code>--sort</code></a> <i>sort</i></dt><dd><p>Column used to order displayed files</p>
+<p>&#91;default: name&#93;</p><p>Possible values:</p>
+<ul>
+<li><code>name</code>:  Source path</li>
+<li><code>statements</code>:  Statement count</li>
+<li><code>misses</code>:  Missing statement count</li>
+<li><code>branches</code>:  Branch count</li>
+<li><code>partial-branches</code>:  Partial branch count</li>
+<li><code>coverage</code>:  Coverage percentage</li>
+</ul></dd></dl>
 
 ### karva coverage help
 


### PR DESCRIPTION
## Summary

Completes `karva coverage report` with selectors, missing arcs, row filtering and sorting, text/Markdown/total formats, file append support, fail-under exit semantics, and pending shard discovery. Closes #1156.

## Test Plan

Full coverage integration tests, renderer unit tests, workspace clippy, and `uvx prek run -a`.