### PR TITLE
Add native coverage combine command

### DIFF
--- a/crates/karva/src/commands/coverage.rs
+++ b/crates/karva/src/commands/coverage.rs
@@ -11,6 +11,8 @@ use karva_python_semantic::current_python_version;
 use crate::ExitStatus;
 use crate::utils::cwd;
 
+mod combine;
+
 pub fn coverage(args: &CoverageCommand) -> Result<ExitStatus> {
     let cwd = cwd()?;
     let config_file = args.config_file.as_ref().map(|path| absolute(path, &cwd));
@@ -28,11 +30,14 @@ pub fn coverage(args: &CoverageCommand) -> Result<ExitStatus> {
     let settings = project.settings().coverage();
     let data_file = absolute(&settings.data_file, project.cwd());
 
-    let data_files = coverage_data_files(&data_file)?;
-
     let filters = karva_coverage::CoverageFilters::new(&settings.include, &settings.omit)?
         .with_contexts(&settings.contexts)?
         .with_path_aliases(&settings.path_aliases)?;
+    if let CoverageAction::Combine(combine) = &args.action {
+        combine::combine(combine, project.cwd(), &data_file, &filters)?;
+        return Ok(ExitStatus::Success);
+    }
+    let data_files = coverage_data_files(&data_file)?;
     let analysis =
         karva_coverage::CoverageAnalysis::load_native(project.cwd(), &data_files, &filters)?
             .with_context(|| format!("coverage data at `{data_file}` contains no source files"))?;
@@ -116,6 +121,7 @@ pub fn coverage(args: &CoverageCommand) -> Result<ExitStatus> {
             let output = absolute(&lcov.output, project.cwd());
             analysis.write_lcov(&output)?
         }
+        CoverageAction::Combine(_) => return Ok(ExitStatus::Success),
     };
     if let Some(threshold) = settings.fail_under
         && total < threshold

--- a/crates/karva/src/commands/coverage/combine.rs
+++ b/crates/karva/src/commands/coverage/combine.rs
@@ -1,0 +1,139 @@
+//! Native coverage artifact combination transaction.
+
+use std::collections::BTreeSet;
+use std::io::ErrorKind;
+
+use anyhow::{Context, Result, bail};
+use camino::{Utf8Path, Utf8PathBuf};
+use karva_cli::CoverageCombineCommand;
+use karva_coverage::CoverageFilters;
+use karva_coverage::native::NativeCoverage;
+use karva_project::path::absolute;
+
+pub(super) fn combine(
+    args: &CoverageCombineCommand,
+    project_root: &Utf8Path,
+    data_file: &Utf8Path,
+    filters: &CoverageFilters,
+) -> Result<()> {
+    let inputs = combine_inputs(args, project_root, data_file)?;
+    let mut errors = Vec::new();
+    let mut artifacts = Vec::new();
+    for path in &inputs {
+        match NativeCoverage::read(path).and_then(|artifact| filters.map_native_paths(artifact)) {
+            Ok(artifact) => artifacts.push((path, artifact)),
+            Err(error) => errors.push(format!("`{path}`: {error:#}")),
+        }
+    }
+
+    let mut combined = if args.append && data_file.exists() {
+        match NativeCoverage::read(data_file)
+            .and_then(|artifact| filters.map_native_paths(artifact))
+        {
+            Ok(artifact) => Some(artifact),
+            Err(error) => {
+                errors.push(format!("`{data_file}`: {error:#}"));
+                None
+            }
+        }
+    } else {
+        None
+    };
+    for (path, artifact) in artifacts {
+        if let Some(current) = &combined {
+            let mut candidate = current.clone();
+            match candidate.merge(artifact) {
+                Ok(()) => combined = Some(candidate),
+                Err(error) => errors.push(format!("`{path}`: {error:#}")),
+            }
+        } else {
+            combined = Some(artifact);
+        }
+    }
+    if !errors.is_empty() {
+        bail!(
+            "failed to combine native coverage artifacts:\n{}",
+            errors.join("\n")
+        );
+    }
+    let Some(combined) = combined else {
+        bail!("no native coverage artifacts found to combine");
+    };
+    combined.write(data_file)?;
+    if !args.keep {
+        for input in inputs {
+            std::fs::remove_file(&input)
+                .with_context(|| format!("combined coverage but failed to remove `{input}`"))?;
+        }
+    }
+    Ok(())
+}
+
+fn combine_inputs(
+    args: &CoverageCombineCommand,
+    project_root: &Utf8Path,
+    data_file: &Utf8Path,
+) -> Result<Vec<Utf8PathBuf>> {
+    let requested = if args.inputs.is_empty() {
+        vec![
+            data_file
+                .parent()
+                .unwrap_or_else(|| Utf8Path::new("."))
+                .join("pending"),
+        ]
+    } else {
+        args.inputs
+            .iter()
+            .map(|path| absolute(path, project_root))
+            .collect()
+    };
+    let mut files = BTreeSet::new();
+    for path in requested {
+        collect_inputs(&path, &mut files)?;
+    }
+    files.remove(data_file);
+    if files.is_empty() {
+        bail!("no native coverage artifacts found to combine");
+    }
+    Ok(files.into_iter().collect())
+}
+
+fn collect_inputs(path: &Utf8Path, files: &mut BTreeSet<Utf8PathBuf>) -> Result<()> {
+    match std::fs::metadata(path) {
+        Ok(metadata) if metadata.is_file() => {
+            files.insert(path.to_path_buf());
+        }
+        Ok(metadata) if metadata.is_dir() => {
+            for entry in std::fs::read_dir(path)
+                .with_context(|| format!("failed to read coverage artifact directory `{path}`"))?
+            {
+                let entry = entry.with_context(|| {
+                    format!("failed to read coverage artifact directory `{path}`")
+                })?;
+                let child = Utf8PathBuf::from_path_buf(entry.path()).map_err(|path| {
+                    anyhow::anyhow!(
+                        "coverage artifact path contains non-Unicode characters: `{}`",
+                        path.display()
+                    )
+                })?;
+                if entry
+                    .file_type()
+                    .with_context(|| format!("failed to inspect coverage artifact `{child}`"))?
+                    .is_dir()
+                    || child.extension() == Some("json")
+                {
+                    collect_inputs(&child, files)?;
+                }
+            }
+        }
+        Ok(_) => bail!("coverage artifact input `{path}` is not a file or directory"),
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            bail!("coverage artifact input `{path}` does not exist")
+        }
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("failed to inspect coverage artifact `{path}`"));
+        }
+    }
+    Ok(())
+}

--- a/crates/karva/tests/it/coverage_command.rs
+++ b/crates/karva/tests/it/coverage_command.rs
@@ -9,6 +9,10 @@ use crate::common::TestContext;
 const SOURCE: &str = "first = 1\nsecond = 2\n";
 
 fn write_coverage(context: &TestContext, path: &Utf8Path) {
+    write_coverage_lines(context, path, BTreeSet::from([1]));
+}
+
+fn write_coverage_lines(context: &TestContext, path: &Utf8Path, executed: BTreeSet<u32>) {
     context.write_file("src/app.py", SOURCE);
     let root = context.root();
     let artifact = NativeCoverage::new(
@@ -21,7 +25,7 @@ fn write_coverage(context: &TestContext, path: &Utf8Path) {
                 source_fingerprint: SourceFingerprint::from_bytes(SOURCE.as_bytes()),
                 executable: BTreeSet::from([1, 2]),
                 excluded: BTreeSet::new(),
-                executed: BTreeSet::from([1]),
+                executed,
                 line_contexts: BTreeMap::from([(1, BTreeSet::from(["test_example".to_owned()]))]),
                 branches: None,
             },
@@ -30,6 +34,161 @@ fn write_coverage(context: &TestContext, path: &Utf8Path) {
     artifact
         .write(&root.join(path))
         .expect("write coverage data");
+}
+
+#[test]
+fn combine_unions_pending_artifacts_and_removes_inputs() {
+    let context = TestContext::new();
+    let first = Utf8Path::new(".karva/coverage/pending/first.json");
+    let second = Utf8Path::new(".karva/coverage/pending/second.json");
+    write_coverage_lines(&context, first, BTreeSet::from([1]));
+    write_coverage_lines(&context, second, BTreeSet::from([2]));
+
+    assert_cmd_snapshot!(context.coverage("combine"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+
+    let combined = NativeCoverage::read(&context.root().join(".karva/coverage/data.json"))
+        .expect("read combined coverage");
+    let file = combined
+        .files
+        .get(Utf8Path::new("src/app.py"))
+        .expect("combined source");
+    assert_eq!(file.executed, BTreeSet::from([1, 2]));
+    assert!(!context.root().join(first).exists());
+    assert!(!context.root().join(second).exists());
+}
+
+#[test]
+fn combine_failure_preserves_output_and_inputs() {
+    let context = TestContext::new();
+    let output = Utf8Path::new(".karva/coverage/data.json");
+    let valid = Utf8Path::new("inputs/valid.json");
+    let rejected = Utf8Path::new("inputs/rejected.json");
+    write_coverage_lines(&context, output, BTreeSet::from([1]));
+    write_coverage_lines(&context, valid, BTreeSet::from([2]));
+    context.write_file(rejected.as_str(), "not native coverage");
+    let original = context.read_file(output.as_str());
+
+    assert_cmd_snapshot!(
+        context
+            .coverage("combine")
+            .args([valid.as_str(), rejected.as_str()]),
+        @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Karva failed
+      Cause: failed to combine native coverage artifacts:
+    `<temp_dir>/inputs/rejected.json`: failed to parse native coverage artifact `<temp_dir>/inputs/rejected.json`: expected ident at line 1 column 2
+    "
+    );
+
+    assert_eq!(context.read_file(output.as_str()), original);
+    assert!(context.root().join(valid).exists());
+    assert!(context.root().join(rejected).exists());
+}
+
+#[test]
+fn combine_appends_directory_inputs_and_keeps_them() {
+    let context = TestContext::new();
+    let output = Utf8Path::new(".karva/coverage/data.json");
+    let shard = Utf8Path::new("artifacts/nested/shard.json");
+    write_coverage_lines(&context, output, BTreeSet::from([1]));
+    write_coverage_lines(&context, shard, BTreeSet::from([2]));
+
+    assert_cmd_snapshot!(
+        context
+            .coverage("combine")
+            .args(["artifacts", "--append", "--keep"]),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    "
+    );
+
+    let combined = NativeCoverage::read(&context.root().join(output)).expect("read combined data");
+    let file = combined
+        .files
+        .get(Utf8Path::new("src/app.py"))
+        .expect("combined source");
+    assert_eq!(file.executed, BTreeSet::from([1, 2]));
+    assert!(context.root().join(shard).exists());
+}
+
+#[test]
+fn combine_maps_cross_platform_paths_deterministically() {
+    let context = TestContext::new();
+    context.write_file(
+        "karva.toml",
+        r"
+[profile.default.coverage]
+path-aliases = ['C:\repo=.']
+",
+    );
+    let unix = Utf8Path::new("artifacts/unix.json");
+    let windows = Utf8Path::new("artifacts/windows.json");
+    write_coverage(&context, unix);
+    let mut windows_artifact =
+        NativeCoverage::read(&context.root().join(unix)).expect("read portable coverage artifact");
+    windows_artifact.source_roots = BTreeSet::from([Utf8PathBuf::from(r"C:\repo\src")]);
+    let file = windows_artifact
+        .files
+        .remove(Utf8Path::new("src/app.py"))
+        .expect("portable source");
+    windows_artifact
+        .files
+        .insert(Utf8PathBuf::from(r"C:\repo\src\app.py"), file);
+    windows_artifact
+        .write(&context.root().join(windows))
+        .expect("write Windows artifact");
+
+    assert_cmd_snapshot!(
+        context.coverage("combine").args([
+            windows.as_str(),
+            unix.as_str(),
+            "--keep",
+        ]),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    "
+    );
+    let output = ".karva/coverage/data.json";
+    let first = context.read_file(output);
+
+    assert_cmd_snapshot!(
+        context.coverage("combine").args([
+            unix.as_str(),
+            windows.as_str(),
+            "--keep",
+        ]),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    "
+    );
+    assert_eq!(context.read_file(output), first);
+    let combined = NativeCoverage::read(&context.root().join(output)).expect("read combined data");
+    assert_eq!(
+        combined.files.keys().collect::<Vec<_>>(),
+        vec![Utf8Path::new("src/app.py")]
+    );
 }
 
 #[test]

--- a/crates/karva_cli/src/coverage.rs
+++ b/crates/karva_cli/src/coverage.rs
@@ -111,6 +111,25 @@ pub enum CoverageAction {
 
     /// Generate an LCOV tracefile.
     Lcov(CoverageLcovCommand),
+
+    /// Combine native coverage artifacts.
+    Combine(CoverageCombineCommand),
+}
+
+#[derive(Debug, Args)]
+/// Options specific to combining native coverage artifacts.
+pub struct CoverageCombineCommand {
+    /// Native coverage files or directories containing them.
+    #[arg(value_name = "PATH")]
+    pub inputs: Vec<Utf8PathBuf>,
+
+    /// Include an existing combined artifact in the result.
+    #[arg(long)]
+    pub append: bool,
+
+    /// Keep input artifacts after a successful combination.
+    #[arg(long)]
+    pub keep: bool,
 }
 
 #[derive(Debug, Args)]

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -16,8 +16,9 @@ mod verbosity;
 
 pub use cache::{CacheAction, CacheCommand};
 pub use coverage::{
-    CoverageAction, CoverageCommand, CoverageFormat, CoverageHtmlCommand, CoverageJsonCommand,
-    CoverageLcovCommand, CoverageReportCommand, CoverageSort, CoverageXmlCommand,
+    CoverageAction, CoverageCombineCommand, CoverageCommand, CoverageFormat, CoverageHtmlCommand,
+    CoverageJsonCommand, CoverageLcovCommand, CoverageReportCommand, CoverageSort,
+    CoverageXmlCommand,
 };
 pub use enums::{
     CovContext, CovReport, FlakyResult, JunitFlakyFailStatus, NoTests, OutputFormat, ResultFormat,

--- a/crates/karva_coverage/src/native.rs
+++ b/crates/karva_coverage/src/native.rs
@@ -185,6 +185,26 @@ impl NativeCoverage {
         }
         Ok(())
     }
+
+    /// Rewrites source identities and merges compatible paths that become equal.
+    pub(crate) fn map_paths(mut self, map: impl Fn(&str) -> String) -> Result<Self> {
+        self.source_roots = self
+            .source_roots
+            .iter()
+            .map(|path| Utf8PathBuf::from(map(path.as_str())))
+            .collect();
+        let mut files = BTreeMap::new();
+        for (path, incoming) in std::mem::take(&mut self.files) {
+            let mapped = Utf8PathBuf::from(map(path.as_str()));
+            if let Some(current) = files.get_mut(&mapped) {
+                merge_native_file(&mapped, current, incoming)?;
+            } else {
+                files.insert(mapped, incoming);
+            }
+        }
+        self.files = files;
+        Ok(self)
+    }
 }
 
 fn merge_worker_file(

--- a/crates/karva_coverage/src/report/mod.rs
+++ b/crates/karva_coverage/src/report/mod.rs
@@ -62,6 +62,14 @@ impl CoverageFilters {
         Ok(self)
     }
 
+    /// Applies configured aliases to native artifact source roots and file paths.
+    pub fn map_native_paths(
+        &self,
+        artifact: crate::native::NativeCoverage,
+    ) -> Result<crate::native::NativeCoverage> {
+        artifact.map_paths(|path| self.map_path(path))
+    }
+
     fn matches(&self, path: &str) -> bool {
         self.include
             .as_ref()

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -367,6 +367,7 @@ karva coverage [OPTIONS] <COMMAND>
 <dt><a href="#karva-coverage-xml"><code>karva coverage xml</code></a></dt><dd><p>Generate a Cobertura-compatible XML coverage report</p></dd>
 <dt><a href="#karva-coverage-json"><code>karva coverage json</code></a></dt><dd><p>Export documented JSON coverage data</p></dd>
 <dt><a href="#karva-coverage-lcov"><code>karva coverage lcov</code></a></dt><dd><p>Generate an LCOV tracefile</p></dd>
+<dt><a href="#karva-coverage-combine"><code>karva coverage combine</code></a></dt><dd><p>Combine native coverage artifacts</p></dd>
 <dt><a href="#karva-coverage-help"><code>karva coverage help</code></a></dt><dd><p>Print this message or the help of the given subcommand(s)</p></dd>
 </dl>
 
@@ -522,6 +523,36 @@ karva coverage lcov [OPTIONS]
 </dd><dt id="karva-coverage-lcov--output"><a href="#karva-coverage-lcov--output"><code>--output</code></a> <i>path</i></dt><dd><p>Path receiving the LCOV tracefile</p>
 <p>&#91;default: coverage.lcov&#93;</p></dd><dt id="karva-coverage-lcov--precision"><a href="#karva-coverage-lcov--precision"><code>--precision</code></a> <i>n</i></dt><dd><p>Decimal places shown in coverage percentages</p>
 </dd><dt id="karva-coverage-lcov--profile"><a href="#karva-coverage-lcov--profile"><code>--profile</code></a>, <code>-P</code> <i>name</i></dt><dd><p>Configuration profile to resolve</p>
+<p>May also be set with the <code>KARVA_PROFILE</code> environment variable.</p></dd></dl>
+
+### karva coverage combine
+
+Combine native coverage artifacts
+
+<h3 class="cli-reference">Usage</h3>
+
+```
+karva coverage combine [OPTIONS] [PATH]...
+```
+
+<h3 class="cli-reference">Arguments</h3>
+
+<dl class="cli-reference"><dt id="karva-coverage-combine--inputs"><a href="#karva-coverage-combine--inputs"><code>INPUTS</code></a></dt><dd><p>Native coverage files or directories containing them</p>
+</dd></dl>
+
+<h3 class="cli-reference">Options</h3>
+
+<dl class="cli-reference"><dt id="karva-coverage-combine--append"><a href="#karva-coverage-combine--append"><code>--append</code></a></dt><dd><p>Include an existing combined artifact in the result</p>
+</dd><dt id="karva-coverage-combine--config-file"><a href="#karva-coverage-combine--config-file"><code>--config-file</code></a> <i>path</i></dt><dd><p>The path to a <code>karva.toml</code> file to use for configuration</p>
+<p>May also be set with the <code>KARVA_CONFIG_FILE</code> environment variable.</p></dd><dt id="karva-coverage-combine--contexts"><a href="#karva-coverage-combine--contexts"><code>--contexts</code></a> <i>regex</i></dt><dd><p>Include execution attributed to a matching context regular expression</p>
+</dd><dt id="karva-coverage-combine--data-file"><a href="#karva-coverage-combine--data-file"><code>--data-file</code></a> <i>path</i></dt><dd><p>Native coverage artifact path, relative to the project root</p>
+</dd><dt id="karva-coverage-combine--fail-under"><a href="#karva-coverage-combine--fail-under"><code>--fail-under</code></a> <i>percent</i></dt><dd><p>Fail when total coverage is below this percentage</p>
+</dd><dt id="karva-coverage-combine--help"><a href="#karva-coverage-combine--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Print help</p>
+</dd><dt id="karva-coverage-combine--include"><a href="#karva-coverage-combine--include"><code>--include</code></a> <i>glob</i></dt><dd><p>Include only report paths matching this glob</p>
+</dd><dt id="karva-coverage-combine--keep"><a href="#karva-coverage-combine--keep"><code>--keep</code></a></dt><dd><p>Keep input artifacts after a successful combination</p>
+</dd><dt id="karva-coverage-combine--omit"><a href="#karva-coverage-combine--omit"><code>--omit</code></a> <i>glob</i></dt><dd><p>Exclude report paths matching this glob after inclusion</p>
+</dd><dt id="karva-coverage-combine--precision"><a href="#karva-coverage-combine--precision"><code>--precision</code></a> <i>n</i></dt><dd><p>Decimal places shown in coverage percentages</p>
+</dd><dt id="karva-coverage-combine--profile"><a href="#karva-coverage-combine--profile"><code>--profile</code></a>, <code>-P</code> <i>name</i></dt><dd><p>Configuration profile to resolve</p>
 <p>May also be set with the <code>KARVA_PROFILE</code> environment variable.</p></dd></dl>
 
 ### karva coverage help

--- a/docs/usage/writing-tests/coverage.md
+++ b/docs/usage/writing-tests/coverage.md
@@ -135,6 +135,15 @@ uv run karva coverage lcov --output build/coverage.lcov
 
 LCOV `SF`, `DA`, `LF`, `LH`, `BRDA`, `BRF`, and `BRH` records are a supported external contract. Source paths are portable project-relative paths after configured path aliases are applied.
 
+Combine native artifacts from CI shards before reporting:
+
+```bash
+uv run karva coverage combine artifacts/
+uv run karva coverage combine shard-a.json shard-b.json
+```
+
+With no paths, `combine` discovers artifacts under `.karva/coverage/pending/`. Successfully consumed inputs are removed after the combined artifact is atomically replaced. Pass `--keep` to retain them or `--append` to include the existing combined artifact.
+
 `--cov-report=html[:DIR]` writes a simple browsable HTML report. If `DIR` is omitted, karva writes `htmlcov/` in the project root:
 
 ```bash


### PR DESCRIPTION
## Summary

Add `uv run karva coverage combine` for deterministic, atomic union of native coverage artifacts from files, directories, or pending shards. Support append, keep, recursive discovery, path aliases, aggregated validation errors, and deletion only after a successful replacement.

Closes #1160.

## Test Plan

`just test` and `uvx prek run -a`