### PR TITLE
Publish complete benchmark reports in CI

### DIFF
--- a/.github/workflows/pr-benchmarks.yml
+++ b/.github/workflows/pr-benchmarks.yml
@@ -279,6 +279,7 @@ jobs:
             --output-markdown "${RUNNER_TEMP}/benchmark-report.md" \
             --output-html "${RUNNER_TEMP}/benchmark-report.html" \
             --output-diagnostics-markdown "${RUNNER_TEMP}/diagnostic-report.md" \
+            --output-diagnostics-summary-markdown "${RUNNER_TEMP}/diagnostic-summary.md" \
             --output-diagnostics-html "${RUNNER_TEMP}/diagnostic-report.html"
 
       - name: Merge memory benchmark reports
@@ -290,12 +291,12 @@ jobs:
             --output-markdown "${RUNNER_TEMP}/benchmark-memory-report.md" \
             --output-html "${RUNNER_TEMP}/benchmark-memory-report.html"
 
-      - name: Publish full benchmark summary
+      - name: Publish benchmark summary
         run: |
           cat \
             "${RUNNER_TEMP}/benchmark-report.md" \
             "${RUNNER_TEMP}/benchmark-memory-report.md" \
-            "${RUNNER_TEMP}/diagnostic-report.md" \
+            "${RUNNER_TEMP}/diagnostic-summary.md" \
             >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Upload full benchmark reports
@@ -330,7 +331,7 @@ jobs:
 
 
           > [!NOTE]
-          > Report truncated to fit GitHub's comment limit. [View the complete report online](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) or [download the report artifact](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}#artifacts).
+          > Report truncated to fit GitHub's comment limit. [View the complete summary online](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) or [download the full report artifact](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}#artifacts).
           EOF
             )
 
@@ -366,5 +367,5 @@ jobs:
             "${RUNNER_TEMP}/benchmark-memory-comment.json"
           comment_report \
             "<!-- karva-diagnostic-comparison -->" \
-            "${RUNNER_TEMP}/diagnostic-report.md" \
+            "${RUNNER_TEMP}/diagnostic-summary.md" \
             "${RUNNER_TEMP}/diagnostic-comment.json"

--- a/.github/workflows/pr-benchmarks.yml
+++ b/.github/workflows/pr-benchmarks.yml
@@ -110,9 +110,9 @@ jobs:
           git worktree add --detach "${base_worktree}" "${BASE_SHA}"
           (
             cd "${base_worktree}"
-            uv run --no-project --with maturin maturin build --out "${base_wheel_dir}"
+            uv run --no-project --with maturin maturin build --release --out "${base_wheel_dir}"
           )
-          uv run --no-project --with maturin maturin build --out "${head_wheel_dir}"
+          uv run --no-project --with maturin maturin build --release --out "${head_wheel_dir}"
 
           base_wheel=$(find "${base_wheel_dir}" -maxdepth 1 -name "karva-*.whl" -print -quit)
           head_wheel=$(find "${head_wheel_dir}" -maxdepth 1 -name "karva-*.whl" -print -quit)
@@ -277,7 +277,9 @@ jobs:
           cargo run -p karva_benchmark --bin karva-benchmark -- merge-reports \
             --input-dir "${RUNNER_TEMP}/benchmark-reports" \
             --output-markdown "${RUNNER_TEMP}/benchmark-report.md" \
-            --output-diagnostics-markdown "${RUNNER_TEMP}/diagnostic-report.md"
+            --output-html "${RUNNER_TEMP}/benchmark-report.html" \
+            --output-diagnostics-markdown "${RUNNER_TEMP}/diagnostic-report.md" \
+            --output-diagnostics-html "${RUNNER_TEMP}/diagnostic-report.html"
 
       - name: Merge memory benchmark reports
         env:
@@ -285,15 +287,27 @@ jobs:
         run: |
           cargo run -p karva_benchmark --bin karva-benchmark -- merge-reports \
             --input-dir "${RUNNER_TEMP}/benchmark-memory-reports" \
-            --output-markdown "${RUNNER_TEMP}/benchmark-memory-report.md"
+            --output-markdown "${RUNNER_TEMP}/benchmark-memory-report.md" \
+            --output-html "${RUNNER_TEMP}/benchmark-memory-report.html"
+
+      - name: Publish full benchmark summary
+        run: |
+          cat \
+            "${RUNNER_TEMP}/benchmark-report.md" \
+            "${RUNNER_TEMP}/benchmark-memory-report.md" \
+            "${RUNNER_TEMP}/diagnostic-report.md" \
+            >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Upload full benchmark reports
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: benchmark-markdown-reports
+          name: benchmark-reports
           path: |
+            ${{ runner.temp }}/benchmark-report.html
             ${{ runner.temp }}/benchmark-report.md
+            ${{ runner.temp }}/benchmark-memory-report.html
             ${{ runner.temp }}/benchmark-memory-report.md
+            ${{ runner.temp }}/diagnostic-report.html
             ${{ runner.temp }}/diagnostic-report.md
 
       - name: Comment benchmark reports
@@ -316,7 +330,7 @@ jobs:
 
 
           > [!NOTE]
-          > Report truncated to fit GitHub's comment limit. [Download the complete report artifact](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}#artifacts).
+          > Report truncated to fit GitHub's comment limit. [View the complete report online](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) or [download the report artifact](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}#artifacts).
           EOF
             )
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,3 +44,24 @@ Do not mix formatter churn with logic changes or add AI tools as authors.
 
 Use only the `internal` label when nothing changes for users and only `ci` for
 CI performance changes. Reserve `performance` for user-facing improvements.
+
+## Reviewing PR Benchmarks
+
+Open the `PR Benchmarks` workflow run to review the complete wall-time, memory,
+and diagnostic summary online. Changed test workloads are shown separately from
+comparable performance results because their raw totals measure different work.
+
+The `benchmark-reports` artifact contains rendered HTML and Markdown reports.
+Its diagnostic report includes the normalized baseline and candidate output for
+every project, including each passing, failing, errored, and skipped test. To
+inspect the artifact locally, set `RUN_ID` to the workflow run ID:
+
+```sh
+gh run download "$RUN_ID" \
+  --repo MatthewMckee4/karva \
+  --name benchmark-reports \
+  --dir benchmark-reports
+```
+
+Open `benchmark-reports/diagnostic-report.html` in a browser. The wall-time and
+memory reports are beside it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,6 +1140,7 @@ dependencies = [
  "karva_project",
  "karva_runner",
  "karva_static",
+ "markdown",
  "regex",
  "ruff_python_ast",
  "serde",

--- a/crates/karva_benchmark/Cargo.toml
+++ b/crates/karva_benchmark/Cargo.toml
@@ -28,6 +28,7 @@ karva_metadata = { workspace = true }
 karva_project = { workspace = true }
 karva_runner = { workspace = true }
 karva_static = { workspace = true }
+markdown = { workspace = true }
 regex = { workspace = true }
 ruff_python_ast = { workspace = true }
 serde = { workspace = true }

--- a/crates/karva_benchmark/src/bin/karva_benchmark.rs
+++ b/crates/karva_benchmark/src/bin/karva_benchmark.rs
@@ -93,6 +93,9 @@ struct MergeReportsArgs {
     output_diagnostics_markdown: Option<PathBuf>,
 
     #[arg(long, value_name = "PATH")]
+    output_diagnostics_summary_markdown: Option<PathBuf>,
+
+    #[arg(long, value_name = "PATH")]
     output_diagnostics_html: Option<PathBuf>,
 }
 
@@ -140,6 +143,10 @@ struct DiagnosticComparison {
     workload_changed: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     diff: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    baseline_output: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    candidate_output: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -295,6 +302,8 @@ fn compare(args: CompareArgs) -> Result<()> {
                 candidate: diagnostics.candidate.clone(),
                 workload_changed: diagnostics.workload_changed,
                 diff: None,
+                baseline_output: None,
+                candidate_output: None,
             });
 
         wall_time_comparisons.push(ProjectComparison {
@@ -361,11 +370,14 @@ fn merge_reports(args: MergeReportsArgs) -> Result<()> {
     if let Some(path) = args.output_diagnostics_markdown {
         write_diagnostics_markdown(&utf8_path(path)?, &report)?;
     }
+    if let Some(path) = args.output_diagnostics_summary_markdown {
+        write_diagnostics_summary_markdown(&utf8_path(path)?, &report)?;
+    }
     if let Some(path) = args.output_diagnostics_html {
         write_html(
             &utf8_path(path)?,
             "Diagnostic comparison",
-            &diagnostics_markdown_report(&report)
+            &diagnostics_markdown_report(&report, true)
                 .context("Failed to render HTML diagnostics report")?,
         )?;
     }
@@ -672,6 +684,8 @@ fn diagnostic_comparison(
         candidate: candidate_stats,
         workload_changed,
         diff,
+        baseline_output: Some(baseline.to_string()),
+        candidate_output: Some(candidate.to_string()),
     })
 }
 
@@ -744,8 +758,15 @@ fn write_markdown(path: &Utf8Path, report: &ComparisonReport) -> Result<()> {
 
 fn write_diagnostics_markdown(path: &Utf8Path, report: &ComparisonReport) -> Result<()> {
     create_parent_dir(path)?;
-    let body = diagnostics_markdown_report(report)
+    let body = diagnostics_markdown_report(report, true)
         .context("Failed to render markdown diagnostics report")?;
+    fs::write(path, body).with_context(|| format!("Failed to write `{path}`"))
+}
+
+fn write_diagnostics_summary_markdown(path: &Utf8Path, report: &ComparisonReport) -> Result<()> {
+    create_parent_dir(path)?;
+    let body = diagnostics_markdown_report(report, false)
+        .context("Failed to render markdown diagnostics summary")?;
     fs::write(path, body).with_context(|| format!("Failed to write `{path}`"))
 }
 
@@ -881,6 +902,7 @@ fn markdown_report(report: &ComparisonReport) -> std::result::Result<String, std
 
 fn diagnostics_markdown_report(
     report: &ComparisonReport,
+    include_full_output: bool,
 ) -> std::result::Result<String, std::fmt::Error> {
     use std::fmt::Write as _;
 
@@ -923,11 +945,19 @@ fn diagnostics_markdown_report(
     body.push_str("\n</details>\n");
 
     for project in &report.projects {
-        let Some(diff) = project
-            .diagnostics
-            .as_ref()
-            .and_then(|diagnostics| diagnostics.diff.as_deref())
-        else {
+        let Some(diagnostics) = &project.diagnostics else {
+            continue;
+        };
+        let Some(diff) = diagnostics.diff.as_deref() else {
+            if include_full_output {
+                write_full_diagnostic_output(
+                    &mut body,
+                    project,
+                    diagnostics,
+                    &report.baseline_label,
+                    &report.candidate_label,
+                )?;
+            }
             continue;
         };
         writeln!(
@@ -936,11 +966,80 @@ fn diagnostics_markdown_report(
             project.name
         )?;
         body.push_str("Durations and memory addresses are normalized.\n\n");
-        writeln!(body, "```diff\n{diff}```\n")?;
+        write_code_block(&mut body, "diff", diff)?;
+        writeln!(body)?;
         body.push_str("</details>\n");
+
+        if include_full_output {
+            write_full_diagnostic_output(
+                &mut body,
+                project,
+                diagnostics,
+                &report.baseline_label,
+                &report.candidate_label,
+            )?;
+        }
     }
 
     Ok(body)
+}
+
+fn write_full_diagnostic_output(
+    body: &mut String,
+    project: &ProjectComparison,
+    diagnostics: &DiagnosticComparison,
+    baseline_label: &str,
+    candidate_label: &str,
+) -> std::result::Result<(), std::fmt::Error> {
+    use std::fmt::Write as _;
+
+    writeln!(
+        body,
+        "\n<details>\n<summary><code>{}</code> full diagnostic output</summary>\n",
+        project.name
+    )?;
+    body.push_str("Durations and memory addresses are normalized.\n\n");
+    writeln!(body, "#### Baseline: `{baseline_label}`\n")?;
+    write_optional_code_block(body, diagnostics.baseline_output.as_deref())?;
+    writeln!(body, "\n#### Candidate: `{candidate_label}`\n")?;
+    write_optional_code_block(body, diagnostics.candidate_output.as_deref())?;
+    body.push_str("\n</details>\n");
+    Ok(())
+}
+
+fn write_optional_code_block(
+    body: &mut String,
+    output: Option<&str>,
+) -> std::result::Result<(), std::fmt::Error> {
+    if let Some(output) = output {
+        write_code_block(body, "text", output)
+    } else {
+        body.push_str("Diagnostic output unavailable.\n");
+        Ok(())
+    }
+}
+
+fn write_code_block(
+    body: &mut String,
+    language: &str,
+    contents: &str,
+) -> std::result::Result<(), std::fmt::Error> {
+    use std::fmt::Write as _;
+
+    let (longest, trailing) = contents.bytes().fold((0_usize, 0_usize), |state, byte| {
+        if byte == b'`' {
+            (state.0, state.1 + 1)
+        } else {
+            (state.0.max(state.1), 0)
+        }
+    });
+    let fence = "`".repeat(longest.max(trailing).saturating_add(1).max(3));
+    writeln!(body, "{fence}{language}")?;
+    body.push_str(contents);
+    if !contents.ends_with('\n') {
+        body.push('\n');
+    }
+    writeln!(body, "{fence}")
 }
 
 fn test_result(stats: Option<&TestStats>) -> String {
@@ -1222,7 +1321,7 @@ mod tests {
         FAST_PROJECT_ITERATIONS, LONG_PROJECT_ITERATIONS, MEDIUM_PROJECT_ITERATIONS, Measurement,
         ProjectComparison, TestStats, diagnostic_comparison, diagnostics_markdown_report,
         is_benchmarkable_exit, karva_invocation, markdown_report, matrix_iterations,
-        normalize_diagnostic_text, standalone_html, trend,
+        normalize_diagnostic_text, standalone_html, trend, write_code_block,
     };
 
     #[test]
@@ -1324,6 +1423,8 @@ mod tests {
             }),
             workload_changed: true,
             diff: None,
+            baseline_output: None,
+            candidate_output: None,
         });
 
         let markdown =
@@ -1403,8 +1504,12 @@ mod tests {
         comparison.diagnostics =
             diagnostic_comparison(Some(&baseline), Some(&candidate), "main", "PR");
 
-        let markdown = diagnostics_markdown_report(&report_with_projects(vec![comparison]))
-            .expect("report should render");
+        let report = report_with_projects(vec![comparison]);
+        let markdown = diagnostics_markdown_report(&report, true).expect("report should render");
+        let summary = diagnostics_markdown_report(&report, false).expect("summary should render");
+
+        assert!(summary.contains("concise output diff"));
+        assert!(!summary.contains("full diagnostic output"));
 
         insta::assert_snapshot!(markdown, @"
         <!-- karva-diagnostic-comparison -->
@@ -1432,6 +1537,28 @@ mod tests {
         -Summary [TIME] 3 tests run: 2 passed, 1 skipped
         +new diagnostic
         +Summary [TIME] 3 tests run: 1 passed, 1 error, 1 skipped
+        ```
+
+        </details>
+
+        <details>
+        <summary><code>requests</code> full diagnostic output</summary>
+
+        Durations and memory addresses are normalized.
+
+        #### Baseline: `main`
+
+        ```text
+            PASS [TIME] test_hooks(hook=<function hook at 0xADDR>)
+        Summary [TIME] 3 tests run: 2 passed, 1 skipped
+        ```
+
+        #### Candidate: `PR`
+
+        ```text
+            PASS [TIME] test_hooks(hook=<function hook at 0xADDR>)
+        new diagnostic
+        Summary [TIME] 3 tests run: 1 passed, 1 error, 1 skipped
         ```
 
         </details>
@@ -1465,6 +1592,16 @@ mod tests {
     }
 
     #[test]
+    fn diagnostic_code_blocks_expand_around_embedded_fences() {
+        let mut markdown = String::new();
+
+        write_code_block(&mut markdown, "text", "before\n```\nafter\n")
+            .expect("code block should render");
+
+        assert_eq!(markdown, "````text\nbefore\n```\nafter\n````\n");
+    }
+
+    #[test]
     fn diagnostics_report_omits_unchanged_diffs() {
         let output = normalize_diagnostic_text(
             "    PASS [   0.001s] test_pass\n\
@@ -1473,8 +1610,11 @@ mod tests {
         let mut comparison = project("requests", 21, 1.0, 1.0);
         comparison.diagnostics = diagnostic_comparison(Some(&output), Some(&output), "main", "PR");
 
-        let markdown = diagnostics_markdown_report(&report_with_projects(vec![comparison]))
-            .expect("report should render");
+        let report = report_with_projects(vec![comparison]);
+        let markdown = diagnostics_markdown_report(&report, true).expect("report should render");
+        let summary = diagnostics_markdown_report(&report, false).expect("summary should render");
+
+        assert!(!summary.contains("full diagnostic output"));
 
         insta::assert_snapshot!(markdown, @"
         <!-- karva-diagnostic-comparison -->
@@ -1486,6 +1626,27 @@ mod tests {
         | Project | Previous | New |
         | --- | --- | --- |
         | `requests` | :white_check_mark: 1 pass · 0 fail · 0 error · 0 skip | :white_check_mark: 1 pass · 0 fail · 0 error · 0 skip |
+
+        </details>
+
+        <details>
+        <summary><code>requests</code> full diagnostic output</summary>
+
+        Durations and memory addresses are normalized.
+
+        #### Baseline: `main`
+
+        ```text
+            PASS [TIME] test_pass
+        Summary [TIME] 1 test run: 1 passed, 0 skipped
+        ```
+
+        #### Candidate: `PR`
+
+        ```text
+            PASS [TIME] test_pass
+        Summary [TIME] 1 test run: 1 passed, 0 skipped
+        ```
 
         </details>
         ");

--- a/crates/karva_benchmark/src/bin/karva_benchmark.rs
+++ b/crates/karva_benchmark/src/bin/karva_benchmark.rs
@@ -87,7 +87,13 @@ struct MergeReportsArgs {
     output_markdown: PathBuf,
 
     #[arg(long, value_name = "PATH")]
+    output_html: Option<PathBuf>,
+
+    #[arg(long, value_name = "PATH")]
     output_diagnostics_markdown: Option<PathBuf>,
+
+    #[arg(long, value_name = "PATH")]
+    output_diagnostics_html: Option<PathBuf>,
 }
 
 #[derive(Debug, Serialize)]
@@ -125,16 +131,18 @@ struct ProjectComparison {
     diagnostics: Option<DiagnosticComparison>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 /// Normalized test-summary comparison retained beside performance results.
 struct DiagnosticComparison {
     baseline: Option<TestStats>,
     candidate: Option<TestStats>,
+    #[serde(default)]
+    workload_changed: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     diff: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 struct TestStats {
     passed: usize,
     failed: usize,
@@ -157,6 +165,7 @@ struct ReportSummary {
     faster: usize,
     slower: usize,
     unchanged: usize,
+    changed_workloads: usize,
 }
 
 struct Subject<'a> {
@@ -273,6 +282,20 @@ fn compare(args: CompareArgs) -> Result<()> {
         let candidate_wall_time = Measurement::new(candidate_wall_time_values);
         let wall_time_percent_change =
             percent_change(baseline_wall_time.median, candidate_wall_time.median);
+        let diagnostics = diagnostic_comparison(
+            baseline_diagnostic_output.as_deref(),
+            candidate_diagnostic_output.as_deref(),
+            &args.baseline_label,
+            &args.candidate_label,
+        );
+        let memory_diagnostics = diagnostics
+            .as_ref()
+            .map(|diagnostics| DiagnosticComparison {
+                baseline: diagnostics.baseline.clone(),
+                candidate: diagnostics.candidate.clone(),
+                workload_changed: diagnostics.workload_changed,
+                diff: None,
+            });
 
         wall_time_comparisons.push(ProjectComparison {
             name: config.name.to_string(),
@@ -280,12 +303,7 @@ fn compare(args: CompareArgs) -> Result<()> {
             baseline: baseline_wall_time,
             candidate: candidate_wall_time,
             percent_change: wall_time_percent_change,
-            diagnostics: diagnostic_comparison(
-                baseline_diagnostic_output.as_deref(),
-                candidate_diagnostic_output.as_deref(),
-                &args.baseline_label,
-                &args.candidate_label,
-            ),
+            diagnostics,
         });
 
         let baseline_memory = Measurement::new(baseline_memory_values);
@@ -298,7 +316,7 @@ fn compare(args: CompareArgs) -> Result<()> {
             baseline: baseline_memory,
             candidate: candidate_memory,
             percent_change: memory_percent_change,
-            diagnostics: None,
+            diagnostics: memory_diagnostics,
         });
     }
 
@@ -333,8 +351,23 @@ fn merge_reports(args: MergeReportsArgs) -> Result<()> {
     let report = merge_report_files(&input_dir)?;
 
     write_markdown(&output_markdown, &report)?;
+    if let Some(path) = args.output_html {
+        write_html(
+            &utf8_path(path)?,
+            report.metric.report_title(),
+            &markdown_report(&report).context("Failed to render HTML benchmark report")?,
+        )?;
+    }
     if let Some(path) = args.output_diagnostics_markdown {
         write_diagnostics_markdown(&utf8_path(path)?, &report)?;
+    }
+    if let Some(path) = args.output_diagnostics_html {
+        write_html(
+            &utf8_path(path)?,
+            "Diagnostic comparison",
+            &diagnostics_markdown_report(&report)
+                .context("Failed to render HTML diagnostics report")?,
+        )?;
     }
 
     Ok(())
@@ -629,12 +662,31 @@ fn diagnostic_comparison(
             .header(baseline_label, candidate_label)
             .to_string()
     });
+    let baseline_stats = parse_test_stats(baseline);
+    let candidate_stats = parse_test_stats(candidate);
+    let workload_changed =
+        baseline_stats != candidate_stats || test_workload(baseline) != test_workload(candidate);
 
     Some(DiagnosticComparison {
-        baseline: parse_test_stats(baseline),
-        candidate: parse_test_stats(candidate),
+        baseline: baseline_stats,
+        candidate: candidate_stats,
+        workload_changed,
         diff,
     })
+}
+
+fn test_workload(output: &str) -> Vec<&str> {
+    static TEST_RESULT: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?m)^\s+(?:PASS|FAIL|ERROR|SKIP|FLAKY \d+/\d+) \[TIME\] (?P<test>.+)$")
+            .expect("test result regex should be valid")
+    });
+
+    let mut tests = TEST_RESULT
+        .captures_iter(output)
+        .filter_map(|captures| captures.name("test").map(|value| value.as_str()))
+        .collect::<Vec<_>>();
+    tests.sort_unstable();
+    tests
 }
 
 fn parse_test_stats(output: &str) -> Option<TestStats> {
@@ -697,6 +749,43 @@ fn write_diagnostics_markdown(path: &Utf8Path, report: &ComparisonReport) -> Res
     fs::write(path, body).with_context(|| format!("Failed to write `{path}`"))
 }
 
+fn write_html(path: &Utf8Path, title: &str, report: &str) -> Result<()> {
+    create_parent_dir(path)?;
+    let body = standalone_html(title, report).context("Failed to render HTML report")?;
+    fs::write(path, body).with_context(|| format!("Failed to write `{path}`"))
+}
+
+fn standalone_html(title: &str, report: &str) -> Result<String> {
+    let mut options = markdown::Options::gfm();
+    options.compile.allow_dangerous_html = true;
+    let report = markdown::to_html_with_options(report, &options)
+        .map_err(|error| anyhow::anyhow!(error.to_string()))?;
+    let title = escape_html(title);
+    Ok(format!(
+        "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">\
+         <meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">\
+         <title>{title}</title><style>\
+         :root{{color-scheme:light dark;font-family:ui-sans-serif,system-ui,sans-serif}}\
+         body{{margin:0 auto;max-width:120rem;padding:2rem;line-height:1.45}}\
+         table{{border-collapse:collapse;display:block;overflow:auto;width:max-content;max-width:100%}}\
+         th,td{{border:1px solid color-mix(in srgb,currentColor 20%,transparent);padding:.35rem .6rem;text-align:left}}\
+         th{{background:color-mix(in srgb,currentColor 8%,transparent)}}\
+         code,pre{{font-family:ui-monospace,SFMono-Regular,Consolas,monospace}}\
+         pre{{background:color-mix(in srgb,currentColor 6%,transparent);border:1px solid color-mix(in srgb,currentColor 18%,transparent);border-radius:.5rem;overflow:auto;padding:1rem}}\
+         details{{margin-block:1rem}}summary{{cursor:pointer;font-weight:600}}\
+         blockquote{{border-left:.25rem solid currentColor;margin-left:0;padding-left:1rem}}\
+         </style></head><body><h1>{title}</h1><main>{report}</main></body></html>"
+    ))
+}
+
+fn escape_html(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
 fn create_parent_dir(path: &Utf8Path) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
@@ -714,7 +803,7 @@ fn markdown_report(report: &ComparisonReport) -> std::result::Result<String, std
     let (marker, verdict) = verdict(report.metric, &summary);
     writeln!(body, "### {marker} {verdict}")?;
 
-    if summary.slower > 0 {
+    if summary.slower > 0 || summary.changed_workloads > 0 {
         writeln!(body)?;
         writeln!(
             body,
@@ -732,24 +821,51 @@ fn markdown_report(report: &ComparisonReport) -> std::result::Result<String, std
             summary.unchanged,
             "unchanged benchmark",
         )?;
-        writeln!(body)?;
-        writeln!(body, "> [!WARNING]")?;
-        writeln!(
-            body,
-            "> Benchmark regressions were detected. Review the {} changes before merging.",
-            report.metric.warning_label()
-        )?;
-        writeln!(body)?;
+        if summary.changed_workloads > 0 {
+            write_summary_line(
+                &mut body,
+                ":warning:",
+                summary.changed_workloads,
+                "changed workload",
+            )?;
+        }
+        if summary.slower > 0 {
+            writeln!(body)?;
+            writeln!(body, "> [!WARNING]")?;
+            writeln!(
+                body,
+                "> Benchmark regressions were detected. Review the {} changes before merging.",
+                report.metric.warning_label()
+            )?;
+            writeln!(body)?;
 
-        body.push_str("#### Performance Changes\n\n");
-        write_project_table(
-            &mut body,
-            report.metric,
-            report
-                .projects
-                .iter()
-                .filter(|project| is_material_change(project.percent_change)),
-        )?;
+            body.push_str("#### Performance Changes\n\n");
+            write_project_table(
+                &mut body,
+                report.metric,
+                report.projects.iter().filter(|project| {
+                    !project.workload_changed() && is_material_change(project.percent_change)
+                }),
+            )?;
+        }
+        if summary.changed_workloads > 0 {
+            writeln!(body)?;
+            writeln!(body, "> [!NOTE]")?;
+            writeln!(
+                body,
+                "> Changed workloads execute different test sets. Their raw totals are shown but are not classified as performance changes."
+            )?;
+            writeln!(body)?;
+            body.push_str("#### Workload Changes\n\n");
+            write_project_table(
+                &mut body,
+                report.metric,
+                report
+                    .projects
+                    .iter()
+                    .filter(|project| project.workload_changed()),
+            )?;
+        }
     }
 
     writeln!(body)?;
@@ -858,7 +974,7 @@ fn write_project_table<'a>(
         writeln!(
             body,
             "| {} | {} | `{}` | {} | {} | {} | {} |",
-            trend_marker(project.percent_change),
+            project.trend_marker(),
             metric.mode_label(),
             project.name,
             metric.format_value(project.baseline.median),
@@ -876,6 +992,10 @@ impl ReportSummary {
         let mut summary = Self::default();
 
         for project in projects {
+            if project.workload_changed() {
+                summary.changed_workloads += 1;
+                continue;
+            }
             match trend(project.percent_change) {
                 "faster" => summary.faster += 1,
                 "slower" => summary.slower += 1,
@@ -890,6 +1010,8 @@ impl ReportSummary {
 fn verdict(metric: BenchmarkMetric, summary: &ReportSummary) -> (&'static str, &'static str) {
     if summary.slower > 0 {
         (":x:", metric.regression_verdict())
+    } else if summary.changed_workloads > 0 {
+        (":warning:", "Benchmark includes changed test workloads")
     } else if summary.faster > 0 {
         (":zap:", metric.improvement_verdict())
     } else {
@@ -932,15 +1054,35 @@ fn is_material_change(percent_change: f64) -> bool {
     percent_change.abs() >= MATERIAL_CHANGE_PERCENT
 }
 
-fn trend_marker(percent_change: f64) -> &'static str {
-    match trend(percent_change) {
-        "faster" => ":zap:",
-        "slower" => ":x:",
-        _ => ":white_check_mark:",
+impl ProjectComparison {
+    fn workload_changed(&self) -> bool {
+        let Some(diagnostics) = &self.diagnostics else {
+            return false;
+        };
+        diagnostics.workload_changed || diagnostics.baseline != diagnostics.candidate
+    }
+
+    fn trend_marker(&self) -> &'static str {
+        if self.workload_changed() {
+            ":warning:"
+        } else {
+            match trend(self.percent_change) {
+                "faster" => ":zap:",
+                "slower" => ":x:",
+                _ => ":white_check_mark:",
+            }
+        }
     }
 }
 
 impl BenchmarkMetric {
+    fn report_title(self) -> &'static str {
+        match self {
+            Self::WallTime => "Wall-time benchmark comparison",
+            Self::Memory => "Memory benchmark comparison",
+        }
+    }
+
     fn marker(self) -> &'static str {
         match self {
             Self::WallTime => "<!-- karva-benchmark-comparison -->",
@@ -965,10 +1107,10 @@ impl BenchmarkMetric {
     fn report_context(self) -> &'static str {
         match self {
             Self::WallTime => {
-                "Each benchmark compares median CLI wall time on one GitHub Actions runner, alternating install order. Runs warm the duration cache before measuring and include default per-test status output. Lower is better."
+                "Each benchmark compares median CLI wall time from optimized wheels on one GitHub Actions runner, alternating install order. Runs warm the duration cache before measuring and include default per-test status output. Raw totals are directly comparable only when both revisions execute the same tests. Lower is better."
             }
             Self::Memory => {
-                "Each benchmark compares median peak RSS for the installed Karva CLI on one GitHub Actions runner, alternating install order. Runs warm the duration cache before measuring and are configured per project. Lower is better."
+                "Each benchmark compares median peak RSS from optimized wheels on one GitHub Actions runner, alternating install order. Runs warm the duration cache before measuring and are configured per project. Raw totals are directly comparable only when both revisions execute the same tests. Lower is better."
             }
         }
     }
@@ -1076,11 +1218,29 @@ mod tests {
     use camino::Utf8Path;
 
     use super::{
-        BenchmarkMetric, ComparisonReport, EXTRA_LONG_PROJECT_ITERATIONS, FAST_PROJECT_ITERATIONS,
-        LONG_PROJECT_ITERATIONS, MEDIUM_PROJECT_ITERATIONS, Measurement, ProjectComparison,
-        diagnostic_comparison, diagnostics_markdown_report, is_benchmarkable_exit,
-        karva_invocation, markdown_report, matrix_iterations, normalize_diagnostic_text, trend,
+        BenchmarkMetric, ComparisonReport, DiagnosticComparison, EXTRA_LONG_PROJECT_ITERATIONS,
+        FAST_PROJECT_ITERATIONS, LONG_PROJECT_ITERATIONS, MEDIUM_PROJECT_ITERATIONS, Measurement,
+        ProjectComparison, TestStats, diagnostic_comparison, diagnostics_markdown_report,
+        is_benchmarkable_exit, karva_invocation, markdown_report, matrix_iterations,
+        normalize_diagnostic_text, standalone_html, trend,
     };
+
+    #[test]
+    fn standalone_html_is_complete_and_escapes_report_content() {
+        let html = standalone_html(
+            "Report <title>",
+            "## Results\n\n| Name |\n| --- |\n| value |\n\ndiff & <script>alert(1)</script>",
+        )
+        .expect("report should render");
+
+        assert!(html.starts_with("<!doctype html>"));
+        assert!(html.contains("Report &lt;title&gt;"));
+        assert!(html.contains("<h2>Results</h2>"));
+        assert!(html.contains("<table>"));
+        assert!(html.contains("diff &amp; &lt;script>"));
+        assert!(!html.contains("<script>"));
+        assert!(html.ends_with("</body></html>"));
+    }
 
     #[test]
     fn markdown_report_renders_regressions() {
@@ -1096,7 +1256,7 @@ mod tests {
         <!-- karva-benchmark-comparison -->
         ### :x: Merging this PR may alter performance
 
-        Baseline: `main`. Candidate: `PR`. Each benchmark compares median CLI wall time on one GitHub Actions runner, alternating install order. Runs warm the duration cache before measuring and include default per-test status output. Lower is better.
+        Baseline: `main`. Candidate: `PR`. Each benchmark compares median CLI wall time from optimized wheels on one GitHub Actions runner, alternating install order. Runs warm the duration cache before measuring and include default per-test status output. Raw totals are directly comparable only when both revisions execute the same tests. Lower is better.
 
         :zap: **1** improved benchmark
         :x: **1** regressed benchmark
@@ -1141,6 +1301,60 @@ mod tests {
         |  | Mode | Benchmark | Base | Head | Change | Runs |
         | --- | --- | --- | ---: | ---: | ---: | ---: |
         | :white_check_mark: | WallTime | `flat-project` | 1.000 s | 1.004 s | +0.4% | 21 |
+
+        </details>
+        ");
+    }
+
+    #[test]
+    fn markdown_report_does_not_classify_changed_workload_as_regression() {
+        let mut comparison = project("expanded-project", 7, 1.0, 1.8);
+        comparison.diagnostics = Some(DiagnosticComparison {
+            baseline: Some(TestStats {
+                passed: 10,
+                failed: 0,
+                errors: 5,
+                skipped: 0,
+            }),
+            candidate: Some(TestStats {
+                passed: 20,
+                failed: 0,
+                errors: 0,
+                skipped: 0,
+            }),
+            workload_changed: true,
+            diff: None,
+        });
+
+        let markdown =
+            markdown_report(&report_with_projects(vec![comparison])).expect("report should render");
+
+        insta::assert_snapshot!(markdown, @"
+        <!-- karva-benchmark-comparison -->
+        ### :warning: Benchmark includes changed test workloads
+
+        Baseline: `main`. Candidate: `PR`. Each benchmark compares median CLI wall time from optimized wheels on one GitHub Actions runner, alternating install order. Runs warm the duration cache before measuring and include default per-test status output. Raw totals are directly comparable only when both revisions execute the same tests. Lower is better.
+
+        :zap: **0** improved benchmarks
+        :x: **0** regressed benchmarks
+        :white_check_mark: **0** unchanged benchmarks
+        :warning: **1** changed workload
+
+        > [!NOTE]
+        > Changed workloads execute different test sets. Their raw totals are shown but are not classified as performance changes.
+
+        #### Workload Changes
+
+        |  | Mode | Benchmark | Base | Head | Change | Runs |
+        | --- | --- | --- | ---: | ---: | ---: | ---: |
+        | :warning: | WallTime | `expanded-project` | 1.000 s | 1.800 s | +80.0% | 7 |
+
+        <details>
+        <summary>All benchmark scores</summary>
+
+        |  | Mode | Benchmark | Base | Head | Change | Runs |
+        | --- | --- | --- | ---: | ---: | ---: | ---: |
+        | :warning: | WallTime | `expanded-project` | 1.000 s | 1.800 s | +80.0% | 7 |
 
         </details>
         ");
@@ -1222,6 +1436,32 @@ mod tests {
 
         </details>
         ");
+    }
+
+    #[test]
+    fn diagnostic_comparison_detects_equal_sized_workload_changes() {
+        let baseline =
+            "    PASS [TIME] test_first\nSummary [TIME] 1 test run: 1 passed, 0 skipped\n";
+        let candidate =
+            "    PASS [TIME] test_second\nSummary [TIME] 1 test run: 1 passed, 0 skipped\n";
+
+        let comparison = diagnostic_comparison(Some(baseline), Some(candidate), "main", "PR")
+            .expect("diagnostics should be available");
+
+        assert_eq!(comparison.baseline, comparison.candidate);
+        assert!(comparison.workload_changed);
+    }
+
+    #[test]
+    fn diagnostic_comparison_detects_equal_sized_skipped_workload_changes() {
+        let baseline = "    SKIP [TIME] test_first: unavailable\nSummary [TIME] 1 test run: 0 passed, 1 skipped\n";
+        let candidate = "    SKIP [TIME] test_second: unavailable\nSummary [TIME] 1 test run: 0 passed, 1 skipped\n";
+
+        let comparison = diagnostic_comparison(Some(baseline), Some(candidate), "main", "PR")
+            .expect("diagnostics should be available");
+
+        assert_eq!(comparison.baseline, comparison.candidate);
+        assert!(comparison.workload_changed);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Publishes complete wall-time, memory, and diagnostic benchmark reports as rendered HTML and Markdown artifacts, with a size-safe concise view in the Actions summary and PR comments. Diagnostic artifacts include normalized baseline and candidate output for every project, optimized wheels make comparisons representative, and changed test workloads are reported separately instead of being mislabeled as performance regressions. CONTRIBUTING documents how to review and download the reports.

## Test Plan

Focused benchmark tests, Clippy, repository hooks, and workflow validation.