### PR TITLE
Add native JSON coverage export

### DIFF
--- a/crates/karva/src/commands/coverage.rs
+++ b/crates/karva/src/commands/coverage.rs
@@ -102,6 +102,16 @@ pub fn coverage(args: &CoverageCommand) -> Result<ExitStatus> {
             let output = absolute(&xml.output, project.cwd());
             analysis.write_cobertura_xml(&output)?
         }
+        CoverageAction::Json(json) => {
+            let output = absolute(&json.output, project.cwd());
+            analysis.write_json_with_options(
+                &output,
+                &karva_coverage::JsonReportOptions {
+                    pretty_print: json.pretty_print,
+                    show_contexts: json.show_contexts,
+                },
+            )?
+        }
     };
     if let Some(threshold) = settings.fail_under
         && total < threshold

--- a/crates/karva/tests/it/coverage_command.rs
+++ b/crates/karva/tests/it/coverage_command.rs
@@ -22,7 +22,7 @@ fn write_coverage(context: &TestContext, path: &Utf8Path) {
                 executable: BTreeSet::from([1, 2]),
                 excluded: BTreeSet::new(),
                 executed: BTreeSet::from([1]),
-                line_contexts: BTreeMap::new(),
+                line_contexts: BTreeMap::from([(1, BTreeSet::from(["test_example".to_owned()]))]),
                 branches: None,
             },
         )]),
@@ -114,6 +114,73 @@ fn xml_writes_cobertura_report() {
         </package>
       </packages>
     </coverage>
+    "#);
+}
+
+#[test]
+fn json_exports_pretty_report_with_contexts() {
+    let context = TestContext::new();
+    write_coverage(&context, Utf8Path::new(".karva/coverage/data.json"));
+
+    assert_cmd_snapshot!(context.coverage("json"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+    assert!(!context.read_file("coverage.json").contains('\n'));
+
+    assert_cmd_snapshot!(
+        context
+            .coverage("json")
+            .args(["--pretty-print", "--show-contexts"]),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    "
+    );
+    insta::assert_snapshot!(context.read_file("coverage.json"), @r#"
+    {
+      "meta": {
+        "format": 2,
+        "version": "karva",
+        "show_contexts": true
+      },
+      "files": {
+        "src/app.py": {
+          "executed_lines": [
+            1
+          ],
+          "summary": {
+            "covered_lines": 1,
+            "num_statements": 2,
+            "percent_covered": 50.0,
+            "missing_lines": [
+              2
+            ],
+            "excluded_lines": []
+          },
+          "missing_lines": [
+            2
+          ],
+          "excluded_lines": [],
+          "contexts": {
+            "1": [
+              "test_example"
+            ]
+          }
+        }
+      },
+      "totals": {
+        "covered_lines": 1,
+        "num_statements": 2,
+        "percent_covered": 50.0
+      }
+    }
     "#);
 }
 

--- a/crates/karva_cli/src/coverage.rs
+++ b/crates/karva_cli/src/coverage.rs
@@ -105,6 +105,25 @@ pub enum CoverageAction {
 
     /// Generate a Cobertura-compatible XML coverage report.
     Xml(CoverageXmlCommand),
+
+    /// Export documented JSON coverage data.
+    Json(CoverageJsonCommand),
+}
+
+#[derive(Debug, Args)]
+/// Options specific to exported JSON coverage data.
+pub struct CoverageJsonCommand {
+    /// Path receiving the JSON report.
+    #[arg(long, value_name = "PATH", default_value = "coverage.json")]
+    pub output: Utf8PathBuf,
+
+    /// Format output with indentation and line breaks.
+    #[arg(long)]
+    pub pretty_print: bool,
+
+    /// Include per-line execution contexts.
+    #[arg(long)]
+    pub show_contexts: bool,
 }
 
 #[derive(Debug, Args)]

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -16,8 +16,8 @@ mod verbosity;
 
 pub use cache::{CacheAction, CacheCommand};
 pub use coverage::{
-    CoverageAction, CoverageCommand, CoverageFormat, CoverageHtmlCommand, CoverageReportCommand,
-    CoverageSort, CoverageXmlCommand,
+    CoverageAction, CoverageCommand, CoverageFormat, CoverageHtmlCommand, CoverageJsonCommand,
+    CoverageReportCommand, CoverageSort, CoverageXmlCommand,
 };
 pub use enums::{
     CovContext, CovReport, FlakyResult, JunitFlakyFailStatus, NoTests, OutputFormat, ResultFormat,

--- a/crates/karva_coverage/src/lib.rs
+++ b/crates/karva_coverage/src/lib.rs
@@ -27,7 +27,7 @@ pub mod tracer;
 
 pub use report::{
     CoverageAnalysis, CoverageFilters, CoverageReportFormat, CoverageReportOptions,
-    CoverageReportSort, HtmlReportOptions, combine_and_report, write_cobertura_xml,
-    write_html_report, write_json_report,
+    CoverageReportSort, HtmlReportOptions, JsonReportOptions, combine_and_report,
+    write_cobertura_xml, write_html_report, write_json_report,
 };
 pub use tracer::{CoverageConfig, CoverageSession};

--- a/crates/karva_coverage/src/report/json.rs
+++ b/crates/karva_coverage/src/report/json.rs
@@ -73,6 +73,15 @@ struct JsonMeta {
     show_contexts: bool,
 }
 
+/// Presentation settings for exported JSON coverage data.
+#[derive(Debug, Default)]
+pub struct JsonReportOptions {
+    /// Whether output uses indentation and line breaks.
+    pub pretty_print: bool,
+    /// Whether per-line execution contexts are included.
+    pub show_contexts: bool,
+}
+
 #[expect(
     clippy::trivially_copy_pass_by_ref,
     reason = "serde skip_serializing_if passes a reference to the field"
@@ -81,7 +90,7 @@ fn is_false(value: &bool) -> bool {
     !*value
 }
 
-pub(super) fn build_json_report(rows: &[FileRow]) -> Result<String> {
+pub(super) fn build_json_report(rows: &[FileRow], options: &JsonReportOptions) -> Result<String> {
     let files = rows
         .iter()
         .map(|row| {
@@ -92,7 +101,11 @@ pub(super) fn build_json_report(rows: &[FileRow]) -> Result<String> {
                     summary: json_summary(row),
                     missing_lines: missing_lines(row),
                     excluded_lines: row.excluded.clone(),
-                    contexts: row.contexts.clone(),
+                    contexts: if options.show_contexts {
+                        row.contexts.clone()
+                    } else {
+                        BTreeMap::new()
+                    },
                     executed_branches: row
                         .branches_enabled
                         .then(|| branch_pairs(&row.branch_executed)),
@@ -105,18 +118,22 @@ pub(super) fn build_json_report(rows: &[FileRow]) -> Result<String> {
         .collect();
 
     let totals_row = totals_row(rows);
-    let show_contexts = rows.iter().any(|row| !row.contexts.is_empty());
     let report = JsonReport {
         meta: JsonMeta {
             format: 2,
             version: "karva",
-            show_contexts,
+            show_contexts: options.show_contexts,
         },
         files,
         totals: json_totals_summary(&totals_row),
     };
 
-    serde_json::to_string_pretty(&report).context("failed to serialize coverage json")
+    if options.pretty_print {
+        serde_json::to_string_pretty(&report)
+    } else {
+        serde_json::to_string(&report)
+    }
+    .context("failed to serialize coverage json")
 }
 
 fn json_summary(row: &FileRow) -> JsonFileSummary {

--- a/crates/karva_coverage/src/report/mod.rs
+++ b/crates/karva_coverage/src/report/mod.rs
@@ -13,6 +13,7 @@ use globset::{Glob, GlobSet, GlobSetBuilder};
 use regex::RegexSet;
 
 pub use html::HtmlReportOptions;
+pub use json::JsonReportOptions;
 pub use terminal::combine_and_report;
 pub use terminal::write_cobertura_xml;
 pub use terminal::write_html_report;

--- a/crates/karva_coverage/src/report/terminal.rs
+++ b/crates/karva_coverage/src/report/terminal.rs
@@ -7,7 +7,7 @@ use fs_err as fs;
 
 use super::combined_rows;
 use super::html::{HtmlReportOptions, build_html_report};
-use super::json::build_json_report;
+use super::json::{JsonReportOptions, build_json_report};
 use super::shared::{FileRow, row_percent, total_percent, totals_row};
 use super::xml::build_cobertura_xml;
 use super::{CoverageAnalysis, CoverageFilters};
@@ -176,8 +176,23 @@ impl CoverageAnalysis {
 
     /// Writes a coverage.py-compatible JSON report and returns total coverage.
     pub fn write_json(&self, output: &Utf8Path) -> Result<f64> {
+        self.write_json_with_options(
+            output,
+            &JsonReportOptions {
+                pretty_print: true,
+                show_contexts: self.rows.iter().any(|row| !row.contexts.is_empty()),
+            },
+        )
+    }
+
+    /// Writes configured exported JSON coverage data and returns total coverage.
+    pub fn write_json_with_options(
+        &self,
+        output: &Utf8Path,
+        options: &JsonReportOptions,
+    ) -> Result<f64> {
         create_output_parent(output)?;
-        let json = build_json_report(&self.rows)?;
+        let json = build_json_report(&self.rows, options)?;
         fs::write(output.as_std_path(), json)
             .with_context(|| format!("failed to write coverage json {output}"))?;
         Ok(self.total_percent())

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -365,6 +365,7 @@ karva coverage [OPTIONS] <COMMAND>
 <dl class="cli-reference"><dt><a href="#karva-coverage-report"><code>karva coverage report</code></a></dt><dd><p>Print the compact terminal coverage report</p></dd>
 <dt><a href="#karva-coverage-html"><code>karva coverage html</code></a></dt><dd><p>Generate a navigable annotated HTML coverage report</p></dd>
 <dt><a href="#karva-coverage-xml"><code>karva coverage xml</code></a></dt><dd><p>Generate a Cobertura-compatible XML coverage report</p></dd>
+<dt><a href="#karva-coverage-json"><code>karva coverage json</code></a></dt><dd><p>Export documented JSON coverage data</p></dd>
 <dt><a href="#karva-coverage-help"><code>karva coverage help</code></a></dt><dd><p>Print this message or the help of the given subcommand(s)</p></dd>
 </dl>
 
@@ -471,6 +472,32 @@ karva coverage xml [OPTIONS]
 <p>&#91;default: coverage.xml&#93;</p></dd><dt id="karva-coverage-xml--precision"><a href="#karva-coverage-xml--precision"><code>--precision</code></a> <i>n</i></dt><dd><p>Decimal places shown in coverage percentages</p>
 </dd><dt id="karva-coverage-xml--profile"><a href="#karva-coverage-xml--profile"><code>--profile</code></a>, <code>-P</code> <i>name</i></dt><dd><p>Configuration profile to resolve</p>
 <p>May also be set with the <code>KARVA_PROFILE</code> environment variable.</p></dd></dl>
+
+### karva coverage json
+
+Export documented JSON coverage data
+
+<h3 class="cli-reference">Usage</h3>
+
+```
+karva coverage json [OPTIONS]
+```
+
+<h3 class="cli-reference">Options</h3>
+
+<dl class="cli-reference"><dt id="karva-coverage-json--config-file"><a href="#karva-coverage-json--config-file"><code>--config-file</code></a> <i>path</i></dt><dd><p>The path to a <code>karva.toml</code> file to use for configuration</p>
+<p>May also be set with the <code>KARVA_CONFIG_FILE</code> environment variable.</p></dd><dt id="karva-coverage-json--contexts"><a href="#karva-coverage-json--contexts"><code>--contexts</code></a> <i>regex</i></dt><dd><p>Include execution attributed to a matching context regular expression</p>
+</dd><dt id="karva-coverage-json--data-file"><a href="#karva-coverage-json--data-file"><code>--data-file</code></a> <i>path</i></dt><dd><p>Native coverage artifact path, relative to the project root</p>
+</dd><dt id="karva-coverage-json--fail-under"><a href="#karva-coverage-json--fail-under"><code>--fail-under</code></a> <i>percent</i></dt><dd><p>Fail when total coverage is below this percentage</p>
+</dd><dt id="karva-coverage-json--help"><a href="#karva-coverage-json--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Print help</p>
+</dd><dt id="karva-coverage-json--include"><a href="#karva-coverage-json--include"><code>--include</code></a> <i>glob</i></dt><dd><p>Include only report paths matching this glob</p>
+</dd><dt id="karva-coverage-json--omit"><a href="#karva-coverage-json--omit"><code>--omit</code></a> <i>glob</i></dt><dd><p>Exclude report paths matching this glob after inclusion</p>
+</dd><dt id="karva-coverage-json--output"><a href="#karva-coverage-json--output"><code>--output</code></a> <i>path</i></dt><dd><p>Path receiving the JSON report</p>
+<p>&#91;default: coverage.json&#93;</p></dd><dt id="karva-coverage-json--precision"><a href="#karva-coverage-json--precision"><code>--precision</code></a> <i>n</i></dt><dd><p>Decimal places shown in coverage percentages</p>
+</dd><dt id="karva-coverage-json--pretty-print"><a href="#karva-coverage-json--pretty-print"><code>--pretty-print</code></a></dt><dd><p>Format output with indentation and line breaks</p>
+</dd><dt id="karva-coverage-json--profile"><a href="#karva-coverage-json--profile"><code>--profile</code></a>, <code>-P</code> <i>name</i></dt><dd><p>Configuration profile to resolve</p>
+<p>May also be set with the <code>KARVA_PROFILE</code> environment variable.</p></dd><dt id="karva-coverage-json--show-contexts"><a href="#karva-coverage-json--show-contexts"><code>--show-contexts</code></a></dt><dd><p>Include per-line execution contexts</p>
+</dd></dl>
 
 ### karva coverage help
 

--- a/docs/usage/writing-tests/coverage.md
+++ b/docs/usage/writing-tests/coverage.md
@@ -116,6 +116,16 @@ Pass `--cov-context=test` with JSON reports to include a `contexts` map from exe
 karva test --cov=src --cov-context=test --cov-report=json
 ```
 
+Persisted native coverage data can be exported independently. Output is compact by default:
+
+```bash
+uv run karva coverage json
+uv run karva coverage json --output build/coverage.json --pretty-print
+uv run karva coverage json --show-contexts
+```
+
+Exported JSON is separate from Karva's native artifact. `meta.format` versions its documented schema; breaking field or semantic changes increment that number, while consumers must tolerate additive fields within a format version. Files contain executed, missing, and excluded lines, optional contexts, branch arcs when collected, and per-file summaries. `totals` contains aggregate line and branch metrics.
+
 `--cov-report=html[:DIR]` writes a simple browsable HTML report. If `DIR` is omitted, karva writes `htmlcov/` in the project root:
 
 ```bash


### PR DESCRIPTION
## Summary

Add `uv run karva coverage json` for exporting documented JSON from persisted native coverage data. Output is compact by default, supports pretty printing and optional contexts, retains line and branch detail, and remains distinct from Karva native artifacts.

Closes #1158.

## Test Plan

`just test -p karva coverage`; workspace Clippy; `uvx prek run -a`