### PR TITLE
Add phase-aware coverage contexts

### DIFF
--- a/crates/karva/tests/it/coverage.rs
+++ b/crates/karva/tests/it/coverage.rs
@@ -1217,19 +1217,28 @@ def test_two():
           "missing_lines": [],
           "excluded_lines": [],
           "contexts": {
+            "1": [
+              "session"
+            ],
             "2": [
-              "test_context::test_one",
-              "test_context::test_two"
+              "test_context::test_one|run",
+              "test_context::test_two|run"
             ],
             "3": [
-              "test_context::test_one",
-              "test_context::test_two"
+              "test_context::test_one|run",
+              "test_context::test_two|run"
+            ],
+            "5": [
+              "session"
             ],
             "6": [
-              "test_context::test_one"
+              "test_context::test_one|run"
+            ],
+            "8": [
+              "session"
             ],
             "9": [
-              "test_context::test_two"
+              "test_context::test_two|run"
             ]
           }
         }
@@ -1241,6 +1250,146 @@ def test_two():
       }
     }
     "#);
+}
+
+#[test]
+fn test_cov_context_records_static_test_phases_and_filters_reports() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.default.coverage]
+sources = ["src"]
+context = "python=3.14"
+"#,
+        ),
+        (
+            "src/app.py",
+            r"
+def setup_value():
+    return 1
+
+def run_value(value):
+    return value
+
+def teardown_value():
+    return None
+",
+        ),
+        (
+            "test_context_phases.py",
+            r#"
+import karva
+import pytest
+from src.app import run_value, setup_value, teardown_value
+
+@karva.fixture
+def lifecycle():
+    setup_value()
+    yield
+    teardown_value()
+
+@karva.tags.parametrize("value", [
+    pytest.param(1, id="one"),
+    pytest.param(2, id="two"),
+])
+def test_phase(lifecycle, value):
+    assert run_value(value) == value
+"#,
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context.command().args([
+            "--num-workers=2",
+            "--cov-context=test",
+            "--cov-report=json",
+            "--status-level=none",
+            "test_context_phases.py",
+        ]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+
+    insta::assert_snapshot!(context.read_file("coverage.json"), @r#"
+    {
+      "meta": {
+        "format": 2,
+        "version": "karva",
+        "show_contexts": true
+      },
+      "files": {
+        "src/app.py": {
+          "executed_lines": [
+            2,
+            3,
+            5,
+            6,
+            8,
+            9
+          ],
+          "summary": {
+            "covered_lines": 6,
+            "num_statements": 6,
+            "percent_covered": 100.0,
+            "missing_lines": [],
+            "excluded_lines": []
+          },
+          "missing_lines": [],
+          "excluded_lines": [],
+          "contexts": {
+            "2": [
+              "python=3.14|session"
+            ],
+            "3": [
+              "python=3.14|test_context_phases::test_phase(one)|setup",
+              "python=3.14|test_context_phases::test_phase(two)|setup"
+            ],
+            "5": [
+              "python=3.14|session"
+            ],
+            "6": [
+              "python=3.14|test_context_phases::test_phase(one)|run",
+              "python=3.14|test_context_phases::test_phase(two)|run"
+            ],
+            "8": [
+              "python=3.14|session"
+            ],
+            "9": [
+              "python=3.14|test_context_phases::test_phase(one)|teardown",
+              "python=3.14|test_context_phases::test_phase(two)|teardown"
+            ]
+          }
+        }
+      },
+      "totals": {
+        "covered_lines": 6,
+        "num_statements": 6,
+        "percent_covered": 100.0
+      }
+    }
+    "#);
+
+    assert_cmd_snapshot!(
+        context
+            .coverage("report")
+            .args(["--contexts", r"\|setup$", "--format", "total"]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    17
+
+    ----- stderr -----
+    "
+    );
 }
 
 #[test]
@@ -1313,11 +1462,17 @@ def test_flaky():
           "missing_lines": [],
           "excluded_lines": [],
           "contexts": {
+            "1": [
+              "session"
+            ],
             "2": [
-              "test_retry::test_flaky"
+              "test_retry::test_flaky|run"
+            ],
+            "4": [
+              "session"
             ],
             "5": [
-              "test_retry::test_flaky"
+              "test_retry::test_flaky|run"
             ]
           }
         }

--- a/crates/karva_cli/src/coverage.rs
+++ b/crates/karva_cli/src/coverage.rs
@@ -83,6 +83,7 @@ impl CoverageCommand {
                 path_aliases: None,
                 include: (!self.include.is_empty()).then(|| self.include.clone()),
                 omit: (!self.omit.is_empty()).then(|| self.omit.clone()),
+                context: None,
                 contexts: (!self.contexts.is_empty()).then(|| self.contexts.clone()),
                 precision: self.precision,
                 append: None,

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -319,6 +319,10 @@ pub struct SubTestCommand {
     #[clap(long, hide = true, action = clap::ArgAction::Append)]
     pub cov_partial_branch: Vec<String>,
 
+    /// Internal: static coverage context forwarded to workers.
+    #[clap(long, hide = true)]
+    pub cov_static_context: Option<String>,
+
     /// Internal: a single per-test override entry, encoded as JSON.
     ///
     /// Workers receive overrides from the main process via this flag, one
@@ -526,6 +530,7 @@ impl SubTestCommand {
                 omit: (!self.cov_omit.is_empty()).then_some(self.cov_omit),
                 exclude_lines: None,
                 partial_branches: None,
+                context: None,
                 contexts: None,
                 precision: None,
                 append: self.cov_append,

--- a/crates/karva_coverage/src/context.rs
+++ b/crates/karva_coverage/src/context.rs
@@ -1,0 +1,48 @@
+//! Stable formatting for static and dynamic coverage contexts.
+
+/// Context used for execution outside a concrete test lifecycle.
+pub(crate) const SESSION_CONTEXT: &str = "session";
+
+/// Internal context replaced once first-attempt fixture setup reveals the full test identity.
+pub(crate) const PENDING_SETUP_CONTEXT: &str = "\0karva-pending-setup";
+
+/// Escapes one context component before `|`-separated composition.
+fn escape_component(component: &str) -> String {
+    component.replace('\\', "\\\\").replace('|', "\\|")
+}
+
+/// Formats optional static context followed by dynamic context components.
+pub(crate) fn compose_context(static_context: Option<&str>, dynamic: &[&str]) -> Option<String> {
+    static_context
+        .into_iter()
+        .chain(dynamic.iter().copied())
+        .map(escape_component)
+        .reduce(|mut context, component| {
+            context.push('|');
+            context.push_str(&component);
+            context
+        })
+}
+
+/// Prefixes an already-formatted dynamic context with one static component.
+pub(crate) fn prefix_context(static_context: &str, dynamic: &str) -> String {
+    let mut context = escape_component(static_context);
+    if !dynamic.is_empty() {
+        context.push('|');
+        context.push_str(dynamic);
+    }
+    context
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn context_components_escape_separators_and_backslashes() {
+        assert_eq!(
+            compose_context(Some(r"os=win\dows"), &["test|case", "run"]),
+            Some(r"os=win\\dows|test\|case|run".to_owned())
+        );
+    }
+}

--- a/crates/karva_coverage/src/lib.rs
+++ b/crates/karva_coverage/src/lib.rs
@@ -19,6 +19,7 @@
 #![warn(unreachable_pub)]
 
 pub(crate) mod branches;
+pub mod context;
 pub mod data;
 pub mod executable;
 pub mod native;
@@ -30,4 +31,4 @@ pub use report::{
     CoverageReportSort, HtmlReportOptions, JsonReportOptions, combine_and_report,
     write_cobertura_xml, write_html_report, write_json_report,
 };
-pub use tracer::{CoverageConfig, CoverageSession};
+pub use tracer::{CoverageConfig, CoveragePhase, CoverageSession};

--- a/crates/karva_coverage/src/native.rs
+++ b/crates/karva_coverage/src/native.rs
@@ -16,10 +16,11 @@ use serde::{Deserialize, Serialize};
 use siphasher::sip128::{Hasher128, SipHasher13};
 use tempfile::NamedTempFile;
 
+use crate::context::{compose_context, prefix_context};
 use crate::data::{BranchArc, WorkerFile};
 
 /// Current native coverage schema version.
-pub const FORMAT_VERSION: u32 = 3;
+pub const FORMAT_VERSION: u32 = 4;
 
 /// Karva coverage data retained after one or more test runs.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -165,7 +166,7 @@ impl NativeCoverage {
     }
 
     /// Unions compatible observations into this artifact.
-    pub fn merge(&mut self, other: Self) -> Result<()> {
+    pub fn merge(&mut self, mut other: Self) -> Result<()> {
         if self.mode != other.mode {
             bail!(
                 "cannot append coverage collected in {:?} mode to coverage collected in {:?} mode",
@@ -177,7 +178,8 @@ impl NativeCoverage {
             bail!("cannot append coverage collected from different source roots");
         }
         if self.run_context != other.run_context {
-            bail!("cannot append coverage collected with different run contexts");
+            self.materialize_run_context();
+            other.materialize_run_context();
         }
 
         for (path, incoming) in other.files {
@@ -188,6 +190,37 @@ impl NativeCoverage {
             }
         }
         Ok(())
+    }
+
+    /// Moves a whole-run context onto every observed line and branch before merging runs.
+    fn materialize_run_context(&mut self) {
+        let Some(run_context) = self.run_context.take() else {
+            return;
+        };
+        for file in self.files.values_mut() {
+            for line in &file.executed {
+                prefix_observation_contexts(
+                    file.line_contexts.entry(*line).or_default(),
+                    &run_context,
+                );
+            }
+            if let Some(branches) = &mut file.branches {
+                for arc in &branches.executed {
+                    let mut entry = branches
+                        .contexts
+                        .iter()
+                        .find(|entry| entry.arc == *arc)
+                        .cloned()
+                        .unwrap_or_else(|| NativeArcContexts {
+                            arc: *arc,
+                            contexts: BTreeSet::new(),
+                        });
+                    branches.contexts.remove(&entry);
+                    prefix_observation_contexts(&mut entry.contexts, &run_context);
+                    branches.contexts.insert(entry);
+                }
+            }
+        }
     }
 
     /// Rewrites source identities and merges compatible paths that become equal.
@@ -208,6 +241,17 @@ impl NativeCoverage {
         }
         self.files = files;
         Ok(self)
+    }
+}
+
+fn prefix_observation_contexts(contexts: &mut BTreeSet<String>, run_context: &str) {
+    if contexts.is_empty() {
+        contexts.extend(compose_context(Some(run_context), &[]));
+    } else {
+        *contexts = contexts
+            .iter()
+            .map(|context| prefix_context(run_context, context))
+            .collect();
     }
 }
 
@@ -518,18 +562,55 @@ mod tests {
     }
 
     #[test]
+    fn merge_preserves_different_run_contexts() {
+        let mut first = artifact();
+        let mut second = artifact();
+        second.run_context = Some("windows-py313".to_owned());
+
+        first.merge(second).expect("merge static contexts");
+
+        assert_eq!(first.run_context, None);
+        let file = first
+            .files
+            .get(Utf8Path::new("src/package.py"))
+            .expect("fixture file");
+        assert_eq!(
+            file.line_contexts.get(&1),
+            Some(&BTreeSet::from([
+                "linux-py313|tests/test_package.py::test_ready".to_owned(),
+                "windows-py313|tests/test_package.py::test_ready".to_owned(),
+            ]))
+        );
+        let branch_contexts = &file
+            .branches
+            .as_ref()
+            .expect("branch coverage")
+            .contexts
+            .first()
+            .expect("branch context")
+            .contexts;
+        assert_eq!(
+            branch_contexts,
+            &BTreeSet::from([
+                "linux-py313|tests/test_package.py::test_ready".to_owned(),
+                "windows-py313|tests/test_package.py::test_ready".to_owned(),
+            ])
+        );
+    }
+
+    #[test]
     fn unsupported_version_names_path_and_versions() {
         let directory = tempfile::tempdir().expect("create temp directory");
         let path = Utf8PathBuf::from_path_buf(directory.path().join("data.json"))
             .expect("UTF-8 temp path");
-        fs::write(&path, br#"{"format_version":4}"#).expect("write artifact");
+        fs::write(&path, br#"{"format_version":5}"#).expect("write artifact");
 
         let error = NativeCoverage::read(&path).expect_err("reject future version");
         let message = error.to_string();
 
         assert!(message.contains(path.as_str()));
-        assert!(message.contains("found format version 4"));
-        assert!(message.contains("supported version is 3"));
+        assert!(message.contains("found format version 5"));
+        assert!(message.contains("supported version is 4"));
     }
 
     #[test]

--- a/crates/karva_coverage/src/report/shared.rs
+++ b/crates/karva_coverage/src/report/shared.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use fs_err as fs;
 
+use crate::context::{compose_context, prefix_context};
 use crate::data::{BranchArc, WorkerFile};
 use crate::native::{CoverageMode, NativeCoverage, SourceFingerprint};
 use crate::report::CoverageFilters;
@@ -152,10 +153,6 @@ fn merge_native(
     artifact: &NativeCoverage,
     filters: &CoverageFilters,
 ) -> Result<()> {
-    let run_context_matches = artifact
-        .run_context
-        .as_deref()
-        .is_some_and(|context| filters.matches_context(context));
     for (source_path, file) in &artifact.files {
         let mapped_path = filters.map_path(source_path.as_str());
         let bucket = combined.entry(mapped_path.clone()).or_default();
@@ -175,12 +172,12 @@ fn merge_native(
         bucket.executable.extend(&file.executable);
         bucket.excluded.extend(&file.excluded);
         bucket.branches_enabled = artifact.mode == CoverageMode::Branch;
-        merge_line_observations(bucket, file, filters, run_context_matches);
+        merge_line_observations(bucket, file, artifact.run_context.as_deref(), filters);
         if let Some(branches) = &file.branches {
             bucket.branches_enabled = true;
             bucket.branch_possible.extend(&branches.possible);
             bucket.branch_partial_lines.extend(&branches.partial);
-            merge_branch_observations(bucket, branches, filters, run_context_matches);
+            merge_branch_observations(bucket, branches, artifact.run_context.as_deref(), filters);
         }
     }
     Ok(())
@@ -215,27 +212,21 @@ pub(super) fn verify_combined_sources(
 fn merge_line_observations(
     bucket: &mut CombinedFile,
     file: &crate::native::NativeFileCoverage,
+    run_context: Option<&str>,
     filters: &CoverageFilters,
-    run_context_matches: bool,
 ) {
-    if !filters.has_contexts() || run_context_matches {
-        bucket.executed.extend(&file.executed);
-    }
-    for (line, contexts) in &file.line_contexts {
+    for line in &file.executed {
+        let contexts = observation_contexts(run_context, file.line_contexts.get(line));
         let matching: BTreeSet<String> = contexts
             .iter()
             .filter(|context| filters.matches_context(context))
             .cloned()
             .collect();
-        if !matching.is_empty() {
+        if !filters.has_contexts() || !matching.is_empty() {
             bucket.executed.insert(*line);
+        }
+        if !matching.is_empty() {
             bucket.contexts.entry(*line).or_default().extend(matching);
-        } else if !filters.has_contexts() {
-            bucket
-                .contexts
-                .entry(*line)
-                .or_default()
-                .extend(contexts.iter().cloned());
         }
     }
 }
@@ -243,33 +234,49 @@ fn merge_line_observations(
 fn merge_branch_observations(
     bucket: &mut CombinedFile,
     branches: &crate::native::NativeBranchCoverage,
+    run_context: Option<&str>,
     filters: &CoverageFilters,
-    run_context_matches: bool,
 ) {
-    if !filters.has_contexts() || run_context_matches {
-        bucket.branch_executed.extend(&branches.executed);
-    }
-    for entry in &branches.contexts {
-        let matching: BTreeSet<String> = entry
-            .contexts
+    let dynamic_by_arc: BTreeMap<BranchArc, &BTreeSet<String>> = branches
+        .contexts
+        .iter()
+        .map(|entry| (entry.arc, &entry.contexts))
+        .collect();
+    for arc in &branches.executed {
+        let dynamic = dynamic_by_arc.get(arc).copied();
+        let contexts = observation_contexts(run_context, dynamic);
+        let matching: BTreeSet<String> = contexts
             .iter()
             .filter(|context| filters.matches_context(context))
             .cloned()
             .collect();
+        if !filters.has_contexts() || !matching.is_empty() {
+            bucket.branch_executed.insert(*arc);
+        }
         if !matching.is_empty() {
-            bucket.branch_executed.insert(entry.arc);
             bucket
                 .arc_contexts
-                .entry(entry.arc)
+                .entry(*arc)
                 .or_default()
                 .extend(matching);
-        } else if !filters.has_contexts() {
-            bucket
-                .arc_contexts
-                .entry(entry.arc)
-                .or_default()
-                .extend(entry.contexts.iter().cloned());
         }
+    }
+}
+
+fn observation_contexts(
+    run_context: Option<&str>,
+    dynamic: Option<&BTreeSet<String>>,
+) -> BTreeSet<String> {
+    match (run_context, dynamic) {
+        (Some(run_context), Some(dynamic)) if !dynamic.is_empty() => dynamic
+            .iter()
+            .map(|context| prefix_context(run_context, context))
+            .collect(),
+        (Some(run_context), _) => compose_context(Some(run_context), &[])
+            .into_iter()
+            .collect(),
+        (None, Some(dynamic)) => dynamic.clone(),
+        (None, None) => BTreeSet::new(),
     }
 }
 

--- a/crates/karva_coverage/src/snapshots/karva_coverage__native__tests__artifact_schema_snapshot.snap
+++ b/crates/karva_coverage/src/snapshots/karva_coverage__native__tests__artifact_schema_snapshot.snap
@@ -3,7 +3,7 @@ source: crates/karva_coverage/src/native.rs
 expression: "serde_json::to_string_pretty(&artifact()).expect(\"serialize artifact\")"
 ---
 {
-  "format_version": 3,
+  "format_version": 4,
   "karva_version": "0.0.0",
   "mode": "branch",
   "source_roots": [

--- a/crates/karva_coverage/src/tracer.rs
+++ b/crates/karva_coverage/src/tracer.rs
@@ -15,6 +15,7 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 use crate::branches::{CoveragePartials, branch_analysis_with_exclusions};
+use crate::context::{PENDING_SETUP_CONTEXT, SESSION_CONTEXT, compose_context};
 use crate::data::{BranchArc, BranchContextEntry, BranchEntry, FileEntry, WorkerFile};
 use crate::executable::{CoverageExclusions, executable_lines_with_exclusions};
 
@@ -31,6 +32,9 @@ pub struct CoverageConfig {
     /// Whether to record the current test context for each executed line.
     pub contexts: bool,
 
+    /// User-provided context attached to every observation in this run.
+    pub static_context: Option<String>,
+
     /// Whether to record branch arcs in addition to executed lines.
     pub branches: bool,
 
@@ -39,6 +43,27 @@ pub struct CoverageConfig {
 
     /// Regular expressions suppressing missing arcs from matched branch lines.
     pub partial_branches: Vec<String>,
+}
+
+/// Test lifecycle phase recorded in a dynamic coverage context.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CoveragePhase {
+    /// Function-scoped fixture setup.
+    Setup,
+    /// Test function execution.
+    Run,
+    /// Function-scoped fixture teardown.
+    Teardown,
+}
+
+impl CoveragePhase {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Setup => "setup",
+            Self::Run => "run",
+            Self::Teardown => "teardown",
+        }
+    }
 }
 
 /// Path components inside a source root that suppress tracking. These match
@@ -63,14 +88,25 @@ impl CoverageSession {
         let partials = CoveragePartials::new(&config.partial_branches)
             .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?;
         let roots = resolve_source_roots(py, cwd, &config.sources)?;
+        let record_contexts = config.contexts || config.static_context.is_some();
+        let initial_context = if config.contexts {
+            compose_context(config.static_context.as_deref(), &[SESSION_CONTEXT])
+        } else {
+            compose_context(config.static_context.as_deref(), &[])
+        };
 
         let tracer = Py::new(
             py,
             CoverageTracer {
                 roots,
-                contexts: config.contexts,
+                contexts: record_contexts,
+                test_contexts: config.contexts,
+                static_context: config.static_context.clone(),
                 branches: config.branches,
-                state: Mutex::new(TracerState::default()),
+                state: Mutex::new(TracerState {
+                    current_context: initial_context,
+                    ..TracerState::default()
+                }),
                 monitoring_tool_id: OnceLock::new(),
                 monitoring_disable: OnceLock::new(),
             },
@@ -155,9 +191,27 @@ impl CoverageSession {
         Ok(())
     }
 
-    /// Attributes subsequent observations to a test, or clears attribution between tests.
-    pub fn set_current_context(&self, py: Python<'_>, context: Option<&str>) {
-        self.tracer.bind(py).borrow().set_current_context(context);
+    /// Starts first-attempt setup before fixture-derived test identity is available.
+    pub fn begin_pending_test_setup(&self, py: Python<'_>) {
+        self.tracer.bind(py).borrow().begin_pending_test_setup();
+    }
+
+    /// Reattributes first-attempt setup after fixture-derived test identity is available.
+    pub fn resolve_pending_test_setup(&self, py: Python<'_>, test: &str) {
+        self.tracer
+            .bind(py)
+            .borrow()
+            .resolve_pending_test_setup(test);
+    }
+
+    /// Attributes subsequent observations to one test lifecycle phase.
+    pub fn set_test_context(&self, py: Python<'_>, test: &str, phase: CoveragePhase) {
+        self.tracer.bind(py).borrow().set_test_context(test, phase);
+    }
+
+    /// Restores attribution for execution outside a concrete test lifecycle.
+    pub fn clear_test_context(&self, py: Python<'_>) {
+        self.tracer.bind(py).borrow().clear_test_context();
     }
 }
 
@@ -173,6 +227,12 @@ struct TracerState {
     arc_contexts: HashMap<TrackedPath, HashMap<BranchArc, HashSet<String>>>,
     /// Current test context, if `--cov-context=test` is active and a test is running.
     current_context: Option<String>,
+    /// Temporary setup context awaiting fixture-derived test identity.
+    pending_context: Option<String>,
+    /// Lines observed while [`Self::pending_context`] is active.
+    pending_lines: HashMap<TrackedPath, HashSet<u32>>,
+    /// Branches observed while [`Self::pending_context`] is active.
+    pending_arcs: HashMap<TrackedPath, HashSet<BranchArc>>,
     /// Memoized result of [`compute_tracked_path`] per filename string.
     track_cache: HashMap<String, Option<TrackedPath>>,
     /// Memoized result of [`compute_tracked_path`] per live Python code object.
@@ -209,6 +269,8 @@ struct CodeLineRange {
 struct CoverageTracer {
     roots: Vec<PathBuf>,
     contexts: bool,
+    test_contexts: bool,
+    static_context: Option<String>,
     branches: bool,
     state: Mutex<TracerState>,
     monitoring_tool_id: OnceLock<u8>,
@@ -340,12 +402,64 @@ impl CoverageTracer {
 }
 
 impl CoverageTracer {
-    fn set_current_context(&self, context: Option<&str>) {
-        if !self.contexts {
+    fn begin_pending_test_setup(&self) {
+        if !self.test_contexts {
             return;
         }
         if let Ok(mut state) = self.state.lock() {
-            state.current_context = context.map(ToOwned::to_owned);
+            let pending = compose_context(self.static_context.as_deref(), &[PENDING_SETUP_CONTEXT]);
+            state.current_context.clone_from(&pending);
+            state.pending_context = pending;
+            state.pending_lines.clear();
+            state.pending_arcs.clear();
+        }
+    }
+
+    fn resolve_pending_test_setup(&self, test: &str) {
+        if !self.test_contexts {
+            return;
+        }
+        let Some(resolved) = compose_context(
+            self.static_context.as_deref(),
+            &[test, CoveragePhase::Setup.as_str()],
+        ) else {
+            return;
+        };
+        if let Ok(mut state) = self.state.lock() {
+            let Some(pending) = state.pending_context.take() else {
+                return;
+            };
+            let pending_lines = std::mem::take(&mut state.pending_lines);
+            let pending_arcs = std::mem::take(&mut state.pending_arcs);
+            replace_pending_context(&mut state.contexts, pending_lines, &pending, &resolved);
+            replace_pending_context(&mut state.arc_contexts, pending_arcs, &pending, &resolved);
+            state.current_context = Some(resolved);
+        }
+    }
+
+    fn set_test_context(&self, test: &str, phase: CoveragePhase) {
+        if !self.test_contexts {
+            return;
+        }
+        if let Ok(mut state) = self.state.lock() {
+            state.pending_context = None;
+            state.pending_lines.clear();
+            state.pending_arcs.clear();
+            state.current_context =
+                compose_context(self.static_context.as_deref(), &[test, phase.as_str()]);
+        }
+    }
+
+    fn clear_test_context(&self) {
+        if !self.test_contexts {
+            return;
+        }
+        if let Ok(mut state) = self.state.lock() {
+            state.pending_context = None;
+            state.pending_lines.clear();
+            state.pending_arcs.clear();
+            state.current_context =
+                compose_context(self.static_context.as_deref(), &[SESSION_CONTEXT]);
         }
     }
 
@@ -498,6 +612,26 @@ impl CoverageTracer {
     }
 }
 
+fn replace_pending_context<K: Copy + Eq + std::hash::Hash>(
+    contexts: &mut HashMap<TrackedPath, HashMap<K, HashSet<String>>>,
+    pending: HashMap<TrackedPath, HashSet<K>>,
+    old: &str,
+    new: &str,
+) {
+    for (path, keys) in pending {
+        let Some(observations) = contexts.get_mut(&path) else {
+            continue;
+        };
+        for key in keys {
+            if let Some(values) = observations.get_mut(&key)
+                && values.remove(old)
+            {
+                values.insert(new.to_owned());
+            }
+        }
+    }
+}
+
 #[derive(Clone)]
 struct TrackedCodeInfo {
     path: TrackedPath,
@@ -512,6 +646,13 @@ fn record_line_in_state(
     lineno: u32,
 ) {
     if contexts_enabled && let Some(context) = state.current_context.clone() {
+        if state.pending_context.is_some() {
+            state
+                .pending_lines
+                .entry(path.clone())
+                .or_default()
+                .insert(lineno);
+        }
         state
             .executed
             .entry(path.clone())
@@ -539,6 +680,13 @@ fn record_arc_in_state(
         return;
     }
     if contexts_enabled && let Some(context) = state.current_context.clone() {
+        if state.pending_context.is_some() {
+            state
+                .pending_arcs
+                .entry(path.clone())
+                .or_default()
+                .insert(arc);
+        }
         state.arcs.entry(path.clone()).or_default().insert(arc);
         state
             .arc_contexts
@@ -1023,6 +1171,8 @@ mod tests {
             let tracer = CoverageTracer {
                 roots: vec![root],
                 contexts: false,
+                test_contexts: false,
+                static_context: None,
                 branches: false,
                 state: Mutex::new(TracerState::default()),
                 monitoring_tool_id: OnceLock::new(),
@@ -1106,6 +1256,8 @@ code = Code()
             let tracer = CoverageTracer {
                 roots: Vec::new(),
                 contexts: false,
+                test_contexts: false,
+                static_context: None,
                 branches: false,
                 state: Mutex::new(TracerState::default()),
                 monitoring_tool_id: OnceLock::new(),

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -686,6 +686,17 @@ pub struct CoverageOptions {
     )]
     pub partial_branches: Option<Vec<CoveragePartialPattern>>,
 
+    /// Static context component attached to every observation in the run.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"null"#,
+        value_type = r#"str"#,
+        example = r#"
+            context = "python=3.14"
+        "#
+    )]
+    pub context: Option<String>,
+
     /// Include execution attributed to contexts matching these regular expressions.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[option(
@@ -799,6 +810,7 @@ impl Combine for CoverageOptions {
         self.omit = self.omit.take().combine(other.omit);
         self.exclude_lines = self.exclude_lines.take().combine(other.exclude_lines);
         self.partial_branches = self.partial_branches.take().combine(other.partial_branches);
+        self.context = self.context.take().combine(other.context);
         self.contexts = self.contexts.take().combine(other.contexts);
         self.precision = self.precision.combine(other.precision);
         self.append = self.append.combine(other.append);
@@ -833,6 +845,7 @@ impl CoverageOptions {
             omit: self.omit.clone().unwrap_or_default(),
             exclude_lines: self.exclude_lines.clone().unwrap_or_default(),
             partial_branches: self.partial_branches.clone().unwrap_or_default(),
+            context: self.context.clone(),
             contexts: self.contexts.clone().unwrap_or_default(),
             precision: self.precision.unwrap_or_default(),
             append: self.append.unwrap_or_default(),
@@ -1471,6 +1484,7 @@ path-aliases = ["/workspace=."]
 sources = ["src", "tests"]
 include = ["src/**"]
 omit = ["**/generated.py"]
+context = "python=3.14"
 contexts = ["python=3\\.14"]
 precision = 2
 report = "term-missing"
@@ -1509,6 +1523,9 @@ report-path = "build/coverage.xml"
                 ),
                 exclude_lines: None,
                 partial_branches: None,
+                context: Some(
+                    "python=3.14",
+                ),
                 contexts: Some(
                     [
                         "python=3\\.14",
@@ -1607,6 +1624,7 @@ store-failure-output = false
             omit: None,
             exclude_lines: None,
             partial_branches: None,
+            context: None,
             contexts: None,
             precision: None,
             append: None,
@@ -1653,6 +1671,7 @@ store-failure-output = false
             ),
             exclude_lines: None,
             partial_branches: None,
+            context: None,
             contexts: None,
             precision: None,
             append: None,
@@ -1720,6 +1739,7 @@ store-failure-output = false
             omit: None,
             exclude_lines: None,
             partial_branches: None,
+            context: None,
             contexts: None,
             precision: None,
             append: None,
@@ -1764,7 +1784,7 @@ disabled = true
           |
         3 | disabled = true
           | ^^^^^^^^
-        unknown field `disabled`, expected one of `data-file`, `path-aliases`, `sources`, `include`, `omit`, `exclude-lines`, `partial-branches`, `contexts`, `precision`, `append`, `report`, `report-path`, `branch`, `fail-under`
+        unknown field `disabled`, expected one of `data-file`, `path-aliases`, `sources`, `include`, `omit`, `exclude-lines`, `partial-branches`, `context`, `contexts`, `precision`, `append`, `report`, `report-path`, `branch`, `fail-under`
         "
         );
     }
@@ -1783,7 +1803,7 @@ nonsense = 1
           |
         4 | nonsense = 1
           | ^^^^^^^^
-        unknown field `nonsense`, expected one of `data-file`, `path-aliases`, `sources`, `include`, `omit`, `exclude-lines`, `partial-branches`, `contexts`, `precision`, `append`, `report`, `report-path`, `branch`, `fail-under`
+        unknown field `nonsense`, expected one of `data-file`, `path-aliases`, `sources`, `include`, `omit`, `exclude-lines`, `partial-branches`, `context`, `contexts`, `precision`, `append`, `report`, `report-path`, `branch`, `fail-under`
         "
         );
     }

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -688,6 +688,9 @@ pub struct CoverageSettings {
     /// Regular expressions suppressing missing arcs from matched branch lines.
     pub partial_branches: Vec<CoveragePartialPattern>,
 
+    /// Static context component attached to every observation in the run.
+    pub context: Option<String>,
+
     /// Regular expressions selecting execution contexts for reports.
     pub contexts: Vec<String>,
 

--- a/crates/karva_runner/src/worker_args.rs
+++ b/crates/karva_runner/src/worker_args.rs
@@ -192,6 +192,10 @@ fn inner_cli_args(settings: &ProjectSettings, args: &SubTestCommand) -> Vec<Stri
         cli_args.push(format!("--cov-partial-branch={}", pattern.as_str()));
     }
 
+    if let Some(context) = &settings.coverage().context {
+        cli_args.push(format!("--cov-static-context={context}"));
+    }
+
     if let Some(context) = args.cov_context {
         push_value_arg(&mut cli_args, "--cov-context", context.as_str());
     }

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/attempt.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/attempt.rs
@@ -2,6 +2,7 @@
 
 use std::time::{Duration, Instant};
 
+use karva_coverage::CoveragePhase;
 use karva_diagnostic::{CapturedTestOutput, TestExecutionAttempt, TestExecutionOutcome};
 use pyo3::prelude::*;
 
@@ -56,6 +57,7 @@ impl VariantRunner<'_, '_, '_, '_, '_> {
         };
 
         let skipped = body.outcome.is_skipped();
+        self.set_coverage_context(&settings.qualified_name, CoveragePhase::Teardown);
         let teardown_start = Instant::now();
         let finalizer_diagnostics = self
             .package_runner

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
@@ -5,6 +5,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use karva_coverage::CoveragePhase;
 use karva_diagnostic::{CapturedTestOutput, TestCaseRetry, TestExecutionOutcome};
 use karva_metadata::filter::EvalContext;
 use karva_metadata::{FlakyResult, JunitFlakyFailStatus, RunIgnoredMode};
@@ -113,8 +114,10 @@ impl<'runner, 'context, 'settings, 'test, 'py>
 
         let retry_params = self.params.clone();
         let first_params = std::mem::take(&mut self.params);
+        self.begin_pending_coverage_setup();
         let first_attempt = self.prepare_attempt(first_params, self.start_output_capture());
         let settings = self.settings(&first_attempt.fixtures.function_arguments);
+        self.resolve_pending_coverage_setup(&settings.qualified_name);
         let function = self.test.py_function.clone_ref(self.py);
         let test_name_env_result =
             set_test_name_env(self.py, &settings.qualified_test_name.to_string());
@@ -123,7 +126,6 @@ impl<'runner, 'context, 'settings, 'test, 'py>
         self.package_runner
             .context
             .report_test_started(&settings.qualified_test_name);
-        self.set_coverage_context(Some(&settings.qualified_name));
 
         let mut attempt_number = 1;
         let mut prepared_attempt = Some(first_attempt);
@@ -135,6 +137,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             let prepared = prepared_attempt
                 .take()
                 .unwrap_or_else(|| self.prepare_retry(retry_params.clone(), &settings));
+            self.set_coverage_context(&settings.qualified_name, CoveragePhase::Run);
             let attempt = self.execute_attempt(
                 &settings,
                 &function,
@@ -185,16 +188,14 @@ impl<'runner, 'context, 'settings, 'test, 'py>
         }
     }
 
-    /// Prepares a retry while ensuring coverage excludes fixture setup.
+    /// Prepares a retry under its setup coverage context.
     fn prepare_retry(
         &mut self,
         params: HashMap<String, Arc<Py<PyAny>>>,
         settings: &VariantSettings,
     ) -> PreparedTestAttempt {
-        self.set_coverage_context(None);
-        let prepared = self.prepare_attempt(params, self.start_output_capture());
-        self.set_coverage_context(Some(&settings.qualified_name));
-        prepared
+        self.set_coverage_context(&settings.qualified_name, CoveragePhase::Setup);
+        self.prepare_attempt(params, self.start_output_capture())
     }
 
     /// Derives identity and execution policy after first fixture setup.
@@ -320,7 +321,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
         prior_attempts: Vec<TestLifecycleAttempt>,
         final_attempt: TestLifecycleAttempt,
     ) -> bool {
-        self.set_coverage_context(None);
+        self.clear_coverage_context();
         let captured_output = combine_captured_output(
             prior_attempts
                 .iter()
@@ -454,10 +455,31 @@ impl<'runner, 'context, 'settings, 'test, 'py>
         }
     }
 
-    /// Updates coverage context when coverage is active for this worker.
-    fn set_coverage_context(&self, context: Option<&str>) {
+    /// Marks setup whose full fixture-derived test identity is not known yet.
+    fn begin_pending_coverage_setup(&self) {
         if let Some(coverage) = self.package_runner.coverage {
-            coverage.set_current_context(self.py, context);
+            coverage.begin_pending_test_setup(self.py);
+        }
+    }
+
+    /// Resolves pending setup observations to the final qualified test identity.
+    fn resolve_pending_coverage_setup(&self, test: &str) {
+        if let Some(coverage) = self.package_runner.coverage {
+            coverage.resolve_pending_test_setup(self.py, test);
+        }
+    }
+
+    /// Updates coverage attribution for one test lifecycle phase.
+    fn set_coverage_context(&self, test: &str, phase: CoveragePhase) {
+        if let Some(coverage) = self.package_runner.coverage {
+            coverage.set_test_context(self.py, test, phase);
+        }
+    }
+
+    /// Restores session attribution between test variants.
+    fn clear_coverage_context(&self) {
+        if let Some(coverage) = self.package_runner.coverage {
+            coverage.clear_test_context(self.py);
         }
     }
 }

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -210,6 +210,7 @@ fn worker_coverage_config(
         sources: sub_command.cov.clone(),
         data_file,
         contexts: sub_command.cov_context == Some(karva_cli::CovContext::Test),
+        static_context: sub_command.cov_static_context.clone(),
         branches: sub_command.cov_branch,
         exclude_lines: sub_command.cov_exclude_line.clone(),
         partial_branches: sub_command.cov_partial_branch.clone(),

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -73,6 +73,23 @@ branch = true
 
 ---
 
+### `context`
+
+Static context component attached to every observation in the run.
+
+**Default value**: `null`
+
+**Type**: `str`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.karva.profile.default.coverage]
+context = "python=3.14"
+```
+
+---
+
 ### `contexts`
 
 Include execution attributed to contexts matching these regular expressions.

--- a/docs/usage/writing-tests/coverage.md
+++ b/docs/usage/writing-tests/coverage.md
@@ -111,10 +111,27 @@ karva test --cov=src --cov-report=json
 karva test --cov=src --cov-report=json:build/coverage.json
 ```
 
-Pass `--cov-context=test` with JSON reports to include a `contexts` map from executed source lines to the qualified test names that covered them:
+Pass `--cov-context=test` to record qualified test names and lifecycle phases. Execution outside a test uses `session`; test execution uses `setup`, `run`, or `teardown`:
 
 ```bash
-karva test --cov=src --cov-context=test --cov-report=json
+uv run karva test --cov=src --cov-context=test --cov-report=json
+```
+
+Add a static run context in configuration when reports must distinguish environments or shards:
+
+```toml
+[tool.karva.profile.ci.coverage]
+context = "python=3.14"
+```
+
+Contexts compose as `<static>|<qualified-test>|<phase>`, for example `python=3.14|test_checkout::test_card(visa)|run`. Karva escapes `\` and `|` within each component as `\\` and `\|` so names remain unambiguous.
+
+Filter every report to one or more context regular expressions. Any matching context includes its observation, and totals are recalculated from those observations:
+
+```bash
+uv run karva coverage report --contexts 'test_checkout'
+uv run karva coverage html --contexts 'python=3\.14' --show-contexts
+uv run karva coverage json --contexts '\|setup$' --show-contexts
 ```
 
 Persisted native coverage data can be exported independently. Output is compact by default:

--- a/karva.schema.json
+++ b/karva.schema.json
@@ -94,6 +94,13 @@
             "null"
           ]
         },
+        "context": {
+          "description": "Static context component attached to every observation in the run.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "contexts": {
           "description": "Include execution attributed to contexts matching these regular expressions.",
           "type": [


### PR DESCRIPTION
## Summary

Add stable static, session, setup, run, and teardown coverage contexts with escaping and composition. Preserve attribution across workers and native merges, then apply context filters consistently to recalculated reports.

Closes #1164.

## Test Plan

Full test suite, workspace Clippy, and pre-commit hooks.