### PR TITLE
Collect coverage from Python child processes

### DIFF
--- a/crates/karva/tests/it/coverage.rs
+++ b/crates/karva/tests/it/coverage.rs
@@ -1487,6 +1487,214 @@ def test_flaky():
 }
 
 #[test]
+fn test_cov_collects_python_child_processes() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.default.coverage]
+sources = ["src"]
+branch = true
+context = "child-process"
+"#,
+        ),
+        (
+            "src/child.py",
+            r#"
+def subprocess_path(value):
+    if value == "normal":
+        return 1
+    if value == "exit":
+        return 2
+    return 3
+
+def multiprocessing_path():
+    return 4
+"#,
+        ),
+        (
+            "test_children.py",
+            r#"
+import multiprocessing
+import os
+import subprocess
+import sys
+
+def process_target():
+    from src.child import multiprocessing_path
+    multiprocessing_path()
+
+
+def test_subprocess_normal_exit_and_exec():
+    subprocess.run(
+        [sys.executable, "-c", "from src.child import subprocess_path; subprocess_path('normal')"],
+        check=True,
+    )
+    subprocess.run(
+        [sys.executable, "-c", "from src.child import subprocess_path; subprocess_path('exit'); import os; os._exit(0)"],
+        check=True,
+    )
+    subprocess.run(
+        [sys.executable, "-c", "from src.child import subprocess_path; subprocess_path('exec'); import os, sys; os.execv(sys.executable, [sys.executable, '-c', 'pass'])"],
+        check=True,
+    )
+
+
+def test_multiprocessing():
+    for method in ("spawn", "fork"):
+        if method in multiprocessing.get_all_start_methods():
+            process = multiprocessing.get_context(method).Process(target=process_target)
+            process.start()
+            process.join()
+            assert process.exitcode == 0
+"#,
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
+            "--cov-report=json",
+            "--status-level=none",
+            "test_children.py",
+        ]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+
+    insta::assert_snapshot!(context.read_file("coverage.json"), @r#"
+    {
+      "meta": {
+        "format": 2,
+        "version": "karva",
+        "show_contexts": true
+      },
+      "files": {
+        "src/child.py": {
+          "executed_lines": [
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            9,
+            10
+          ],
+          "summary": {
+            "covered_lines": 8,
+            "num_statements": 8,
+            "percent_covered": 100.0,
+            "missing_lines": [],
+            "excluded_lines": [],
+            "num_branches": 4,
+            "num_partial_branches": 0,
+            "covered_branches": 4,
+            "missing_branches": 0,
+            "percent_branches_covered": 100.0
+          },
+          "missing_lines": [],
+          "excluded_lines": [],
+          "contexts": {
+            "2": [
+              "child-process"
+            ],
+            "3": [
+              "child-process"
+            ],
+            "4": [
+              "child-process"
+            ],
+            "5": [
+              "child-process"
+            ],
+            "6": [
+              "child-process"
+            ],
+            "7": [
+              "child-process"
+            ],
+            "9": [
+              "child-process"
+            ],
+            "10": [
+              "child-process"
+            ]
+          },
+          "executed_branches": [
+            [
+              3,
+              4
+            ],
+            [
+              3,
+              5
+            ],
+            [
+              5,
+              6
+            ],
+            [
+              5,
+              7
+            ]
+          ],
+          "missing_branches": []
+        }
+      },
+      "totals": {
+        "covered_lines": 8,
+        "num_statements": 8,
+        "percent_covered": 100.0,
+        "num_branches": 4,
+        "num_partial_branches": 0,
+        "covered_branches": 4,
+        "missing_branches": 0,
+        "percent_branches_covered": 100.0
+      }
+    }
+    "#);
+}
+
+#[test]
+fn test_child_process_coverage_is_not_enabled_without_cov() {
+    let context = TestContext::with_file(
+        "test_child.py",
+        r#"
+import subprocess
+import sys
+
+def test_child_has_no_coverage_activation():
+    subprocess.run(
+        [sys.executable, "-c", "import os; assert '_KARVA_COVERAGE_CONFIG' not in os.environ"],
+        check=True,
+    )
+"#,
+    );
+
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .args(["--status-level=none", "test_child.py"]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
 fn test_cov_report_cli_override_uses_default_path_when_config_path_is_stale() {
     let context = TestContext::with_files([
         (

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -223,7 +223,30 @@ impl RunCache {
             if path.exists() {
                 files.push(path);
             }
+            let child_directory = worker_dir.join("coverage-children");
+            match fs::read_dir(&child_directory) {
+                Ok(entries) => {
+                    for entry in entries {
+                        let path = Utf8PathBuf::from_path_buf(entry?.path()).map_err(|path| {
+                            anyhow::anyhow!(
+                                "child coverage path contains non-Unicode characters: `{}`",
+                                path.display()
+                            )
+                        })?;
+                        if path.extension() == Some("json") {
+                            files.push(path);
+                        }
+                    }
+                }
+                Err(error) if error.kind() == ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!("failed to read child coverage directory `{child_directory}`")
+                    });
+                }
+            }
         }
+        files.sort();
         Ok(files)
     }
 
@@ -614,6 +637,36 @@ mod tests {
             "worker-old",
         ]
         "#);
+    }
+
+    #[test]
+    fn coverage_files_include_sorted_child_shards() {
+        let tmp = tempfile::tempdir().expect("temporary directory");
+        let cache_dir =
+            Utf8PathBuf::try_from(tmp.path().to_path_buf()).expect("UTF-8 temporary path");
+        let run_hash = RunHash::from_existing("run-coverage");
+        let cache = RunCache::new(&cache_dir, &run_hash);
+        let worker = cache.coverage_data_file(0);
+        let child_directory = worker
+            .parent()
+            .expect("worker coverage parent")
+            .join("coverage-children");
+        fs::create_dir_all(&child_directory).expect("child coverage directory");
+        fs::write(&worker, "{}").expect("worker coverage");
+        fs::write(child_directory.join("b.json"), "{}").expect("child coverage b");
+        fs::write(child_directory.join("a.json"), "{}").expect("child coverage a");
+        fs::write(child_directory.join("unfinished"), "{}").expect("unfinished temporary file");
+
+        let files = cache.coverage_files().expect("coverage files");
+
+        assert_eq!(
+            files,
+            vec![
+                child_directory.join("a.json"),
+                child_directory.join("b.json"),
+                worker,
+            ]
+        );
     }
 
     #[test]

--- a/crates/karva_coverage/src/lib.rs
+++ b/crates/karva_coverage/src/lib.rs
@@ -31,4 +31,6 @@ pub use report::{
     CoverageReportSort, HtmlReportOptions, JsonReportOptions, combine_and_report,
     write_cobertura_xml, write_html_report, write_json_report,
 };
-pub use tracer::{CoverageConfig, CoveragePhase, CoverageSession};
+pub use tracer::{
+    ChildCoverageSession, CoverageConfig, CoveragePhase, CoverageSession, start_child_coverage,
+};

--- a/crates/karva_coverage/src/tracer.rs
+++ b/crates/karva_coverage/src/tracer.rs
@@ -6,6 +6,7 @@
 //! [`CoverageConfig::data_file`].
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -78,11 +79,64 @@ pub struct CoverageSession {
     data_file: Utf8PathBuf,
     exclusions: CoverageExclusions,
     partials: CoveragePartials,
+    include_unexecuted: bool,
+}
+
+/// Native coverage session owned by an opted-in Python child interpreter.
+#[pyclass(name = "_ChildCoverageSession", module = "karva._karva")]
+pub struct ChildCoverageSession {
+    session: Option<CoverageSession>,
+}
+
+#[pymethods]
+impl ChildCoverageSession {
+    /// Stops collection and atomically writes this child's coverage shard.
+    fn stop_and_save(&mut self, py: Python<'_>) -> PyResult<()> {
+        if let Some(session) = self.session.take() {
+            session.stop_and_save(py)?;
+        }
+        Ok(())
+    }
+}
+
+/// Starts native coverage inside an opted-in Python child interpreter.
+#[pyfunction(name = "_start_child_coverage")]
+pub fn start_child_coverage(
+    py: Python<'_>,
+    roots: Vec<String>,
+    data_file: String,
+    branches: bool,
+    exclude_lines: Vec<String>,
+    partial_branches: Vec<String>,
+    static_context: Option<String>,
+) -> PyResult<ChildCoverageSession> {
+    let config = CoverageConfig {
+        sources: roots,
+        data_file: Utf8PathBuf::from(data_file),
+        contexts: false,
+        static_context,
+        branches,
+        exclude_lines,
+        partial_branches,
+    };
+    let session = CoverageSession::start_inner(py, Utf8Path::new(""), &config, false)?;
+    Ok(ChildCoverageSession {
+        session: Some(session),
+    })
 }
 
 impl CoverageSession {
     /// Installs the best tracer supported by the embedded Python version.
     pub fn start(py: Python<'_>, cwd: &Utf8Path, config: &CoverageConfig) -> PyResult<Self> {
+        Self::start_inner(py, cwd, config, true)
+    }
+
+    fn start_inner(
+        py: Python<'_>,
+        cwd: &Utf8Path,
+        config: &CoverageConfig,
+        include_unexecuted: bool,
+    ) -> PyResult<Self> {
         let exclusions = CoverageExclusions::new(&config.exclude_lines)
             .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?;
         let partials = CoveragePartials::new(&config.partial_branches)
@@ -123,6 +177,7 @@ impl CoverageSession {
             data_file: config.data_file.clone(),
             exclusions,
             partials,
+            include_unexecuted,
         })
     }
 
@@ -133,6 +188,7 @@ impl CoverageSession {
             data_file,
             exclusions,
             partials,
+            include_unexecuted,
         } = self;
         let bound = tracer.bind(py);
         let tool_id = bound.borrow().monitoring_tool_id.get().copied();
@@ -182,6 +238,7 @@ impl CoverageSession {
             &roots,
             &exclusions,
             &partials,
+            include_unexecuted,
         )
         .map_err(|err| {
             pyo3::exceptions::PyOSError::new_err(format!(
@@ -189,6 +246,24 @@ impl CoverageSession {
             ))
         })?;
         Ok(())
+    }
+
+    /// Returns canonical source roots for descendant-process collection.
+    pub fn source_roots(&self, py: Python<'_>) -> PyResult<Vec<String>> {
+        self.tracer
+            .bind(py)
+            .borrow()
+            .roots
+            .iter()
+            .map(|root| {
+                root.to_str().map(ToOwned::to_owned).ok_or_else(|| {
+                    PyValueError::new_err(format!(
+                        "coverage source contains non-Unicode characters: `{}`",
+                        root.display()
+                    ))
+                })
+            })
+            .collect()
     }
 
     /// Starts first-attempt setup before fixture-derived test identity is available.
@@ -1012,6 +1087,7 @@ fn save_data(
     roots: &[PathBuf],
     exclusions: &CoverageExclusions,
     partials: &CoveragePartials,
+    include_unexecuted: bool,
 ) -> std::io::Result<()> {
     let CollectedCoverage {
         mut executed,
@@ -1019,8 +1095,10 @@ fn save_data(
         mut arcs,
         mut arc_contexts,
     } = collected;
-    for path in walk_source_files(roots) {
-        executed.entry(path).or_default();
+    if include_unexecuted {
+        for path in walk_source_files(roots) {
+            executed.entry(path).or_default();
+        }
     }
 
     let mut files = BTreeMap::new();
@@ -1082,11 +1160,11 @@ fn save_data(
         );
     }
 
-    if let Some(parent) = data_file.parent()
-        && !parent.as_str().is_empty()
-    {
-        fs::create_dir_all(parent.as_std_path())?;
-    }
+    let parent = data_file
+        .parent()
+        .filter(|parent| !parent.as_str().is_empty())
+        .unwrap_or_else(|| Utf8Path::new("."));
+    fs::create_dir_all(parent.as_std_path())?;
     let source_roots = roots
         .iter()
         .map(|root| root.to_string_lossy().into_owned())
@@ -1095,7 +1173,12 @@ fn save_data(
         source_roots,
         files,
     })?;
-    fs::write(data_file.as_std_path(), bytes)
+    let mut temporary = tempfile::NamedTempFile::new_in(parent.as_std_path())?;
+    temporary.write_all(&bytes)?;
+    temporary
+        .persist(data_file.as_std_path())
+        .map(|_| ())
+        .map_err(|error| error.error)
 }
 
 #[cfg(test)]
@@ -1314,6 +1397,7 @@ code = Code()
             &[],
             &CoverageExclusions::default(),
             &CoveragePartials::default(),
+            true,
         )
         .expect_err("missing source should fail");
 

--- a/crates/karva_test_semantic/src/lib.rs
+++ b/crates/karva_test_semantic/src/lib.rs
@@ -15,11 +15,13 @@ pub(crate) use context::{Context, RunState};
 pub use karva_coverage::CoverageConfig;
 pub use python::init_module;
 
-use camino::Utf8Path;
+use camino::{Utf8Path, Utf8PathBuf};
 use karva_coverage::CoverageSession;
 use karva_diagnostic::{Reporter, TestRunResult};
 use karva_metadata::ProjectSettings;
 use karva_project::path::{TestPath, TestPathError};
+use pyo3::prelude::{PyResult, Python};
+use pyo3::types::PyAnyMethods;
 use ruff_python_ast::PythonVersion;
 
 use crate::diagnostic::failed_to_start_coverage_diagnostic;
@@ -52,6 +54,13 @@ pub fn run_tests(
                 None
             }
         });
+        if let (Some(session), Some(config)) = (&cov_session, coverage)
+            && let Err(err) = configure_child_process_coverage(py, session, config)
+        {
+            state.add_run_diagnostic(failed_to_start_coverage_diagnostic(
+                &err.value(py).to_string(),
+            ));
+        }
 
         let discovery = StandardDiscoverer::new(&context).discover_with_py(py, test_paths);
 
@@ -78,4 +87,28 @@ pub fn run_tests(
 
         state.into_result()
     })
+}
+
+fn configure_child_process_coverage(
+    py: Python<'_>,
+    session: &CoverageSession,
+    config: &CoverageConfig,
+) -> PyResult<()> {
+    let roots = session.source_roots(py)?;
+    let shard_directory = config.data_file.parent().map_or_else(
+        || Utf8PathBuf::from("coverage-children"),
+        |parent| parent.join("coverage-children"),
+    );
+    py.import("karva._coverage")?.call_method1(
+        "_configure",
+        (
+            roots,
+            shard_directory.as_str(),
+            config.branches,
+            &config.exclude_lines,
+            &config.partial_branches,
+            config.static_context.as_deref(),
+        ),
+    )?;
+    Ok(())
 }

--- a/crates/karva_test_semantic/src/python.rs
+++ b/crates/karva_test_semantic/src/python.rs
@@ -16,6 +16,8 @@ use crate::extensions::tags::python::{PyTags, PyTestFunction, tags};
 
 /// Populates the native `karva` Python module with its functions, classes, and exceptions.
 pub fn init_module(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(karva_coverage::start_child_coverage, m)?)?;
+    m.add_class::<karva_coverage::ChildCoverageSession>()?;
     m.add_function(wrap_pyfunction!(fixture_decorator, m)?)?;
     m.add_function(wrap_pyfunction!(skip, m)?)?;
     m.add_function(wrap_pyfunction!(fail, m)?)?;

--- a/docs/usage/writing-tests/coverage.md
+++ b/docs/usage/writing-tests/coverage.md
@@ -134,6 +134,10 @@ uv run karva coverage html --contexts 'python=3\.14' --show-contexts
 uv run karva coverage json --contexts '\|setup$' --show-contexts
 ```
 
+Coverage-enabled runs also collect Python code executed by descendant interpreters. This includes Python launched through `subprocess`, `multiprocessing` spawn and fork modes, normal interpreter exit, `os._exit`, and `os.exec*` process replacement. Descendants inherit source roots, branch mode, and static context, then write collision-free shards merged through the same native data path.
+
+Hard termination cannot flush in-process data. `SIGKILL`, forced process termination, crashes, and Python launched with `-S` are not covered after their last successful flush.
+
 Persisted native coverage data can be exported independently. Output is compact by default:
 
 ```bash

--- a/python/karva/_coverage.py
+++ b/python/karva/_coverage.py
@@ -1,0 +1,164 @@
+"""Bootstrap native coverage in opted-in Python child processes."""
+
+from __future__ import annotations
+
+import atexit
+import json
+import os
+import uuid
+import warnings
+from collections.abc import Callable
+from pathlib import Path
+from typing import NoReturn, TypedDict, cast
+
+from karva._karva import _ChildCoverageSession, _start_child_coverage
+
+_CONFIG_ENV = "_KARVA_COVERAGE_CONFIG"
+_collector: _ChildCoverageSession | None = None
+_configured = False
+
+
+class _Config(TypedDict):
+    roots: list[str]
+    directory: str
+    branches: bool
+    exclude_lines: list[str]
+    partial_branches: list[str]
+    context: str | None
+
+
+def _load_config(raw: str) -> _Config:
+    value = json.loads(raw)
+    if not isinstance(value, dict):
+        raise TypeError("Karva child coverage config must be an object")
+    for name in ("roots", "exclude_lines", "partial_branches"):
+        items = value.get(name)
+        if not isinstance(items, list) or not all(
+            isinstance(item, str) for item in items
+        ):
+            raise TypeError(f"Karva child coverage {name} must contain strings")
+    if not isinstance(value.get("directory"), str):
+        raise TypeError("Karva child coverage directory must be a string")
+    if not isinstance(value.get("branches"), bool):
+        raise TypeError("Karva child coverage branches must be a boolean")
+    context = value.get("context")
+    if context is not None and not isinstance(context, str):
+        raise TypeError("Karva child coverage context must be a string or null")
+    return cast(_Config, value)
+
+
+def _start() -> None:
+    global _collector
+    raw = os.environ.get(_CONFIG_ENV)
+    if raw is None:
+        return
+    config = _load_config(raw)
+    data_file = Path(config["directory"]) / f"{os.getpid()}-{uuid.uuid4()}.json"
+    _collector = _start_child_coverage(
+        config["roots"],
+        str(data_file),
+        config["branches"],
+        config["exclude_lines"],
+        config["partial_branches"],
+        config["context"],
+    )
+
+
+def _save() -> None:
+    global _collector
+    if _collector is None:
+        return
+    try:
+        _collector.stop_and_save()
+        _collector = None
+    except Exception as error:
+        warnings.warn(
+            f"Karva failed to save child-process coverage: {error}", stacklevel=2
+        )
+
+
+def _exec_wrapper(original: Callable[..., NoReturn]) -> Callable[..., NoReturn]:
+    def exec_with_coverage(*args: object, **kwargs: object) -> NoReturn:
+        was_active = _collector is not None
+        _save()
+        try:
+            original(*args, **kwargs)
+        except BaseException:
+            if was_active:
+                _start()
+            raise
+
+    return exec_with_coverage
+
+
+def _wrap_exit_and_exec() -> None:
+    original_exit = os._exit
+
+    def exit_with_coverage(status: int) -> NoReturn:
+        _save()
+        original_exit(status)
+
+    setattr(os, "_exit", exit_with_coverage)  # noqa: B010
+    for name in (
+        "execl",
+        "execle",
+        "execlp",
+        "execlpe",
+        "execv",
+        "execve",
+        "execvp",
+        "execvpe",
+    ):
+        original_value = getattr(os, name)
+        if not callable(original_value):
+            raise TypeError(f"os.{name} must be callable")
+        setattr(
+            os,
+            name,
+            _exec_wrapper(cast(Callable[..., NoReturn], original_value)),
+        )
+
+
+def _install_hooks() -> None:
+    global _configured
+    if _configured:
+        return
+    _configured = True
+    atexit.register(_save)
+    if hasattr(os, "register_at_fork"):
+        os.register_at_fork(after_in_child=_start)
+    _wrap_exit_and_exec()
+
+
+def _configure(
+    roots: list[str],
+    directory: str,
+    branches: bool,
+    exclude_lines: list[str],
+    partial_branches: list[str],
+    context: str | None,
+) -> None:
+    os.environ[_CONFIG_ENV] = json.dumps(
+        {
+            "roots": roots,
+            "directory": directory,
+            "branches": branches,
+            "exclude_lines": exclude_lines,
+            "partial_branches": partial_branches,
+            "context": context,
+        },
+        separators=(",", ":"),
+    )
+    bootstrap = str(Path(__file__).with_name("_coverage_bootstrap"))
+    python_path = os.environ.get("PYTHONPATH")
+    os.environ["PYTHONPATH"] = os.pathsep.join(
+        [bootstrap, python_path] if python_path else [bootstrap]
+    )
+    _install_hooks()
+
+
+def _bootstrap() -> None:
+    if os.environ.get(_CONFIG_ENV) is None:
+        return
+    _start()
+    _install_hooks()

--- a/python/karva/_coverage_bootstrap/__init__.py
+++ b/python/karva/_coverage_bootstrap/__init__.py
@@ -1,0 +1,1 @@
+"""Interpreter startup hook for Karva child-process coverage."""

--- a/python/karva/_coverage_bootstrap/sitecustomize.py
+++ b/python/karva/_coverage_bootstrap/sitecustomize.py
@@ -1,0 +1,5 @@
+"""Start Karva coverage in opted-in Python child processes."""
+
+from karva._coverage import _bootstrap
+
+_bootstrap()

--- a/python/karva/_karva/__init__.pyi
+++ b/python/karva/_karva/__init__.pyi
@@ -15,6 +15,24 @@ def karva_run() -> int:
     """Run Karva using the current process arguments."""
 
 
+class _ChildCoverageSession:
+    """Own native coverage collection in an opted-in child interpreter."""
+
+    def stop_and_save(self) -> None:
+        """Stop collection and atomically write child coverage data."""
+
+
+def _start_child_coverage(
+    roots: list[str],
+    data_file: str,
+    branches: bool,
+    exclude_lines: list[str],
+    partial_branches: list[str],
+    static_context: str | None,
+) -> _ChildCoverageSession:
+    """Start native coverage collection for a Python child interpreter."""
+
+
 class FixtureFunctionMarker(Generic[_P, _T]):
     """Mark a function as a fixture."""
 


### PR DESCRIPTION
## Summary

Collect native coverage from Python descendants launched through subprocess, multiprocessing spawn/fork, normal exit, os._exit, and exec replacement. Descendants inherit source, branch, and static-context settings and write atomic collision-free shards merged through the existing native path.

Closes #1165.

## Test Plan

Full test suite, workspace Clippy, and pre-commit hooks.