### PR TITLE
Add native Cobertura XML command

### DIFF
--- a/crates/karva/src/commands/coverage.rs
+++ b/crates/karva/src/commands/coverage.rs
@@ -98,6 +98,10 @@ pub fn coverage(args: &CoverageCommand) -> Result<ExitStatus> {
                 },
             )?
         }
+        CoverageAction::Xml(xml) => {
+            let output = absolute(&xml.output, project.cwd());
+            analysis.write_cobertura_xml(&output)?
+        }
     };
     if let Some(threshold) = settings.fail_under
         && total < threshold

--- a/crates/karva/tests/it/coverage_command.rs
+++ b/crates/karva/tests/it/coverage_command.rs
@@ -83,6 +83,41 @@ fn html_writes_navigable_annotated_report() {
 }
 
 #[test]
+fn xml_writes_cobertura_report() {
+    let context = TestContext::new();
+    write_coverage(&context, Utf8Path::new(".karva/coverage/data.json"));
+
+    assert_cmd_snapshot!(context.coverage("xml"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+    insta::assert_snapshot!(context.read_file("coverage.xml"), @r#"
+    <?xml version="1.0" ?>
+    <coverage version="1.0" timestamp="[TIMESTAMP]" lines-valid="2" lines-covered="1" line-rate="0.5000" branches-covered="0" branches-valid="0" branch-rate="0.0000" complexity="0.0">
+      <sources>
+        <source><temp_dir>/</source>
+      </sources>
+      <packages>
+        <package name="." line-rate="0.5000" branch-rate="0.0000" complexity="0.0">
+          <classes>
+            <class name="src/app.py" filename="src/app.py" line-rate="0.5000" branch-rate="0.0000" complexity="0.0">
+              <methods/>
+              <lines>
+                <line number="1" hits="1" branch="false"/>
+                <line number="2" hits="0" branch="false"/>
+              </lines>
+            </class>
+          </classes>
+        </package>
+      </packages>
+    </coverage>
+    "#);
+}
+
+#[test]
 fn report_auto_combines_pending_shards() {
     let context = TestContext::new();
     write_coverage(

--- a/crates/karva_cli/src/coverage.rs
+++ b/crates/karva_cli/src/coverage.rs
@@ -102,6 +102,17 @@ pub enum CoverageAction {
 
     /// Generate a navigable annotated HTML coverage report.
     Html(CoverageHtmlCommand),
+
+    /// Generate a Cobertura-compatible XML coverage report.
+    Xml(CoverageXmlCommand),
+}
+
+#[derive(Debug, Args)]
+/// Options specific to the Cobertura XML coverage report.
+pub struct CoverageXmlCommand {
+    /// Path receiving the XML report.
+    #[arg(long, value_name = "PATH", default_value = "coverage.xml")]
+    pub output: Utf8PathBuf,
 }
 
 #[derive(Debug, Args)]

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -17,7 +17,7 @@ mod verbosity;
 pub use cache::{CacheAction, CacheCommand};
 pub use coverage::{
     CoverageAction, CoverageCommand, CoverageFormat, CoverageHtmlCommand, CoverageReportCommand,
-    CoverageSort,
+    CoverageSort, CoverageXmlCommand,
 };
 pub use enums::{
     CovContext, CovReport, FlakyResult, JunitFlakyFailStatus, NoTests, OutputFormat, ResultFormat,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -364,6 +364,7 @@ karva coverage [OPTIONS] <COMMAND>
 
 <dl class="cli-reference"><dt><a href="#karva-coverage-report"><code>karva coverage report</code></a></dt><dd><p>Print the compact terminal coverage report</p></dd>
 <dt><a href="#karva-coverage-html"><code>karva coverage html</code></a></dt><dd><p>Generate a navigable annotated HTML coverage report</p></dd>
+<dt><a href="#karva-coverage-xml"><code>karva coverage xml</code></a></dt><dd><p>Generate a Cobertura-compatible XML coverage report</p></dd>
 <dt><a href="#karva-coverage-help"><code>karva coverage help</code></a></dt><dd><p>Print this message or the help of the given subcommand(s)</p></dd>
 </dl>
 
@@ -446,6 +447,30 @@ karva coverage html [OPTIONS]
 </dd><dt id="karva-coverage-html--skip-empty"><a href="#karva-coverage-html--skip-empty"><code>--skip-empty</code></a></dt><dd><p>Omit sources with no statements or branches from the index</p>
 </dd><dt id="karva-coverage-html--title"><a href="#karva-coverage-html--title"><code>--title</code></a> <i>title</i></dt><dd><p>Report title shown in the browser</p>
 <p>&#91;default: Coverage report&#93;</p></dd></dl>
+
+### karva coverage xml
+
+Generate a Cobertura-compatible XML coverage report
+
+<h3 class="cli-reference">Usage</h3>
+
+```
+karva coverage xml [OPTIONS]
+```
+
+<h3 class="cli-reference">Options</h3>
+
+<dl class="cli-reference"><dt id="karva-coverage-xml--config-file"><a href="#karva-coverage-xml--config-file"><code>--config-file</code></a> <i>path</i></dt><dd><p>The path to a <code>karva.toml</code> file to use for configuration</p>
+<p>May also be set with the <code>KARVA_CONFIG_FILE</code> environment variable.</p></dd><dt id="karva-coverage-xml--contexts"><a href="#karva-coverage-xml--contexts"><code>--contexts</code></a> <i>regex</i></dt><dd><p>Include execution attributed to a matching context regular expression</p>
+</dd><dt id="karva-coverage-xml--data-file"><a href="#karva-coverage-xml--data-file"><code>--data-file</code></a> <i>path</i></dt><dd><p>Native coverage artifact path, relative to the project root</p>
+</dd><dt id="karva-coverage-xml--fail-under"><a href="#karva-coverage-xml--fail-under"><code>--fail-under</code></a> <i>percent</i></dt><dd><p>Fail when total coverage is below this percentage</p>
+</dd><dt id="karva-coverage-xml--help"><a href="#karva-coverage-xml--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Print help</p>
+</dd><dt id="karva-coverage-xml--include"><a href="#karva-coverage-xml--include"><code>--include</code></a> <i>glob</i></dt><dd><p>Include only report paths matching this glob</p>
+</dd><dt id="karva-coverage-xml--omit"><a href="#karva-coverage-xml--omit"><code>--omit</code></a> <i>glob</i></dt><dd><p>Exclude report paths matching this glob after inclusion</p>
+</dd><dt id="karva-coverage-xml--output"><a href="#karva-coverage-xml--output"><code>--output</code></a> <i>path</i></dt><dd><p>Path receiving the XML report</p>
+<p>&#91;default: coverage.xml&#93;</p></dd><dt id="karva-coverage-xml--precision"><a href="#karva-coverage-xml--precision"><code>--precision</code></a> <i>n</i></dt><dd><p>Decimal places shown in coverage percentages</p>
+</dd><dt id="karva-coverage-xml--profile"><a href="#karva-coverage-xml--profile"><code>--profile</code></a>, <code>-P</code> <i>name</i></dt><dd><p>Configuration profile to resolve</p>
+<p>May also be set with the <code>KARVA_PROFILE</code> environment variable.</p></dd></dl>
 
 ### karva coverage help
 

--- a/docs/usage/writing-tests/coverage.md
+++ b/docs/usage/writing-tests/coverage.md
@@ -85,6 +85,15 @@ karva test --cov=src --cov-report=xml
 karva test --cov=src --cov-report=xml:build/coverage.xml
 ```
 
+Persisted native coverage data can produce the same report after the test run:
+
+```bash
+uv run karva coverage xml
+uv run karva coverage xml --output build/coverage.xml
+```
+
+Cobertura structure, line and branch totals, project-relative class filenames, and XML escaping are supported external contracts for CI consumers.
+
 Equivalent configuration:
 
 ```toml


### PR DESCRIPTION
## Summary

Add `uv run karva coverage xml` for generating Cobertura XML from persisted native coverage data, including compatible pending shards, filters, branch data, and fail-under handling. The command writes `coverage.xml` by default and supports custom output paths.

Closes #1155.

## Test Plan

`just test -p karva coverage_command`; workspace Clippy; `uvx prek run -a`