### PR TITLE
Add native coverage erase command

### DIFF
--- a/crates/karva/src/commands/coverage.rs
+++ b/crates/karva/src/commands/coverage.rs
@@ -12,6 +12,7 @@ use crate::ExitStatus;
 use crate::utils::cwd;
 
 mod combine;
+mod erase;
 
 pub fn coverage(args: &CoverageCommand) -> Result<ExitStatus> {
     let cwd = cwd()?;
@@ -33,9 +34,16 @@ pub fn coverage(args: &CoverageCommand) -> Result<ExitStatus> {
     let filters = karva_coverage::CoverageFilters::new(&settings.include, &settings.omit)?
         .with_contexts(&settings.contexts)?
         .with_path_aliases(&settings.path_aliases)?;
-    if let CoverageAction::Combine(combine) = &args.action {
-        combine::combine(combine, project.cwd(), &data_file, &filters)?;
-        return Ok(ExitStatus::Success);
+    match &args.action {
+        CoverageAction::Combine(combine) => {
+            combine::combine(combine, project.cwd(), &data_file, &filters)?;
+            return Ok(ExitStatus::Success);
+        }
+        CoverageAction::Erase => {
+            erase::erase(&data_file)?;
+            return Ok(ExitStatus::Success);
+        }
+        _ => {}
     }
     let data_files = coverage_data_files(&data_file)?;
     let analysis =
@@ -122,6 +130,7 @@ pub fn coverage(args: &CoverageCommand) -> Result<ExitStatus> {
             analysis.write_lcov(&output)?
         }
         CoverageAction::Combine(_) => return Ok(ExitStatus::Success),
+        CoverageAction::Erase => return Ok(ExitStatus::Success),
     };
     if let Some(threshold) = settings.fail_under
         && total < threshold

--- a/crates/karva/src/commands/coverage/erase.rs
+++ b/crates/karva/src/commands/coverage/erase.rs
@@ -1,0 +1,61 @@
+//! Selective native coverage data deletion.
+
+use std::io::ErrorKind;
+
+use anyhow::{Context, Result};
+use camino::{Utf8Path, Utf8PathBuf};
+use karva_coverage::native::NativeCoverage;
+
+pub(super) fn erase(data_file: &Utf8Path) -> Result<()> {
+    remove_if_present(data_file)?;
+    let pending = data_file
+        .parent()
+        .unwrap_or_else(|| Utf8Path::new("."))
+        .join("pending");
+    for shard in recognized_shards(&pending)? {
+        remove_if_present(&shard)?;
+    }
+    Ok(())
+}
+
+fn recognized_shards(directory: &Utf8Path) -> Result<Vec<Utf8PathBuf>> {
+    let entries = match std::fs::read_dir(directory) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("failed to read coverage shard directory `{directory}`"));
+        }
+    };
+    let mut shards = Vec::new();
+    for entry in entries {
+        let entry = entry
+            .with_context(|| format!("failed to read coverage shard directory `{directory}`"))?;
+        let path = Utf8PathBuf::from_path_buf(entry.path()).map_err(|path| {
+            anyhow::anyhow!(
+                "coverage shard path contains non-Unicode characters: `{}`",
+                path.display()
+            )
+        })?;
+        let file_type = entry
+            .file_type()
+            .with_context(|| format!("failed to inspect coverage shard `{path}`"))?;
+        if file_type.is_dir() {
+            shards.extend(recognized_shards(&path)?);
+        } else if file_type.is_file() && NativeCoverage::read(&path).is_ok() {
+            shards.push(path);
+        }
+    }
+    shards.sort();
+    Ok(shards)
+}
+
+fn remove_if_present(path: &Utf8Path) -> Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => {
+            Err(error).with_context(|| format!("failed to delete coverage data `{path}`"))
+        }
+    }
+}

--- a/crates/karva/tests/it/coverage_command.rs
+++ b/crates/karva/tests/it/coverage_command.rs
@@ -192,6 +192,65 @@ path-aliases = ['C:\repo=.']
 }
 
 #[test]
+fn erase_is_idempotent_and_preserves_reports_and_neighbors() {
+    let context = TestContext::new();
+    context.write_file("karva.toml", "");
+    let combined = Utf8Path::new(".karva/coverage/data.json");
+    let shard = Utf8Path::new(".karva/coverage/pending/nested/shard.json");
+    write_coverage(&context, combined);
+    write_coverage(&context, shard);
+    context.write_file(".karva/coverage/notes.json", "unrelated");
+    context.write_file(".karva/coverage/pending/notes.txt", "unrelated");
+    context.write_file("coverage.xml", "xml report");
+    context.write_file("coverage.json", "json report");
+    context.write_file("coverage.lcov", "lcov report");
+    context.write_file("htmlcov/index.html", "html report");
+    context.write_file("nested/.gitkeep", "");
+    let mut command = context.karva_command_in(context.root().join("nested"));
+    command.args(["coverage", "erase"]);
+
+    assert_cmd_snapshot!(command, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+    assert!(!context.root().join(combined).exists());
+    assert!(!context.root().join(shard).exists());
+    for path in [
+        ".karva/coverage/notes.json",
+        ".karva/coverage/pending/notes.txt",
+        "coverage.xml",
+        "coverage.json",
+        "coverage.lcov",
+        "htmlcov/index.html",
+    ] {
+        assert!(
+            context.root().join(path).exists(),
+            "expected `{path}` to survive"
+        );
+    }
+
+    assert_cmd_snapshot!(context.coverage("erase"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+    assert_cmd_snapshot!(context.coverage("report"), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Karva failed
+      Cause: no coverage data found at `<temp_dir>/.karva/coverage/data.json`; run `uv run karva test --cov` first
+    ");
+}
+
+#[test]
 fn report_reads_default_native_data() {
     let context = TestContext::new();
     write_coverage(&context, Utf8Path::new(".karva/coverage/data.json"));

--- a/crates/karva_cli/src/coverage.rs
+++ b/crates/karva_cli/src/coverage.rs
@@ -114,6 +114,9 @@ pub enum CoverageAction {
 
     /// Combine native coverage artifacts.
     Combine(CoverageCombineCommand),
+
+    /// Delete native combined and shard coverage data.
+    Erase,
 }
 
 #[derive(Debug, Args)]

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -368,6 +368,7 @@ karva coverage [OPTIONS] <COMMAND>
 <dt><a href="#karva-coverage-json"><code>karva coverage json</code></a></dt><dd><p>Export documented JSON coverage data</p></dd>
 <dt><a href="#karva-coverage-lcov"><code>karva coverage lcov</code></a></dt><dd><p>Generate an LCOV tracefile</p></dd>
 <dt><a href="#karva-coverage-combine"><code>karva coverage combine</code></a></dt><dd><p>Combine native coverage artifacts</p></dd>
+<dt><a href="#karva-coverage-erase"><code>karva coverage erase</code></a></dt><dd><p>Delete native combined and shard coverage data</p></dd>
 <dt><a href="#karva-coverage-help"><code>karva coverage help</code></a></dt><dd><p>Print this message or the help of the given subcommand(s)</p></dd>
 </dl>
 
@@ -553,6 +554,29 @@ karva coverage combine [OPTIONS] [PATH]...
 </dd><dt id="karva-coverage-combine--omit"><a href="#karva-coverage-combine--omit"><code>--omit</code></a> <i>glob</i></dt><dd><p>Exclude report paths matching this glob after inclusion</p>
 </dd><dt id="karva-coverage-combine--precision"><a href="#karva-coverage-combine--precision"><code>--precision</code></a> <i>n</i></dt><dd><p>Decimal places shown in coverage percentages</p>
 </dd><dt id="karva-coverage-combine--profile"><a href="#karva-coverage-combine--profile"><code>--profile</code></a>, <code>-P</code> <i>name</i></dt><dd><p>Configuration profile to resolve</p>
+<p>May also be set with the <code>KARVA_PROFILE</code> environment variable.</p></dd></dl>
+
+### karva coverage erase
+
+Delete native combined and shard coverage data
+
+<h3 class="cli-reference">Usage</h3>
+
+```
+karva coverage erase [OPTIONS]
+```
+
+<h3 class="cli-reference">Options</h3>
+
+<dl class="cli-reference"><dt id="karva-coverage-erase--config-file"><a href="#karva-coverage-erase--config-file"><code>--config-file</code></a> <i>path</i></dt><dd><p>The path to a <code>karva.toml</code> file to use for configuration</p>
+<p>May also be set with the <code>KARVA_CONFIG_FILE</code> environment variable.</p></dd><dt id="karva-coverage-erase--contexts"><a href="#karva-coverage-erase--contexts"><code>--contexts</code></a> <i>regex</i></dt><dd><p>Include execution attributed to a matching context regular expression</p>
+</dd><dt id="karva-coverage-erase--data-file"><a href="#karva-coverage-erase--data-file"><code>--data-file</code></a> <i>path</i></dt><dd><p>Native coverage artifact path, relative to the project root</p>
+</dd><dt id="karva-coverage-erase--fail-under"><a href="#karva-coverage-erase--fail-under"><code>--fail-under</code></a> <i>percent</i></dt><dd><p>Fail when total coverage is below this percentage</p>
+</dd><dt id="karva-coverage-erase--help"><a href="#karva-coverage-erase--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Print help</p>
+</dd><dt id="karva-coverage-erase--include"><a href="#karva-coverage-erase--include"><code>--include</code></a> <i>glob</i></dt><dd><p>Include only report paths matching this glob</p>
+</dd><dt id="karva-coverage-erase--omit"><a href="#karva-coverage-erase--omit"><code>--omit</code></a> <i>glob</i></dt><dd><p>Exclude report paths matching this glob after inclusion</p>
+</dd><dt id="karva-coverage-erase--precision"><a href="#karva-coverage-erase--precision"><code>--precision</code></a> <i>n</i></dt><dd><p>Decimal places shown in coverage percentages</p>
+</dd><dt id="karva-coverage-erase--profile"><a href="#karva-coverage-erase--profile"><code>--profile</code></a>, <code>-P</code> <i>name</i></dt><dd><p>Configuration profile to resolve</p>
 <p>May also be set with the <code>KARVA_PROFILE</code> environment variable.</p></dd></dl>
 
 ### karva coverage help

--- a/docs/usage/writing-tests/coverage.md
+++ b/docs/usage/writing-tests/coverage.md
@@ -144,6 +144,12 @@ uv run karva coverage combine shard-a.json shard-b.json
 
 With no paths, `combine` discovers artifacts under `.karva/coverage/pending/`. Successfully consumed inputs are removed after the combined artifact is atomically replaced. Pass `--keep` to retain them or `--append` to include the existing combined artifact.
 
+Delete combined native data and recognized pending shards without touching generated reports:
+
+```bash
+uv run karva coverage erase
+```
+
 `--cov-report=html[:DIR]` writes a simple browsable HTML report. If `DIR` is omitted, karva writes `htmlcov/` in the project root:
 
 ```bash


### PR DESCRIPTION
## Summary

Add idempotent `uv run karva coverage erase` deletion for the configured native artifact and recognized pending shards. Preserve generated reports and unrelated neighboring files, including when invoked from project subdirectories.

Closes #1161.

## Test Plan

`just test -p karva coverage_command` and `uvx prek run -a`