### PR TITLE
Validate coverage exports against downstream tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,6 +1212,7 @@ dependencies = [
  "fs-err",
  "globset",
  "insta",
+ "lcov",
  "pyo3",
  "regex",
  "ruff_python_ast",
@@ -1478,6 +1479,15 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lcov"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dab4f1d99e0dd8008da0d3452bb71ce08e1645465c2accc124bcb599c6b3143"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "leb128fmt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ ignore = { version = "0.4.25" }
 insta = { version = "1.47.1" }
 insta-cmd = { version = "0.7.0" }
 itertools = { version = "0.15.0" }
+lcov = { version = "0.8.2" }
 libc = { version = "0.2.178" }
 markdown = { version = "1.0.0" }
 notify-debouncer-mini = { version = "0.7" }

--- a/crates/karva/tests/it/coverage.rs
+++ b/crates/karva/tests/it/coverage.rs
@@ -979,7 +979,7 @@ def test_only_covered():
     <?xml version="1.0" ?>
     <coverage version="1.0" timestamp="[TIMESTAMP]" lines-valid="6" lines-covered="5" line-rate="0.8333" branches-covered="0" branches-valid="0" branch-rate="0.0000" complexity="0.0">
       <sources>
-        <source><temp_dir>/</source>
+        <source>.</source>
       </sources>
       <packages>
         <package name="." line-rate="0.8333" branch-rate="0.0000" complexity="0.0">
@@ -1049,7 +1049,7 @@ def test_only_covered():
     <?xml version="1.0" ?>
     <coverage version="1.0" timestamp="[TIMESTAMP]" lines-valid="6" lines-covered="5" line-rate="0.8333" branches-covered="0" branches-valid="0" branch-rate="0.0000" complexity="0.0">
       <sources>
-        <source><temp_dir>/</source>
+        <source>.</source>
       </sources>
       <packages>
         <package name="." line-rate="0.8333" branch-rate="0.0000" complexity="0.0">

--- a/crates/karva/tests/it/coverage_command.rs
+++ b/crates/karva/tests/it/coverage_command.rs
@@ -316,7 +316,7 @@ fn xml_writes_cobertura_report() {
     <?xml version="1.0" ?>
     <coverage version="1.0" timestamp="[TIMESTAMP]" lines-valid="2" lines-covered="1" line-rate="0.5000" branches-covered="0" branches-valid="0" branch-rate="0.0000" complexity="0.0">
       <sources>
-        <source><temp_dir>/</source>
+        <source>.</source>
       </sources>
       <packages>
         <package name="." line-rate="0.5000" branch-rate="0.0000" complexity="0.0">

--- a/crates/karva_coverage/Cargo.toml
+++ b/crates/karva_coverage/Cargo.toml
@@ -32,6 +32,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
+lcov = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/karva_coverage/src/report/lcov.rs
+++ b/crates/karva_coverage/src/report/lcov.rs
@@ -75,7 +75,7 @@ mod tests {
             miss: 1,
             missing: "2".to_owned(),
             executable: vec![1, 2],
-            excluded: Vec::new(),
+            excluded: vec![3],
             executed: vec![1],
             contexts: BTreeMap::new(),
             branches_enabled: true,
@@ -88,8 +88,31 @@ mod tests {
             branch_missing: vec![missing],
             arc_contexts: BTreeMap::new(),
         };
+        let uncovered = FileRow {
+            name: "src/uncovered.py".to_owned(),
+            absolute_name: "/project/src/uncovered.py".to_owned(),
+            stmts: 1,
+            hit: 0,
+            miss: 1,
+            missing: "1".to_owned(),
+            executable: vec![1],
+            excluded: Vec::new(),
+            executed: Vec::new(),
+            contexts: BTreeMap::new(),
+            branches_enabled: true,
+            branches: 0,
+            branch_hit: 0,
+            branch_miss: 0,
+            branch_partial: 0,
+            branch_possible: Vec::new(),
+            branch_executed: Vec::new(),
+            branch_missing: Vec::new(),
+            arc_contexts: BTreeMap::new(),
+        };
 
-        insta::assert_snapshot!(build_lcov_report(&[row]).expect("build LCOV report"), @r"
+        let report = build_lcov_report(&[row, uncovered]).expect("build LCOV report");
+
+        insta::assert_snapshot!(report, @r"
         SF:src/app.py
         DA:1,1
         DA:2,0
@@ -100,7 +123,76 @@ mod tests {
         BRF:2
         BRH:1
         end_of_record
+        SF:src/uncovered.py
+        DA:1,0
+        LF:1
+        LH:0
+        end_of_record
         ");
+        let records = lcov::Reader::new(report.as_bytes())
+            .collect::<Result<Vec<_>, _>>()
+            .expect("standard LCOV parser accepts report");
+        insta::assert_debug_snapshot!(records, @r#"
+        [
+            SourceFile {
+                path: "src/app.py",
+            },
+            LineData {
+                line: 1,
+                count: 1,
+                checksum: None,
+            },
+            LineData {
+                line: 2,
+                count: 0,
+                checksum: None,
+            },
+            LinesFound {
+                found: 2,
+            },
+            LinesHit {
+                hit: 1,
+            },
+            BranchData {
+                line: 1,
+                block: 0,
+                branch: 0,
+                taken: Some(
+                    1,
+                ),
+            },
+            BranchData {
+                line: 1,
+                block: 0,
+                branch: 1,
+                taken: Some(
+                    0,
+                ),
+            },
+            BranchesFound {
+                found: 2,
+            },
+            BranchesHit {
+                hit: 1,
+            },
+            EndOfRecord,
+            SourceFile {
+                path: "src/uncovered.py",
+            },
+            LineData {
+                line: 1,
+                count: 0,
+                checksum: None,
+            },
+            LinesFound {
+                found: 1,
+            },
+            LinesHit {
+                hit: 0,
+            },
+            EndOfRecord,
+        ]
+        "#);
     }
 
     #[test]

--- a/crates/karva_coverage/src/report/xml.rs
+++ b/crates/karva_coverage/src/report/xml.rs
@@ -40,8 +40,6 @@ pub(super) fn build_cobertura_xml(
         .duration_since(UNIX_EPOCH)
         .with_context(|| format!("coverage root modification time is before UNIX epoch: {cwd}"))?
         .as_secs();
-    let source_root = cwd_real.to_string_lossy().trim_end_matches('/').to_string();
-
     let mut xml = String::new();
     xml.push_str("<?xml version=\"1.0\" ?>\n");
     writeln!(
@@ -49,7 +47,7 @@ pub(super) fn build_cobertura_xml(
         "<coverage version=\"1.0\" timestamp=\"{timestamp}\" lines-valid=\"{total_stmts}\" lines-covered=\"{total_hit}\" line-rate=\"{line_rate:.4}\" branches-covered=\"{total_branch_hit}\" branches-valid=\"{total_branches}\" branch-rate=\"{branch_rate:.4}\" complexity=\"0.0\">"
     )?;
     xml.push_str("  <sources>\n");
-    writeln!(xml, "    <source>{}</source>", escape_xml(&source_root))?;
+    xml.push_str("    <source>.</source>\n");
     xml.push_str("  </sources>\n");
     xml.push_str("  <packages>\n");
     writeln!(
@@ -121,8 +119,11 @@ fn branch_lines(row: &FileRow) -> BTreeMap<u32, (u32, u32)> {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
+    use std::path::Path;
 
     use camino::Utf8Path;
+    use pyo3::prelude::*;
+    use pyo3::types::PyAnyMethods;
 
     use super::{branch_lines, build_cobertura_xml};
     use crate::data::BranchArc;
@@ -171,5 +172,94 @@ mod tests {
         };
 
         assert_eq!(branch_lines(&row), BTreeMap::from([(1, (2, 2))]));
+    }
+
+    #[test]
+    fn standard_xml_parser_accepts_portable_branch_report() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let cwd = Utf8Path::from_path(directory.path()).expect("UTF-8 temporary path");
+        let taken = BranchArc { from: 2, to: 3 };
+        let missing = BranchArc { from: 2, to: 5 };
+        let row = FileRow {
+            name: "src/app.py".to_owned(),
+            absolute_name: "/workspace/src/app.py".to_owned(),
+            stmts: 3,
+            hit: 2,
+            miss: 1,
+            missing: "3".to_owned(),
+            executable: vec![1, 2, 3],
+            excluded: vec![4],
+            executed: vec![1, 2],
+            contexts: BTreeMap::new(),
+            branches_enabled: true,
+            branches: 2,
+            branch_hit: 1,
+            branch_miss: 1,
+            branch_partial: 1,
+            branch_possible: vec![taken, missing],
+            branch_executed: vec![taken],
+            branch_missing: vec![missing],
+            arc_contexts: BTreeMap::new(),
+        };
+        let uncovered = FileRow {
+            name: "src/uncovered.py".to_owned(),
+            absolute_name: "/workspace/src/uncovered.py".to_owned(),
+            stmts: 1,
+            hit: 0,
+            miss: 1,
+            missing: "1".to_owned(),
+            executable: vec![1],
+            excluded: Vec::new(),
+            executed: Vec::new(),
+            contexts: BTreeMap::new(),
+            branches_enabled: true,
+            branches: 0,
+            branch_hit: 0,
+            branch_miss: 0,
+            branch_partial: 0,
+            branch_possible: Vec::new(),
+            branch_executed: Vec::new(),
+            branch_missing: Vec::new(),
+            arc_contexts: BTreeMap::new(),
+        };
+        let report = build_cobertura_xml(cwd, Path::new("/workspace"), &[row, uncovered])
+            .expect("build Cobertura report");
+        Python::initialize();
+        Python::attach(|py| -> PyResult<()> {
+            let root = py
+                .import("xml.etree.ElementTree")?
+                .call_method1("fromstring", (&report,))?;
+            assert_eq!(root.getattr("tag")?.extract::<String>()?, "coverage");
+            assert_eq!(
+                root.call_method1("findtext", ("./sources/source",))?
+                    .extract::<String>()?,
+                "."
+            );
+            let mut filenames = Vec::new();
+            for class in root.call_method1("findall", (".//class",))?.try_iter()? {
+                filenames.push(
+                    class?
+                        .getattr("attrib")?
+                        .get_item("filename")?
+                        .extract::<String>()?,
+                );
+            }
+            assert_eq!(filenames, ["src/app.py", "src/uncovered.py"]);
+            let branch = root.call_method1("find", (".//line[@branch='true']",))?;
+            assert!(!branch.is_none());
+            assert_eq!(
+                branch
+                    .getattr("attrib")?
+                    .get_item("condition-coverage")?
+                    .extract::<String>()?,
+                "50% (1/2)"
+            );
+            assert!(
+                root.call_method1("find", (".//line[@number='4']",))?
+                    .is_none()
+            );
+            Ok(())
+        })
+        .expect("standard XML parser accepts report");
     }
 }

--- a/docs/usage/writing-tests/coverage.md
+++ b/docs/usage/writing-tests/coverage.md
@@ -153,6 +153,20 @@ uv run karva coverage lcov --output build/coverage.lcov
 
 LCOV `SF`, `DA`, `LF`, `LH`, `BRDA`, `BRF`, and `BRH` records are a supported external contract. Source paths are portable project-relative paths after configured path aliases are applied.
 
+### CI integrations
+
+Prefer Cobertura XML unless an integration specifically expects LCOV. Both exports use repository-relative source paths; run upload and analysis tools from the repository root.
+
+| Integration | Karva export | Configuration |
+| --- | --- | --- |
+| [Codecov](https://docs.codecov.com/docs/supported-report-formats) | Cobertura XML | Upload `coverage.xml`; Codecov also accepts LCOV. |
+| [Coveralls](https://github.com/coverallsapp/coverage-reporter#supported-coverage-report-formats) | LCOV | Run `coveralls report coverage.lcov --format=lcov`. |
+| [GitLab coverage visualization](https://docs.gitlab.com/ci/testing/code_coverage/cobertura/) | Cobertura XML | Upload `coverage.xml` as a `cobertura` coverage report artifact. |
+| [SonarQube Python coverage](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/test-coverage/python-test-coverage) | Cobertura XML | Set `sonar.python.coverage.reportPaths=coverage.xml`. |
+| [diff-cover](https://github.com/Bachmann1234/diff-cover#readme) | Cobertura XML | Run `diff-cover coverage.xml` from repository root. |
+
+Cobertura `<source>` is `.` and each `<class filename>` is repository-relative. LCOV `SF` paths are also repository-relative. This keeps reports portable when CI generates and consumes artifacts in different checkout directories.
+
 Combine native artifacts from CI shards before reporting:
 
 ```bash


### PR DESCRIPTION
## Summary

Make Cobertura artifacts portable across CI checkouts, validate generated Cobertura and LCOV reports with independent parsers, and document recommended exports for Codecov, Coveralls, GitLab, SonarQube, and diff-cover.

Closes #1166.

## Test Plan

Full test suite, workspace Clippy, documentation build, pre-commit hooks, and diff-cover parser validation.