### PR TITLE
Add annotated HTML coverage reports

### DIFF
--- a/crates/karva/src/commands/coverage.rs
+++ b/crates/karva/src/commands/coverage.rs
@@ -37,7 +37,7 @@ pub fn coverage(args: &CoverageCommand) -> Result<ExitStatus> {
         karva_coverage::CoverageAnalysis::load_native(project.cwd(), &data_files, &filters)?
             .with_context(|| format!("coverage data at `{data_file}` contains no source files"))?;
 
-    match &args.action {
+    let total = match &args.action {
         CoverageAction::Report(report) => {
             if report.append == Some(true) && report.format != CoverageFormat::Markdown {
                 bail!("`--append` requires `--format markdown`");
@@ -64,7 +64,7 @@ pub fn coverage(args: &CoverageCommand) -> Result<ExitStatus> {
                     CoverageFormat::Total => karva_coverage::CoverageReportFormat::Total,
                 },
             };
-            let total = if let Some(output) = &report.output {
+            if let Some(output) = &report.output {
                 let output = absolute(output, project.cwd());
                 if let Some(parent) = output.parent()
                     && !parent.as_str().is_empty()
@@ -83,19 +83,32 @@ pub fn coverage(args: &CoverageCommand) -> Result<ExitStatus> {
                 analysis.write_report(&options, &mut file)?
             } else {
                 analysis.write_report(&options, &mut std::io::stdout().lock())?
-            };
-            if let Some(threshold) = settings.fail_under
-                && total < threshold
-            {
-                let mut stderr = std::io::stderr().lock();
-                writeln!(
-                    stderr,
-                    "coverage failure: required total coverage of {threshold}% not reached, total coverage was {:.*}%",
-                    settings.precision.0, total
-                )?;
-                return Ok(ExitStatus::Error);
             }
         }
+        CoverageAction::Html(html) => {
+            let output = absolute(&html.directory, project.cwd());
+            analysis.write_html_with_options(
+                &output,
+                &karva_coverage::HtmlReportOptions {
+                    title: html.title.clone(),
+                    show_contexts: html.show_contexts,
+                    skip_covered: html.skip_covered,
+                    skip_empty: html.skip_empty,
+                    precision: settings.precision.0,
+                },
+            )?
+        }
+    };
+    if let Some(threshold) = settings.fail_under
+        && total < threshold
+    {
+        let mut stderr = std::io::stderr().lock();
+        writeln!(
+            stderr,
+            "coverage failure: required total coverage of {threshold}% not reached, total coverage was {:.*}%",
+            settings.precision.0, total
+        )?;
+        return Ok(ExitStatus::Error);
     }
 
     Ok(ExitStatus::Success)

--- a/crates/karva/tests/it/coverage.rs
+++ b/crates/karva/tests/it/coverage.rs
@@ -1240,17 +1240,15 @@ def test_only_covered():
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1">
       <title>Coverage report</title>
-      <style>body{font-family:system-ui,sans-serif;margin:2rem;}table{border-collapse:collapse;width:100%;}th,td{padding:.5rem;border-bottom:1px solid #ddd;text-align:left;}td.num{text-align:right;font-variant-numeric:tabular-nums;}code{font-family:ui-monospace,SFMono-Regular,monospace;}thead{background:#f5f5f5;}h1{margin-top:0;}</style>
+      <style>body{font-family:system-ui,sans-serif;margin:2rem;color:#202124}table{border-collapse:collapse;width:100%}th,td{padding:.5rem;border-bottom:1px solid #ddd;text-align:left}td.num{text-align:right;font-variant-numeric:tabular-nums}code,.source{font-family:ui-monospace,SFMono-Regular,monospace}thead{background:#f5f5f5}h1{margin-top:0}a{color:#0969da}.source{display:block;overflow:auto;background:#f6f8fa;padding:1rem}.line{display:block;min-height:1.35em}.number{display:inline-block;width:3rem;text-align:right;color:#6e7781;text-decoration:none}.executed{background:#dafbe1}.missing{background:#ffebe9}.excluded{background:#f0f0f0;color:#6e7781}.partial{background:#fff8c5}.branches{color:#9a6700}.contexts{float:right;color:#57606a;font-size:.85em}</style>
     </head>
     <body>
       <h1>Coverage report</h1>
       <p>Total coverage: <strong>83%</strong> (5/6)</p>
       <table>
-        <thead>
-          <tr><th>Name</th><th>Stmts</th><th>Miss</th><th>Cover</th><th>Missing</th></tr>
-        </thead>
+        <thead><tr><th>Name</th><th>Stmts</th><th>Miss</th><th>Cover</th><th>Missing</th></tr></thead>
         <tbody>
-          <tr><td><code>test_partial.py</code></td><td class="num">6</td><td class="num">1</td><td class="num">83%</td><td><code>6</code></td></tr>
+          <tr><td><a href="source-746573745f7061727469616c2e7079.html"><code>test_partial.py</code></a></td><td class="num">6</td><td class="num">1</td><td class="num">83%</td><td><code>6</code></td></tr>
           <tr><td><strong>TOTAL</strong></td><td class="num"><strong>6</strong></td><td class="num"><strong>1</strong></td><td class="num"><strong>83%</strong></td><td></td></tr>
         </tbody>
       </table>

--- a/crates/karva/tests/it/coverage_command.rs
+++ b/crates/karva/tests/it/coverage_command.rs
@@ -53,6 +53,36 @@ fn report_reads_default_native_data() {
 }
 
 #[test]
+fn html_writes_navigable_annotated_report() {
+    let context = TestContext::new();
+    write_coverage(&context, Utf8Path::new(".karva/coverage/data.json"));
+
+    assert_cmd_snapshot!(
+        context.coverage("html").args([
+            "--directory",
+            "coverage-site",
+            "--title",
+            "Karva <coverage>",
+        ]),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    "
+    );
+    insta::assert_snapshot!(
+        "coverage_html_index",
+        context.read_file("coverage-site/index.html")
+    );
+    insta::assert_snapshot!(
+        "coverage_html_source",
+        context.read_file("coverage-site/source-7372632f6170702e7079.html")
+    );
+}
+
+#[test]
 fn report_auto_combines_pending_shards() {
     let context = TestContext::new();
     write_coverage(

--- a/crates/karva/tests/it/snapshots/it__coverage_command__coverage_html_index.snap
+++ b/crates/karva/tests/it/snapshots/it__coverage_command__coverage_html_index.snap
@@ -1,0 +1,24 @@
+---
+source: crates/karva/tests/it/coverage_command.rs
+expression: "context.read_file(\"coverage-site/index.html\")"
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Karva &lt;coverage&gt;</title>
+  <style>body{font-family:system-ui,sans-serif;margin:2rem;color:#202124}table{border-collapse:collapse;width:100%}th,td{padding:.5rem;border-bottom:1px solid #ddd;text-align:left}td.num{text-align:right;font-variant-numeric:tabular-nums}code,.source{font-family:ui-monospace,SFMono-Regular,monospace}thead{background:#f5f5f5}h1{margin-top:0}a{color:#0969da}.source{display:block;overflow:auto;background:#f6f8fa;padding:1rem}.line{display:block;min-height:1.35em}.number{display:inline-block;width:3rem;text-align:right;color:#6e7781;text-decoration:none}.executed{background:#dafbe1}.missing{background:#ffebe9}.excluded{background:#f0f0f0;color:#6e7781}.partial{background:#fff8c5}.branches{color:#9a6700}.contexts{float:right;color:#57606a;font-size:.85em}</style>
+</head>
+<body>
+  <h1>Karva &lt;coverage&gt;</h1>
+  <p>Total coverage: <strong>50%</strong> (1/2)</p>
+  <table>
+    <thead><tr><th>Name</th><th>Stmts</th><th>Miss</th><th>Cover</th><th>Missing</th></tr></thead>
+    <tbody>
+      <tr><td><a href="source-7372632f6170702e7079.html"><code>src/app.py</code></a></td><td class="num">2</td><td class="num">1</td><td class="num">50%</td><td><code>2</code></td></tr>
+      <tr><td><strong>TOTAL</strong></td><td class="num"><strong>2</strong></td><td class="num"><strong>1</strong></td><td class="num"><strong>50%</strong></td><td></td></tr>
+    </tbody>
+  </table>
+</body>
+</html>

--- a/crates/karva/tests/it/snapshots/it__coverage_command__coverage_html_source.snap
+++ b/crates/karva/tests/it/snapshots/it__coverage_command__coverage_html_source.snap
@@ -1,0 +1,22 @@
+---
+source: crates/karva/tests/it/coverage_command.rs
+expression: "context.read_file(\"coverage-site/source-7372632f6170702e7079.html\")"
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>src/app.py — Karva &lt;coverage&gt;</title>
+  <style>body{font-family:system-ui,sans-serif;margin:2rem;color:#202124}table{border-collapse:collapse;width:100%}th,td{padding:.5rem;border-bottom:1px solid #ddd;text-align:left}td.num{text-align:right;font-variant-numeric:tabular-nums}code,.source{font-family:ui-monospace,SFMono-Regular,monospace}thead{background:#f5f5f5}h1{margin-top:0}a{color:#0969da}.source{display:block;overflow:auto;background:#f6f8fa;padding:1rem}.line{display:block;min-height:1.35em}.number{display:inline-block;width:3rem;text-align:right;color:#6e7781;text-decoration:none}.executed{background:#dafbe1}.missing{background:#ffebe9}.excluded{background:#f0f0f0;color:#6e7781}.partial{background:#fff8c5}.branches{color:#9a6700}.contexts{float:right;color:#57606a;font-size:.85em}</style>
+</head>
+<body>
+  <p><a href="index.html">← Index</a></p>
+  <h1><code>src/app.py</code></h1>
+  <p>Coverage: <strong>50%</strong></p>
+  <pre class="source">
+<span class="line executed"><a id="L1" href="#L1" class="number">    1</a> <code>first = 1</code></span>
+<span class="line missing"><a id="L2" href="#L2" class="number">    2</a> <code>second = 2</code></span>
+  </pre>
+</body>
+</html>

--- a/crates/karva_cli/src/coverage.rs
+++ b/crates/karva_cli/src/coverage.rs
@@ -99,6 +99,33 @@ impl CoverageCommand {
 pub enum CoverageAction {
     /// Print the compact terminal coverage report.
     Report(CoverageReportCommand),
+
+    /// Generate a navigable annotated HTML coverage report.
+    Html(CoverageHtmlCommand),
+}
+
+#[derive(Debug, Args)]
+/// Options specific to the annotated HTML coverage report.
+pub struct CoverageHtmlCommand {
+    /// Directory receiving the report files.
+    #[arg(long, value_name = "PATH", default_value = "htmlcov")]
+    pub directory: Utf8PathBuf,
+
+    /// Report title shown in the browser.
+    #[arg(long, default_value = "Coverage report")]
+    pub title: String,
+
+    /// Show execution contexts beside annotated source lines.
+    #[arg(long)]
+    pub show_contexts: bool,
+
+    /// Omit fully covered source pages from the index.
+    #[arg(long)]
+    pub skip_covered: bool,
+
+    /// Omit sources with no statements or branches from the index.
+    #[arg(long)]
+    pub skip_empty: bool,
 }
 
 #[derive(Debug, Args)]

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -16,7 +16,8 @@ mod verbosity;
 
 pub use cache::{CacheAction, CacheCommand};
 pub use coverage::{
-    CoverageAction, CoverageCommand, CoverageFormat, CoverageReportCommand, CoverageSort,
+    CoverageAction, CoverageCommand, CoverageFormat, CoverageHtmlCommand, CoverageReportCommand,
+    CoverageSort,
 };
 pub use enums::{
     CovContext, CovReport, FlakyResult, JunitFlakyFailStatus, NoTests, OutputFormat, ResultFormat,

--- a/crates/karva_coverage/src/lib.rs
+++ b/crates/karva_coverage/src/lib.rs
@@ -27,7 +27,7 @@ pub mod tracer;
 
 pub use report::{
     CoverageAnalysis, CoverageFilters, CoverageReportFormat, CoverageReportOptions,
-    CoverageReportSort, combine_and_report, write_cobertura_xml, write_html_report,
-    write_json_report,
+    CoverageReportSort, HtmlReportOptions, combine_and_report, write_cobertura_xml,
+    write_html_report, write_json_report,
 };
 pub use tracer::{CoverageConfig, CoverageSession};

--- a/crates/karva_coverage/src/report/html.rs
+++ b/crates/karva_coverage/src/report/html.rs
@@ -1,107 +1,310 @@
-use std::fmt;
+use std::collections::BTreeSet;
+use std::fmt::{self, Write};
 
-use super::shared::{FileRow, escape_html, format_percent, row_percent, totals_row};
+use super::shared::{FileRow, escape_html, row_percent, total_percent, totals_row};
 
-pub(super) fn build_html_report(rows: &[FileRow]) -> String {
-    HtmlReport { rows }.to_string()
+/// Presentation settings for an annotated HTML coverage report.
+#[derive(Debug)]
+pub struct HtmlReportOptions {
+    /// Browser title and report heading.
+    pub title: String,
+    /// Whether line and branch contexts appear on source pages.
+    pub show_contexts: bool,
+    /// Whether fully covered files are omitted from the index and source pages.
+    pub skip_covered: bool,
+    /// Whether files without statements or branches are omitted.
+    pub skip_empty: bool,
+    /// Decimal places shown for percentages.
+    pub precision: usize,
 }
 
-struct HtmlReport<'a> {
-    rows: &'a [FileRow],
+impl Default for HtmlReportOptions {
+    fn default() -> Self {
+        Self {
+            title: "Coverage report".to_owned(),
+            show_contexts: false,
+            skip_covered: false,
+            skip_empty: false,
+            precision: 0,
+        }
+    }
 }
 
-impl fmt::Display for HtmlReport<'_> {
-    fn fmt(&self, html: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(html, "<!DOCTYPE html>")?;
-        writeln!(html, "<html lang=\"en\">")?;
-        writeln!(html, "<head>")?;
-        writeln!(html, "  <meta charset=\"utf-8\">")?;
-        writeln!(
-            html,
-            "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">"
-        )?;
-        writeln!(html, "  <title>Coverage report</title>")?;
-        writeln!(
-            html,
-            "  <style>body{{font-family:system-ui,sans-serif;margin:2rem;}}table{{border-collapse:collapse;width:100%;}}th,td{{padding:.5rem;border-bottom:1px solid #ddd;text-align:left;}}td.num{{text-align:right;font-variant-numeric:tabular-nums;}}code{{font-family:ui-monospace,SFMono-Regular,monospace;}}thead{{background:#f5f5f5;}}h1{{margin-top:0;}}</style>"
-        )?;
-        writeln!(html, "</head>")?;
-        writeln!(html, "<body>")?;
-        writeln!(html, "  <h1>Coverage report</h1>")?;
+/// Fully rendered report files, relative to the requested output directory.
+pub(super) struct HtmlReport {
+    pub(super) index: String,
+    pub(super) sources: Vec<(String, String)>,
+}
 
-        let total = totals_row(self.rows);
-        let show_branches = total.branches_enabled;
-        let total_covered = total.hit.saturating_add(total.branch_hit);
-        let total_valid = total.stmts.saturating_add(total.branches);
+pub(super) fn build_html_report(
+    rows: &[FileRow],
+    sources: &[String],
+    options: &HtmlReportOptions,
+) -> Result<HtmlReport, fmt::Error> {
+    let visible: Vec<(&FileRow, &String)> = rows
+        .iter()
+        .zip(sources)
+        .filter(|(row, _)| !options.skip_covered || row_percent(row) < 100.0)
+        .filter(|(row, _)| !options.skip_empty || row.stmts > 0 || row.branches > 0)
+        .collect();
+    let index = render_index(rows, &visible, options)?;
+    let mut pages = Vec::with_capacity(visible.len());
+    for (row, source) in visible {
+        pages.push((
+            source_filename(&row.name),
+            render_source(row, source, options)?,
+        ));
+    }
+    Ok(HtmlReport {
+        index,
+        sources: pages,
+    })
+}
+
+fn render_index(
+    all_rows: &[FileRow],
+    visible: &[(&FileRow, &String)],
+    options: &HtmlReportOptions,
+) -> Result<String, fmt::Error> {
+    let mut html = String::new();
+    document_start(&mut html, &options.title)?;
+    writeln!(html, "  <h1>{}</h1>", escape_html(&options.title))?;
+    let total = totals_row(all_rows);
+    let total_hit = total.hit.saturating_add(total.branch_hit);
+    let total_valid = total.stmts.saturating_add(total.branches);
+    writeln!(
+        html,
+        "  <p>Total coverage: <strong>{:.precision$}%</strong> ({total_hit}/{total_valid})</p>",
+        row_percent(&total),
+        precision = options.precision
+    )?;
+    let show_branches = all_rows.iter().any(|row| row.branches_enabled);
+    writeln!(html, "  <table>")?;
+    write!(
+        html,
+        "    <thead><tr><th>Name</th><th>Stmts</th><th>Miss</th>"
+    )?;
+    if show_branches {
+        write!(html, "<th>Branch</th><th>BrPart</th>")?;
+    }
+    writeln!(html, "<th>Cover</th><th>Missing</th></tr></thead>")?;
+    writeln!(html, "    <tbody>")?;
+    for (row, _) in visible {
+        write!(
+            html,
+            "      <tr><td><a href=\"{}\"><code>{}</code></a></td><td class=\"num\">{}</td><td class=\"num\">{}</td>",
+            source_filename(&row.name),
+            escape_html(&row.name),
+            row.stmts,
+            row.miss
+        )?;
+        if show_branches {
+            write!(
+                html,
+                "<td class=\"num\">{}</td><td class=\"num\">{}</td>",
+                row.branches, row.branch_partial
+            )?;
+        }
         writeln!(
             html,
-            "  <p>Total coverage: <strong>{:.0}%</strong> ({}/{})</p>",
-            row_percent(&total),
-            total_covered,
-            total_valid
+            "<td class=\"num\">{:.precision$}%</td><td><code>{}</code></td></tr>",
+            row_percent(row),
+            escape_html(&row.missing),
+            precision = options.precision
         )?;
-        writeln!(html, "  <table>")?;
-        writeln!(html, "    <thead>")?;
-        if show_branches {
-            writeln!(
+    }
+    write!(
+        html,
+        "      <tr><td><strong>TOTAL</strong></td><td class=\"num\"><strong>{}</strong></td><td class=\"num\"><strong>{}</strong></td>",
+        total.stmts, total.miss
+    )?;
+    if show_branches {
+        write!(
+            html,
+            "<td class=\"num\"><strong>{}</strong></td><td class=\"num\"><strong>{}</strong></td>",
+            total.branches, total.branch_partial
+        )?;
+    }
+    writeln!(
+        html,
+        "<td class=\"num\"><strong>{:.precision$}%</strong></td><td></td></tr>",
+        total_percent(all_rows),
+        precision = options.precision
+    )?;
+    writeln!(html, "    </tbody>")?;
+    writeln!(html, "  </table>")?;
+    document_end(&mut html)?;
+    Ok(html)
+}
+
+fn render_source(
+    row: &FileRow,
+    source: &str,
+    options: &HtmlReportOptions,
+) -> Result<String, fmt::Error> {
+    let mut html = String::new();
+    let page_title = format!("{} — {}", row.name, options.title);
+    document_start(&mut html, &page_title)?;
+    writeln!(html, "  <p><a href=\"index.html\">← Index</a></p>")?;
+    writeln!(html, "  <h1><code>{}</code></h1>", escape_html(&row.name))?;
+    writeln!(
+        html,
+        "  <p>Coverage: <strong>{:.precision$}%</strong></p>",
+        row_percent(row),
+        precision = options.precision
+    )?;
+    writeln!(html, "  <pre class=\"source\">")?;
+    for (index, text) in source.lines().enumerate() {
+        let line = u32::try_from(index + 1).unwrap_or(u32::MAX);
+        let state = line_state(row, line);
+        let missing_branches: Vec<String> = row
+            .branch_missing
+            .iter()
+            .filter(|arc| arc.from == i32::try_from(line).unwrap_or(i32::MAX))
+            .map(|arc| arc.to.to_string())
+            .collect();
+        let contexts = line_contexts(row, line);
+        write!(
+            html,
+            "<span class=\"line {state}\"><a id=\"L{line}\" href=\"#L{line}\" class=\"number\">{line:>5}</a> <code>{}</code>",
+            escape_html(text)
+        )?;
+        if !missing_branches.is_empty() {
+            write!(
                 html,
-                "      <tr><th>Name</th><th>Stmts</th><th>Miss</th><th>Branch</th><th>BrPart</th><th>Cover</th><th>Missing</th></tr>"
+                " <span class=\"branches\">missing → {}</span>",
+                escape_html(&missing_branches.join(", "))
             )?;
+        }
+        if options.show_contexts && !contexts.is_empty() {
+            write!(
+                html,
+                " <span class=\"contexts\">{}</span>",
+                escape_html(&contexts.into_iter().collect::<Vec<_>>().join(", "))
+            )?;
+        }
+        writeln!(html, "</span>")?;
+    }
+    writeln!(html, "  </pre>")?;
+    document_end(&mut html)?;
+    Ok(html)
+}
+
+fn line_state(row: &FileRow, line: u32) -> &'static str {
+    if row.excluded.contains(&line) {
+        "excluded"
+    } else if row.executed.contains(&line) {
+        if row.branch_missing.iter().any(|arc| {
+            arc.from == i32::try_from(line).unwrap_or(i32::MAX)
+                && row.branch_executed.iter().any(|hit| hit.from == arc.from)
+        }) {
+            "partial"
         } else {
-            writeln!(
-                html,
-                "      <tr><th>Name</th><th>Stmts</th><th>Miss</th><th>Cover</th><th>Missing</th></tr>"
-            )?;
+            "executed"
         }
-        writeln!(html, "    </thead>")?;
-        writeln!(html, "    <tbody>")?;
-        for row in self.rows {
-            if show_branches {
-                writeln!(
-                    html,
-                    "      <tr><td><code>{}</code></td><td class=\"num\">{}</td><td class=\"num\">{}</td><td class=\"num\">{}</td><td class=\"num\">{}</td><td class=\"num\">{:.0}%</td><td><code>{}</code></td></tr>",
-                    escape_html(&row.name),
-                    row.stmts,
-                    row.miss,
-                    row.branches,
-                    row.branch_partial,
-                    row_percent(row),
-                    escape_html(&row.missing)
-                )?;
-            } else {
-                writeln!(
-                    html,
-                    "      <tr><td><code>{}</code></td><td class=\"num\">{}</td><td class=\"num\">{}</td><td class=\"num\">{}</td><td><code>{}</code></td></tr>",
-                    escape_html(&row.name),
-                    row.stmts,
-                    row.miss,
-                    format_percent(row.stmts, row.miss),
-                    escape_html(&row.missing)
-                )?;
-            }
+    } else if row.executable.contains(&line) {
+        "missing"
+    } else {
+        "neutral"
+    }
+}
+
+fn line_contexts(row: &FileRow, line: u32) -> BTreeSet<String> {
+    let mut contexts = row.contexts.get(&line).cloned().unwrap_or_default();
+    for (arc, arc_contexts) in &row.arc_contexts {
+        if arc.from == i32::try_from(line).unwrap_or(i32::MAX) {
+            contexts.extend(arc_contexts.iter().cloned());
         }
-        if show_branches {
-            writeln!(
-                html,
-                "      <tr><td><strong>TOTAL</strong></td><td class=\"num\"><strong>{}</strong></td><td class=\"num\"><strong>{}</strong></td><td class=\"num\"><strong>{}</strong></td><td class=\"num\"><strong>{}</strong></td><td class=\"num\"><strong>{:.0}%</strong></td><td></td></tr>",
-                total.stmts,
-                total.miss,
-                total.branches,
-                total.branch_partial,
-                row_percent(&total)
-            )?;
-        } else {
-            writeln!(
-                html,
-                "      <tr><td><strong>TOTAL</strong></td><td class=\"num\"><strong>{}</strong></td><td class=\"num\"><strong>{}</strong></td><td class=\"num\"><strong>{}</strong></td><td></td></tr>",
-                total.stmts,
-                total.miss,
-                format_percent(total.stmts, total.miss)
-            )?;
-        }
-        writeln!(html, "    </tbody>")?;
-        writeln!(html, "  </table>")?;
-        writeln!(html, "</body>")?;
-        writeln!(html, "</html>")
+    }
+    contexts
+}
+
+fn source_filename(path: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut filename = String::with_capacity(12 + path.len() * 2);
+    filename.push_str("source-");
+    for byte in path.bytes() {
+        filename.push(char::from(HEX[usize::from(byte >> 4)]));
+        filename.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    filename.push_str(".html");
+    filename
+}
+
+fn document_start(html: &mut String, title: &str) -> Result<(), fmt::Error> {
+    writeln!(html, "<!DOCTYPE html>")?;
+    writeln!(html, "<html lang=\"en\">")?;
+    writeln!(html, "<head>")?;
+    writeln!(html, "  <meta charset=\"utf-8\">")?;
+    writeln!(
+        html,
+        "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">"
+    )?;
+    writeln!(html, "  <title>{}</title>", escape_html(title))?;
+    writeln!(
+        html,
+        "  <style>body{{font-family:system-ui,sans-serif;margin:2rem;color:#202124}}table{{border-collapse:collapse;width:100%}}th,td{{padding:.5rem;border-bottom:1px solid #ddd;text-align:left}}td.num{{text-align:right;font-variant-numeric:tabular-nums}}code,.source{{font-family:ui-monospace,SFMono-Regular,monospace}}thead{{background:#f5f5f5}}h1{{margin-top:0}}a{{color:#0969da}}.source{{display:block;overflow:auto;background:#f6f8fa;padding:1rem}}.line{{display:block;min-height:1.35em}}.number{{display:inline-block;width:3rem;text-align:right;color:#6e7781;text-decoration:none}}.executed{{background:#dafbe1}}.missing{{background:#ffebe9}}.excluded{{background:#f0f0f0;color:#6e7781}}.partial{{background:#fff8c5}}.branches{{color:#9a6700}}.contexts{{float:right;color:#57606a;font-size:.85em}}</style>"
+    )?;
+    writeln!(html, "</head>")?;
+    writeln!(html, "<body>")
+}
+
+fn document_end(html: &mut String) -> Result<(), fmt::Error> {
+    writeln!(html, "</body>")?;
+    writeln!(html, "</html>")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    use crate::data::BranchArc;
+
+    use super::*;
+
+    #[test]
+    fn source_filenames_are_deterministic_and_path_safe() {
+        assert_eq!(
+            source_filename("src/app.py"),
+            "source-7372632f6170702e7079.html"
+        );
+    }
+
+    #[test]
+    fn source_page_annotates_and_escapes_coverage_details() {
+        let missing_arc = BranchArc { from: 3, to: 5 };
+        let row = FileRow {
+            name: "src/<app>.py".to_owned(),
+            absolute_name: "/project/src/<app>.py".to_owned(),
+            stmts: 3,
+            hit: 2,
+            miss: 1,
+            missing: "2".to_owned(),
+            executable: vec![1, 2, 3],
+            excluded: vec![4],
+            executed: vec![1, 3],
+            contexts: BTreeMap::from([(1, BTreeSet::from(["test<&>".to_owned()]))]),
+            branches_enabled: true,
+            branches: 2,
+            branch_hit: 1,
+            branch_miss: 1,
+            branch_partial: 1,
+            branch_possible: vec![BranchArc { from: 3, to: 4 }, missing_arc],
+            branch_executed: vec![BranchArc { from: 3, to: 4 }],
+            branch_missing: vec![missing_arc],
+            arc_contexts: BTreeMap::new(),
+        };
+        let page = render_source(
+            &row,
+            "hit = '<&>'\nmiss = 2\nif hit:\n    excluded = 4\n",
+            &HtmlReportOptions {
+                title: "Coverage <report>".to_owned(),
+                show_contexts: true,
+                ..HtmlReportOptions::default()
+            },
+        )
+        .expect("render source page");
+
+        insta::assert_snapshot!(page);
     }
 }

--- a/crates/karva_coverage/src/report/mod.rs
+++ b/crates/karva_coverage/src/report/mod.rs
@@ -12,6 +12,7 @@ use fs_err as fs;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use regex::RegexSet;
 
+pub use html::HtmlReportOptions;
 pub use terminal::combine_and_report;
 pub use terminal::write_cobertura_xml;
 pub use terminal::write_html_report;

--- a/crates/karva_coverage/src/report/shared.rs
+++ b/crates/karva_coverage/src/report/shared.rs
@@ -447,11 +447,6 @@ pub(super) fn row_percent(row: &FileRow) -> f64 {
     )
 }
 
-pub(super) fn format_percent(total: u32, miss: u32) -> String {
-    let pct = percent(total, miss);
-    format!("{pct:.0}%")
-}
-
 pub(super) fn collapse_ranges(lines: &BTreeSet<u32>) -> String {
     let mut parts: Vec<String> = Vec::new();
     let mut iter = lines.iter().copied();
@@ -564,17 +559,17 @@ mod tests {
 
     #[test]
     fn percent_full_coverage() {
-        assert_eq!(format_percent(10, 0), "100%");
+        assert!((percent(10, 0) - 100.0).abs() < f64::EPSILON);
     }
 
     #[test]
     fn percent_partial() {
-        assert_eq!(format_percent(10, 3), "70%");
+        assert!((percent(10, 3) - 70.0).abs() < f64::EPSILON);
     }
 
     #[test]
     fn percent_zero_stmts() {
-        assert_eq!(format_percent(0, 0), "100%");
+        assert!((percent(0, 0) - 100.0).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/crates/karva_coverage/src/report/snapshots/karva_coverage__report__html__tests__source_page_annotates_and_escapes_coverage_details.snap
+++ b/crates/karva_coverage/src/report/snapshots/karva_coverage__report__html__tests__source_page_annotates_and_escapes_coverage_details.snap
@@ -1,0 +1,24 @@
+---
+source: crates/karva_coverage/src/report/html.rs
+expression: page
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>src/&lt;app&gt;.py — Coverage &lt;report&gt;</title>
+  <style>body{font-family:system-ui,sans-serif;margin:2rem;color:#202124}table{border-collapse:collapse;width:100%}th,td{padding:.5rem;border-bottom:1px solid #ddd;text-align:left}td.num{text-align:right;font-variant-numeric:tabular-nums}code,.source{font-family:ui-monospace,SFMono-Regular,monospace}thead{background:#f5f5f5}h1{margin-top:0}a{color:#0969da}.source{display:block;overflow:auto;background:#f6f8fa;padding:1rem}.line{display:block;min-height:1.35em}.number{display:inline-block;width:3rem;text-align:right;color:#6e7781;text-decoration:none}.executed{background:#dafbe1}.missing{background:#ffebe9}.excluded{background:#f0f0f0;color:#6e7781}.partial{background:#fff8c5}.branches{color:#9a6700}.contexts{float:right;color:#57606a;font-size:.85em}</style>
+</head>
+<body>
+  <p><a href="index.html">← Index</a></p>
+  <h1><code>src/&lt;app&gt;.py</code></h1>
+  <p>Coverage: <strong>60%</strong></p>
+  <pre class="source">
+<span class="line executed"><a id="L1" href="#L1" class="number">    1</a> <code>hit = &#39;&lt;&amp;&gt;&#39;</code> <span class="contexts">test&lt;&amp;&gt;</span></span>
+<span class="line missing"><a id="L2" href="#L2" class="number">    2</a> <code>miss = 2</code></span>
+<span class="line partial"><a id="L3" href="#L3" class="number">    3</a> <code>if hit:</code> <span class="branches">missing → 5</span></span>
+<span class="line excluded"><a id="L4" href="#L4" class="number">    4</a> <code>    excluded = 4</code></span>
+  </pre>
+</body>
+</html>

--- a/crates/karva_coverage/src/report/terminal.rs
+++ b/crates/karva_coverage/src/report/terminal.rs
@@ -6,7 +6,7 @@ use colored::Colorize;
 use fs_err as fs;
 
 use super::combined_rows;
-use super::html::build_html_report;
+use super::html::{HtmlReportOptions, build_html_report};
 use super::json::build_json_report;
 use super::shared::{FileRow, row_percent, total_percent, totals_row};
 use super::xml::build_cobertura_xml;
@@ -185,12 +185,40 @@ impl CoverageAnalysis {
 
     /// Writes a standalone HTML report and returns total coverage.
     pub fn write_html(&self, output_dir: &Utf8Path) -> Result<f64> {
+        self.write_html_with_options(output_dir, &HtmlReportOptions::default())
+    }
+
+    /// Writes an annotated standalone HTML report and returns total coverage.
+    pub fn write_html_with_options(
+        &self,
+        output_dir: &Utf8Path,
+        options: &HtmlReportOptions,
+    ) -> Result<f64> {
         fs::create_dir_all(output_dir.as_std_path())
             .with_context(|| format!("failed to create coverage html directory {output_dir}"))?;
-        let html = build_html_report(&self.rows);
+        let sources = self
+            .rows
+            .iter()
+            .map(|row| {
+                let path = Utf8Path::new(&row.absolute_name);
+                let path = if path.is_absolute() {
+                    path.to_path_buf()
+                } else {
+                    self.coverage_root.join(path)
+                };
+                fs::read_to_string(path.as_std_path())
+                    .with_context(|| format!("failed to read coverage source {path}"))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let report = build_html_report(&self.rows, &sources, options)?;
         let output_file = output_dir.join("index.html");
-        fs::write(output_file.as_std_path(), html)
+        fs::write(output_file.as_std_path(), report.index)
             .with_context(|| format!("failed to write coverage html {output_file}"))?;
+        for (filename, html) in report.sources {
+            let output_file = output_dir.join(filename);
+            fs::write(output_file.as_std_path(), html)
+                .with_context(|| format!("failed to write coverage html {output_file}"))?;
+        }
         Ok(self.total_percent())
     }
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -363,6 +363,7 @@ karva coverage [OPTIONS] <COMMAND>
 <h3 class="cli-reference">Commands</h3>
 
 <dl class="cli-reference"><dt><a href="#karva-coverage-report"><code>karva coverage report</code></a></dt><dd><p>Print the compact terminal coverage report</p></dd>
+<dt><a href="#karva-coverage-html"><code>karva coverage html</code></a></dt><dd><p>Generate a navigable annotated HTML coverage report</p></dd>
 <dt><a href="#karva-coverage-help"><code>karva coverage help</code></a></dt><dd><p>Print this message or the help of the given subcommand(s)</p></dd>
 </dl>
 
@@ -417,6 +418,34 @@ karva coverage report [OPTIONS] [SELECTOR]...
 <li><code>partial-branches</code>:  Partial branch count</li>
 <li><code>coverage</code>:  Coverage percentage</li>
 </ul></dd></dl>
+
+### karva coverage html
+
+Generate a navigable annotated HTML coverage report
+
+<h3 class="cli-reference">Usage</h3>
+
+```
+karva coverage html [OPTIONS]
+```
+
+<h3 class="cli-reference">Options</h3>
+
+<dl class="cli-reference"><dt id="karva-coverage-html--config-file"><a href="#karva-coverage-html--config-file"><code>--config-file</code></a> <i>path</i></dt><dd><p>The path to a <code>karva.toml</code> file to use for configuration</p>
+<p>May also be set with the <code>KARVA_CONFIG_FILE</code> environment variable.</p></dd><dt id="karva-coverage-html--contexts"><a href="#karva-coverage-html--contexts"><code>--contexts</code></a> <i>regex</i></dt><dd><p>Include execution attributed to a matching context regular expression</p>
+</dd><dt id="karva-coverage-html--data-file"><a href="#karva-coverage-html--data-file"><code>--data-file</code></a> <i>path</i></dt><dd><p>Native coverage artifact path, relative to the project root</p>
+</dd><dt id="karva-coverage-html--directory"><a href="#karva-coverage-html--directory"><code>--directory</code></a> <i>path</i></dt><dd><p>Directory receiving the report files</p>
+<p>&#91;default: htmlcov&#93;</p></dd><dt id="karva-coverage-html--fail-under"><a href="#karva-coverage-html--fail-under"><code>--fail-under</code></a> <i>percent</i></dt><dd><p>Fail when total coverage is below this percentage</p>
+</dd><dt id="karva-coverage-html--help"><a href="#karva-coverage-html--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Print help</p>
+</dd><dt id="karva-coverage-html--include"><a href="#karva-coverage-html--include"><code>--include</code></a> <i>glob</i></dt><dd><p>Include only report paths matching this glob</p>
+</dd><dt id="karva-coverage-html--omit"><a href="#karva-coverage-html--omit"><code>--omit</code></a> <i>glob</i></dt><dd><p>Exclude report paths matching this glob after inclusion</p>
+</dd><dt id="karva-coverage-html--precision"><a href="#karva-coverage-html--precision"><code>--precision</code></a> <i>n</i></dt><dd><p>Decimal places shown in coverage percentages</p>
+</dd><dt id="karva-coverage-html--profile"><a href="#karva-coverage-html--profile"><code>--profile</code></a>, <code>-P</code> <i>name</i></dt><dd><p>Configuration profile to resolve</p>
+<p>May also be set with the <code>KARVA_PROFILE</code> environment variable.</p></dd><dt id="karva-coverage-html--show-contexts"><a href="#karva-coverage-html--show-contexts"><code>--show-contexts</code></a></dt><dd><p>Show execution contexts beside annotated source lines</p>
+</dd><dt id="karva-coverage-html--skip-covered"><a href="#karva-coverage-html--skip-covered"><code>--skip-covered</code></a></dt><dd><p>Omit fully covered source pages from the index</p>
+</dd><dt id="karva-coverage-html--skip-empty"><a href="#karva-coverage-html--skip-empty"><code>--skip-empty</code></a></dt><dd><p>Omit sources with no statements or branches from the index</p>
+</dd><dt id="karva-coverage-html--title"><a href="#karva-coverage-html--title"><code>--title</code></a> <i>title</i></dt><dd><p>Report title shown in the browser</p>
+<p>&#91;default: Coverage report&#93;</p></dd></dl>
 
 ### karva coverage help
 


### PR DESCRIPTION
## Summary

Add `uv run karva coverage html` with a linked summary index and self-contained annotated source pages. Reports distinguish executed, missing, excluded, and partial-branch lines, show missing branch destinations, and support contexts, filtering, titles, precision, and skip options.

Closes #1157.

## Test Plan

`just test -p karva coverage`; workspace Clippy; `uvx prek run -a`