### PR TITLE
Add native LCOV coverage export

### DIFF
--- a/crates/karva/src/commands/coverage.rs
+++ b/crates/karva/src/commands/coverage.rs
@@ -112,6 +112,10 @@ pub fn coverage(args: &CoverageCommand) -> Result<ExitStatus> {
                 },
             )?
         }
+        CoverageAction::Lcov(lcov) => {
+            let output = absolute(&lcov.output, project.cwd());
+            analysis.write_lcov(&output)?
+        }
     };
     if let Some(threshold) = settings.fail_under
         && total < threshold

--- a/crates/karva/tests/it/coverage_command.rs
+++ b/crates/karva/tests/it/coverage_command.rs
@@ -185,6 +185,28 @@ fn json_exports_pretty_report_with_contexts() {
 }
 
 #[test]
+fn lcov_writes_portable_tracefile() {
+    let context = TestContext::new();
+    write_coverage(&context, Utf8Path::new(".karva/coverage/data.json"));
+
+    assert_cmd_snapshot!(context.coverage("lcov"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+    insta::assert_snapshot!(context.read_file("coverage.lcov"), @r"
+    SF:src/app.py
+    DA:1,1
+    DA:2,0
+    LF:2
+    LH:1
+    end_of_record
+    ");
+}
+
+#[test]
 fn report_auto_combines_pending_shards() {
     let context = TestContext::new();
     write_coverage(

--- a/crates/karva_cli/src/coverage.rs
+++ b/crates/karva_cli/src/coverage.rs
@@ -108,6 +108,17 @@ pub enum CoverageAction {
 
     /// Export documented JSON coverage data.
     Json(CoverageJsonCommand),
+
+    /// Generate an LCOV tracefile.
+    Lcov(CoverageLcovCommand),
+}
+
+#[derive(Debug, Args)]
+/// Options specific to the LCOV tracefile.
+pub struct CoverageLcovCommand {
+    /// Path receiving the LCOV tracefile.
+    #[arg(long, value_name = "PATH", default_value = "coverage.lcov")]
+    pub output: Utf8PathBuf,
 }
 
 #[derive(Debug, Args)]

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -17,7 +17,7 @@ mod verbosity;
 pub use cache::{CacheAction, CacheCommand};
 pub use coverage::{
     CoverageAction, CoverageCommand, CoverageFormat, CoverageHtmlCommand, CoverageJsonCommand,
-    CoverageReportCommand, CoverageSort, CoverageXmlCommand,
+    CoverageLcovCommand, CoverageReportCommand, CoverageSort, CoverageXmlCommand,
 };
 pub use enums::{
     CovContext, CovReport, FlakyResult, JunitFlakyFailStatus, NoTests, OutputFormat, ResultFormat,

--- a/crates/karva_coverage/src/report/lcov.rs
+++ b/crates/karva_coverage/src/report/lcov.rs
@@ -1,0 +1,134 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
+
+use anyhow::{Result, bail};
+
+use super::shared::FileRow;
+use crate::data::BranchArc;
+
+pub(super) fn build_lcov_report(rows: &[FileRow]) -> Result<String> {
+    let mut report = String::new();
+    for row in rows {
+        writeln!(report, "SF:{}", row.name)?;
+        let executed: BTreeSet<u32> = row.executed.iter().copied().collect();
+        for line in &row.executable {
+            writeln!(report, "DA:{line},{}", u8::from(executed.contains(line)))?;
+        }
+        if row.stmts > 0 {
+            writeln!(report, "LF:{}", row.stmts)?;
+            writeln!(report, "LH:{}", row.hit)?;
+        }
+        write_branches(&mut report, row)?;
+        report.push_str("end_of_record\n");
+    }
+    Ok(report)
+}
+
+fn write_branches(report: &mut String, row: &FileRow) -> Result<()> {
+    if row.branches == 0 {
+        return Ok(());
+    }
+    let executed: BTreeSet<BranchArc> = row.branch_executed.iter().copied().collect();
+    let mut by_line: BTreeMap<u32, Vec<BranchArc>> = BTreeMap::new();
+    for arc in &row.branch_possible {
+        let Ok(line) = u32::try_from(arc.from) else {
+            bail!("cannot write LCOV branch with negative origin {}", arc.from);
+        };
+        by_line.entry(line).or_default().push(*arc);
+    }
+    for (line, mut arcs) in by_line {
+        arcs.sort_by_key(|arc| (arc.to < 0, arc.to));
+        let any_taken = arcs.iter().any(|arc| executed.contains(arc));
+        for (branch, arc) in arcs.iter().enumerate() {
+            let taken = if executed.contains(arc) {
+                "1"
+            } else if any_taken {
+                "0"
+            } else {
+                "-"
+            };
+            writeln!(report, "BRDA:{line},0,{branch},{taken}")?;
+        }
+    }
+    writeln!(report, "BRF:{}", row.branches)?;
+    writeln!(report, "BRH:{}", row.branch_hit)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::build_lcov_report;
+    use crate::data::BranchArc;
+    use crate::report::shared::FileRow;
+
+    #[test]
+    fn report_contains_deterministic_line_and_branch_records() {
+        let taken = BranchArc { from: 1, to: 2 };
+        let missing = BranchArc { from: 1, to: -1 };
+        let row = FileRow {
+            name: "src/app.py".to_owned(),
+            absolute_name: "/project/src/app.py".to_owned(),
+            stmts: 2,
+            hit: 1,
+            miss: 1,
+            missing: "2".to_owned(),
+            executable: vec![1, 2],
+            excluded: Vec::new(),
+            executed: vec![1],
+            contexts: BTreeMap::new(),
+            branches_enabled: true,
+            branches: 2,
+            branch_hit: 1,
+            branch_miss: 1,
+            branch_partial: 1,
+            branch_possible: vec![missing, taken],
+            branch_executed: vec![taken],
+            branch_missing: vec![missing],
+            arc_contexts: BTreeMap::new(),
+        };
+
+        insta::assert_snapshot!(build_lcov_report(&[row]).expect("build LCOV report"), @r"
+        SF:src/app.py
+        DA:1,1
+        DA:2,0
+        LF:2
+        LH:1
+        BRDA:1,0,0,1
+        BRDA:1,0,1,0
+        BRF:2
+        BRH:1
+        end_of_record
+        ");
+    }
+
+    #[test]
+    fn report_rejects_negative_branch_origins() {
+        let row = FileRow {
+            name: "src/app.py".to_owned(),
+            absolute_name: "/project/src/app.py".to_owned(),
+            stmts: 0,
+            hit: 0,
+            miss: 0,
+            missing: String::new(),
+            executable: Vec::new(),
+            excluded: Vec::new(),
+            executed: Vec::new(),
+            contexts: BTreeMap::new(),
+            branches_enabled: true,
+            branches: 1,
+            branch_hit: 0,
+            branch_miss: 1,
+            branch_partial: 0,
+            branch_possible: vec![BranchArc { from: -1, to: 1 }],
+            branch_executed: Vec::new(),
+            branch_missing: vec![BranchArc { from: -1, to: 1 }],
+            arc_contexts: BTreeMap::new(),
+        };
+
+        let error = build_lcov_report(&[row]).expect_err("reject invalid branch origin");
+
+        assert!(error.to_string().contains("negative origin -1"));
+    }
+}

--- a/crates/karva_coverage/src/report/mod.rs
+++ b/crates/karva_coverage/src/report/mod.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod html;
 pub(crate) mod json;
+pub(crate) mod lcov;
 pub(crate) mod shared;
 mod terminal;
 pub(crate) mod xml;

--- a/crates/karva_coverage/src/report/terminal.rs
+++ b/crates/karva_coverage/src/report/terminal.rs
@@ -8,6 +8,7 @@ use fs_err as fs;
 use super::combined_rows;
 use super::html::{HtmlReportOptions, build_html_report};
 use super::json::{JsonReportOptions, build_json_report};
+use super::lcov::build_lcov_report;
 use super::shared::{FileRow, row_percent, total_percent, totals_row};
 use super::xml::build_cobertura_xml;
 use super::{CoverageAnalysis, CoverageFilters};
@@ -195,6 +196,15 @@ impl CoverageAnalysis {
         let json = build_json_report(&self.rows, options)?;
         fs::write(output.as_std_path(), json)
             .with_context(|| format!("failed to write coverage json {output}"))?;
+        Ok(self.total_percent())
+    }
+
+    /// Writes an LCOV tracefile and returns total coverage.
+    pub fn write_lcov(&self, output: &Utf8Path) -> Result<f64> {
+        create_output_parent(output)?;
+        let lcov = build_lcov_report(&self.rows)?;
+        fs::write(output.as_std_path(), lcov)
+            .with_context(|| format!("failed to write coverage lcov {output}"))?;
         Ok(self.total_percent())
     }
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -366,6 +366,7 @@ karva coverage [OPTIONS] <COMMAND>
 <dt><a href="#karva-coverage-html"><code>karva coverage html</code></a></dt><dd><p>Generate a navigable annotated HTML coverage report</p></dd>
 <dt><a href="#karva-coverage-xml"><code>karva coverage xml</code></a></dt><dd><p>Generate a Cobertura-compatible XML coverage report</p></dd>
 <dt><a href="#karva-coverage-json"><code>karva coverage json</code></a></dt><dd><p>Export documented JSON coverage data</p></dd>
+<dt><a href="#karva-coverage-lcov"><code>karva coverage lcov</code></a></dt><dd><p>Generate an LCOV tracefile</p></dd>
 <dt><a href="#karva-coverage-help"><code>karva coverage help</code></a></dt><dd><p>Print this message or the help of the given subcommand(s)</p></dd>
 </dl>
 
@@ -498,6 +499,30 @@ karva coverage json [OPTIONS]
 </dd><dt id="karva-coverage-json--profile"><a href="#karva-coverage-json--profile"><code>--profile</code></a>, <code>-P</code> <i>name</i></dt><dd><p>Configuration profile to resolve</p>
 <p>May also be set with the <code>KARVA_PROFILE</code> environment variable.</p></dd><dt id="karva-coverage-json--show-contexts"><a href="#karva-coverage-json--show-contexts"><code>--show-contexts</code></a></dt><dd><p>Include per-line execution contexts</p>
 </dd></dl>
+
+### karva coverage lcov
+
+Generate an LCOV tracefile
+
+<h3 class="cli-reference">Usage</h3>
+
+```
+karva coverage lcov [OPTIONS]
+```
+
+<h3 class="cli-reference">Options</h3>
+
+<dl class="cli-reference"><dt id="karva-coverage-lcov--config-file"><a href="#karva-coverage-lcov--config-file"><code>--config-file</code></a> <i>path</i></dt><dd><p>The path to a <code>karva.toml</code> file to use for configuration</p>
+<p>May also be set with the <code>KARVA_CONFIG_FILE</code> environment variable.</p></dd><dt id="karva-coverage-lcov--contexts"><a href="#karva-coverage-lcov--contexts"><code>--contexts</code></a> <i>regex</i></dt><dd><p>Include execution attributed to a matching context regular expression</p>
+</dd><dt id="karva-coverage-lcov--data-file"><a href="#karva-coverage-lcov--data-file"><code>--data-file</code></a> <i>path</i></dt><dd><p>Native coverage artifact path, relative to the project root</p>
+</dd><dt id="karva-coverage-lcov--fail-under"><a href="#karva-coverage-lcov--fail-under"><code>--fail-under</code></a> <i>percent</i></dt><dd><p>Fail when total coverage is below this percentage</p>
+</dd><dt id="karva-coverage-lcov--help"><a href="#karva-coverage-lcov--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Print help</p>
+</dd><dt id="karva-coverage-lcov--include"><a href="#karva-coverage-lcov--include"><code>--include</code></a> <i>glob</i></dt><dd><p>Include only report paths matching this glob</p>
+</dd><dt id="karva-coverage-lcov--omit"><a href="#karva-coverage-lcov--omit"><code>--omit</code></a> <i>glob</i></dt><dd><p>Exclude report paths matching this glob after inclusion</p>
+</dd><dt id="karva-coverage-lcov--output"><a href="#karva-coverage-lcov--output"><code>--output</code></a> <i>path</i></dt><dd><p>Path receiving the LCOV tracefile</p>
+<p>&#91;default: coverage.lcov&#93;</p></dd><dt id="karva-coverage-lcov--precision"><a href="#karva-coverage-lcov--precision"><code>--precision</code></a> <i>n</i></dt><dd><p>Decimal places shown in coverage percentages</p>
+</dd><dt id="karva-coverage-lcov--profile"><a href="#karva-coverage-lcov--profile"><code>--profile</code></a>, <code>-P</code> <i>name</i></dt><dd><p>Configuration profile to resolve</p>
+<p>May also be set with the <code>KARVA_PROFILE</code> environment variable.</p></dd></dl>
 
 ### karva coverage help
 

--- a/docs/usage/writing-tests/coverage.md
+++ b/docs/usage/writing-tests/coverage.md
@@ -126,6 +126,15 @@ uv run karva coverage json --show-contexts
 
 Exported JSON is separate from Karva's native artifact. `meta.format` versions its documented schema; breaking field or semantic changes increment that number, while consumers must tolerate additive fields within a format version. Files contain executed, missing, and excluded lines, optional contexts, branch arcs when collected, and per-file summaries. `totals` contains aggregate line and branch metrics.
 
+`uv run karva coverage lcov` writes a deterministic LCOV tracefile from persisted native data. Use `--output` to select another destination:
+
+```bash
+uv run karva coverage lcov
+uv run karva coverage lcov --output build/coverage.lcov
+```
+
+LCOV `SF`, `DA`, `LF`, `LH`, `BRDA`, `BRF`, and `BRH` records are a supported external contract. Source paths are portable project-relative paths after configured path aliases are applied.
+
 `--cov-report=html[:DIR]` writes a simple browsable HTML report. If `DIR` is omitted, karva writes `htmlcov/` in the project root:
 
 ```bash


### PR DESCRIPTION
## Summary

Add `uv run karva coverage lcov` with deterministic line and branch tracefile records, portable normalized paths, shared filters, pending-shard loading, and fail-under behavior. Document the LCOV record set as a supported external contract.

Closes #1159.

## Test Plan

`just test` and `uvx prek run -a`