### PR TITLE
Run cargo Hawk in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
+  # renovate: datasource=github-releases depName=astral-sh/hawk
+  HAWK_VERSION: 0.1.9
   # Keep this exact version preinstalled before nextest starts.
   PYTHON_VERSION: "3.14.4"
   RUSTUP_MAX_RETRIES: 10
@@ -141,6 +143,29 @@ jobs:
 
       - name: "Lint Rust"
         run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+
+  cargo-hawk:
+    name: "cargo hawk"
+
+    runs-on: ubuntu-latest
+    # Cold local check completed in 28 seconds; 10 minutes leaves CI headroom.
+    timeout-minutes: 10
+
+    needs: determine_changes
+    if: ${{ (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: "Install Hawk"
+        run: |
+          curl --proto '=https' --tlsv1.2 -LsSf \
+            "https://github.com/astral-sh/hawk/releases/download/${HAWK_VERSION}/cargo-hawk-installer.sh" | sh
+
+      - name: "Check public Rust APIs"
+        run: cargo hawk check -D warnings -D hawk::unnecessary_crate_visibility
 
   cargo-shear:
     name: "cargo shear"

--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -376,7 +376,7 @@ fn no_tests_collected(result: &AggregatedResults) -> bool {
 /// Print the message shown when a run is stopped by `--run-timeout`.
 ///
 /// Shared by the one-shot and watch-mode paths.
-pub(super) fn print_run_timed_out(printer: Printer) -> std::io::Result<()> {
+fn print_run_timed_out(printer: Printer) -> std::io::Result<()> {
     let mut stdout = printer.stream_for_message().lock();
     writeln!(stdout, "\nerror: run timed out before all tests completed")
 }

--- a/crates/karva_benchmark/src/lib.rs
+++ b/crates/karva_benchmark/src/lib.rs
@@ -52,19 +52,19 @@ pub struct BenchmarkProject {
     pub name: &'static str,
 
     /// Git repository cloned for this workload.
-    pub repository: &'static str,
+    repository: &'static str,
 
     /// Exact Git revision preventing workload drift.
-    pub commit: &'static str,
+    commit: &'static str,
 
     /// Test selections executed inside checkout.
     pub paths: &'static [&'static str],
 
     /// Python grammar and environment version for workload.
-    pub python_version: PythonVersion,
+    python_version: PythonVersion,
 
     /// Reproducible dependency installation recipe.
-    pub dependency_setup: DependencySetup,
+    dependency_setup: DependencySetup,
 
     /// Whether Karva must import modules to discover this project's fixtures.
     pub try_import_fixtures: bool,
@@ -94,7 +94,7 @@ pub const REQUESTS_PROJECT: BenchmarkProject = BenchmarkProject {
     try_import_fixtures: true,
 };
 
-pub const FASTAPI_PROJECT: BenchmarkProject = BenchmarkProject {
+const FASTAPI_PROJECT: BenchmarkProject = BenchmarkProject {
     name: "fastapi",
     repository: "https://github.com/fastapi/fastapi",
     commit: "53d2453d1a77f3384a1648d717f8ddafb5e9e460",
@@ -108,7 +108,7 @@ pub const FASTAPI_PROJECT: BenchmarkProject = BenchmarkProject {
     try_import_fixtures: true,
 };
 
-pub const HTTPX_PROJECT: BenchmarkProject = BenchmarkProject {
+const HTTPX_PROJECT: BenchmarkProject = BenchmarkProject {
     name: "httpx",
     repository: "https://github.com/encode/httpx",
     commit: "ae1b9f66238f75ced3ced5e4485408435de10768",

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -175,7 +175,7 @@ impl RunCache {
     }
 
     /// Path to the directory for a specific worker. Does not create it.
-    pub fn worker_dir(&self, worker_id: usize) -> Utf8PathBuf {
+    fn worker_dir(&self, worker_id: usize) -> Utf8PathBuf {
         self.run_dir.join(worker_folder(worker_id))
     }
 

--- a/crates/karva_cache/src/hash.rs
+++ b/crates/karva_cache/src/hash.rs
@@ -84,7 +84,7 @@ impl RunHash {
     /// Falls back to a zero timestamp and nil UUID if the input cannot be
     /// parsed; this keeps callers from having to handle malformed legacy
     /// directories that may exist on disk.
-    pub fn from_existing(hash: &str) -> Self {
+    pub(super) fn from_existing(hash: &str) -> Self {
         let inner = hash.strip_prefix(RUN_PREFIX).unwrap_or(hash);
         let (ts_str, uuid_str) = inner.split_once('-').unwrap_or((inner, ""));
         let timestamp = ts_str.parse().unwrap_or(0);
@@ -137,12 +137,12 @@ impl RunHash {
     }
 
     /// Returns the directory name used in the cache (`run-<ms>-<uuid>`).
-    pub fn dir_name(&self) -> String {
+    pub(super) fn dir_name(&self) -> String {
         format!("{RUN_PREFIX}{}", self.inner())
     }
 
     /// Returns the underlying timestamp, used for ordering runs chronologically.
-    pub fn sort_key(&self) -> u128 {
+    pub(super) fn sort_key(&self) -> u128 {
         self.timestamp
     }
 }

--- a/crates/karva_cli/src/coverage.rs
+++ b/crates/karva_cli/src/coverage.rs
@@ -19,19 +19,19 @@ pub struct CoverageCommand {
         value_name = "PATH",
         help_heading = "Coverage options"
     )]
-    pub data_file: Option<Utf8PathBuf>,
+    data_file: Option<Utf8PathBuf>,
 
     /// Include only report paths matching this glob.
     #[arg(long, global = true, value_name = "GLOB", action = clap::ArgAction::Append, help_heading = "Coverage options")]
-    pub include: Vec<String>,
+    include: Vec<String>,
 
     /// Exclude report paths matching this glob after inclusion.
     #[arg(long, global = true, value_name = "GLOB", action = clap::ArgAction::Append, help_heading = "Coverage options")]
-    pub omit: Vec<String>,
+    omit: Vec<String>,
 
     /// Include execution attributed to a matching context regular expression.
     #[arg(long = "contexts", global = true, value_name = "REGEX", action = clap::ArgAction::Append, help_heading = "Coverage options")]
-    pub contexts: Vec<String>,
+    contexts: Vec<String>,
 
     /// Decimal places shown in coverage percentages.
     #[arg(
@@ -40,7 +40,7 @@ pub struct CoverageCommand {
         value_name = "N",
         help_heading = "Coverage options"
     )]
-    pub precision: Option<CoveragePrecision>,
+    precision: Option<CoveragePrecision>,
 
     /// Fail when total coverage is below this percentage.
     #[arg(
@@ -50,7 +50,7 @@ pub struct CoverageCommand {
         value_parser = parse_cov_fail_under,
         help_heading = "Coverage options"
     )]
-    pub fail_under: Option<f64>,
+    fail_under: Option<f64>,
 
     /// The path to a `karva.toml` file to use for configuration.
     #[arg(

--- a/crates/karva_cli/src/partition.rs
+++ b/crates/karva_cli/src/partition.rs
@@ -16,11 +16,13 @@ pub struct PartitionSelection {
 
 impl PartitionSelection {
     /// Creates a slice partition when `index` is within `1..=total`.
+    #[cfg(test)]
     #[must_use]
-    pub fn new(index: NonZeroU32, total: NonZeroU32) -> Option<Self> {
+    fn new(index: NonZeroU32, total: NonZeroU32) -> Option<Self> {
         Self::with_strategy(PartitionStrategy::Slice, index, total)
     }
 
+    #[cfg(test)]
     fn with_strategy(
         strategy: PartitionStrategy,
         index: NonZeroU32,
@@ -37,21 +39,10 @@ impl PartitionSelection {
         }
     }
 
-    /// Returns the selected one-based partition index.
-    #[must_use]
-    pub fn index(self) -> NonZeroU32 {
-        self.index
-    }
-
-    /// Returns the total number of partitions.
-    #[must_use]
-    pub fn total(self) -> NonZeroU32 {
-        self.total
-    }
-
     /// Returns true if the zero-based test position belongs to this slice.
+    #[cfg(test)]
     #[must_use]
-    pub fn contains(self, position: usize) -> bool {
+    fn contains(self, position: usize) -> bool {
         self.contains_position(position)
     }
 

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -375,7 +375,7 @@ pub struct TestCommand {
     /// remaining workers and exits with a failure status. Accepts fractional
     /// seconds such as `--run-timeout=1800` or `--run-timeout=0.5`.
     #[clap(long, value_name = "SECONDS", help_heading = "Runner options")]
-    pub run_timeout: Option<f64>,
+    run_timeout: Option<f64>,
 
     /// Grace period before force-killing workers during shutdown, in seconds.
     ///
@@ -384,7 +384,7 @@ pub struct TestCommand {
     /// are still running after this period, karva force-kills them. Pass `0`
     /// to force-kill immediately after graceful termination.
     #[clap(long, value_name = "SECONDS", help_heading = "Runner options")]
-    pub termination_grace_period: Option<f64>,
+    termination_grace_period: Option<f64>,
 
     /// Disable parallel execution (equivalent to `--num-workers 1`)
     #[clap(long, default_missing_value = "true", require_equals = true, num_args=0..=1, help_heading = "Runner options")]

--- a/crates/karva_collector/src/models.rs
+++ b/crates/karva_collector/src/models.rs
@@ -25,7 +25,7 @@ pub struct CollectedModule {
 }
 
 impl CollectedModule {
-    pub(crate) fn new(path: ModulePath, module_type: ModuleType, source_text: String) -> Self {
+    pub(super) fn new(path: ModulePath, module_type: ModuleType, source_text: String) -> Self {
         Self {
             path,
             module_type,
@@ -35,15 +35,15 @@ impl CollectedModule {
         }
     }
 
-    pub(crate) fn add_test_function_def(&mut self, function_def: StmtFunctionDef) {
+    pub(super) fn add_test_function_def(&mut self, function_def: StmtFunctionDef) {
         self.test_function_defs.push(function_def);
     }
 
-    pub(crate) fn add_fixture_function_def(&mut self, function_def: StmtFunctionDef) {
+    pub(super) fn add_fixture_function_def(&mut self, function_def: StmtFunctionDef) {
         self.fixture_function_defs.push(function_def);
     }
 
-    pub(crate) fn file_path(&self) -> &Utf8PathBuf {
+    fn file_path(&self) -> &Utf8PathBuf {
         self.path.path()
     }
 
@@ -52,7 +52,7 @@ impl CollectedModule {
         self.module_type
     }
 
-    pub(crate) fn is_empty(&self) -> bool {
+    fn is_empty(&self) -> bool {
         self.test_function_defs.is_empty() && self.fixture_function_defs.is_empty()
     }
 }
@@ -85,7 +85,7 @@ impl CollectedPackage {
         }
     }
 
-    pub(crate) fn path(&self) -> &Utf8PathBuf {
+    fn path(&self) -> &Utf8PathBuf {
         &self.path
     }
 
@@ -180,7 +180,7 @@ impl CollectedPackage {
         }
     }
 
-    pub(crate) fn update(&mut self, package: Self) {
+    fn update(&mut self, package: Self) {
         for (_, module) in package.modules {
             self.add_module(module);
         }
@@ -212,7 +212,7 @@ impl CollectedPackage {
         module_tests + package_tests
     }
 
-    pub(crate) fn is_empty(&self) -> bool {
+    fn is_empty(&self) -> bool {
         self.modules.is_empty() && self.packages.is_empty()
     }
 
@@ -230,7 +230,7 @@ impl CollectedPackage {
 impl CollectedModule {
     /// Update this module with another module.
     /// Merges function definitions from the other module into this one.
-    pub(crate) fn update(&mut self, module: Self) {
+    fn update(&mut self, module: Self) {
         if self.path == module.path {
             add_new_definitions(&mut self.test_function_defs, module.test_function_defs);
             add_new_definitions(

--- a/crates/karva_coverage/src/context.rs
+++ b/crates/karva_coverage/src/context.rs
@@ -1,10 +1,15 @@
 //! Stable formatting for static and dynamic coverage contexts.
 
+#![expect(
+    clippy::redundant_pub_crate,
+    reason = "parent visibility is required by sibling coverage modules"
+)]
+
 /// Context used for execution outside a concrete test lifecycle.
-pub(crate) const SESSION_CONTEXT: &str = "session";
+pub(super) const SESSION_CONTEXT: &str = "session";
 
 /// Internal context replaced once first-attempt fixture setup reveals the full test identity.
-pub(crate) const PENDING_SETUP_CONTEXT: &str = "\0karva-pending-setup";
+pub(super) const PENDING_SETUP_CONTEXT: &str = "\0karva-pending-setup";
 
 /// Escapes one context component before `|`-separated composition.
 fn escape_component(component: &str) -> String {
@@ -12,7 +17,7 @@ fn escape_component(component: &str) -> String {
 }
 
 /// Formats optional static context followed by dynamic context components.
-pub(crate) fn compose_context(static_context: Option<&str>, dynamic: &[&str]) -> Option<String> {
+pub(super) fn compose_context(static_context: Option<&str>, dynamic: &[&str]) -> Option<String> {
     static_context
         .into_iter()
         .chain(dynamic.iter().copied())
@@ -25,7 +30,7 @@ pub(crate) fn compose_context(static_context: Option<&str>, dynamic: &[&str]) ->
 }
 
 /// Prefixes an already-formatted dynamic context with one static component.
-pub(crate) fn prefix_context(static_context: &str, dynamic: &str) -> String {
+pub(super) fn prefix_context(static_context: &str, dynamic: &str) -> String {
     let mut context = escape_component(static_context);
     if !dynamic.is_empty() {
         context.push('|');

--- a/crates/karva_coverage/src/data.rs
+++ b/crates/karva_coverage/src/data.rs
@@ -10,68 +10,68 @@ use serde::{Deserialize, Serialize};
 pub struct WorkerFile {
     /// Canonical source roots resolved by the worker's Python environment.
     #[serde(default)]
-    pub source_roots: BTreeSet<String>,
+    pub(super) source_roots: BTreeSet<String>,
 
     /// Per-source coverage collected by the worker.
-    pub files: BTreeMap<String, FileEntry>,
+    pub(super) files: BTreeMap<String, FileEntry>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 /// Executable and observed coverage for one Python source file.
 pub struct FileEntry {
     /// Sorted executable source-line numbers.
-    pub executable: Vec<u32>,
+    pub(super) executable: Vec<u32>,
 
     /// Executable source lines removed by exclusion rules.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub excluded: Vec<u32>,
+    pub(super) excluded: Vec<u32>,
 
     /// Source-line numbers observed at runtime.
-    pub executed: Vec<u32>,
+    pub(super) executed: Vec<u32>,
 
     /// Test contexts that executed each source line.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub contexts: BTreeMap<u32, BTreeSet<String>>,
+    pub(super) contexts: BTreeMap<u32, BTreeSet<String>>,
 
     /// Branch coverage, absent when branch tracing was disabled.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub branches: Option<BranchEntry>,
+    pub(super) branches: Option<BranchEntry>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
 /// Directed control-flow edge between source lines.
 pub struct BranchArc {
     /// Origin line, or coverage.py's negative function-entry sentinel.
-    pub from: i32,
+    pub(super) from: i32,
 
     /// Destination line, or coverage.py's negative function-exit sentinel.
-    pub to: i32,
+    pub(super) to: i32,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 /// Possible and executed control-flow edges for one source file.
 pub struct BranchEntry {
     /// Statically discovered branch edges.
-    pub possible: Vec<BranchArc>,
+    pub(super) possible: Vec<BranchArc>,
 
     /// Branch edges observed at runtime.
-    pub executed: Vec<BranchArc>,
+    pub(super) executed: Vec<BranchArc>,
 
     /// Branch source lines whose unobserved destinations are intentional.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub partial: Vec<u32>,
+    pub(super) partial: Vec<u32>,
 
     /// Test contexts grouped by executed edge.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub contexts: Vec<BranchContextEntry>,
+    pub(super) contexts: Vec<BranchContextEntry>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 /// Test contexts that executed one branch edge.
 pub struct BranchContextEntry {
     /// Executed control-flow edge.
-    pub arc: BranchArc,
+    pub(super) arc: BranchArc,
 
     /// Qualified test names that traversed the edge.
-    pub contexts: BTreeSet<String>,
+    pub(super) contexts: BTreeSet<String>,
 }

--- a/crates/karva_coverage/src/executable.rs
+++ b/crates/karva_coverage/src/executable.rs
@@ -25,7 +25,8 @@ use ruff_source_file::LineIndex;
 use ruff_text_size::{Ranged, TextSize};
 
 /// Parse `path` and return the set of line numbers that contain a statement.
-pub fn executable_lines(path: &Path) -> io::Result<HashSet<u32>> {
+#[cfg(test)]
+fn executable_lines(path: &Path) -> io::Result<HashSet<u32>> {
     executable_lines_with_exclusions(path, &CoverageExclusions::default())
         .map(|(executable, _)| executable)
 }
@@ -54,7 +55,7 @@ impl CoverageExclusions {
 }
 
 /// Analyze executable and excluded lines using configured expressions.
-pub fn executable_lines_with_exclusions(
+pub(crate) fn executable_lines_with_exclusions(
     path: &Path,
     exclusions: &CoverageExclusions,
 ) -> io::Result<(HashSet<u32>, HashSet<u32>)> {
@@ -66,11 +67,12 @@ pub fn executable_lines_with_exclusions(
 
 /// Compute executable line numbers from a source string. Exposed separately
 /// so unit tests can avoid touching the filesystem.
-pub fn executable_lines_for_source(source: &str) -> HashSet<u32> {
+#[cfg(test)]
+fn executable_lines_for_source(source: &str) -> HashSet<u32> {
     executable_lines_for_source_with_exclusions(source, &CoverageExclusions::default()).0
 }
 
-pub(crate) fn executable_lines_for_source_with_exclusions(
+pub(super) fn executable_lines_for_source_with_exclusions(
     source: &str,
     exclusions: &CoverageExclusions,
 ) -> (HashSet<u32>, HashSet<u32>) {

--- a/crates/karva_coverage/src/lib.rs
+++ b/crates/karva_coverage/src/lib.rs
@@ -19,7 +19,7 @@
 #![warn(unreachable_pub)]
 
 pub(crate) mod branches;
-pub mod context;
+mod context;
 pub mod data;
 pub mod executable;
 pub mod native;
@@ -28,7 +28,6 @@ pub mod tracer;
 
 pub use report::{
     CoverageAnalysis, CoverageFilters, CoverageReportFormat, CoverageReportOptions,
-    CoverageReportSort, HtmlReportOptions, JsonReportOptions, combine_and_report,
-    write_cobertura_xml, write_html_report, write_json_report,
+    CoverageReportSort, HtmlReportOptions, JsonReportOptions,
 };
 pub use tracer::{CoverageConfig, CoveragePhase, CoverageSession};

--- a/crates/karva_coverage/src/native.rs
+++ b/crates/karva_coverage/src/native.rs
@@ -20,22 +20,22 @@ use crate::context::{compose_context, prefix_context};
 use crate::data::{BranchArc, WorkerFile};
 
 /// Current native coverage schema version.
-pub const FORMAT_VERSION: u32 = 4;
+const FORMAT_VERSION: u32 = 4;
 
 /// Karva coverage data retained after one or more test runs.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct NativeCoverage {
     /// Native artifact schema version.
-    pub format_version: u32,
+    format_version: u32,
     /// Karva version that produced this artifact.
-    pub karva_version: String,
+    karva_version: String,
     /// Whether collection measured statements alone or statements and branches.
-    pub mode: CoverageMode,
+    pub(super) mode: CoverageMode,
     /// Portable project-relative source roots, or absolute roots outside the project.
     pub source_roots: BTreeSet<Utf8PathBuf>,
     /// User-provided context attached to the whole run.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub run_context: Option<String>,
+    pub(super) run_context: Option<String>,
     /// Coverage keyed by `/`-separated project-relative paths.
     ///
     /// Sources outside the project retain normalized absolute paths and require
@@ -106,7 +106,8 @@ impl NativeCoverage {
     }
 
     /// Fails when any source differs from the bytes measured during collection.
-    pub fn verify_sources(&self, project_root: &Utf8Path) -> Result<()> {
+    #[cfg(test)]
+    fn verify_sources(&self, project_root: &Utf8Path) -> Result<()> {
         for (source_path, coverage) in &self.files {
             let path = project_root.join(source_path);
             let source = fs::read(&path)
@@ -224,7 +225,7 @@ impl NativeCoverage {
     }
 
     /// Rewrites source identities and merges compatible paths that become equal.
-    pub(crate) fn map_paths(mut self, map: impl Fn(&str) -> String) -> Result<Self> {
+    pub(super) fn map_paths(mut self, map: impl Fn(&str) -> String) -> Result<Self> {
         self.source_roots = self
             .source_roots
             .iter()
@@ -432,24 +433,24 @@ pub struct NativeFileCoverage {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct NativeBranchCoverage {
     /// Statically discovered control-flow edges.
-    pub possible: BTreeSet<BranchArc>,
+    pub(super) possible: BTreeSet<BranchArc>,
     /// Control-flow edges observed at runtime.
-    pub executed: BTreeSet<BranchArc>,
+    pub(super) executed: BTreeSet<BranchArc>,
     /// Branch source lines whose unobserved destinations are intentional.
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
-    pub partial: BTreeSet<u32>,
+    pub(super) partial: BTreeSet<u32>,
     /// Contexts grouped by executed edge, sorted by edge.
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
-    pub contexts: BTreeSet<NativeArcContexts>,
+    pub(super) contexts: BTreeSet<NativeArcContexts>,
 }
 
 /// Contexts that traversed one branch edge.
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct NativeArcContexts {
     /// Executed control-flow edge.
-    pub arc: BranchArc,
+    pub(super) arc: BranchArc,
     /// Context names that traversed the edge.
-    pub contexts: BTreeSet<String>,
+    pub(super) contexts: BTreeSet<String>,
 }
 
 /// Stable 128-bit fingerprint of source content.
@@ -467,12 +468,12 @@ impl SourceFingerprint {
     }
 
     /// Returns the lowercase hexadecimal fingerprint.
-    pub fn as_str(&self) -> &str {
+    pub(super) fn as_str(&self) -> &str {
         &self.0
     }
 
     /// Returns whether `source` has the content captured by this fingerprint.
-    pub fn matches(&self, source: &[u8]) -> bool {
+    pub(super) fn matches(&self, source: &[u8]) -> bool {
         *self == Self::from_bytes(source)
     }
 }

--- a/crates/karva_coverage/src/report/mod.rs
+++ b/crates/karva_coverage/src/report/mod.rs
@@ -15,13 +15,9 @@ use regex::RegexSet;
 
 pub use html::HtmlReportOptions;
 pub use json::JsonReportOptions;
-pub use terminal::combine_and_report;
-pub use terminal::write_cobertura_xml;
-pub use terminal::write_html_report;
-pub use terminal::write_json_report;
 pub use terminal::{CoverageReportFormat, CoverageReportOptions, CoverageReportSort};
 
-use self::shared::{FileRow, combine, combine_native, total_percent, verify_combined_sources};
+use self::shared::{FileRow, combine_native, total_percent, verify_combined_sources};
 
 #[derive(Debug, Default)]
 /// File globs and context regexes applied before coverage metrics are calculated.
@@ -250,7 +246,8 @@ impl CoverageAnalysis {
     }
 
     /// Returns the number of source files retained by the filters.
-    pub fn file_count(&self) -> usize {
+    #[cfg(test)]
+    fn file_count(&self) -> usize {
         self.rows.len()
     }
 }
@@ -269,28 +266,6 @@ fn compile_globs(kind: &str, patterns: &[String]) -> Result<Option<GlobSet>> {
         );
     }
     Ok(Some(builder.build()?))
-}
-
-fn combined_rows(
-    cwd: &Utf8Path,
-    files: &[impl AsRef<Utf8Path>],
-    filters: &CoverageFilters,
-) -> Result<Option<CoverageAnalysis>> {
-    let combined = combine(files)?;
-    if combined.is_empty() {
-        return Ok(None);
-    }
-
-    let cwd_real = canonical_root(cwd);
-    let rows = shared::build_rows(&cwd_real, &combined, true)
-        .into_iter()
-        .filter(|row| filters.matches(&row.name))
-        .collect();
-    Ok(Some(CoverageAnalysis {
-        coverage_root: cwd.to_path_buf(),
-        cwd_real,
-        rows,
-    }))
 }
 
 fn canonical_root(cwd: &Utf8Path) -> std::path::PathBuf {

--- a/crates/karva_coverage/src/report/shared.rs
+++ b/crates/karva_coverage/src/report/shared.rs
@@ -5,7 +5,9 @@ use camino::{Utf8Path, Utf8PathBuf};
 use fs_err as fs;
 
 use crate::context::{compose_context, prefix_context};
-use crate::data::{BranchArc, WorkerFile};
+use crate::data::BranchArc;
+#[cfg(test)]
+use crate::data::WorkerFile;
 use crate::native::{CoverageMode, NativeCoverage, SourceFingerprint};
 use crate::report::CoverageFilters;
 
@@ -57,7 +59,8 @@ pub(super) struct FileRow {
 }
 
 /// Unions per-worker payloads so each source path has one coverage record.
-pub(super) fn combine(files: &[impl AsRef<Utf8Path>]) -> Result<BTreeMap<String, CombinedFile>> {
+#[cfg(test)]
+fn combine(files: &[impl AsRef<Utf8Path>]) -> Result<BTreeMap<String, CombinedFile>> {
     let mut combined: BTreeMap<String, CombinedFile> = BTreeMap::new();
 
     for path in files {
@@ -468,7 +471,7 @@ pub(super) fn row_percent(row: &FileRow) -> f64 {
     )
 }
 
-pub(super) fn collapse_ranges(lines: &BTreeSet<u32>) -> String {
+fn collapse_ranges(lines: &BTreeSet<u32>) -> String {
     let mut parts: Vec<String> = Vec::new();
     let mut iter = lines.iter().copied();
     let Some(mut start) = iter.next() else {
@@ -528,7 +531,7 @@ fn collapse_missing(lines: &BTreeSet<u32>, branches: &BTreeSet<BranchArc>) -> St
     parts.join(", ")
 }
 
-pub(super) fn format_branch_arc(arc: BranchArc) -> String {
+fn format_branch_arc(arc: BranchArc) -> String {
     let to = if arc.to < 0 {
         "exit".to_string()
     } else {

--- a/crates/karva_coverage/src/report/terminal.rs
+++ b/crates/karva_coverage/src/report/terminal.rs
@@ -5,13 +5,12 @@ use camino::Utf8Path;
 use colored::Colorize;
 use fs_err as fs;
 
-use super::combined_rows;
+use super::CoverageAnalysis;
 use super::html::{HtmlReportOptions, build_html_report};
 use super::json::{JsonReportOptions, build_json_report};
 use super::lcov::build_lcov_report;
 use super::shared::{FileRow, row_percent, total_percent, totals_row};
 use super::xml::build_cobertura_xml;
-use super::{CoverageAnalysis, CoverageFilters};
 
 /// Terminal coverage report representation.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -56,66 +55,7 @@ pub struct CoverageReportOptions {
     pub format: CoverageReportFormat,
 }
 
-/// Prints the terminal coverage table and returns its total percentage.
-///
-/// Returns `None` when no worker coverage artifacts contain source data.
-pub fn combine_and_report(
-    cwd: &Utf8Path,
-    files: &[impl AsRef<Utf8Path>],
-    show_missing: bool,
-    filters: &CoverageFilters,
-) -> Result<Option<f64>> {
-    let Some(analysis) = combined_rows(cwd, files, filters)? else {
-        return Ok(None);
-    };
-    analysis.report(show_missing).map(Some)
-}
-
-/// Writes a Cobertura-compatible XML report and returns its total percentage.
-pub fn write_cobertura_xml(
-    cwd: &Utf8Path,
-    files: &[impl AsRef<Utf8Path>],
-    output: &Utf8Path,
-    filters: &CoverageFilters,
-) -> Result<Option<f64>> {
-    let Some(analysis) = combined_rows(cwd, files, filters)? else {
-        return Ok(None);
-    };
-    analysis.write_cobertura_xml(output).map(Some)
-}
-
-/// Writes a coverage.py-compatible JSON report and returns its total percentage.
-pub fn write_json_report(
-    cwd: &Utf8Path,
-    files: &[impl AsRef<Utf8Path>],
-    output: &Utf8Path,
-    filters: &CoverageFilters,
-) -> Result<Option<f64>> {
-    let Some(analysis) = combined_rows(cwd, files, filters)? else {
-        return Ok(None);
-    };
-    analysis.write_json(output).map(Some)
-}
-
-/// Writes a standalone HTML coverage report and returns its total percentage.
-pub fn write_html_report(
-    cwd: &Utf8Path,
-    files: &[impl AsRef<Utf8Path>],
-    output_dir: &Utf8Path,
-    filters: &CoverageFilters,
-) -> Result<Option<f64>> {
-    let Some(analysis) = combined_rows(cwd, files, filters)? else {
-        return Ok(None);
-    };
-    analysis.write_html(output_dir).map(Some)
-}
-
 impl CoverageAnalysis {
-    /// Prints the compact terminal report and returns total coverage.
-    pub fn report(&self, show_missing: bool) -> Result<f64> {
-        self.report_with_precision(show_missing, 0)
-    }
-
     /// Prints the compact terminal report using `precision` decimal places.
     pub fn report_with_precision(&self, show_missing: bool, precision: usize) -> Result<f64> {
         self.write_report(

--- a/crates/karva_diagnostic/src/lib.rs
+++ b/crates/karva_diagnostic/src/lib.rs
@@ -7,10 +7,10 @@ mod traceback;
 
 pub use reporter::{DummyReporter, Reporter, TestCaseReporter};
 pub use result::{
-    CapturedTestOutput, DisplayFlakyTest, DisplayFlakyTests, FixtureFailure, FixtureUsage,
-    FlakyTest, IndividualTestResultKind, RenderedDiagnostic, TestCaseAttempt, TestCaseOutcome,
-    TestCaseResult, TestCaseRetry, TestExecutionAttempt, TestExecutionOutcome, TestExecutionResult,
-    TestResultKind, TestResultStats, TestRunResult,
+    CapturedTestOutput, DisplayFlakyTests, FixtureFailure, FixtureUsage, FlakyTest,
+    IndividualTestResultKind, RenderedDiagnostic, TestCaseAttempt, TestCaseOutcome, TestCaseResult,
+    TestCaseRetry, TestExecutionAttempt, TestExecutionOutcome, TestExecutionResult, TestResultKind,
+    TestResultStats, TestRunResult,
 };
 
 #[cfg(feature = "traceback")]

--- a/crates/karva_diagnostic/src/result/case.rs
+++ b/crates/karva_diagnostic/src/result/case.rs
@@ -34,7 +34,7 @@ pub struct TestCaseResult<D = RenderedDiagnostic> {
 
 impl<D> TestCaseResult<D> {
     /// Builds a result for a test executed once.
-    pub fn new(
+    pub(super) fn new(
         test_case_name: &QualifiedTestName,
         outcome: TestCaseOutcome<D>,
         duration: Duration,
@@ -61,7 +61,7 @@ impl<D> TestCaseResult<D> {
     }
 
     /// Builds a result whose final outcome followed earlier failed attempts.
-    pub fn retried(
+    pub(super) fn retried(
         test_case_name: &QualifiedTestName,
         outcome: TestCaseOutcome<D>,
         duration: Duration,
@@ -263,7 +263,7 @@ impl TestCaseRetry {
         self.flaky_failure
     }
 
-    pub fn is_junit_flaky_failure(&self) -> bool {
+    fn is_junit_flaky_failure(&self) -> bool {
         self.junit_flaky_failure
     }
 }
@@ -444,14 +444,6 @@ impl FixtureFailure {
             usage,
             dependency_chain,
         }
-    }
-
-    pub fn fixture(&self) -> &str {
-        &self.fixture
-    }
-
-    pub fn usage(&self) -> FixtureUsage {
-        self.usage
     }
 
     pub fn dependency_chain(&self) -> &[String] {

--- a/crates/karva_diagnostic/src/result/diagnostic.rs
+++ b/crates/karva_diagnostic/src/result/diagnostic.rs
@@ -54,10 +54,6 @@ impl RenderedDiagnostic {
         &self.code
     }
 
-    pub fn severity(&self) -> Severity {
-        self.severity
-    }
-
     pub fn severity_name(&self) -> &'static str {
         match self.severity {
             Severity::Info => "info",

--- a/crates/karva_diagnostic/src/result/flaky.rs
+++ b/crates/karva_diagnostic/src/result/flaky.rs
@@ -9,23 +9,23 @@ use serde::{Deserialize, Serialize};
 /// Test that failed at least once before eventually passing.
 pub struct FlakyTest {
     /// Import-qualified Python module containing the test.
-    pub module_name: String,
+    module_name: String,
 
     /// Function name without parameter display suffix.
-    pub function_name: String,
+    function_name: String,
 
     /// Parameter display suffix, including delimiters.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub params: Option<String>,
+    params: Option<String>,
 
     /// One-based attempt on which the test passed.
-    pub passed_on: u32,
+    passed_on: u32,
 
     /// Maximum attempts permitted by retry configuration.
-    pub total_attempts: u32,
+    total_attempts: u32,
 
     /// Combined duration across all attempts.
-    pub duration: Duration,
+    duration: Duration,
 }
 
 impl FlakyTest {
@@ -52,13 +52,13 @@ impl FlakyTest {
     }
 
     /// Returns terminal-display formatting for this flaky result.
-    pub fn display(&self) -> DisplayFlakyTest<'_> {
+    fn display(&self) -> DisplayFlakyTest<'_> {
         DisplayFlakyTest(self)
     }
 }
 
 /// Terminal-display wrapper for one flaky result.
-pub struct DisplayFlakyTest<'a>(&'a FlakyTest);
+struct DisplayFlakyTest<'a>(&'a FlakyTest);
 
 impl fmt::Display for DisplayFlakyTest<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/karva_diagnostic/src/result/mod.rs
+++ b/crates/karva_diagnostic/src/result/mod.rs
@@ -19,7 +19,7 @@ pub use case::{
     TestExecutionAttempt, TestExecutionOutcome, TestExecutionResult,
 };
 pub use diagnostic::RenderedDiagnostic;
-pub use flaky::{DisplayFlakyTest, DisplayFlakyTests, FlakyTest};
+pub use flaky::{DisplayFlakyTests, FlakyTest};
 pub use kind::{IndividualTestResultKind, TestResultKind};
 pub use output::CapturedTestOutput;
 pub use stats::TestResultStats;
@@ -64,11 +64,6 @@ fn diagnostic_display_ordering(a: &Diagnostic, b: &Diagnostic) -> std::cmp::Orde
 }
 
 impl TestRunResult {
-    /// Returns diagnostics belonging to collection or run infrastructure.
-    pub fn run_diagnostics(&self) -> &[Diagnostic] {
-        &self.run_diagnostics
-    }
-
     /// Adds a diagnostic not owned by one test case.
     pub fn add_run_diagnostic(&mut self, diagnostic: Diagnostic) {
         self.run_diagnostics.push(diagnostic);
@@ -187,14 +182,6 @@ impl TestRunResult {
                 .then_with(|| a.name().cmp(b.name()))
         });
         self
-    }
-
-    pub fn durations(&self) -> &HashMap<QualifiedFunctionName, std::time::Duration> {
-        &self.durations
-    }
-
-    pub fn test_cases(&self) -> &[TestExecutionResult] {
-        &self.test_cases
     }
 
     /// Decomposes this run for serialization into the worker cache.

--- a/crates/karva_diagnostic/src/traceback.rs
+++ b/crates/karva_diagnostic/src/traceback.rs
@@ -44,11 +44,6 @@ struct TracebackLocation {
 }
 
 impl Traceback {
-    /// Extracts traceback frames, loading referenced files from disk when available.
-    pub fn from_error(py: Python, error: &PyErr) -> Option<Self> {
-        Self::from_error_with_fallback(py, error, None)
-    }
-
     /// Extracts traceback frames while reusing a known source snapshot when it matches.
     pub fn from_error_with_source(
         py: Python,

--- a/crates/karva_logging/src/printer.rs
+++ b/crates/karva_logging/src/printer.rs
@@ -22,10 +22,6 @@ impl Printer {
         self.status_level
     }
 
-    pub fn final_status_level(self) -> FinalStatusLevel {
-        self.final_status_level
-    }
-
     /// Stream for the "Starting N tests" header and per-test result lines.
     ///
     /// The reporter additionally filters individual results by [`StatusLevel`].

--- a/crates/karva_logging/src/verbosity.rs
+++ b/crates/karva_logging/src/verbosity.rs
@@ -21,7 +21,7 @@ pub enum VerbosityLevel {
 
 impl VerbosityLevel {
     /// Returns the maximum tracing level enabled for Karva targets.
-    pub fn level_filter(self) -> LevelFilter {
+    pub(super) fn level_filter(self) -> LevelFilter {
         match self {
             Self::Default => LevelFilter::WARN,
             Self::Verbose => LevelFilter::INFO,
@@ -34,11 +34,11 @@ impl VerbosityLevel {
         matches!(self, Self::Default)
     }
 
-    pub fn is_trace(self) -> bool {
+    pub(super) fn is_trace(self) -> bool {
         matches!(self, Self::Trace)
     }
 
-    pub fn is_extra_verbose(self) -> bool {
+    pub(super) fn is_extra_verbose(self) -> bool {
         matches!(self, Self::ExtraVerbose)
     }
 

--- a/crates/karva_metadata/src/filter.rs
+++ b/crates/karva_metadata/src/filter.rs
@@ -83,7 +83,7 @@ pub struct Filterset {
 
 impl Filterset {
     /// Parses one filter DSL expression into an evaluable tree.
-    pub fn new(input: &str) -> Result<Self, FilterError> {
+    fn new(input: &str) -> Result<Self, FilterError> {
         let tokens = tokenize(input)?;
         let mut parser = Parser::new(&tokens, input);
         let expr = parser.parse_or()?;
@@ -97,7 +97,7 @@ impl Filterset {
     }
 
     /// Evaluates this expression against one test and its tags.
-    pub fn matches(&self, ctx: &EvalContext<'_>) -> bool {
+    fn matches(&self, ctx: &EvalContext<'_>) -> bool {
         self.expr.matches(ctx)
     }
 }
@@ -116,7 +116,7 @@ pub struct ValidatedFilter {
 
 impl ValidatedFilter {
     /// Validates and compiles a filter while retaining its serialized spelling.
-    pub fn new(raw: String) -> Result<Self, FilterError> {
+    fn new(raw: String) -> Result<Self, FilterError> {
         let compiled = Filterset::new(&raw)?;
         Ok(Self { raw, compiled })
     }
@@ -126,12 +126,8 @@ impl ValidatedFilter {
     }
 
     /// Evaluates the precompiled filter against one test.
-    pub fn matches(&self, ctx: &EvalContext<'_>) -> bool {
+    pub(super) fn matches(&self, ctx: &EvalContext<'_>) -> bool {
         self.compiled.matches(ctx)
-    }
-
-    pub fn filterset(&self) -> &Filterset {
-        &self.compiled
     }
 }
 

--- a/crates/karva_metadata/src/lib.rs
+++ b/crates/karva_metadata/src/lib.rs
@@ -2,7 +2,6 @@
 
 use camino::{Utf8Path, Utf8PathBuf};
 use fs_err as fs;
-use karva_combine::Combine;
 use ruff_python_ast::PythonVersion;
 use thiserror::Error;
 
@@ -14,19 +13,20 @@ mod settings;
 
 pub use max_fail::MaxFail;
 pub use options::{
-    Config, CovReport, CoverageOptions, DEFAULT_PROFILE, IncompatibleVersionError, JunitOptions,
-    Options, OutputFormat, OverrideJunitOptions, OverrideOptions, ProjectOptionsOverrides,
-    SrcOptions, TerminalOptions, TestOptions, UnknownProfile,
+    Config, CovReport, CoverageOptions, IncompatibleVersionError, JunitOptions, Options,
+    OutputFormat, OverrideJunitOptions, OverrideOptions, ProjectOptionsOverrides, SrcOptions,
+    TerminalOptions, TestOptions, UnknownProfile,
 };
-pub use pyproject::{PyProject, PyProjectError};
+pub use pyproject::PyProjectError;
 pub use settings::{
-    CovFailUnder, CoverageExcludePattern, CoveragePrecision, CoverageSettings,
-    DEFAULT_COVERAGE_DATA_FILE, FailSlowSecs, FlakyResult, JunitFlakyFailStatus, JunitSettings,
-    NoTestsMode, OverrideSettings, ProjectSettings, RunIgnoredMode, RunTimeoutSecs,
-    SlowTimeoutSecs, TerminationGracePeriodSecs, TestTimeoutSecs,
+    CovFailUnder, CoverageExcludePattern, CoveragePrecision, CoverageSettings, FailSlowSecs,
+    FlakyResult, JunitFlakyFailStatus, JunitSettings, NoTestsMode, OverrideSettings,
+    ProjectSettings, RunIgnoredMode, RunTimeoutSecs, SlowTimeoutSecs, TerminationGracePeriodSecs,
+    TestTimeoutSecs,
 };
 
 use crate::options::KarvaTomlError;
+use crate::pyproject::PyProject;
 
 /// File-level configuration paired with the resolved per-profile [`Options`].
 ///
@@ -36,13 +36,13 @@ use crate::options::KarvaTomlError;
 #[derive(Default, Debug, Clone)]
 pub struct ProjectMetadata {
     /// Directory against which relative project paths resolve.
-    pub root: Utf8PathBuf,
+    root: Utf8PathBuf,
 
     /// Target Python grammar version used during syntax collection.
-    pub python_version: PythonVersion,
+    python_version: PythonVersion,
 
     /// Parsed file-level configuration before profile selection.
-    pub config: Config,
+    config: Config,
 
     /// Effective options after profile and CLI precedence is applied.
     pub options: Options,
@@ -85,7 +85,7 @@ impl ProjectMetadata {
     }
 
     /// Loads a project from a `pyproject.toml` file.
-    pub(crate) fn from_pyproject(
+    fn from_pyproject(
         pyproject: PyProject,
         root: Utf8PathBuf,
         python_version: PythonVersion,
@@ -94,7 +94,7 @@ impl ProjectMetadata {
     }
 
     /// Loads a project from a parsed [`Config`].
-    pub fn from_config(config: Config, root: Utf8PathBuf, python_version: PythonVersion) -> Self {
+    fn from_config(config: Config, root: Utf8PathBuf, python_version: PythonVersion) -> Self {
         Self {
             root,
             python_version,
@@ -205,13 +205,6 @@ impl ProjectMetadata {
         &self.root
     }
 
-    /// Replaces root while preserving parsed configuration and resolved options.
-    #[must_use]
-    pub fn with_root(mut self, root: Utf8PathBuf) -> Self {
-        self.root = root;
-        self
-    }
-
     /// Resolve the requested profile from the parsed [`Config`] and combine
     /// CLI overrides on top, populating `self.options`.
     pub fn apply_overrides(
@@ -221,11 +214,6 @@ impl ProjectMetadata {
         let config = std::mem::take(&mut self.config);
         self.options = overrides.apply_to(config)?;
         Ok(())
-    }
-
-    /// Combine the project options with the CLI options where the CLI options take precedence.
-    pub fn apply_options(&mut self, options: Options) {
-        self.options = options.combine(std::mem::take(&mut self.options));
     }
 }
 

--- a/crates/karva_metadata/src/max_fail.rs
+++ b/crates/karva_metadata/src/max_fail.rs
@@ -24,13 +24,13 @@ impl MaxFail {
 
     /// Returns a `MaxFail` that stops after the given number of failures,
     /// treating `0` as unlimited.
-    pub fn from_count(count: u32) -> Self {
+    fn from_count(count: u32) -> Self {
         Self(NonZeroU32::new(count))
     }
 
     /// The legacy `fail-fast` boolean: `true` maps to stopping after a single
     /// failure, `false` maps to never stopping.
-    pub fn from_fail_fast(fail_fast: bool) -> Self {
+    pub(super) fn from_fail_fast(fail_fast: bool) -> Self {
         if fail_fast {
             Self::from_count(1)
         } else {
@@ -54,15 +54,12 @@ impl MaxFail {
     /// `MaxFail::unlimited()` wraps `None`, which serializers like TOML
     /// cannot represent — this is exposed primarily so `serde`'s
     /// `skip_serializing_if` can omit the field.
-    pub fn is_unlimited(&self) -> bool {
+    #[expect(
+        clippy::trivially_copy_pass_by_ref,
+        reason = "serde skip_serializing_if requires a shared reference"
+    )]
+    pub(super) fn is_unlimited(&self) -> bool {
         self.0.is_none()
-    }
-
-    /// Returns `true` when the configuration would stop after a single failure.
-    ///
-    /// This is how the legacy `--fail-fast` boolean is surfaced internally.
-    pub fn is_fail_fast(self) -> bool {
-        matches!(self.0, Some(limit) if limit.get() == 1)
     }
 
     /// Returns the configured limit as a raw `u32`, if any.

--- a/crates/karva_metadata/src/options/config.rs
+++ b/crates/karva_metadata/src/options/config.rs
@@ -8,10 +8,7 @@ use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use super::Options;
-
-/// The implicit name of the default profile.
-pub const DEFAULT_PROFILE: &str = "default";
+use super::{DEFAULT_PROFILE, Options};
 
 /// File-level configuration: a collection of named profiles.
 ///
@@ -37,12 +34,12 @@ pub struct Config {
     )]
     #[cfg_attr(feature = "schemars", schemars(with = "Option<String>"))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub required_version: Option<VersionReq>,
+    required_version: Option<VersionReq>,
 
     #[cfg_attr(feature = "schemars", schemars(schema_with = "profile_schema"))]
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     /// Named option profiles; `default` forms the base for every named profile.
-    pub profile: BTreeMap<String, Options>,
+    pub(crate) profile: BTreeMap<String, Options>,
 }
 
 #[cfg(feature = "schemars")]
@@ -60,7 +57,7 @@ fn profile_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema
 
 impl Config {
     /// Parses configuration text and validates all profile names.
-    pub fn from_toml_str(content: &str) -> Result<Self, KarvaTomlError> {
+    pub(crate) fn from_toml_str(content: &str) -> Result<Self, KarvaTomlError> {
         let config: Self = toml::from_str(content)?;
         validate_profile_names(&config.profile)?;
         Ok(config)
@@ -71,7 +68,10 @@ impl Config {
     /// `current` is parsed once with [`semver::Version::parse`]; karva's
     /// own version is well-formed semver, so a parse failure here is an
     /// internal error rather than a configuration problem.
-    pub fn check_required_version(&self, current: &str) -> Result<(), IncompatibleVersionError> {
+    pub(crate) fn check_required_version(
+        &self,
+        current: &str,
+    ) -> Result<(), IncompatibleVersionError> {
         let Some(required) = &self.required_version else {
             return Ok(());
         };
@@ -105,7 +105,8 @@ impl Config {
 
     /// Returns true if `name` is defined as a profile in this configuration.
     /// The implicit `default` profile always exists.
-    pub fn has_profile(&self, name: &str) -> bool {
+    #[cfg(test)]
+    pub(super) fn has_profile(&self, name: &str) -> bool {
         if name == DEFAULT_PROFILE {
             return true;
         }
@@ -121,7 +122,7 @@ impl Config {
     ///
     /// Returns [`UnknownProfile`] when `name` refers to a profile that is
     /// not defined.
-    pub fn resolve_profile(mut self, name: Option<&str>) -> Result<Options, UnknownProfile> {
+    pub(super) fn resolve_profile(mut self, name: Option<&str>) -> Result<Options, UnknownProfile> {
         let requested = name.unwrap_or(DEFAULT_PROFILE);
 
         let default_overrides = self.profile.remove(DEFAULT_PROFILE);
@@ -185,10 +186,10 @@ fn validate_profile_names(profiles: &BTreeMap<String, Options>) -> Result<(), Ka
 )]
 pub struct UnknownProfile {
     /// Requested undefined profile name.
-    pub name: String,
+    name: String,
 
     /// Sorted profile names available to the user, including implicit `default`.
-    pub available: Vec<String>,
+    available: Vec<String>,
 }
 
 #[derive(Debug, Error)]

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -9,10 +9,11 @@ use karva_macros::{Combine, OptionsMetadata};
 use ruff_db::diagnostic::DiagnosticFormat;
 use serde::{Deserialize, Serialize};
 
-pub use config::{
-    Config, DEFAULT_PROFILE, IncompatibleVersionError, KarvaTomlError, UnknownProfile,
-};
+pub use config::{Config, IncompatibleVersionError, KarvaTomlError, UnknownProfile};
 pub use overrides::ProjectOptionsOverrides;
+
+/// The implicit name of the default profile.
+pub const DEFAULT_PROFILE: &str = "default";
 
 use crate::filter::{FiltersetSet, ValidatedFilter};
 use crate::max_fail::MaxFail;
@@ -116,7 +117,7 @@ pub struct OverrideOptions {
         "#
     )]
     #[cfg_attr(feature = "schemars", schemars(with = "String"))]
-    pub filter: ValidatedFilter,
+    filter: ValidatedFilter,
 
     /// Number of times to retry a matching test before giving up. Mirrors
     /// the profile-level [`retry`](#retry) field.
@@ -128,7 +129,7 @@ pub struct OverrideOptions {
         "#
     )]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub retries: Option<u32>,
+    retries: Option<u32>,
 
     /// Whether matching flaky tests pass or fail the run.
     #[option(
@@ -139,12 +140,12 @@ pub struct OverrideOptions {
         "#
     )]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub flaky_result: Option<FlakyResult>,
+    flaky_result: Option<FlakyResult>,
 
     /// `JUnit` behavior for matching flaky tests configured to fail.
     #[option_group]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub junit: Option<OverrideJunitOptions>,
+    junit: Option<OverrideJunitOptions>,
 
     /// Hard per-test timeout, in seconds, applied to matching tests.
     /// Mirrors the profile-level [`timeout`](#timeout) field. A value of
@@ -158,7 +159,7 @@ pub struct OverrideOptions {
         "#
     )]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub timeout: Option<TestTimeoutSecs>,
+    timeout: Option<TestTimeoutSecs>,
 
     /// Threshold (in seconds) above which a matching test is flagged as
     /// slow. Mirrors the profile-level
@@ -172,7 +173,7 @@ pub struct OverrideOptions {
         "#
     )]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub slow_timeout: Option<SlowTimeoutSecs>,
+    slow_timeout: Option<SlowTimeoutSecs>,
 
     /// Duration budget (in seconds) for a matching test's full lifecycle.
     /// Mirrors the profile-level [`fail-slow`](#fail-slow) field. A
@@ -185,11 +186,11 @@ pub struct OverrideOptions {
         "#
     )]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub fail_slow: Option<FailSlowSecs>,
+    fail_slow: Option<FailSlowSecs>,
 }
 
 impl OverrideOptions {
-    pub(crate) fn to_settings(&self) -> OverrideSettings {
+    fn to_settings(&self) -> OverrideSettings {
         OverrideSettings {
             filter: self.filter.clone(),
             retries: self.retries,
@@ -220,7 +221,7 @@ pub struct OverrideJunitOptions {
         "#
     )]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub flaky_fail_status: Option<JunitFlakyFailStatus>,
+    flaky_fail_status: Option<JunitFlakyFailStatus>,
 }
 
 #[derive(
@@ -263,7 +264,7 @@ pub struct SrcOptions {
 }
 
 impl SrcOptions {
-    pub(crate) fn to_settings(&self) -> SrcSettings {
+    fn to_settings(&self) -> SrcSettings {
         SrcSettings {
             respect_ignore_files: self.respect_ignore_files.unwrap_or(true),
             include_paths: self.include.clone().unwrap_or_default(),
@@ -341,7 +342,7 @@ pub struct TerminalOptions {
 
 impl TerminalOptions {
     /// Applies defaults and produces terminal settings ready for runtime use.
-    pub fn to_settings(&self) -> TerminalSettings {
+    fn to_settings(&self) -> TerminalSettings {
         TerminalSettings {
             output_format: self.output_format.unwrap_or_default(),
             show_python_output: self.show_python_output.unwrap_or_default(),
@@ -558,7 +559,7 @@ pub struct TestOptions {
 
 impl TestOptions {
     /// Applies defaults and converts second-based limits into platform durations.
-    pub fn to_settings(&self) -> TestSettings {
+    fn to_settings(&self) -> TestSettings {
         let max_fail = self
             .max_fail
             .or_else(|| self.fail_fast.map(MaxFail::from_fail_fast))
@@ -828,7 +829,7 @@ impl Combine for CoverageOptions {
 
 impl CoverageOptions {
     /// Applies defaults and honors runtime-only coverage disablement.
-    pub fn to_settings(&self) -> CoverageSettings {
+    fn to_settings(&self) -> CoverageSettings {
         let sources = if self.disabled.unwrap_or(false) {
             Vec::new()
         } else {
@@ -924,7 +925,7 @@ pub struct JunitOptions {
 
 impl JunitOptions {
     /// Applies `JUnit` defaults and produces report settings.
-    pub fn to_settings(&self) -> JunitSettings {
+    fn to_settings(&self) -> JunitSettings {
         JunitSettings {
             path: self.path.clone(),
             report_name: self
@@ -1005,15 +1006,6 @@ pub enum OutputFormat {
 }
 
 impl OutputFormat {
-    /// Returns `true` if this format is intended for users to read directly, in contrast to
-    /// machine-readable or structured formats.
-    ///
-    /// This can be used to check whether information beyond the diagnostics, such as a header or
-    /// `Found N diagnostics` footer, should be included.
-    pub fn is_human_readable(self) -> bool {
-        matches!(self, Self::Full | Self::Concise)
-    }
-
     /// Returns canonical configuration spelling.
     pub fn as_str(&self) -> &'static str {
         match self {

--- a/crates/karva_metadata/src/options/overrides.rs
+++ b/crates/karva_metadata/src/options/overrides.rs
@@ -7,13 +7,13 @@ use super::{Config, Options, UnknownProfile};
 /// Explicit config path, profile, and CLI options supplied by one invocation.
 pub struct ProjectOptionsOverrides {
     /// Configuration file replacing automatic project discovery.
-    pub config_file_override: Option<Utf8PathBuf>,
+    config_file_override: Option<Utf8PathBuf>,
 
     /// Named profile selected from loaded configuration.
-    pub profile: Option<String>,
+    profile: Option<String>,
 
     /// Highest-precedence options parsed from CLI arguments.
-    pub options: Options,
+    options: Options,
 }
 
 impl ProjectOptionsOverrides {
@@ -35,7 +35,7 @@ impl ProjectOptionsOverrides {
 
     /// Resolve the requested profile from `config` and combine the CLI
     /// overrides on top.
-    pub fn apply_to(&self, config: Config) -> Result<Options, UnknownProfile> {
+    pub(crate) fn apply_to(&self, config: Config) -> Result<Options, UnknownProfile> {
         let resolved = config.resolve_profile(self.profile.as_deref())?;
         let disable_flaky_result_overrides = self
             .options

--- a/crates/karva_metadata/src/pyproject.rs
+++ b/crates/karva_metadata/src/pyproject.rs
@@ -11,11 +11,11 @@ use crate::settings::CoverageExcludePattern;
 #[serde(rename_all = "kebab-case")]
 pub struct PyProject {
     /// Tool-specific metadata.
-    pub tool: Option<Tool>,
+    tool: Option<Tool>,
 }
 
 impl PyProject {
-    pub(crate) fn karva(&self) -> Option<&Config> {
+    pub(super) fn karva(&self) -> Option<&Config> {
         self.tool.as_ref().and_then(|tool| tool.karva.as_ref())
     }
 }
@@ -40,7 +40,7 @@ pub enum PyProjectError {
 }
 
 impl PyProject {
-    pub(crate) fn from_toml_str(content: &str) -> Result<Self, PyProjectError> {
+    pub(super) fn from_toml_str(content: &str) -> Result<Self, PyProjectError> {
         toml::from_str(content).map_err(PyProjectError::TomlSyntax)
     }
 }
@@ -72,7 +72,7 @@ pub struct CoveragePyReportOptions {
 }
 
 impl PyProject {
-    pub(crate) fn into_karva_config(self) -> Config {
+    pub(super) fn into_karva_config(self) -> Config {
         let mut config = self
             .tool
             .as_ref()
@@ -82,7 +82,7 @@ impl PyProject {
         config
     }
 
-    pub(crate) fn apply_coverage_exclusions(&self, config: &mut Config) {
+    pub(super) fn apply_coverage_exclusions(&self, config: &mut Config) {
         let patterns = self
             .tool
             .as_ref()

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -208,7 +208,7 @@ impl Eq for SlowTimeoutSecs {}
 
 impl SlowTimeoutSecs {
     /// Converts positive, platform-representable seconds; non-positive values disable tracking.
-    pub fn as_duration(self) -> Option<Duration> {
+    pub(super) fn as_duration(self) -> Option<Duration> {
         if self.0.is_finite() && self.0 > 0.0 {
             Duration::try_from_secs_f64(self.0)
                 .ok()
@@ -245,7 +245,7 @@ impl Eq for TestTimeoutSecs {}
 
 impl TestTimeoutSecs {
     /// Converts positive, platform-representable seconds; non-positive values disable timeout.
-    pub fn as_duration(self) -> Option<Duration> {
+    pub(super) fn as_duration(self) -> Option<Duration> {
         if self.0.is_finite() && self.0 > 0.0 {
             Duration::try_from_secs_f64(self.0)
                 .ok()
@@ -317,7 +317,7 @@ impl Eq for RunTimeoutSecs {}
 
 impl RunTimeoutSecs {
     /// Converts positive, platform-representable seconds; non-positive values disable timeout.
-    pub fn as_duration(self) -> Option<Duration> {
+    pub(super) fn as_duration(self) -> Option<Duration> {
         if self.0.is_finite() && self.0 > 0.0 {
             Duration::try_from_secs_f64(self.0)
                 .ok()
@@ -350,7 +350,7 @@ impl Eq for TerminationGracePeriodSecs {}
 
 impl TerminationGracePeriodSecs {
     /// Converts non-negative, platform-representable seconds; zero requests immediate kill.
-    pub fn as_duration(self) -> Option<Duration> {
+    pub(super) fn as_duration(self) -> Option<Duration> {
         if self.0.is_finite() && self.0 >= 0.0 {
             Duration::try_from_secs_f64(self.0).ok()
         } else {
@@ -459,13 +459,13 @@ impl Combine for CoveragePrecision {
 #[serde(rename_all = "kebab-case")]
 /// Fully resolved settings after configuration profiles and CLI overrides combine.
 pub struct ProjectSettings {
-    pub(crate) src: SrcSettings,
-    pub(crate) terminal: TerminalSettings,
-    pub(crate) test: TestSettings,
-    pub(crate) coverage: CoverageSettings,
-    pub(crate) junit: JunitSettings,
+    pub(super) src: SrcSettings,
+    pub(super) terminal: TerminalSettings,
+    pub(super) test: TestSettings,
+    pub(super) coverage: CoverageSettings,
+    pub(super) junit: JunitSettings,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub(crate) overrides: Vec<OverrideSettings>,
+    pub(super) overrides: Vec<OverrideSettings>,
 }
 
 /// A compiled per-test override applied when its [filter](Self::filter)
@@ -502,7 +502,7 @@ pub struct OverrideSettings {
 }
 
 impl OverrideSettings {
-    pub fn matches(&self, ctx: &EvalContext<'_>) -> bool {
+    pub(super) fn matches(&self, ctx: &EvalContext<'_>) -> bool {
         self.filter.matches(ctx)
     }
 }

--- a/crates/karva_project/src/path/test_path.rs
+++ b/crates/karva_project/src/path/test_path.rs
@@ -111,14 +111,6 @@ impl TestPath {
             Err(TestPathError::InvalidUtf8Path(path))
         }
     }
-
-    pub fn path(&self) -> &Utf8PathBuf {
-        match self {
-            Self::File(path)
-            | Self::Directory(path)
-            | Self::Function(TestPathFunction { path, .. }) => path,
-        }
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Error)]
@@ -132,17 +124,6 @@ pub enum TestPathError {
     InvalidUtf8Path(Utf8PathBuf),
     #[error("path `{0}` is missing a function name")]
     MissingFunctionName(Utf8PathBuf),
-}
-
-impl TestPathError {
-    pub fn path(&self) -> &Utf8PathBuf {
-        match self {
-            Self::NotFound(path)
-            | Self::WrongFileExtension(path)
-            | Self::InvalidUtf8Path(path)
-            | Self::MissingFunctionName(path) => path,
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/karva_python_semantic/src/lib.rs
+++ b/crates/karva_python_semantic/src/lib.rs
@@ -23,7 +23,7 @@ pub fn is_fixture_function(val: &StmtFunctionDef) -> bool {
 }
 
 /// Check whether an expression resolves to a fixture reference.
-pub fn is_fixture(expr: &Expr) -> bool {
+fn is_fixture(expr: &Expr) -> bool {
     match expr {
         Expr::Name(name) => name.id == "fixture",
         Expr::Attribute(attr) => attr.attr.id == "fixture",
@@ -35,7 +35,7 @@ pub fn is_fixture(expr: &Expr) -> bool {
 /// Converts a Python file below `cwd` into its dotted import path.
 ///
 /// Returns `None` when `path` lies outside `cwd`.
-pub fn module_name(cwd: &Utf8Path, path: &Utf8Path) -> Option<String> {
+pub(crate) fn module_name(cwd: &Utf8Path, path: &Utf8Path) -> Option<String> {
     let relative_path = path.strip_prefix(cwd).ok()?;
     let mut components = relative_path.components().peekable();
     let mut name = String::with_capacity(relative_path.as_str().len());

--- a/crates/karva_runner/src/collection.rs
+++ b/crates/karva_runner/src/collection.rs
@@ -35,7 +35,7 @@ impl<'a> ParallelCollector<'a> {
     }
 
     /// Walks a directory concurrently while serializing package mutation on a receiver thread.
-    pub(crate) fn collect_directory(&self, path: &Utf8PathBuf) -> Result<CollectedPackage> {
+    fn collect_directory(&self, path: &Utf8PathBuf) -> Result<CollectedPackage> {
         let (tx, rx) = unbounded::<CollectionMessage>();
 
         let cloned_path = path.clone();

--- a/crates/karva_runner/src/partition.rs
+++ b/crates/karva_runner/src/partition.rs
@@ -91,7 +91,7 @@ impl Partition {
         self.weight
     }
 
-    pub(crate) fn tests(&self) -> &[String] {
+    pub(super) fn tests(&self) -> &[String] {
         &self.tests
     }
 }

--- a/crates/karva_snapshot/src/diff.rs
+++ b/crates/karva_snapshot/src/diff.rs
@@ -92,7 +92,7 @@ pub fn format_diff(old: &str, new: &str) -> String {
 /// Write a diff to the given output stream, adapting borders to terminal width.
 ///
 /// Falls back to 80 characters if terminal width cannot be determined.
-pub fn print_changeset(out: &mut impl io::Write, old: &str, new: &str) -> io::Result<()> {
+pub(crate) fn print_changeset(out: &mut impl io::Write, old: &str, new: &str) -> io::Result<()> {
     let width = terminal_size::terminal_size().map_or(80, |(w, _)| w.0 as usize);
     let mut output = String::new();
     render_diff(&mut output, old, new, width);

--- a/crates/karva_snapshot/src/format.rs
+++ b/crates/karva_snapshot/src/format.rs
@@ -68,7 +68,7 @@ impl SnapshotFile {
     /// ---
     /// snapshot content here
     /// ```
-    pub fn parse(input: &str) -> Result<Self, ParseSnapshotError> {
+    pub(super) fn parse(input: &str) -> Result<Self, ParseSnapshotError> {
         let input = input
             .strip_prefix("---\n")
             .ok_or(ParseSnapshotError::MissingOpeningSeparator)?;
@@ -102,7 +102,7 @@ impl SnapshotFile {
     }
 
     /// Serialize the snapshot file to its string representation.
-    pub fn serialize(&self) -> String {
+    pub(super) fn serialize(&self) -> String {
         let mut output = String::new();
         output.push_str("---\n");
 

--- a/crates/karva_snapshot/src/inline.rs
+++ b/crates/karva_snapshot/src/inline.rs
@@ -4,15 +4,15 @@ use camino::Utf8Path;
 use fs_err as fs;
 
 /// Location of an inline snapshot string literal in source code.
-pub struct InlineLocation {
+struct InlineLocation {
     /// Byte offset of string literal start (including quotes).
-    pub start: usize,
+    start: usize,
 
     /// Byte offset of string literal end (including quotes).
-    pub end: usize,
+    end: usize,
 
     /// Column indentation of the `assert_snapshot` call.
-    pub indent: usize,
+    indent: usize,
 }
 
 /// Strip common leading whitespace from all non-empty lines and trim trailing whitespace.
@@ -62,7 +62,7 @@ pub fn dedent(raw: &str) -> String {
 ///
 /// - Single-line, no problematic chars: `"value"`
 /// - Multi-line: `"""\\\n{indented lines}\n{indent}"""`
-pub fn generate_inline_literal(value: &str, indent: usize) -> String {
+fn generate_inline_literal(value: &str, indent: usize) -> String {
     let content_indent = " ".repeat(indent + 4);
 
     if !value.contains('\n') {
@@ -99,7 +99,7 @@ pub fn generate_inline_literal(value: &str, indent: usize) -> String {
 /// correct function. This handles stale line numbers from multiline inline accepts
 /// that shift subsequent code — without this check, the search could find and
 /// corrupt an intervening function's `inline=` argument.
-pub fn find_inline_argument(
+fn find_inline_argument(
     source: &str,
     line_number: u32,
     function_name: Option<&str>,
@@ -359,7 +359,7 @@ fn find_single_quote_end(source: &str, start: usize, quote: char) -> Option<usiz
 }
 
 /// Replace a byte range in source text.
-pub fn apply_edit(source: &str, start: usize, end: usize, replacement: &str) -> String {
+fn apply_edit(source: &str, start: usize, end: usize, replacement: &str) -> String {
     let mut result = String::with_capacity(source.len() + replacement.len());
     result.push_str(&source[..start]);
     result.push_str(replacement);
@@ -385,7 +385,7 @@ pub fn rewrite_inline_snapshot(
 }
 
 /// Applies one inline snapshot update to source text without writing it.
-pub(crate) fn apply_inline_snapshot_update(
+pub(super) fn apply_inline_snapshot_update(
     source: &str,
     source_path: &str,
     line_number: u32,

--- a/crates/karva_snapshot/src/review.rs
+++ b/crates/karva_snapshot/src/review.rs
@@ -14,13 +14,13 @@ use crate::storage::{
 #[derive(Debug, Default)]
 pub struct ReviewSummary {
     /// Snapshot names accepted during this session.
-    pub accepted: Vec<String>,
+    accepted: Vec<String>,
 
     /// Snapshot names rejected during this session.
-    pub rejected: Vec<String>,
+    rejected: Vec<String>,
 
     /// Snapshot names left pending during this session.
-    pub skipped: Vec<String>,
+    skipped: Vec<String>,
 }
 
 /// Action chosen by the user for a single snapshot.

--- a/crates/karva_snapshot/src/storage.rs
+++ b/crates/karva_snapshot/src/storage.rs
@@ -11,7 +11,7 @@ use crate::format::SnapshotFile;
 /// Return the snapshots directory for a given test file.
 ///
 /// For a test file at `tests/test_example.py`, this returns `tests/snapshots/`.
-pub fn snapshot_dir(test_file: &Utf8Path) -> Utf8PathBuf {
+fn snapshot_dir(test_file: &Utf8Path) -> Utf8PathBuf {
     if let Some(parent) = test_file.parent() {
         parent.join("snapshots")
     } else {
@@ -35,7 +35,7 @@ pub fn snapshot_path(test_file: &Utf8Path, module_name: &str, snapshot_name: &st
 }
 
 /// Return the path to a pending snapshot file (`.snap.new`).
-pub fn pending_path(snap_path: &Utf8Path) -> Utf8PathBuf {
+fn pending_path(snap_path: &Utf8Path) -> Utf8PathBuf {
     Utf8PathBuf::from(format!("{snap_path}.new"))
 }
 
@@ -73,7 +73,7 @@ fn write_snapshot_file(path: &Utf8Path, snapshot: &SnapshotFile) -> io::Result<(
 }
 
 /// Replaces a file only after its complete contents have been written beside it.
-pub(crate) fn write_file_atomically(path: &Utf8Path, content: &[u8]) -> io::Result<()> {
+pub(super) fn write_file_atomically(path: &Utf8Path, content: &[u8]) -> io::Result<()> {
     let parent = path
         .parent()
         .filter(|parent| !parent.as_str().is_empty())
@@ -94,7 +94,7 @@ pub struct PendingSnapshotInfo {
     pub pending_path: Utf8PathBuf,
 
     /// Path to the corresponding `.snap` file (may not exist yet).
-    pub snap_path: Utf8PathBuf,
+    pub(super) snap_path: Utf8PathBuf,
 }
 
 /// Recursively walk a directory tree and collect files that match a filter.
@@ -213,7 +213,7 @@ fn extract_function_name(source: Option<&str>) -> Option<&str> {
 /// For inline snapshots (with `inline_source`/`inline_line` metadata),
 /// rewrites the source file in-place and deletes the `.snap.new` file.
 /// For file-based snapshots, atomically promotes `.snap.new` to `.snap`.
-pub fn accept_pending(pending_path: &Utf8Path) -> io::Result<()> {
+pub(crate) fn accept_pending(pending_path: &Utf8Path) -> io::Result<()> {
     if let Some(snapshot) = read_snapshot(pending_path)?
         && let Some(source_file) = &snapshot.metadata.inline_source
         && let Some(line) = snapshot.metadata.inline_line
@@ -340,7 +340,7 @@ pub fn reject_pending(pending_path: &Utf8Path) -> io::Result<()> {
 #[derive(Debug, Clone)]
 pub struct SnapshotInfo {
     /// Path to committed `.snap` file.
-    pub snap_path: Utf8PathBuf,
+    snap_path: Utf8PathBuf,
 }
 
 /// Why a snapshot is considered unreferenced.
@@ -391,7 +391,7 @@ pub struct UnreferencedSnapshot {
 /// Parse a snapshot's `source` metadata field into `(filename, snapshot_name)`.
 ///
 /// Handles formats like `test.py:5::test_name` and `test.py::test_name`.
-pub fn parse_source(source: &str) -> Option<(&str, &str)> {
+fn parse_source(source: &str) -> Option<(&str, &str)> {
     let (file, name) = source.split_once("::")?;
     let file = file
         .rsplit_once(':')
@@ -409,7 +409,7 @@ pub fn parse_source(source: &str) -> Option<(&str, &str)> {
 /// numbering `test_foo-2` → `test_foo`,
 /// inline suffix `test_foo_inline_5` → `test_foo`,
 /// and class prefix `TestClass::test_method` → `test_method`.
-pub fn base_function_name(name: &str) -> &str {
+fn base_function_name(name: &str) -> &str {
     let name = name.rsplit_once("::").map_or(name, |(_, method)| method);
     let name = name.split_once("--").map_or(name, |(base, _)| base);
     let name = name.split_once('(').map_or(name, |(base, _)| base);
@@ -430,7 +430,7 @@ pub fn base_function_name(name: &str) -> &str {
 }
 
 /// Check whether a function definition `def {name}(` exists in a file.
-pub fn function_exists_in_file(path: &Utf8Path, name: &str) -> io::Result<bool> {
+fn function_exists_in_file(path: &Utf8Path, name: &str) -> io::Result<bool> {
     let content = fs::read_to_string(path).map_err(|err| {
         io::Error::new(
             err.kind(),
@@ -456,7 +456,7 @@ fn line_declares_function(line: &str, name: &str) -> bool {
 }
 
 /// Recursively find all committed snapshot files (`.snap`, not `.snap.new`).
-pub fn find_snapshots(root: &Utf8Path) -> io::Result<Vec<SnapshotInfo>> {
+fn find_snapshots(root: &Utf8Path) -> io::Result<Vec<SnapshotInfo>> {
     let mut results = Vec::new();
     find_recursive(
         root,

--- a/crates/karva_test_semantic/src/context.rs
+++ b/crates/karva_test_semantic/src/context.rs
@@ -34,7 +34,7 @@ pub struct RunState {
 }
 
 impl<'a> Context<'a> {
-    pub(crate) fn new(
+    pub(super) fn new(
         cwd: &'a Utf8Path,
         settings: &'a ProjectSettings,
         python_version: PythonVersion,
@@ -50,19 +50,19 @@ impl<'a> Context<'a> {
         }
     }
 
-    pub(crate) fn cwd(&self) -> &'a Utf8Path {
+    pub(super) fn cwd(&self) -> &'a Utf8Path {
         self.cwd
     }
 
-    pub(crate) fn settings(&self) -> &'a ProjectSettings {
+    pub(super) fn settings(&self) -> &'a ProjectSettings {
         self.settings
     }
 
-    pub(crate) fn is_verbose(&self) -> bool {
+    pub(super) fn is_verbose(&self) -> bool {
         self.verbose
     }
 
-    pub(crate) fn collection_settings(&'a self) -> CollectionSettings<'a> {
+    pub(super) fn collection_settings(&'a self) -> CollectionSettings<'a> {
         CollectionSettings {
             python_version: self.python_version,
             test_function_prefix: &self.settings.test().test_function_prefix,
@@ -91,7 +91,7 @@ impl<'a> Context<'a> {
 }
 
 impl RunState {
-    pub(crate) fn into_result(self) -> TestRunResult {
+    pub(super) fn into_result(self) -> TestRunResult {
         self.result.into_sorted()
     }
 
@@ -119,7 +119,7 @@ impl RunState {
         passed
     }
 
-    pub(crate) fn register_module_skip(
+    pub(super) fn register_module_skip(
         &mut self,
         context: &Context<'_>,
         module_path: &ModulePath,
@@ -196,7 +196,7 @@ impl RunState {
         passed
     }
 
-    pub(crate) fn add_run_diagnostic(&mut self, diagnostic: Diagnostic) {
+    pub(super) fn add_run_diagnostic(&mut self, diagnostic: Diagnostic) {
         self.result.add_run_diagnostic(diagnostic);
     }
 }

--- a/crates/karva_test_semantic/src/diagnostic/metadata.rs
+++ b/crates/karva_test_semantic/src/diagnostic/metadata.rs
@@ -14,7 +14,7 @@ pub struct DiagnosticType {
     pub summary: &'static str,
 
     /// The severity level (error, warning, etc.) of this diagnostic.
-    pub(crate) severity: Severity,
+    pub(super) severity: Severity,
 }
 
 #[macro_export]
@@ -36,7 +36,7 @@ macro_rules! declare_diagnostic_type {
 }
 
 impl DiagnosticType {
-    pub(crate) fn diagnostic(&self, message: impl std::fmt::Display) -> Diagnostic {
+    pub(super) fn diagnostic(&self, message: impl std::fmt::Display) -> Diagnostic {
         Diagnostic::new(DiagnosticId::Lint(self.name), self.severity, message)
     }
 }

--- a/crates/karva_test_semantic/src/discovery/models/module.rs
+++ b/crates/karva_test_semantic/src/discovery/models/module.rs
@@ -81,13 +81,13 @@ impl DiscoveredModule {
         self.source_file.clone()
     }
 
-    pub(crate) fn is_empty(&self) -> bool {
+    pub(super) fn is_empty(&self) -> bool {
         self.test_functions.is_empty()
             && self.fixtures.is_empty()
             && self.rejected_fixtures.is_empty()
     }
 
-    pub(crate) fn shrink(&mut self) {
+    pub(super) fn shrink(&mut self) {
         self.test_functions
             .sort_by_key(|function| function.statement().range.start());
     }

--- a/crates/karva_test_semantic/src/discovery/models/package.rs
+++ b/crates/karva_test_semantic/src/discovery/models/package.rs
@@ -90,7 +90,7 @@ impl DiscoveredPackage {
         self.packages.retain(|_, package| !package.is_empty());
     }
 
-    pub(crate) fn is_empty(&self) -> bool {
+    fn is_empty(&self) -> bool {
         self.modules.is_empty() && self.packages.is_empty()
     }
 }

--- a/crates/karva_test_semantic/src/extensions/fixtures/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/mod.rs
@@ -103,7 +103,7 @@ impl RejectedFixture {
 }
 
 impl DiscoveredFixture {
-    pub(crate) fn new(
+    fn new(
         name: QualifiedFunctionName,
         stmt_function_def: Rc<StmtFunctionDef>,
         source_file: SourceFile,
@@ -141,7 +141,7 @@ impl DiscoveredFixture {
         self.is_generator
     }
 
-    pub(crate) fn auto_use(&self) -> bool {
+    fn auto_use(&self) -> bool {
         self.auto_use
     }
 
@@ -186,7 +186,7 @@ impl DiscoveredFixture {
         )
     }
 
-    pub(crate) fn try_from_pytest_function(
+    fn try_from_pytest_function(
         py: Python<'_>,
         stmt_function_def: Rc<StmtFunctionDef>,
         function: &Bound<'_, PyAny>,
@@ -224,7 +224,7 @@ impl DiscoveredFixture {
         ))
     }
 
-    pub(crate) fn try_from_karva_function(
+    fn try_from_karva_function(
         py: Python<'_>,
         stmt_function_def: Rc<StmtFunctionDef>,
         function: &Bound<'_, PyAny>,

--- a/crates/karva_test_semantic/src/extensions/fixtures/scope.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/scope.rs
@@ -19,7 +19,7 @@ pub enum FixtureScope {
 
 impl FixtureScope {
     /// Returns a list of scopes above the current scope.
-    pub(crate) fn scopes_above(self) -> &'static [Self] {
+    pub(super) fn scopes_above(self) -> &'static [Self] {
         use FixtureScope::{Function, Module, Package, Session};
 
         match self {

--- a/crates/karva_test_semantic/src/extensions/functions/python.rs
+++ b/crates/karva_test_semantic/src/extensions/functions/python.rs
@@ -30,7 +30,7 @@ pub struct Param {
 }
 
 impl Param {
-    pub(crate) fn new(py: Python, values: Vec<Py<PyAny>>, tags: Vec<Py<PyAny>>) -> PyResult<Self> {
+    fn new(py: Python, values: Vec<Py<PyAny>>, tags: Vec<Py<PyAny>>) -> PyResult<Self> {
         let mut new_tags = Vec::new();
 
         for tag in tags {

--- a/crates/karva_test_semantic/src/extensions/tags/custom.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/custom.rs
@@ -16,11 +16,11 @@ pub struct CustomTag {
 }
 
 impl CustomTag {
-    pub(crate) fn name(&self) -> &str {
+    pub(super) fn name(&self) -> &str {
         &self.name
     }
 
-    pub(crate) fn new(
+    pub(super) fn new(
         name: String,
         args: Vec<Arc<Py<PyAny>>>,
         kwargs: Vec<(String, Arc<Py<PyAny>>)>,
@@ -29,7 +29,7 @@ impl CustomTag {
     }
 
     /// Try to create a `CustomTag` from a pytest mark.
-    pub(crate) fn try_from_pytest_mark(py_mark: &Bound<'_, PyAny>) -> Option<Self> {
+    pub(super) fn try_from_pytest_mark(py_mark: &Bound<'_, PyAny>) -> Option<Self> {
         let name = py_mark.getattr("name").ok()?.extract::<String>().ok()?;
 
         let args = if let Ok(args_tuple) = py_mark.getattr("args")

--- a/crates/karva_test_semantic/src/extensions/tags/expect_fail.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/expect_fail.rs
@@ -19,7 +19,7 @@ pub struct ExpectFailTag {
 }
 
 impl ExpectFailTag {
-    pub(crate) fn new(conditions: Vec<bool>, reason: Option<String>) -> Self {
+    pub(super) fn new(conditions: Vec<bool>, reason: Option<String>) -> Self {
         Self { conditions, reason }
     }
 
@@ -38,7 +38,7 @@ impl ExpectFailTag {
         }
     }
 
-    pub(crate) fn try_from_pytest_mark(
+    pub(super) fn try_from_pytest_mark(
         py_mark: &Bound<'_, PyAny>,
         globals: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<Option<Self>> {

--- a/crates/karva_test_semantic/src/extensions/tags/fail_slow.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/fail_slow.rs
@@ -9,7 +9,7 @@ pub struct FailSlowTag {
 }
 
 impl FailSlowTag {
-    pub(crate) fn new(seconds: f64) -> Self {
+    pub(super) fn new(seconds: f64) -> Self {
         Self { seconds }
     }
 

--- a/crates/karva_test_semantic/src/extensions/tags/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/mod.rs
@@ -158,7 +158,7 @@ impl Tag {
     ///
     /// We first check if the object is a `PyTag` or `PyTags`.
     /// If not, we try to call it to see if it returns a `PyTag` or `PyTags`.
-    pub(crate) fn try_from_py_any(py: Python, py_any: &Py<PyAny>) -> Option<Self> {
+    pub(super) fn try_from_py_any(py: Python, py_any: &Py<PyAny>) -> Option<Self> {
         if let Ok(tag) = py_any.cast_bound::<PyTag>(py) {
             return Some(Self::from_karva_tag(py, tag.borrow()));
         } else if let Ok(tag) = py_any.cast_bound::<PyTags>(py)
@@ -180,7 +180,7 @@ impl Tag {
     }
 
     /// Converts a Karva Python tag into our internal representation.
-    pub(crate) fn from_karva_tag<T>(py: Python, py_tag: T) -> Self
+    fn from_karva_tag<T>(py: Python, py_tag: T) -> Self
     where
         T: Deref<Target = PyTag>,
     {
@@ -345,7 +345,7 @@ impl CompiledTags {
 }
 
 impl Tags {
-    pub(crate) fn new(tags: Vec<Tag>) -> Self {
+    pub(super) fn new(tags: Vec<Tag>) -> Self {
         Self { inner: tags }
     }
 

--- a/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
@@ -378,7 +378,7 @@ pub struct Parametrization {
 }
 
 impl Parametrization {
-    pub(crate) fn tags(&self) -> &Tags {
+    fn tags(&self) -> &Tags {
         &self.tags
     }
 }
@@ -411,7 +411,7 @@ pub struct ParametrizationArgs {
 }
 
 impl ParametrizationArgs {
-    pub(crate) fn extend(&mut self, other: Self) {
+    fn extend(&mut self, other: Self) {
         self.values.extend(other.values);
         self.tags.extend(&other.tags);
         if !self.id.is_empty() && !other.id.is_empty() {
@@ -433,7 +433,7 @@ pub struct ParameterPlan {
 }
 
 impl ParameterPlan {
-    pub(crate) fn new(dimensions: Vec<Vec<ParametrizationArgs>>) -> Self {
+    pub(super) fn new(dimensions: Vec<Vec<ParametrizationArgs>>) -> Self {
         Self { dimensions }
     }
 }
@@ -708,18 +708,18 @@ fn extract_parametrize_args<'py>(
 }
 
 impl ParametrizeTag {
-    pub(crate) fn names(&self) -> &[String] {
+    pub(super) fn names(&self) -> &[String] {
         &self.names
     }
 
-    pub(crate) fn new(names: Vec<String>, parametrizations: Vec<Parametrization>) -> Self {
+    fn new(names: Vec<String>, parametrizations: Vec<Parametrization>) -> Self {
         Self {
             names,
             parametrizations,
         }
     }
 
-    pub(crate) fn from_karva(arg_names: Vec<String>, arg_values: Vec<Param>) -> Self {
+    pub(super) fn from_karva(arg_names: Vec<String>, arg_values: Vec<Param>) -> Self {
         Self::new(
             arg_names,
             arg_values
@@ -741,7 +741,7 @@ impl ParametrizeTag {
         )
     }
 
-    pub(crate) fn try_from_pytest_mark(
+    pub(super) fn try_from_pytest_mark(
         py_mark: &Bound<'_, PyAny>,
         globals: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<Option<Self>> {
@@ -753,7 +753,7 @@ impl ParametrizeTag {
         Ok(Some(Self::new(arg_names, parametrizations)))
     }
 
-    pub(crate) fn validate<'a>(
+    pub(super) fn validate<'a>(
         &'a self,
         function_parameter_names: &HashSet<&str>,
         seen_names: &mut HashSet<&'a str>,
@@ -802,7 +802,7 @@ impl ParametrizeTag {
     /// Returns each parameterize case.
     ///
     /// Each [`HashMap`] is used as keyword arguments for the test function.
-    pub(crate) fn each_arg_value(&self) -> Vec<ParametrizationArgs> {
+    pub(super) fn each_arg_value(&self) -> Vec<ParametrizationArgs> {
         let total_combinations = self.parametrizations.len();
         let mut param_args = Vec::with_capacity(total_combinations);
 
@@ -829,7 +829,7 @@ impl ParametrizeTag {
 
 /// Check for instances of `pytest.ParameterSet` and extract the parameters
 /// from it. Also handles regular tuples by extracting their values.
-pub(super) fn handle_custom_parametrize_param(
+fn handle_custom_parametrize_param(
     py: Python,
     param: Py<PyAny>,
     expect_multiple: bool,

--- a/crates/karva_test_semantic/src/extensions/tags/python.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/python.rs
@@ -45,7 +45,7 @@ pub enum PyTag {
 }
 
 impl PyTag {
-    pub(crate) fn clone_ref(&self, py: Python<'_>) -> Self {
+    fn clone_ref(&self, py: Python<'_>) -> Self {
         match self {
             Self::Parametrize {
                 arg_names,
@@ -92,7 +92,7 @@ pub struct PyTags {
 }
 
 impl PyTags {
-    pub(crate) fn clone_ref(&self, py: Python<'_>) -> Self {
+    fn clone_ref(&self, py: Python<'_>) -> Self {
         Self {
             inner: self.inner.iter().map(|tag| tag.clone_ref(py)).collect(),
         }
@@ -290,7 +290,7 @@ pub mod tags {
 #[pyclass(name = "CustomTagBuilder", from_py_object)]
 pub struct CustomTagBuilder {
     /// Attribute name captured from `karva.tags.<name>`.
-    pub(crate) tag_name: String,
+    tag_name: String,
 }
 
 #[pymethods]

--- a/crates/karva_test_semantic/src/extensions/tags/skip.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/skip.rs
@@ -19,18 +19,18 @@ pub struct SkipTag {
 }
 
 impl SkipTag {
-    pub(crate) fn new(conditions: Vec<bool>, reason: Option<String>) -> Self {
+    pub(super) fn new(conditions: Vec<bool>, reason: Option<String>) -> Self {
         Self { conditions, reason }
     }
 
-    pub(crate) fn reason(&self) -> Option<String> {
+    pub(super) fn reason(&self) -> Option<String> {
         self.reason.clone()
     }
 
     /// Check if the test should be skipped.
     /// If there are no conditions, always skip.
     /// If there are conditions, skip only if any condition is true.
-    pub(crate) fn should_skip(&self) -> bool {
+    pub(super) fn should_skip(&self) -> bool {
         if self.conditions.is_empty() {
             true
         } else {
@@ -38,7 +38,7 @@ impl SkipTag {
         }
     }
 
-    pub(crate) fn try_from_pytest_mark(
+    pub(super) fn try_from_pytest_mark(
         py_mark: &Bound<'_, PyAny>,
         globals: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<Option<Self>> {

--- a/crates/karva_test_semantic/src/extensions/tags/timeout.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/timeout.rs
@@ -13,7 +13,7 @@ pub struct TimeoutTag {
 }
 
 impl TimeoutTag {
-    pub(crate) fn new(seconds: f64) -> Self {
+    pub(super) fn new(seconds: f64) -> Self {
         Self { seconds }
     }
 
@@ -22,7 +22,7 @@ impl TimeoutTag {
     }
 
     /// Parse `@pytest.mark.timeout(seconds)`.
-    pub(crate) fn try_from_pytest_mark(py_mark: &Bound<'_, PyAny>) -> PyResult<Option<Self>> {
+    pub(super) fn try_from_pytest_mark(py_mark: &Bound<'_, PyAny>) -> PyResult<Option<Self>> {
         let args = py_mark.getattr("args")?;
         let tuple = args.extract::<Bound<'_, PyTuple>>()?;
         if tuple.is_empty() {

--- a/crates/karva_test_semantic/src/extensions/tags/use_fixtures.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/use_fixtures.rs
@@ -13,15 +13,15 @@ pub struct UseFixturesTag {
 }
 
 impl UseFixturesTag {
-    pub(crate) fn new(fixture_names: Vec<String>) -> Self {
+    pub(super) fn new(fixture_names: Vec<String>) -> Self {
         Self { fixture_names }
     }
 
-    pub(crate) fn fixture_names(&self) -> &[String] {
+    pub(super) fn fixture_names(&self) -> &[String] {
         &self.fixture_names
     }
 
-    pub(crate) fn try_from_pytest_mark(py_mark: &Bound<'_, PyAny>) -> PyResult<Option<Self>> {
+    pub(super) fn try_from_pytest_mark(py_mark: &Bound<'_, PyAny>) -> PyResult<Option<Self>> {
         let args = py_mark.getattr("args")?;
         let tuple = args.extract::<Bound<'_, PyTuple>>()?;
         let fixture_names = tuple

--- a/crates/karva_test_semantic/src/lib.rs
+++ b/crates/karva_test_semantic/src/lib.rs
@@ -9,7 +9,7 @@ mod output_capture;
 mod py_attach;
 mod python;
 mod runner;
-pub mod utils;
+mod utils;
 
 pub(crate) use context::{Context, RunState};
 pub use karva_coverage::CoverageConfig;

--- a/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
@@ -75,11 +75,7 @@ impl PackageRunner<'_, '_> {
     }
 
     /// Clears cached fixture values and runs finalizers for one completed scope.
-    pub(super) fn clean_up_scope(
-        &mut self,
-        py: Python<'_>,
-        scope: ScopeKey<'_>,
-    ) -> Vec<Diagnostic> {
+    fn clean_up_scope(&mut self, py: Python<'_>, scope: ScopeKey<'_>) -> Vec<Diagnostic> {
         let diagnostics = self.finalizer_cache.run_and_clear_scope(py, scope);
         self.fixture_cache.clear_scope(scope);
         diagnostics

--- a/crates/karva_test_semantic/src/utils.rs
+++ b/crates/karva_test_semantic/src/utils.rs
@@ -23,7 +23,7 @@ def _make_sync(async_fn):
 ";
 
 /// Runs a Python coroutine to completion using `asyncio.run()`.
-pub(crate) fn run_coroutine(py: Python<'_>, coroutine: Py<PyAny>) -> PyResult<Py<PyAny>> {
+pub fn run_coroutine(py: Python<'_>, coroutine: Py<PyAny>) -> PyResult<Py<PyAny>> {
     let asyncio = py.import("asyncio")?;
     Ok(asyncio.call_method1("run", (coroutine,))?.unbind())
 }
@@ -36,7 +36,7 @@ pub(crate) fn run_coroutine(py: Python<'_>, coroutine: Py<PyAny>) -> PyResult<Py
 /// abandoned (Python has no safe way to interrupt arbitrary code) and the
 /// executor is shut down without waiting. Async tests are wrapped in
 /// `asyncio.wait_for`, which cancels the coroutine on timeout.
-pub(crate) fn run_test_with_timeout(
+pub fn run_test_with_timeout(
     py: Python<'_>,
     function: &Py<PyAny>,
     kwargs: &FixtureArguments,
@@ -160,7 +160,7 @@ fn rebrand_timeout_error(
 ///
 /// Returns `true` if the function was patched (caller should NOT apply `asyncio.run()`),
 /// or `false` if no patching was needed.
-pub(crate) fn patch_async_test_function(py: Python<'_>, function: &Py<PyAny>) -> PyResult<bool> {
+pub fn patch_async_test_function(py: Python<'_>, function: &Py<PyAny>) -> PyResult<bool> {
     let inspect = py.import("inspect")?;
     let is_coroutine_fn = inspect
         .call_method1("iscoroutinefunction", (function,))?
@@ -203,7 +203,7 @@ pub(crate) fn patch_async_test_function(py: Python<'_>, function: &Py<PyAny>) ->
 
 /// Sets `KARVA_ATTEMPT` and `KARVA_TOTAL_ATTEMPTS` on Python's `os.environ` so
 /// the currently running test can read them.
-pub(crate) fn set_attempt_env(py: Python<'_>, attempt: u32, total_attempts: u32) -> PyResult<()> {
+pub fn set_attempt_env(py: Python<'_>, attempt: u32, total_attempts: u32) -> PyResult<()> {
     let environ = py.import("os")?.getattr("environ")?;
     environ.set_item(WorkerEnvVars::KARVA_ATTEMPT, attempt.to_string())?;
     environ.set_item(
@@ -215,14 +215,14 @@ pub(crate) fn set_attempt_env(py: Python<'_>, attempt: u32, total_attempts: u32)
 
 /// Sets `KARVA_TEST_NAME` on Python's `os.environ` to the qualified name of
 /// the currently running test variant.
-pub(crate) fn set_test_name_env(py: Python<'_>, qualified_name: &str) -> PyResult<()> {
+pub fn set_test_name_env(py: Python<'_>, qualified_name: &str) -> PyResult<()> {
     let environ = py.import("os")?.getattr("environ")?;
     environ.set_item(WorkerEnvVars::KARVA_TEST_NAME, qualified_name)?;
     Ok(())
 }
 
 /// Formats Python values for test identity, quoting strings and escaping NUL bytes.
-pub(crate) fn display_value(value: &Bound<'_, PyAny>) -> String {
+pub fn display_value(value: &Bound<'_, PyAny>) -> String {
     let display = if value.is_instance_of::<PyString>()
         && let Ok(repr) = value.repr()
     {
@@ -258,7 +258,7 @@ fn truncated_display_value(value: &Bound<'_, PyAny>) -> String {
 }
 
 /// Adds a directory path to Python's sys.path at the specified index.
-pub(crate) fn add_to_sys_path(py: Python<'_>, path: &Utf8Path, index: isize) -> PyResult<()> {
+pub fn add_to_sys_path(py: Python<'_>, path: &Utf8Path, index: isize) -> PyResult<()> {
     let sys_module = py.import("sys")?;
     let sys_path = sys_module.getattr("path")?;
     sys_path.call_method1("insert", (index, path.to_string()))?;
@@ -266,7 +266,7 @@ pub(crate) fn add_to_sys_path(py: Python<'_>, path: &Utf8Path, index: isize) -> 
 }
 
 /// Renders parameter-list contents in Python signature order.
-pub(crate) fn test_parameters(
+pub fn test_parameters(
     py: Python,
     kwargs: &FixtureArguments,
     parameters: &Parameters,
@@ -299,7 +299,7 @@ pub(crate) fn test_parameters(
 const TRUNCATE_LENGTH: usize = 30;
 
 /// Truncates user-facing text by Unicode scalar count, preserving a three-character ellipsis.
-pub(crate) fn truncate_string(value: &str) -> String {
+pub fn truncate_string(value: &str) -> String {
     if value.chars().count() > TRUNCATE_LENGTH {
         let truncated: String = value.chars().take(TRUNCATE_LENGTH - 3).collect();
         format!("{truncated}...")

--- a/hawk.toml
+++ b/hawk.toml
@@ -1,0 +1,43 @@
+[[production]]
+package = "karva"
+bin = "karva"
+reason = "shipped controller binary"
+
+[[production]]
+package = "karva_worker"
+bin = "karva-worker"
+reason = "shipped worker binary"
+
+[[production]]
+package = "karva_benchmark"
+bin = "karva-benchmark"
+reason = "benchmark runner"
+
+[[production]]
+package = "karva_dev"
+bin = "karva_dev"
+reason = "developer tooling"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "karva_benchmark"
+item = "prepare_benchmark_project"
+kind = "function"
+level = "expect"
+reason = "called from Divan benchmark registration"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "karva_benchmark"
+item = "prepare_benchmark_project_with_wheel"
+kind = "function"
+level = "expect"
+reason = "called from Divan benchmark registration"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "karva_benchmark"
+item = "try_run_project"
+kind = "function"
+level = "expect"
+reason = "called from Divan benchmark registration"


### PR DESCRIPTION
## Summary

Add a pinned Hawk check to CI, configure Karva’s production binaries with exact Divan expectations, and narrow or remove unused Rust visibility. CI also denies Hawk’s allow-by-default crate-visibility lint; no broad exclusions remain.

## Test Plan

`cargo hawk check -D warnings -D hawk::unnecessary_crate_visibility`, Clippy, the full test suite, pinact, and pre-commit.