### PR TITLE
Support multiple coverage reports

### DIFF
--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -12,7 +12,7 @@ use std::time::{Duration, Instant};
 use anyhow::{Context as _, Result};
 use camino::Utf8PathBuf;
 use karva_cache::{AggregatedResults, DisplayFlakyTests};
-use karva_cli::TestCommand;
+use karva_cli::{CovReport as CliCovReport, TestCommand};
 use karva_logging::{Printer, Stdout, set_colored_override, setup_tracing};
 use karva_metadata::filter::FiltersetSet;
 use karva_metadata::{CovReport, NoTestsMode, ProjectMetadata, ProjectOptionsOverrides};
@@ -49,6 +49,8 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
     };
 
     let sub_command = args.sub_command.clone();
+    let explicit_cov_reports = sub_command.cov_report.clone();
+    let no_cov_on_fail = sub_command.no_cov_on_fail.unwrap_or(false);
     let watch = args.watch;
     let durations = args.durations;
     let result_output = args.result_output.clone();
@@ -132,7 +134,8 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
             karva_coverage::CoverageFilters::new(&coverage.include, &coverage.omit)?
                 .with_contexts(&coverage.contexts)?
                 .with_path_aliases(&coverage.path_aliases)?;
-        if coverage.report_path.is_some()
+        if explicit_cov_reports.is_empty()
+            && coverage.report_path.is_some()
             && matches!(coverage.report, CovReport::Term | CovReport::TermMissing)
         {
             let mut stdout = printer.stream_for_message().lock();
@@ -151,38 +154,30 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
             else {
                 return Ok(None);
             };
-            let total = match coverage.report {
-                CovReport::None => analysis.total_percent(),
-                CovReport::Term => analysis.report_with_precision(false, coverage.precision.0)?,
-                CovReport::TermMissing => {
-                    analysis.report_with_precision(true, coverage.precision.0)?
-                }
-                CovReport::Xml => {
-                    let output = coverage_report_path(
-                        coverage.report_path.as_deref(),
-                        "coverage.xml",
-                        project.cwd(),
-                    );
-                    analysis.write_cobertura_xml(&output)?
-                }
-                CovReport::Json => {
-                    let output = coverage_report_path(
-                        coverage.report_path.as_deref(),
-                        "coverage.json",
-                        project.cwd(),
-                    );
-                    analysis.write_json(&output)?
-                }
-                CovReport::Html => {
-                    let output = coverage_report_path(
-                        coverage.report_path.as_deref(),
-                        "htmlcov",
-                        project.cwd(),
-                    );
-                    analysis.write_html(&output)?
-                }
+            let reports = if explicit_cov_reports.is_empty() {
+                vec![configured_coverage_report(
+                    coverage.report,
+                    coverage.report_path.as_deref(),
+                )]
+            } else {
+                explicit_cov_reports.clone()
             };
-            Ok(Some(total))
+            if !no_cov_on_fail || result.is_success() {
+                for report in &reports {
+                    if let Err(error) = render_coverage_report(
+                        &analysis,
+                        report,
+                        coverage.precision.0,
+                        project.cwd(),
+                    ) {
+                        tracing::error!(
+                            "Coverage {} report failed: {error:#}",
+                            coverage_report_name(report)
+                        );
+                    }
+                }
+            }
+            Ok(Some(analysis.total_percent()))
         })();
         match coverage_result {
             Ok(total) => total,
@@ -238,6 +233,81 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
     };
     write_result_report(exit_status)?;
     Ok(exit_status)
+}
+
+fn configured_coverage_report(report: CovReport, path: Option<&str>) -> CliCovReport {
+    let path = path.map(Utf8PathBuf::from);
+    match report {
+        CovReport::None => CliCovReport::None,
+        CovReport::Term => CliCovReport::Term,
+        CovReport::TermMissing => CliCovReport::TermMissing,
+        CovReport::Xml => CliCovReport::Xml { path },
+        CovReport::Json => CliCovReport::Json { path },
+        CovReport::Html => CliCovReport::Html { path },
+        CovReport::Lcov => CliCovReport::Lcov { path },
+    }
+}
+
+fn render_coverage_report(
+    analysis: &karva_coverage::CoverageAnalysis,
+    report: &CliCovReport,
+    precision: usize,
+    project_root: &camino::Utf8Path,
+) -> Result<()> {
+    match report {
+        CliCovReport::None => {}
+        CliCovReport::Term => {
+            analysis.report_with_precision(false, precision)?;
+        }
+        CliCovReport::TermMissing => {
+            analysis.report_with_precision(true, precision)?;
+        }
+        CliCovReport::Xml { path } => {
+            let output = coverage_report_path(
+                path.as_ref().map(|path| path.as_str()),
+                "coverage.xml",
+                project_root,
+            );
+            analysis.write_cobertura_xml(&output)?;
+        }
+        CliCovReport::Json { path } => {
+            let output = coverage_report_path(
+                path.as_ref().map(|path| path.as_str()),
+                "coverage.json",
+                project_root,
+            );
+            analysis.write_json(&output)?;
+        }
+        CliCovReport::Html { path } => {
+            let output = coverage_report_path(
+                path.as_ref().map(|path| path.as_str()),
+                "htmlcov",
+                project_root,
+            );
+            analysis.write_html(&output)?;
+        }
+        CliCovReport::Lcov { path } => {
+            let output = coverage_report_path(
+                path.as_ref().map(|path| path.as_str()),
+                "coverage.lcov",
+                project_root,
+            );
+            analysis.write_lcov(&output)?;
+        }
+    }
+    Ok(())
+}
+
+fn coverage_report_name(report: &CliCovReport) -> &'static str {
+    match report {
+        CliCovReport::None => "none",
+        CliCovReport::Term => "term",
+        CliCovReport::TermMissing => "term-missing",
+        CliCovReport::Xml { .. } => "xml",
+        CliCovReport::Json { .. } => "json",
+        CliCovReport::Html { .. } => "html",
+        CliCovReport::Lcov { .. } => "lcov",
+    }
 }
 
 fn persist_coverage(

--- a/crates/karva/tests/it/common/mod.rs
+++ b/crates/karva/tests/it/common/mod.rs
@@ -79,6 +79,10 @@ impl TestContext {
         settings.add_filter(r"[-─]{30,}", "[LONG-LINE]");
         settings.add_filter(r"karva \d+\.\d+\.\d+[a-zA-Z0-9._-]*", "karva [VERSION]");
         settings.add_filter(r"karva\.exe", "karva");
+        settings.add_filter(
+            r"(?:File exists \(os error 17\)|Cannot create a file when that file already exists\. \(os error 183\))",
+            "[FILE EXISTS]",
+        );
 
         let settings_scope = settings.bind_to_scope();
 

--- a/crates/karva/tests/it/coverage.rs
+++ b/crates/karva/tests/it/coverage.rs
@@ -302,6 +302,40 @@ def test_fail():
 }
 
 #[test]
+fn test_no_cov_on_fail_skips_reports_but_saves_native_data() {
+    let context = TestContext::with_file(
+        "test_failing.py",
+        r"
+def helper():
+    return 1
+
+def test_fail():
+    assert helper() == 999
+",
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel()
+            .arg("--cov")
+            .arg("--cov-report=xml")
+            .arg("--no-cov-on-fail")
+            .arg("--status-level=none")
+            .arg("--final-status-level=none")
+            .arg("test_failing.py"),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    "
+    );
+
+    assert!(context.root().join(".karva/coverage/data.json").is_file());
+    assert!(!context.root().join("coverage.xml").exists());
+}
+
+#[test]
 fn test_cov_multiple_sources() {
     let context = TestContext::with_files([
         ("pkg_a/__init__.py", ""),
@@ -459,6 +493,98 @@ def test_only_covered():
     ----- stderr -----
     "
     );
+}
+
+#[test]
+fn test_cov_renders_multiple_reports_from_one_run() {
+    let context = TestContext::with_file(
+        "test_partial.py",
+        r"
+def covered():
+    return 1
+
+def uncovered():
+    return 2
+
+def test_only_covered():
+    assert covered() == 1
+",
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel()
+            .arg("--cov")
+            .arg("--cov-report=term-missing")
+            .arg("--cov-report=html:build/htmlcov")
+            .arg("--cov-report=xml:build/coverage.xml")
+            .arg("--cov-report=json:build/coverage.json")
+            .arg("--cov-report=lcov:build/coverage.lcov")
+            .arg("--status-level=none")
+            .arg("test_partial.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    Name              Stmts   Miss   Cover   Missing
+    [LONG-LINE]
+    test_partial.py       6      1     83%   6
+    [LONG-LINE]
+    TOTAL                 6      1     83%
+
+    ----- stderr -----
+    "
+    );
+
+    assert!(context.root().join(".karva/coverage/data.json").is_file());
+    assert!(context.root().join("build/htmlcov/index.html").is_file());
+    assert!(
+        context
+            .read_file("build/coverage.xml")
+            .contains(r#"lines-valid="6" lines-covered="5""#)
+    );
+    assert!(
+        context
+            .read_file("build/coverage.json")
+            .contains(r#""covered_lines": 5"#)
+    );
+    assert!(
+        context
+            .read_file("build/coverage.lcov")
+            .contains("LF:6\nLH:5")
+    );
+}
+
+#[test]
+fn test_cov_report_failure_does_not_block_other_reports() {
+    let context = TestContext::with_files([
+        ("test_covered.py", "def test_pass():\n    assert True\n"),
+        ("blocked", "not a directory"),
+    ]);
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel()
+            .arg("--cov")
+            .arg("--cov-report=xml:blocked/coverage.xml")
+            .arg("--cov-report=json:build/coverage.json")
+            .arg("--status-level=none")
+            .arg("test_covered.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ERROR Coverage xml report failed: failed to create coverage output directory <temp_dir>/blocked: failed to create directory `<temp_dir>/blocked`: [FILE EXISTS]
+    "
+    );
+
+    assert!(context.root().join(".karva/coverage/data.json").is_file());
+    assert!(context.root().join("build/coverage.json").is_file());
 }
 
 #[test]

--- a/crates/karva_cli/src/enums.rs
+++ b/crates/karva_cli/src/enums.rs
@@ -29,6 +29,9 @@ pub enum CovReport {
 
     /// HTML coverage report written to disk, optionally to a custom directory.
     Html { path: Option<Utf8PathBuf> },
+
+    /// LCOV tracefile written to disk, optionally to a custom path.
+    Lcov { path: Option<Utf8PathBuf> },
 }
 
 impl FromStr for CovReport {
@@ -43,8 +46,9 @@ impl FromStr for CovReport {
                 "xml" => Ok(Self::Xml { path: None }),
                 "json" => Ok(Self::Json { path: None }),
                 "html" => Ok(Self::Html { path: None }),
+                "lcov" => Ok(Self::Lcov { path: None }),
                 _ => Err(format!(
-                    "invalid value `{raw}`; expected one of `term`, `term-missing`, `xml[:PATH]`, `json[:PATH]`, or `html[:PATH]`"
+                    "invalid value `{raw}`; expected one of `term`, `term-missing`, `xml[:PATH]`, `json[:PATH]`, `html[:DIR]`, or `lcov[:PATH]`"
                 )),
             },
             Some(("xml", path)) if !path.is_empty() => Ok(Self::Xml {
@@ -56,11 +60,15 @@ impl FromStr for CovReport {
             Some(("html", path)) if !path.is_empty() => Ok(Self::Html {
                 path: Some(Utf8PathBuf::from(path)),
             }),
+            Some(("lcov", path)) if !path.is_empty() => Ok(Self::Lcov {
+                path: Some(Utf8PathBuf::from(path)),
+            }),
             Some(("xml", _)) => Err("`xml` report path cannot be empty".to_string()),
             Some(("json", _)) => Err("`json` report path cannot be empty".to_string()),
             Some(("html", _)) => Err("`html` report path cannot be empty".to_string()),
+            Some(("lcov", _)) => Err("`lcov` report path cannot be empty".to_string()),
             Some((kind, _)) => Err(format!(
-                "report `{kind}` does not accept a path; expected `term`, `term-missing`, `xml[:PATH]`, `json[:PATH]`, or `html[:PATH]`"
+                "report `{kind}` does not accept a path; expected `term`, `term-missing`, `xml[:PATH]`, `json[:PATH]`, `html[:DIR]`, or `lcov[:PATH]`"
             )),
         }
     }
@@ -119,6 +127,7 @@ impl From<CovReport> for karva_metadata::CovReport {
             CovReport::Xml { .. } => Self::Xml,
             CovReport::Json { .. } => Self::Json,
             CovReport::Html { .. } => Self::Html,
+            CovReport::Lcov { .. } => Self::Lcov,
         }
     }
 }

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -268,15 +268,27 @@ pub struct SubTestCommand {
     /// `term` (default) prints a compact terminal table.
     /// `term-missing` extends it with a `Missing` column listing the
     /// uncovered line numbers per file.
-    /// `xml[:PATH]`, `json[:PATH]`, and `html[:DIR]` write reports to disk.
+    /// `xml[:PATH]`, `json[:PATH]`, `html[:DIR]`, and `lcov[:PATH]` write reports to disk.
+    /// May be passed multiple times to render several reports from one analysis.
     /// Pass an empty value (`--cov-report=`) to persist native data only.
     #[clap(
         long = "cov-report",
         value_name = "TYPE",
         value_parser = parse_cov_report,
+        action = clap::ArgAction::Append,
         help_heading = "Coverage options"
     )]
-    pub cov_report: Option<CovReport>,
+    pub cov_report: Vec<CovReport>,
+
+    /// Do not render coverage reports when tests fail.
+    ///
+    /// Native coverage data is still persisted.
+    #[clap(
+        long = "no-cov-on-fail",
+        action = clap::ArgAction::SetTrue,
+        help_heading = "Coverage options"
+    )]
+    pub no_cov_on_fail: Option<bool>,
 
     /// Fail the run if total coverage is below the given percentage.
     ///
@@ -461,10 +473,11 @@ impl SubTestCommand {
             (None, false) => None,
         };
 
-        let coverage_report_path = self.cov_report.as_ref().and_then(|report| match report {
-            CovReport::Xml { path } | CovReport::Json { path } | CovReport::Html { path } => {
-                path.as_ref().map(ToString::to_string)
-            }
+        let coverage_report_path = self.cov_report.first().and_then(|report| match report {
+            CovReport::Xml { path }
+            | CovReport::Json { path }
+            | CovReport::Html { path }
+            | CovReport::Lcov { path } => path.as_ref().map(ToString::to_string),
             CovReport::None | CovReport::Term | CovReport::TermMissing => None,
         });
 
@@ -506,7 +519,7 @@ impl SubTestCommand {
                 contexts: None,
                 precision: None,
                 append: self.cov_append,
-                report: self.cov_report.map(Into::into),
+                report: self.cov_report.first().cloned().map(Into::into),
                 report_path: coverage_report_path,
                 branch: self.cov_branch.then_some(true),
                 fail_under: self.cov_fail_under.map(CovFailUnder),
@@ -642,6 +655,39 @@ mod tests {
     #[test]
     fn parse_html_cov_report_without_path() {
         assert_eq!(parse_cov_report("html"), Ok(CovReport::Html { path: None }));
+    }
+
+    #[test]
+    fn parse_lcov_report_with_path() {
+        assert_eq!(
+            parse_cov_report("lcov:build/coverage.lcov"),
+            Ok(CovReport::Lcov {
+                path: Some(Utf8PathBuf::from("build/coverage.lcov")),
+            })
+        );
+    }
+
+    #[test]
+    fn repeated_cov_reports_preserve_order() {
+        let command = TestCommand::parse_from([
+            "karva-test",
+            "--cov-report=term-missing",
+            "--cov-report=xml:build/coverage.xml",
+            "--cov-report=lcov:build/coverage.lcov",
+        ]);
+
+        assert_eq!(
+            command.sub_command.cov_report,
+            vec![
+                CovReport::TermMissing,
+                CovReport::Xml {
+                    path: Some(Utf8PathBuf::from("build/coverage.xml")),
+                },
+                CovReport::Lcov {
+                    path: Some(Utf8PathBuf::from("build/coverage.lcov")),
+                },
+            ]
+        );
     }
 
     #[test]

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -704,7 +704,7 @@ pub struct CoverageOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[option(
         default = r#"term"#,
-        value_type = r#"none | term | term-missing | xml | json | html"#,
+        value_type = r#"none | term | term-missing | xml | json | html | lcov"#,
         example = r#"
             report = "term-missing"
         "#
@@ -713,10 +713,10 @@ pub struct CoverageOptions {
 
     /// Optional output path for machine-readable coverage reports.
     ///
-    /// When `report = "xml"` or `report = "json"`, this path controls where
-    /// the file is written. When `report = "html"`, it controls the output
-    /// directory. If omitted, karva writes to `coverage.xml`,
-    /// `coverage.json`, or `htmlcov/` in the project root.
+    /// For XML, JSON, and LCOV reports, this controls the output file. For HTML,
+    /// it controls the output directory. If omitted, karva writes to
+    /// `coverage.xml`, `coverage.json`, `coverage.lcov`, or `htmlcov/` in the
+    /// project root.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[option(
         default = r#"null"#,
@@ -921,6 +921,9 @@ pub enum CovReport {
 
     /// HTML written to disk for interactive browsing.
     Html,
+
+    /// LCOV tracefile written to disk for external tooling.
+    Lcov,
 }
 
 impl Combine for CovReport {
@@ -943,6 +946,7 @@ impl CovReport {
             Self::Xml => "xml",
             Self::Json => "json",
             Self::Html => "html",
+            Self::Lcov => "lcov",
         }
     }
 }

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -220,7 +220,7 @@ uncovered line numbers per file. `none` persists native data only.
 
 **Default value**: `term`
 
-**Type**: `none | term | term-missing | xml | json | html`
+**Type**: `none | term | term-missing | xml | json | html | lcov`
 
 **Example usage** (`pyproject.toml`):
 
@@ -235,10 +235,10 @@ report = "term-missing"
 
 Optional output path for machine-readable coverage reports.
 
-When `report = "xml"` or `report = "json"`, this path controls where
-the file is written. When `report = "html"`, it controls the output
-directory. If omitted, karva writes to `coverage.xml`,
-`coverage.json`, or `htmlcov/` in the project root.
+For XML, JSON, and LCOV reports, this controls the output file. For HTML,
+it controls the output directory. If omitted, karva writes to
+`coverage.xml`, `coverage.json`, `coverage.lcov`, or `htmlcov/` in the
+project root.
 
 **Default value**: `null`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -68,7 +68,7 @@ karva test [OPTIONS] [PATH]...
 </dd><dt id="karva-test--cov-omit"><a href="#karva-test--cov-omit"><code>--cov-omit</code></a> <i>glob</i></dt><dd><p>Exclude coverage report files whose project-relative path matches this glob.</p>
 <p>May be passed multiple times.</p>
 </dd><dt id="karva-test--cov-report"><a href="#karva-test--cov-report"><code>--cov-report</code></a> <i>type</i></dt><dd><p>Coverage report type.</p>
-<p><code>term</code> (default) prints a compact terminal table. <code>term-missing</code> extends it with a <code>Missing</code> column listing the uncovered line numbers per file. <code>xml&#91;:PATH&#93;</code>, <code>json&#91;:PATH&#93;</code>, and <code>html&#91;:DIR&#93;</code> write reports to disk. Pass an empty value (<code>--cov-report=</code>) to persist native data only.</p>
+<p><code>term</code> (default) prints a compact terminal table. <code>term-missing</code> extends it with a <code>Missing</code> column listing the uncovered line numbers per file. <code>xml&#91;:PATH&#93;</code>, <code>json&#91;:PATH&#93;</code>, <code>html&#91;:DIR&#93;</code>, and <code>lcov&#91;:PATH&#93;</code> write reports to disk. May be passed multiple times to render several reports from one analysis. Pass an empty value (<code>--cov-report=</code>) to persist native data only.</p>
 </dd><dt id="karva-test--durations"><a href="#karva-test--durations"><code>--durations</code></a> <i>n</i></dt><dd><p>Show the N slowest tests after the run completes</p>
 </dd><dt id="karva-test--fail-fast"><a href="#karva-test--fail-fast"><code>--fail-fast</code></a> <i>fail-fast</i></dt><dd><p>Stop scheduling new tests after the first failure.</p>
 <p>Equivalent to <code>--max-fail=1</code>. Use <code>--no-fail-fast</code> to keep running after failures.</p>
@@ -113,6 +113,8 @@ karva test [OPTIONS] [PATH]...
 <p>Lets stdout/stderr from tests flow directly to the terminal, useful when debugging with print statements or interactive debuggers. Implies <code>--show-output</code> and forces a single worker so output from concurrent tests cannot interleave.</p>
 </dd><dt id="karva-test--no-cov"><a href="#karva-test--no-cov"><code>--no-cov</code></a></dt><dd><p>Disable coverage measurement for this run.</p>
 <p>Overrides any <code>--cov</code> flag and any <code>&#91;coverage&#93; sources</code> configured in <code>karva.toml</code> / <code>pyproject.toml</code>. Useful when iterating locally without editing config.</p>
+</dd><dt id="karva-test--no-cov-on-fail"><a href="#karva-test--no-cov-on-fail"><code>--no-cov-on-fail</code></a></dt><dd><p>Do not render coverage reports when tests fail.</p>
+<p>Native coverage data is still persisted.</p>
 </dd><dt id="karva-test--no-fail-fast"><a href="#karva-test--no-fail-fast"><code>--no-fail-fast</code></a></dt><dd><p>Run every test regardless of how many fail.</p>
 <p>Clears any <code>fail-fast</code> or <code>max-fail</code> value set in configuration. When <code>--max-fail</code> is provided alongside <code>--no-fail-fast</code>, <code>--max-fail</code> takes precedence.</p>
 </dd><dt id="karva-test--no-ignore"><a href="#karva-test--no-ignore"><code>--no-ignore</code></a> <i>no-ignore</i></dt><dd><p>When set, .gitignore files will not be respected</p>

--- a/karva.schema.json
+++ b/karva.schema.json
@@ -64,6 +64,11 @@
           "description": "HTML written to disk for interactive browsing.",
           "type": "string",
           "const": "html"
+        },
+        {
+          "description": "LCOV tracefile written to disk for external tooling.",
+          "type": "string",
+          "const": "lcov"
         }
       ]
     },
@@ -166,7 +171,7 @@
           ]
         },
         "report-path": {
-          "description": "Optional output path for machine-readable coverage reports.\n\nWhen `report = \"xml\"` or `report = \"json\"`, this path controls where\nthe file is written. When `report = \"html\"`, it controls the output\ndirectory. If omitted, karva writes to `coverage.xml`,\n`coverage.json`, or `htmlcov/` in the project root.",
+          "description": "Optional output path for machine-readable coverage reports.\n\nFor XML, JSON, and LCOV reports, this controls the output file. For HTML,\nit controls the output directory. If omitted, karva writes to\n`coverage.xml`, `coverage.json`, `coverage.lcov`, or `htmlcov/` in the\nproject root.",
           "type": [
             "string",
             "null"


### PR DESCRIPTION
## Summary

Make `--cov-report` repeatable across terminal, HTML, XML, JSON, and LCOV outputs while loading native coverage once. Preserve raw-data-only mode, render after failures by default, isolate renderer failures, and add `--no-cov-on-fail`.

Closes #1162.

## Test Plan

`just test` and `uvx prek run -a`
