### PR TITLE
Resolve importable coverage sources

### DIFF
--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -335,7 +335,6 @@ fn persist_coverage(
     };
     let current = karva_coverage::native::NativeCoverage::from_worker_files(
         project.cwd(),
-        &settings.sources,
         mode,
         worker_files,
     )?;

--- a/crates/karva/tests/it/coverage.rs
+++ b/crates/karva/tests/it/coverage.rs
@@ -498,6 +498,96 @@ def test_all():
 }
 
 #[test]
+fn test_cov_resolves_importable_sources() {
+    let context = TestContext::with_files([
+        ("external_one/example_module.py", "value = 1\n"),
+        (
+            "external_one/example_package/__init__.py",
+            "from .used import value\n",
+        ),
+        ("external_one/example_package/used.py", "value = 2\n"),
+        ("external_one/example_package/unused.py", "value = 3\n"),
+        ("external_one/namespace_pkg/one.py", "one = 1\n"),
+        ("external_two/namespace_pkg/two.py", "two = 2\n"),
+        (
+            "test_importable.py",
+            r"
+from example_module import value as module_value
+from example_package import value as package_value
+from namespace_pkg.one import one
+from namespace_pkg.two import two
+
+def test_values():
+    assert module_value + package_value + one + two == 6
+",
+        ),
+    ]);
+    let python_path = std::env::join_paths([
+        context.root().join("external_one"),
+        context.root().join("external_two"),
+    ])
+    .expect("valid Python path");
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel()
+            .env("PYTHONPATH", python_path)
+            .arg("--cov=example_module")
+            .arg("--cov=example_package")
+            .arg("--cov=namespace_pkg")
+            .arg("--cov-report=term-missing")
+            .arg("--status-level=none")
+            .arg("test_importable.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    Name                                       Stmts   Miss   Cover   Missing
+    [LONG-LINE]
+    external_one/example_module.py                 1      0    100%
+    external_one/example_package/__init__.py       1      0    100%
+    external_one/example_package/unused.py         1      1      0%   1
+    external_one/example_package/used.py           1      0    100%
+    external_one/namespace_pkg/one.py              1      0    100%
+    external_two/namespace_pkg/two.py              1      0    100%
+    [LONG-LINE]
+    TOTAL                                          6      1     83%
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
+fn test_cov_reports_unresolved_importable_source() {
+    let context =
+        TestContext::with_file("test_example.py", "def test_example():\n    assert True\n");
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel()
+            .arg("--cov=does_not_exist")
+            .arg("--status-level=none")
+            .arg("test_example.py"),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    diagnostics:
+
+    error[failed-to-start-coverage]: Failed to start coverage measurement: coverage source `does_not_exist` was not found as path `<temp_dir>/does_not_exist` or as an importable module
+
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
 fn test_cov_basic() {
     let context = TestContext::with_file(
         "test_covered.py",

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -193,7 +193,7 @@ pub struct SubTestCommand {
     )]
     pub final_status_level: Option<FinalStatusLevel>,
 
-    /// Measure code coverage for the given source path.
+    /// Measure code coverage for a source path or importable Python name.
     ///
     /// May be passed multiple times to measure several sources. Pass without
     /// a value (`--cov`) to measure the current working directory.

--- a/crates/karva_coverage/src/data.rs
+++ b/crates/karva_coverage/src/data.rs
@@ -8,6 +8,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Serialize, Deserialize)]
 /// Coverage payload persisted by one worker, keyed by normalized source path.
 pub struct WorkerFile {
+    /// Canonical source roots resolved by the worker's Python environment.
+    #[serde(default)]
+    pub source_roots: BTreeSet<String>,
+
     /// Per-source coverage collected by the worker.
     pub files: BTreeMap<String, FileEntry>,
 }

--- a/crates/karva_coverage/src/native.rs
+++ b/crates/karva_coverage/src/native.rs
@@ -120,7 +120,6 @@ impl NativeCoverage {
     /// Builds one durable artifact by unioning transient worker payloads.
     pub fn from_worker_files(
         project_root: &Utf8Path,
-        source_roots: &[String],
         mode: CoverageMode,
         files: &[impl AsRef<Utf8Path>],
     ) -> Result<Self> {
@@ -133,6 +132,7 @@ impl NativeCoverage {
             )
         })?;
         let mut native_files = BTreeMap::new();
+        let mut source_roots = BTreeSet::new();
 
         for worker_path in files {
             let worker_path = worker_path.as_ref();
@@ -140,6 +140,7 @@ impl NativeCoverage {
                 .with_context(|| format!("failed to read coverage file `{worker_path}`"))?;
             let worker: WorkerFile = serde_json::from_slice(&bytes)
                 .with_context(|| format!("failed to parse coverage file `{worker_path}`"))?;
+            source_roots.extend(worker.source_roots);
             for (source, file) in worker.files {
                 merge_worker_file(
                     &canonical_root,
@@ -154,7 +155,10 @@ impl NativeCoverage {
 
         Ok(Self::new(
             mode,
-            normalize_source_roots(&canonical_root, source_roots)?,
+            normalize_source_roots(
+                &canonical_root,
+                &source_roots.into_iter().collect::<Vec<_>>(),
+            )?,
             None,
             native_files,
         ))
@@ -561,6 +565,7 @@ mod tests {
         let first_worker = project_root.join("first-worker.json");
         let second_worker = project_root.join("second-worker.json");
         let worker = |executed, context: &str| WorkerFile {
+            source_roots: BTreeSet::from([source.to_string()]),
             files: BTreeMap::from([(
                 source.to_string(),
                 crate::data::FileEntry {
@@ -583,20 +588,12 @@ mod tests {
         )
         .expect("write second worker");
 
-        let mut first = NativeCoverage::from_worker_files(
-            &project_root,
-            &["app.py".to_owned()],
-            CoverageMode::Line,
-            &[first_worker],
-        )
-        .expect("build first artifact");
-        let second = NativeCoverage::from_worker_files(
-            &project_root,
-            &["app.py".to_owned()],
-            CoverageMode::Line,
-            &[second_worker],
-        )
-        .expect("build second artifact");
+        let mut first =
+            NativeCoverage::from_worker_files(&project_root, CoverageMode::Line, &[first_worker])
+                .expect("build first artifact");
+        let second =
+            NativeCoverage::from_worker_files(&project_root, CoverageMode::Line, &[second_worker])
+                .expect("build second artifact");
 
         first.merge(second).expect("append compatible artifact");
 

--- a/crates/karva_coverage/src/tracer.rs
+++ b/crates/karva_coverage/src/tracer.rs
@@ -11,6 +11,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use fs_err as fs;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 use crate::branches::branch_arcs_with_exclusions;
@@ -55,18 +56,7 @@ impl CoverageSession {
     pub fn start(py: Python<'_>, cwd: &Utf8Path, config: &CoverageConfig) -> PyResult<Self> {
         let exclusions = CoverageExclusions::new(&config.exclude_lines)
             .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?;
-        let roots: Vec<PathBuf> = config
-            .sources
-            .iter()
-            .map(|s| {
-                let raw = if s.is_empty() {
-                    cwd.as_str()
-                } else {
-                    s.as_str()
-                };
-                fs::canonicalize(raw).unwrap_or_else(|_| PathBuf::from(raw))
-            })
-            .collect();
+        let roots = resolve_source_roots(py, cwd, &config.sources)?;
 
         let tracer = Py::new(
             py,
@@ -579,18 +569,86 @@ fn compute_tracked_path(filename: &str, roots: &[PathBuf]) -> Option<PathBuf> {
         return None;
     }
     let canonical = fs::canonicalize(filename).ok()?;
-    if canonical
-        .components()
-        .any(|c| PATH_EXCLUDES.contains(&c.as_os_str().to_str().unwrap_or("")))
-    {
-        return None;
-    }
     for root in roots {
-        if canonical == *root || canonical.starts_with(root) {
+        if canonical == *root {
+            return Some(canonical);
+        }
+        let Ok(relative) = canonical.strip_prefix(root) else {
+            continue;
+        };
+        if !relative
+            .components()
+            .any(|component| PATH_EXCLUDES.contains(&component.as_os_str().to_str().unwrap_or("")))
+        {
             return Some(canonical);
         }
     }
     None
+}
+
+fn resolve_source_roots(
+    py: Python<'_>,
+    cwd: &Utf8Path,
+    sources: &[String],
+) -> PyResult<Vec<PathBuf>> {
+    let importlib = py.import("importlib.util")?;
+    let mut roots = BTreeSet::new();
+
+    for source in sources {
+        let candidate = if source.is_empty() {
+            cwd.to_path_buf()
+        } else {
+            cwd.join(source)
+        };
+        if candidate.exists() {
+            roots.insert(fs::canonicalize(candidate)?);
+            continue;
+        }
+
+        let spec = importlib.call_method1("find_spec", (source,)).map_err(|error| {
+            PyValueError::new_err(format!(
+                "coverage source `{source}` was not found as path `{candidate}` and import lookup failed: {error}"
+            ))
+        })?;
+        if spec.is_none() {
+            return Err(PyValueError::new_err(format!(
+                "coverage source `{source}` was not found as path `{candidate}` or as an importable module"
+            )));
+        }
+
+        let locations = spec.getattr("submodule_search_locations")?;
+        if !locations.is_none() {
+            for location in locations.try_iter()? {
+                let location: String = location?.extract()?;
+                roots.insert(fs::canonicalize(&location).map_err(|error| {
+                    PyValueError::new_err(format!(
+                        "failed to resolve imported coverage source `{source}` at `{location}`: {error}"
+                    ))
+                })?);
+            }
+            continue;
+        }
+
+        let origin: Option<String> = spec.getattr("origin")?.extract()?;
+        let Some(origin) = origin else {
+            return Err(PyValueError::new_err(format!(
+                "importable coverage source `{source}` has no Python source file"
+            )));
+        };
+        let origin_path = PathBuf::from(&origin);
+        if !is_python_source(&origin_path) {
+            return Err(PyValueError::new_err(format!(
+                "importable coverage source `{source}` has no Python source file (origin: `{origin}`)"
+            )));
+        }
+        roots.insert(fs::canonicalize(&origin_path).map_err(|error| {
+            PyValueError::new_err(format!(
+                "failed to resolve imported coverage source `{source}` at `{origin}`: {error}"
+            ))
+        })?);
+    }
+
+    Ok(roots.into_iter().collect())
 }
 
 fn py_version_at_least(py: Python<'_>, major: u8, minor: u8) -> PyResult<bool> {
@@ -870,7 +928,14 @@ fn save_data(
     {
         fs::create_dir_all(parent.as_std_path())?;
     }
-    let bytes = serde_json::to_vec(&WorkerFile { files })?;
+    let source_roots = roots
+        .iter()
+        .map(|root| root.to_string_lossy().into_owned())
+        .collect();
+    let bytes = serde_json::to_vec(&WorkerFile {
+        source_roots,
+        files,
+    })?;
     fs::write(data_file.as_std_path(), bytes)
 }
 
@@ -880,6 +945,38 @@ mod tests {
     use pyo3::types::PyDict;
 
     use super::*;
+
+    #[test]
+    fn source_path_takes_precedence_over_import_lookup() {
+        let directory = tempfile::tempdir().expect("temp directory");
+        let cwd = Utf8Path::from_path(directory.path()).expect("UTF-8 path");
+        fs::create_dir(cwd.join("ambiguous")).expect("source directory");
+
+        Python::initialize();
+        let roots = Python::attach(|py| resolve_source_roots(py, cwd, &["ambiguous".to_string()]))
+            .expect("resolved source");
+
+        assert_eq!(
+            roots,
+            vec![fs::canonicalize(cwd.join("ambiguous")).expect("canonical source")]
+        );
+    }
+
+    #[test]
+    fn sourceless_import_is_rejected() {
+        let directory = tempfile::tempdir().expect("temp directory");
+        let cwd = Utf8Path::from_path(directory.path()).expect("UTF-8 path");
+
+        Python::initialize();
+        let error = Python::attach(|py| resolve_source_roots(py, cwd, &["sys".to_string()]))
+            .expect_err("built-in module has no source");
+
+        assert!(
+            error
+                .to_string()
+                .contains("importable coverage source `sys` has no Python source file")
+        );
+    }
 
     #[test]
     fn record_arc_attributes_the_current_context() {

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -619,9 +619,9 @@ pub struct CoverageOptions {
     )]
     pub path_aliases: Option<Vec<String>>,
 
-    /// Source paths to measure coverage for.
+    /// Source paths or importable Python names to measure coverage for.
     ///
-    /// Equivalent to passing `--cov=<path>` on the command line; may be
+    /// Equivalent to passing `--cov=<source>` on the command line; may be
     /// listed multiple times. An empty entry (`""`) measures the current
     /// working directory, matching pytest-cov's bare `--cov`.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -32,6 +32,17 @@ struct FailedFunctionCallOptions {
 }
 
 declare_diagnostic_type! {
+    /// ## Failed to start coverage
+    ///
+    /// Raised when configured coverage sources cannot be resolved by the
+    /// worker's Python environment.
+    pub static FAILED_TO_START_COVERAGE = {
+        summary: "Failed to start coverage measurement",
+        severity: Severity::Error,
+    }
+}
+
+declare_diagnostic_type! {
     /// ## Failed to collect module
     ///
     /// Raised when karva cannot read a Python file during collection. This is
@@ -41,6 +52,10 @@ declare_diagnostic_type! {
         summary: "Failed to collect python module",
         severity: Severity::Error,
     }
+}
+
+pub fn failed_to_start_coverage_diagnostic(reason: &str) -> Diagnostic {
+    FAILED_TO_START_COVERAGE.diagnostic(format!("Failed to start coverage measurement: {reason}"))
 }
 
 declare_diagnostic_type! {

--- a/crates/karva_test_semantic/src/lib.rs
+++ b/crates/karva_test_semantic/src/lib.rs
@@ -22,6 +22,7 @@ use karva_metadata::ProjectSettings;
 use karva_project::path::{TestPath, TestPathError};
 use ruff_python_ast::PythonVersion;
 
+use crate::diagnostic::failed_to_start_coverage_diagnostic;
 use crate::discovery::{DiscoveryIssue, StandardDiscoverer};
 use crate::py_attach::attach_with_output;
 use crate::runner::PackageRunner;
@@ -45,7 +46,9 @@ pub fn run_tests(
         let cov_session = coverage.and_then(|cfg| match CoverageSession::start(py, cwd, cfg) {
             Ok(session) => Some(session),
             Err(err) => {
-                tracing::error!("Failed to start coverage measurement: {err}");
+                state.add_run_diagnostic(failed_to_start_coverage_diagnostic(
+                    &err.value(py).to_string(),
+                ));
                 None
             }
         });

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -272,9 +272,9 @@ report-path = "build/coverage.xml"
 
 ### `sources`
 
-Source paths to measure coverage for.
+Source paths or importable Python names to measure coverage for.
 
-Equivalent to passing `--cov=<path>` on the command line; may be
+Equivalent to passing `--cov=<source>` on the command line; may be
 listed multiple times. An empty entry (`""`) measures the current
 working directory, matching pytest-cov's bare `--cov`.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -48,7 +48,7 @@ karva test [OPTIONS] [PATH]...
 <li><code>never</code>:  Never display colors</li>
 </ul></dd><dt id="karva-test--config-file"><a href="#karva-test--config-file"><code>--config-file</code></a> <i>path</i></dt><dd><p>The path to a <code>karva.toml</code> file to use for configuration.</p>
 <p>While karva configuration can be included in a <code>pyproject.toml</code> file, it is not allowed in this context.</p>
-<p>May also be set with the <code>KARVA_CONFIG_FILE</code> environment variable.</p></dd><dt id="karva-test--cov"><a href="#karva-test--cov"><code>--cov</code></a> <i>source</i></dt><dd><p>Measure code coverage for the given source path.</p>
+<p>May also be set with the <code>KARVA_CONFIG_FILE</code> environment variable.</p></dd><dt id="karva-test--cov"><a href="#karva-test--cov"><code>--cov</code></a> <i>source</i></dt><dd><p>Measure code coverage for a source path or importable Python name.</p>
 <p>May be passed multiple times to measure several sources. Pass without a value (<code>--cov</code>) to measure the current working directory.</p>
 </dd><dt id="karva-test--cov-append"><a href="#karva-test--cov-append"><code>--cov-append</code></a> <i>cov-append</i></dt><dd><p>Add this run to compatible native coverage data instead of replacing it</p>
 <p>Possible values:</p>

--- a/docs/usage/writing-tests/coverage.md
+++ b/docs/usage/writing-tests/coverage.md
@@ -20,11 +20,12 @@ test_control.py      18      3     83%
 TOTAL                18      3     83%
 ```
 
-Pass a path to limit measurement to specific source roots, or pass `--cov` multiple times to measure several:
+Pass a path or importable module or package name to limit measurement to specific source roots. Pass `--cov` multiple times to measure several:
 
 ```bash
-karva test --cov=src
-karva test --cov=pkg_a --cov=pkg_b
+uv run karva test --cov=src
+uv run karva test --cov=example_package
+uv run karva test --cov=pkg_a --cov=pkg_b
 ```
 
 Equivalent configuration:
@@ -226,7 +227,9 @@ The match is case-insensitive (`# PRAGMA: NO COVER` works) and is only recognise
 
 ## Source roots
 
-Every `--cov` value is canonicalised to an absolute path. A file is included in the report if its path lives under at least one source root and does not contain any of `site-packages`, `dist-packages`, `.venv`, or `.tox` — installed third-party code is filtered automatically.
+Karva first treats each `--cov` value as a path relative to the project root. If that path does not exist, Karva resolves it as a module, regular package, or namespace package using the selected Python environment. Existing paths therefore take precedence over importable names. Modules without Python source and unresolved names produce an error naming both attempted interpretations.
+
+Files under explicitly selected importable packages are measured even when they live in `site-packages` or a virtual environment. Broad path sources still skip nested `site-packages`, `dist-packages`, `.venv`, and `.tox` directories.
 
 ## Parallel runs
 

--- a/karva.schema.json
+++ b/karva.schema.json
@@ -192,7 +192,7 @@
           ]
         },
         "sources": {
-          "description": "Source paths to measure coverage for.\n\nEquivalent to passing `--cov=<path>` on the command line; may be\nlisted multiple times. An empty entry (`\"\"`) measures the current\nworking directory, matching pytest-cov's bare `--cov`.",
+          "description": "Source paths or importable Python names to measure coverage for.\n\nEquivalent to passing `--cov=<source>` on the command line; may be\nlisted multiple times. An empty entry (`\"\"`) measures the current\nworking directory, matching pytest-cov's bare `--cov`.",
           "type": [
             "array",
             "null"


### PR DESCRIPTION
## Summary

Resolve coverage sources as existing paths first, then as importable modules, regular packages, or namespace packages through the worker Python environment. Persist resolved roots in native artifacts, report actionable source errors, and document the precedence and installed-package behavior.

Closes #1080.

## Test Plan

Coverage integration tests, workspace Clippy, and pre-commit hooks.