### PR TITLE
Add profile-scoped test environment variables

### DIFF
--- a/crates/karva/src/lib.rs
+++ b/crates/karva/src/lib.rs
@@ -1,10 +1,12 @@
 //! Top-level CLI entry point shared by the `karva` binary and integration tests.
 
 use std::ffi::OsString;
+use std::io;
 use std::io::stdout;
 
 use anyhow::Context;
 use clap::{CommandFactory, Parser};
+use colored::Colorize;
 use karva_cli::{Args, Command};
 
 pub use karva_cli::ExitStatus;
@@ -14,16 +16,32 @@ mod utils;
 
 pub fn karva_main(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> ExitStatus {
     run(f).unwrap_or_else(|error| {
-        if karva_logging::error_chain_contains_broken_pipe(error.chain()) {
+        use io::Write;
+
+        // Exit "gracefully" on broken pipe errors.
+        //
+        // See: https://github.com/BurntSushi/ripgrep/blob/bf63fe8f258afc09bae6caa48f0ae35eaf115005/crates/core/main.rs#L47C1-L61C14
+        if error.chain().any(|cause| {
+            cause
+                .downcast_ref::<io::Error>()
+                .is_some_and(|ioerr| ioerr.kind() == io::ErrorKind::BrokenPipe)
+        }) {
             return ExitStatus::Success;
         }
 
-        let mut stderr = std::io::stderr().lock();
-        if let Err(err) = karva_logging::write_error_chain(&mut stderr, error.chain()) {
-            if err.kind() == std::io::ErrorKind::BrokenPipe {
-                return ExitStatus::Success;
-            }
+        // Use `writeln` instead of `eprintln` to avoid panicking when the stderr pipe is broken.
+        let mut stderr = io::stderr().lock();
+
+        // This communicates that this isn't a linter error but karva itself hard-errored for
+        // some reason (e.g. failed to resolve the configuration)
+        writeln!(stderr, "{}", "karva failed".red().bold()).ok();
+        // Currently we generally only see one error, but e.g. with io errors when resolving
+        // the configuration it is help to chain errors ("resolving configuration failed" ->
+        // "failed to read file: subdir/pyproject.toml")
+        for cause in error.chain() {
+            writeln!(stderr, "  {} {cause}", "Cause:".bold()).ok();
         }
+
         ExitStatus::Error
     })
 }

--- a/crates/karva/tests/it/basic.rs
+++ b/crates/karva/tests/it/basic.rs
@@ -771,13 +771,13 @@ fn test_text_file() {
 
     assert_cmd_snapshot!(
         context.command().args(["random.txt"]),
-        @r"
+        @"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
+    karva failed
       Cause: path `<temp_dir>/random.txt` has a wrong file extension
     ");
 }
@@ -846,13 +846,13 @@ fn test_quiet_output_failing() {
 fn test_invalid_path() {
     let context = TestContext::new();
 
-    assert_cmd_snapshot!(context.command().arg("non_existing_path.py"), @r"
+    assert_cmd_snapshot!(context.command().arg("non_existing_path.py"), @"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
+    karva failed
       Cause: path `<temp_dir>/non_existing_path.py` could not be found
     ");
 }
@@ -3098,13 +3098,13 @@ fn test_num_workers_zero_is_rejected() {
 fn test_max_parallelism_env_invalid_value() {
     let context = TestContext::with_file("test.py", "def test_1(): pass");
 
-    assert_cmd_snapshot!(context.command().env(EnvVars::KARVA_MAX_PARALLELISM, "0"), @r"
+    assert_cmd_snapshot!(context.command().env(EnvVars::KARVA_MAX_PARALLELISM, "0"), @"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
+    karva failed
       Cause: Failed to determine default worker count
       Cause: invalid KARVA_MAX_PARALLELISM value `0`; expected a positive integer
       Cause: number would be zero for non-zero type
@@ -3327,13 +3327,13 @@ def test_3(): assert False
 fn test_nonexistent_path_exits_nonzero() {
     let context = TestContext::new();
 
-    assert_cmd_snapshot!(context.command().arg("missing.py"), @r"
+    assert_cmd_snapshot!(context.command().arg("missing.py"), @"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
+    karva failed
       Cause: path `<temp_dir>/missing.py` could not be found
     ");
 }

--- a/crates/karva/tests/it/configuration/environment.rs
+++ b/crates/karva/tests/it/configuration/environment.rs
@@ -1,0 +1,120 @@
+use insta_cmd::assert_cmd_snapshot;
+
+use crate::common::TestContext;
+
+#[test]
+fn profile_environment_is_applied_before_test_module_import() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.default.env]
+APP_ENV = "test"
+CACHE_DIR = { value = ".cache/tests", preserve = true }
+PROFILE_ENV_TEST_FALLBACK = { value = "configured", preserve = true }
+LIVE_API_TOKEN = { unset = true }
+PROFILE_VALUE = "default"
+PYTHONUNBUFFERED = "configured"
+
+[profile.ci.env]
+PROFILE_VALUE = "ci"
+"#,
+        ),
+        (
+            "test_environment.py",
+            r#"
+import os
+
+assert os.environ["APP_ENV"] == "test"
+assert os.environ["CACHE_DIR"] == "from-parent"
+assert os.environ["PROFILE_ENV_TEST_FALLBACK"] == "configured"
+assert "LIVE_API_TOKEN" not in os.environ
+assert os.environ["PROFILE_VALUE"] == "ci"
+assert os.environ["PYTHONUNBUFFERED"] == "configured"
+
+def test_environment(): pass
+"#,
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context
+            .command()
+            .args(["--profile", "ci"])
+            .env("CACHE_DIR", "from-parent")
+            .env("LIVE_API_TOKEN", "secret"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test_environment::test_environment
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
+fn karva_environment_variables_are_reserved() {
+    let context = TestContext::with_file(
+        "karva.toml",
+        r#"
+[profile.default.env]
+KARVA_RUN_ID = "mine"
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command(), @r#"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Karva failed
+      Cause: <temp_dir>/karva.toml is not a valid `karva.toml`: TOML parse error at line 3, column 1
+      |
+    3 | KARVA_RUN_ID = "mine"
+      | ^^^^^^^^^^^^
+    environment variable `KARVA_RUN_ID` is reserved by Karva
+
+      Cause: TOML parse error at line 3, column 1
+      |
+    3 | KARVA_RUN_ID = "mine"
+      | ^^^^^^^^^^^^
+    environment variable `KARVA_RUN_ID` is reserved by Karva
+    "#);
+}
+
+#[test]
+fn environment_operation_requires_supported_shape() {
+    let context = TestContext::with_file(
+        "karva.toml",
+        r#"
+[profile.default.env]
+APP_ENV = { value = "test", unset = true }
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command(), @r#"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Karva failed
+      Cause: <temp_dir>/karva.toml is not a valid `karva.toml`: TOML parse error at line 3, column 11
+      |
+    3 | APP_ENV = { value = "test", unset = true }
+      |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    expected exactly `{ value = "...", preserve = true }` or `{ unset = true }`
+
+      Cause: TOML parse error at line 3, column 11
+      |
+    3 | APP_ENV = { value = "test", unset = true }
+      |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    expected exactly `{ value = "...", preserve = true }` or `{ unset = true }`
+    "#);
+}

--- a/crates/karva/tests/it/configuration/environment.rs
+++ b/crates/karva/tests/it/configuration/environment.rs
@@ -218,8 +218,9 @@ KARVA_RUN_ID = "mine"
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
-      Cause: <temp_dir>/karva.toml is not a valid `karva.toml`: TOML parse error at line 3, column 1
+    karva failed
+      Cause: <temp_dir>/karva.toml is not a valid `karva.toml`
+      Cause: TOML parse error at line 3, column 1
       |
     3 | KARVA_RUN_ID = "mine"
       | ^^^^^^^^^^^^
@@ -243,8 +244,9 @@ APP_ENV = { value = "test", unset = true }
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
-      Cause: <temp_dir>/karva.toml is not a valid `karva.toml`: TOML parse error at line 3, column 11
+    karva failed
+      Cause: <temp_dir>/karva.toml is not a valid `karva.toml`
+      Cause: TOML parse error at line 3, column 11
       |
     3 | APP_ENV = { value = "test", unset = true }
       |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/karva/tests/it/configuration/environment.rs
+++ b/crates/karva/tests/it/configuration/environment.rs
@@ -58,6 +58,151 @@ def test_environment(): pass
 }
 
 #[test]
+fn pyproject_environment_is_applied_before_conftest_import() {
+    let context = TestContext::with_files([
+        (
+            "pyproject.toml",
+            r#"
+[tool.karva.profile.default.env]
+CONFTEST_ENV = "ready"
+"#,
+        ),
+        (
+            "conftest.py",
+            r#"
+import os
+
+assert os.environ["CONFTEST_ENV"] == "ready"
+"#,
+        ),
+        ("test_environment.py", "def test_environment(): pass"),
+    ]);
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test_environment::test_environment
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn environment_is_applied_to_every_worker() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.default.env]
+WORKER_ENV = "ready"
+"#,
+        ),
+        (
+            "test_first.py",
+            r#"
+import os
+
+def test_first(): assert os.environ["WORKER_ENV"] == "ready"
+"#,
+        ),
+        (
+            "test_second.py",
+            r#"
+import os
+
+def test_second(): assert os.environ["WORKER_ENV"] == "ready"
+"#,
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context
+            .command()
+            .args(["--num-workers", "2", "--status-level=none"]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
+fn named_profile_can_unset_inherited_value() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.default.env]
+INHERITED_ENV = "default"
+
+[profile.ci.env]
+INHERITED_ENV = { unset = true }
+"#,
+        ),
+        (
+            "test_environment.py",
+            r#"
+import os
+
+def test_environment(): assert "INHERITED_ENV" not in os.environ
+"#,
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command().args(["--profile", "ci"]), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test_environment::test_environment
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn configured_values_are_absent_from_result_report() {
+    const SECRET: &str = "super-secret-profile-value";
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.default.env]
+SECRET_VALUE = "super-secret-profile-value"
+"#,
+        ),
+        ("test_environment.py", "def test_environment(): pass"),
+    ]);
+
+    assert_cmd_snapshot!(
+        context
+            .command()
+            .args(["--status-level=none", "--result-output=results.json"]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+    assert!(!context.read_file("results.json").contains(SECRET));
+}
+
+#[test]
 fn karva_environment_variables_are_reserved() {
     let context = TestContext::with_file(
         "karva.toml",
@@ -75,12 +220,6 @@ KARVA_RUN_ID = "mine"
     ----- stderr -----
     Karva failed
       Cause: <temp_dir>/karva.toml is not a valid `karva.toml`: TOML parse error at line 3, column 1
-      |
-    3 | KARVA_RUN_ID = "mine"
-      | ^^^^^^^^^^^^
-    environment variable `KARVA_RUN_ID` is reserved by Karva
-
-      Cause: TOML parse error at line 3, column 1
       |
     3 | KARVA_RUN_ID = "mine"
       | ^^^^^^^^^^^^
@@ -106,12 +245,6 @@ APP_ENV = { value = "test", unset = true }
     ----- stderr -----
     Karva failed
       Cause: <temp_dir>/karva.toml is not a valid `karva.toml`: TOML parse error at line 3, column 11
-      |
-    3 | APP_ENV = { value = "test", unset = true }
-      |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    expected exactly `{ value = "...", preserve = true }` or `{ unset = true }`
-
-      Cause: TOML parse error at line 3, column 11
       |
     3 | APP_ENV = { value = "test", unset = true }
       |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/karva/tests/it/configuration/mod.rs
+++ b/crates/karva/tests/it/configuration/mod.rs
@@ -1657,9 +1657,9 @@ fn test_config_file_flag_nonexistent_windows() {
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
-      Cause: <temp_dir>/nonexistent.toml is not a valid `karva.toml`: Failed to read `<temp_dir>/nonexistent.toml`: failed to open file `<temp_dir>/nonexistent.toml`: The system cannot find the file specified. (os error 2)
-      Cause: Failed to read `<temp_dir>/nonexistent.toml`: failed to open file `<temp_dir>/nonexistent.toml`: The system cannot find the file specified. (os error 2)
+    karva failed
+      Cause: <temp_dir>/nonexistent.toml is not a valid `karva.toml`
+      Cause: Failed to read `<temp_dir>/nonexistent.toml`
       Cause: failed to open file `<temp_dir>/nonexistent.toml`: The system cannot find the file specified. (os error 2)
     ");
 }

--- a/crates/karva/tests/it/configuration/mod.rs
+++ b/crates/karva/tests/it/configuration/mod.rs
@@ -1,3 +1,4 @@
+mod environment;
 mod overrides;
 mod profile;
 mod required_version;

--- a/crates/karva/tests/it/configuration/mod.rs
+++ b/crates/karva/tests/it/configuration/mod.rs
@@ -1614,7 +1614,7 @@ def test_should_not_run(): pass
 fn test_config_file_flag_nonexistent_unix() {
     let context = TestContext::with_file("test.py", "def test_a(): pass");
 
-    assert_cmd_snapshot!(context.command().arg("--config-file").arg("nonexistent.toml"), @r"
+    assert_cmd_snapshot!(context.command().arg("--config-file").arg("nonexistent.toml"), @"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -1622,8 +1622,6 @@ fn test_config_file_flag_nonexistent_unix() {
     ----- stderr -----
     Karva failed
       Cause: <temp_dir>/nonexistent.toml is not a valid `karva.toml`: Failed to read `<temp_dir>/nonexistent.toml`: failed to open file `<temp_dir>/nonexistent.toml`: No such file or directory (os error 2)
-      Cause: Failed to read `<temp_dir>/nonexistent.toml`: failed to open file `<temp_dir>/nonexistent.toml`: No such file or directory (os error 2)
-      Cause: failed to open file `<temp_dir>/nonexistent.toml`: No such file or directory (os error 2)
     ");
 }
 
@@ -1633,7 +1631,7 @@ fn test_discovered_karva_toml_read_error_unix() {
     let context = TestContext::with_file("test.py", "def test_a(): pass");
     std::fs::create_dir(context.root().join("karva.toml")).expect("create directory config path");
 
-    assert_cmd_snapshot!(context.command(), @r"
+    assert_cmd_snapshot!(context.command(), @"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -1641,8 +1639,6 @@ fn test_discovered_karva_toml_read_error_unix() {
     ----- stderr -----
     Karva failed
       Cause: <temp_dir>/karva.toml is not a valid `karva.toml`: Failed to read `<temp_dir>/karva.toml`: failed to read from file `<temp_dir>/karva.toml`: Is a directory (os error 21)
-      Cause: Failed to read `<temp_dir>/karva.toml`: failed to read from file `<temp_dir>/karva.toml`: Is a directory (os error 21)
-      Cause: failed to read from file `<temp_dir>/karva.toml`: Is a directory (os error 21)
     ");
 }
 

--- a/crates/karva/tests/it/configuration/mod.rs
+++ b/crates/karva/tests/it/configuration/mod.rs
@@ -1620,8 +1620,10 @@ fn test_config_file_flag_nonexistent_unix() {
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
-      Cause: <temp_dir>/nonexistent.toml is not a valid `karva.toml`: Failed to read `<temp_dir>/nonexistent.toml`: failed to open file `<temp_dir>/nonexistent.toml`: No such file or directory (os error 2)
+    karva failed
+      Cause: <temp_dir>/nonexistent.toml is not a valid `karva.toml`
+      Cause: Failed to read `<temp_dir>/nonexistent.toml`
+      Cause: failed to open file `<temp_dir>/nonexistent.toml`: No such file or directory (os error 2)
     ");
 }
 
@@ -1637,8 +1639,10 @@ fn test_discovered_karva_toml_read_error_unix() {
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
-      Cause: <temp_dir>/karva.toml is not a valid `karva.toml`: Failed to read `<temp_dir>/karva.toml`: failed to read from file `<temp_dir>/karva.toml`: Is a directory (os error 21)
+    karva failed
+      Cause: <temp_dir>/karva.toml is not a valid `karva.toml`
+      Cause: Failed to read `<temp_dir>/karva.toml`
+      Cause: failed to read from file `<temp_dir>/karva.toml`: Is a directory (os error 21)
     ");
 }
 

--- a/crates/karva/tests/it/configuration/overrides.rs
+++ b/crates/karva/tests/it/configuration/overrides.rs
@@ -266,12 +266,6 @@ retries = 1
     3 | filter = "tag("
       |          ^^^^^^
     expected a matcher body in filter expression `tag(`
-
-      Cause: TOML parse error at line 3, column 10
-      |
-    3 | filter = "tag("
-      |          ^^^^^^
-    expected a matcher body in filter expression `tag(`
     "#);
 }
 

--- a/crates/karva/tests/it/configuration/overrides.rs
+++ b/crates/karva/tests/it/configuration/overrides.rs
@@ -260,8 +260,9 @@ retries = 1
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
-      Cause: <temp_dir>/karva.toml is not a valid `karva.toml`: TOML parse error at line 3, column 10
+    karva failed
+      Cause: <temp_dir>/karva.toml is not a valid `karva.toml`
+      Cause: TOML parse error at line 3, column 10
       |
     3 | filter = "tag("
       |          ^^^^^^

--- a/crates/karva/tests/it/configuration/profile.rs
+++ b/crates/karva/tests/it/configuration/profile.rs
@@ -432,7 +432,7 @@ test-function-prefix = "check"
         ("test.py", "def test_a(): pass"),
     ]);
 
-    assert_cmd_snapshot!(context.command(), @r"
+    assert_cmd_snapshot!(context.command(), @"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -440,12 +440,6 @@ test-function-prefix = "check"
     ----- stderr -----
     Karva failed
       Cause: <temp_dir>/karva.toml is not a valid `karva.toml`: TOML parse error at line 2, column 2
-      |
-    2 | [test]
-      |  ^^^^
-    unknown field `test`, expected `required-version` or `profile`
-
-      Cause: TOML parse error at line 2, column 2
       |
     2 | [test]
       |  ^^^^
@@ -466,7 +460,7 @@ retry = 1
         ("test.py", "def test_a(): pass"),
     ]);
 
-    assert_cmd_snapshot!(context.command(), @r"
+    assert_cmd_snapshot!(context.command(), @"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -474,6 +468,5 @@ retry = 1
     ----- stderr -----
     Karva failed
       Cause: <temp_dir>/karva.toml is not a valid `karva.toml`: invalid profile name `default-ci`: the `default-` prefix is reserved for built-in profiles
-      Cause: invalid profile name `default-ci`: the `default-` prefix is reserved for built-in profiles
     ");
 }

--- a/crates/karva/tests/it/configuration/profile.rs
+++ b/crates/karva/tests/it/configuration/profile.rs
@@ -153,13 +153,13 @@ test-function-prefix = "check"
         ("test.py", "def test_a(): pass"),
     ]);
 
-    assert_cmd_snapshot!(context.command().args(["--profile", "missing"]), @r"
+    assert_cmd_snapshot!(context.command().args(["--profile", "missing"]), @"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
+    karva failed
       Cause: profile `missing` is not defined in configuration (available: ci, default, fast)
     ");
 }
@@ -438,8 +438,9 @@ test-function-prefix = "check"
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
-      Cause: <temp_dir>/karva.toml is not a valid `karva.toml`: TOML parse error at line 2, column 2
+    karva failed
+      Cause: <temp_dir>/karva.toml is not a valid `karva.toml`
+      Cause: TOML parse error at line 2, column 2
       |
     2 | [test]
       |  ^^^^
@@ -466,7 +467,8 @@ retry = 1
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
-      Cause: <temp_dir>/karva.toml is not a valid `karva.toml`: invalid profile name `default-ci`: the `default-` prefix is reserved for built-in profiles
+    karva failed
+      Cause: <temp_dir>/karva.toml is not a valid `karva.toml`
+      Cause: invalid profile name `default-ci`: the `default-` prefix is reserved for built-in profiles
     ");
 }

--- a/crates/karva/tests/it/configuration/required_version.rs
+++ b/crates/karva/tests/it/configuration/required_version.rs
@@ -45,8 +45,9 @@ required-version = ">=999.0.0"
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
-      Cause: <temp_dir>/karva.toml: the installed karva [VERSION] does not satisfy `required-version = ">=999.0.0"`
+    karva failed
+      Cause: configuration at <temp_dir>/karva.toml is incompatible with this Karva version
+      Cause: the installed karva [VERSION] does not satisfy `required-version = ">=999.0.0"`
     "#);
 }
 
@@ -72,8 +73,9 @@ required-version = ">=999.0.0"
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
-      Cause: <temp_dir>/pyproject.toml: the installed karva [VERSION] does not satisfy `required-version = ">=999.0.0"`
+    karva failed
+      Cause: configuration at <temp_dir>/pyproject.toml is incompatible with this Karva version
+      Cause: the installed karva [VERSION] does not satisfy `required-version = ">=999.0.0"`
     "#);
 }
 
@@ -95,8 +97,9 @@ required-version = "not a version"
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
-      Cause: <temp_dir>/karva.toml is not a valid `karva.toml`: TOML parse error at line 2, column 20
+    karva failed
+      Cause: <temp_dir>/karva.toml is not a valid `karva.toml`
+      Cause: TOML parse error at line 2, column 20
       |
     2 | required-version = "not a version"
       |                    ^^^^^^^^^^^^^^^

--- a/crates/karva/tests/it/configuration/required_version.rs
+++ b/crates/karva/tests/it/configuration/required_version.rs
@@ -47,7 +47,6 @@ required-version = ">=999.0.0"
     ----- stderr -----
     Karva failed
       Cause: <temp_dir>/karva.toml: the installed karva [VERSION] does not satisfy `required-version = ">=999.0.0"`
-      Cause: the installed karva [VERSION] does not satisfy `required-version = ">=999.0.0"`
     "#);
 }
 
@@ -75,7 +74,6 @@ required-version = ">=999.0.0"
     ----- stderr -----
     Karva failed
       Cause: <temp_dir>/pyproject.toml: the installed karva [VERSION] does not satisfy `required-version = ">=999.0.0"`
-      Cause: the installed karva [VERSION] does not satisfy `required-version = ">=999.0.0"`
     "#);
 }
 
@@ -99,12 +97,6 @@ required-version = "not a version"
     ----- stderr -----
     Karva failed
       Cause: <temp_dir>/karva.toml is not a valid `karva.toml`: TOML parse error at line 2, column 20
-      |
-    2 | required-version = "not a version"
-      |                    ^^^^^^^^^^^^^^^
-    unexpected character 'n' while parsing major version number
-
-      Cause: TOML parse error at line 2, column 20
       |
     2 | required-version = "not a version"
       |                    ^^^^^^^^^^^^^^^

--- a/crates/karva/tests/it/coverage.rs
+++ b/crates/karva/tests/it/coverage.rs
@@ -429,15 +429,6 @@ exclude_lines = ["("]
         (
         ^
     error: unclosed group
-
-      Cause: TOML parse error at line 6, column 17
-      |
-    6 | exclude_lines = ["("]
-      |                 ^^^^^
-    invalid coverage exclusion pattern `(`: regex parse error:
-        (
-        ^
-    error: unclosed group
     "#
     );
 }

--- a/crates/karva/tests/it/coverage.rs
+++ b/crates/karva/tests/it/coverage.rs
@@ -420,8 +420,9 @@ exclude_lines = ["("]
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
-      Cause: <temp_dir>/pyproject.toml is not a valid `pyproject.toml`: TOML parse error at line 6, column 17
+    karva failed
+      Cause: <temp_dir>/pyproject.toml is not a valid `pyproject.toml`
+      Cause: TOML parse error at line 6, column 17
       |
     6 | exclude_lines = ["("]
       |                 ^^^^^

--- a/crates/karva/tests/it/coverage_command.rs
+++ b/crates/karva/tests/it/coverage_command.rs
@@ -78,13 +78,13 @@ fn combine_failure_preserves_output_and_inputs() {
         context
             .coverage("combine")
             .args([valid.as_str(), rejected.as_str()]),
-        @r"
+        @"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
+    karva failed
       Cause: failed to combine native coverage artifacts:
     `<temp_dir>/inputs/rejected.json`: failed to parse native coverage artifact `<temp_dir>/inputs/rejected.json`: expected ident at line 1 column 2
     "
@@ -239,13 +239,13 @@ fn erase_is_idempotent_and_preserves_reports_and_neighbors() {
 
     ----- stderr -----
     ");
-    assert_cmd_snapshot!(context.coverage("report"), @r"
+    assert_cmd_snapshot!(context.coverage("report"), @"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
+    karva failed
       Cause: no coverage data found at `<temp_dir>/.karva/coverage/data.json`; run `uv run karva test --cov` first
     ");
 }
@@ -518,7 +518,7 @@ fn report_missing_data_names_default_and_remedy() {
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
+    karva failed
       Cause: no coverage data found at `<temp_dir>/.karva/coverage/data.json`; run `uv run karva test --cov` first
     ");
 }
@@ -584,13 +584,13 @@ fn report_rejects_unmatched_selector() {
     let context = TestContext::new();
     write_coverage(&context, Utf8Path::new(".karva/coverage/data.json"));
 
-    assert_cmd_snapshot!(context.coverage("report").arg("missing.module"), @r"
+    assert_cmd_snapshot!(context.coverage("report").arg("missing.module"), @"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
+    karva failed
       Cause: coverage selector `missing.module` matched no source files
     ");
 }

--- a/crates/karva/tests/it/extensions/snapshot/prune.rs
+++ b/crates/karva/tests/it/extensions/snapshot/prune.rs
@@ -244,7 +244,7 @@ fn test_snapshot_prune_reports_source_read_errors() {
 
     ----- stderr -----
     warning: Prune uses static analysis and may not detect all unreferenced snapshots.
-    Karva failed
+    karva failed
       Cause: failed to read source file `<temp_dir>/test.py`: failed to read from file `<temp_dir>/test.py`: Is a directory (os error 21)
     ");
     #[cfg(not(unix))]

--- a/crates/karva/tests/it/extensions/snapshot/prune.rs
+++ b/crates/karva/tests/it/extensions/snapshot/prune.rs
@@ -255,7 +255,7 @@ fn test_snapshot_prune_reports_source_read_errors() {
 
     ----- stderr -----
     warning: Prune uses static analysis and may not detect all unreferenced snapshots.
-    Karva failed
+    karva failed
       Cause: failed to read source file `<temp_dir>/test.py`: failed to open file `<temp_dir>/test.py`: Access is denied. (os error 5)
     ");
     assert!(

--- a/crates/karva/tests/it/filterset.rs
+++ b/crates/karva/tests/it/filterset.rs
@@ -975,13 +975,13 @@ fn filterset_parenthesized_or_with_and() {
 #[test]
 fn filterset_invalid_regex() {
     let context = TestContext::with_file("test.py", TWO_TESTS);
-    assert_cmd_snapshot!(context.command_no_parallel().arg("-E").arg("test(/[invalid/)"), @r"
+    assert_cmd_snapshot!(context.command_no_parallel().arg("-E").arg("test(/[invalid/)"), @"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
+    karva failed
       Cause: invalid `--filter` expression
       Cause: invalid regex `/[invalid/` in filter expression `test(/[invalid/)`: regex parse error:
         [invalid
@@ -993,13 +993,13 @@ fn filterset_invalid_regex() {
 #[test]
 fn filterset_invalid_regex_unclosed_group() {
     let context = TestContext::with_file("test.py", TWO_TESTS);
-    assert_cmd_snapshot!(context.command_no_parallel().arg("-E").arg("test(/(unclosed/)"), @r"
+    assert_cmd_snapshot!(context.command_no_parallel().arg("-E").arg("test(/(unclosed/)"), @"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
+    karva failed
       Cause: invalid `--filter` expression
       Cause: invalid regex `/(unclosed/` in filter expression `test(/(unclosed/)`: regex parse error:
         (unclosed
@@ -1011,13 +1011,13 @@ fn filterset_invalid_regex_unclosed_group() {
 #[test]
 fn filterset_invalid_regex_invalid_repetition() {
     let context = TestContext::with_file("test.py", TWO_TESTS);
-    assert_cmd_snapshot!(context.command_no_parallel().arg("-E").arg("test(/*invalid/)"), @r"
+    assert_cmd_snapshot!(context.command_no_parallel().arg("-E").arg("test(/*invalid/)"), @"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
+    karva failed
       Cause: invalid `--filter` expression
       Cause: invalid regex `/*invalid/` in filter expression `test(/*invalid/)`: regex parse error:
         *invalid
@@ -1037,7 +1037,7 @@ fn filterset_invalid_regex_bad_escape() {
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
+    karva failed
       Cause: invalid `--filter` expression
       Cause: invalid regex `/\p{Invalid}/` in filter expression `test(/\p{Invalid}/)`: regex parse error:
         \p{Invalid}
@@ -1052,13 +1052,13 @@ fn filterset_unknown_predicate() {
     let context = TestContext::with_file("test.py", "def test_x(): assert True\n");
     assert_cmd_snapshot!(
         context.command_no_parallel().arg("-E").arg("package(foo)"),
-        @r"
+        @"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
+    karva failed
       Cause: invalid `--filter` expression
       Cause: unknown predicate `package` in filter expression `package(foo)` (expected `test` or `tag`)
     "
@@ -1070,13 +1070,13 @@ fn filterset_unclosed_paren() {
     let context = TestContext::with_file("test.py", "def test_x(): assert True\n");
     assert_cmd_snapshot!(
         context.command_no_parallel().arg("-E").arg("tag(slow"),
-        @r"
+        @"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
+    karva failed
       Cause: invalid `--filter` expression
       Cause: expected closing `)` in filter expression `tag(slow`
     "
@@ -1088,13 +1088,13 @@ fn filterset_empty_matcher_body() {
     let context = TestContext::with_file("test.py", "def test_x(): assert True\n");
     assert_cmd_snapshot!(
         context.command_no_parallel().arg("-E").arg("tag()"),
-        @r"
+        @"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
+    karva failed
       Cause: invalid `--filter` expression
       Cause: expected a matcher body in filter expression `tag()`
     "
@@ -1106,13 +1106,13 @@ fn filterset_empty_expression() {
     let context = TestContext::with_file("test.py", "def test_x(): assert True\n");
     assert_cmd_snapshot!(
         context.command_no_parallel().arg("-E").arg(""),
-        @r"
+        @"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
+    karva failed
       Cause: invalid `--filter` expression
       Cause: empty filter expression ``
     "

--- a/crates/karva/tests/it/show_config.rs
+++ b/crates/karva/tests/it/show_config.rs
@@ -384,13 +384,13 @@ retry = 3
 ",
     );
 
-    assert_cmd_snapshot!(context.show_config().args(["--profile", "bogus"]), @r"
+    assert_cmd_snapshot!(context.show_config().args(["--profile", "bogus"]), @"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    Karva failed
+    karva failed
       Cause: profile `bogus` is not defined in configuration (available: ci, default)
     ");
 }

--- a/crates/karva/tests/it/show_config.rs
+++ b/crates/karva/tests/it/show_config.rs
@@ -170,6 +170,75 @@ output-format = "concise"
 }
 
 #[test]
+fn show_config_emits_resolved_environment() {
+    let context = TestContext::with_file(
+        "karva.toml",
+        r#"
+[profile.default.env]
+APP_ENV = "test"
+CACHE_DIR = { value = ".cache/tests", preserve = true }
+LIVE_API_TOKEN = { unset = true }
+
+[profile.ci.env]
+APP_ENV = "ci"
+"#,
+    );
+
+    assert_cmd_snapshot!(context.show_config().args(["--profile", "ci"]), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [env]
+    APP_ENV = "ci"
+
+    [env.CACHE_DIR]
+    value = ".cache/tests"
+    preserve = true
+
+    [env.LIVE_API_TOKEN]
+    unset = true
+
+    [src]
+    respect-ignore-files = true
+    include = []
+
+    [terminal]
+    output-format = "full"
+    show-python-output = false
+    status-level = "pass"
+    final-status-level = "pass"
+
+    [test]
+    test-function-prefix = "test"
+    try-import-fixtures = false
+    retry = 0
+    shuffle = false
+    flaky-result = "pass"
+    no-tests = "auto"
+
+    [coverage]
+    data-file = ".karva/coverage/data.json"
+    path-aliases = []
+    sources = []
+    include = []
+    omit = []
+    exclude-lines = []
+    partial-branches = []
+    contexts = []
+    precision = 0
+    append = false
+    report = "term"
+
+    [junit]
+    report-name = "karva-tests"
+    store-failure-output = true
+    flaky-fail-status = "failure"
+
+    ----- stderr -----
+    "#);
+}
+
+#[test]
 fn show_config_emits_set_timeouts_and_coverage() {
     let context = TestContext::with_file(
         "karva.toml",

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::num::{NonZeroU32, NonZeroUsize};
 
 use camino::Utf8PathBuf;
@@ -502,6 +503,7 @@ impl SubTestCommand {
         });
 
         Options {
+            env: BTreeMap::default(),
             src: Some(SrcOptions {
                 respect_ignore_files: self.no_ignore.map(|no_ignore| !no_ignore),
                 include: Some(self.paths),

--- a/crates/karva_logging/src/lib.rs
+++ b/crates/karva_logging/src/lib.rs
@@ -23,38 +23,6 @@ pub use printer::{Printer, Stdout};
 pub use status_level::{FinalStatusLevel, StatusLevel};
 pub use verbosity::VerbosityLevel;
 
-/// Whether an error chain contains stdout's normal early-consumer shutdown signal.
-pub fn error_chain_contains_broken_pipe<'a>(
-    causes: impl IntoIterator<Item = &'a (dyn std::error::Error + 'static)>,
-) -> bool {
-    causes.into_iter().any(|cause| {
-        cause
-            .downcast_ref::<io::Error>()
-            .is_some_and(|err| err.kind() == io::ErrorKind::BrokenPipe)
-    })
-}
-
-/// Writes Karva's top-level failure heading followed by each distinct causal error.
-pub fn write_error_chain<'a>(
-    writer: &mut impl io::Write,
-    causes: impl IntoIterator<Item = &'a (dyn std::error::Error + 'static)>,
-) -> io::Result<()> {
-    writeln!(writer, "{}", "Karva failed".red().bold())?;
-    let mut previous = None;
-    for cause in causes {
-        let cause = cause.to_string();
-        if previous
-            .as_ref()
-            .is_some_and(|previous: &String| previous.ends_with(&cause))
-        {
-            continue;
-        }
-        writeln!(writer, "  {} {cause}", "Cause:".bold())?;
-        previous = Some(cause);
-    }
-    Ok(())
-}
-
 /// Installs process-global tracing and returns resources that must outlive the run.
 pub fn setup_tracing(level: VerbosityLevel) -> TracingGuard {
     use tracing_subscriber::prelude::*;
@@ -297,75 +265,5 @@ impl TerminalColor {
             Self::Always => "always",
             Self::Never => "never",
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::io;
-
-    use super::{error_chain_contains_broken_pipe, setup_profile_file, write_error_chain};
-
-    struct FailingWriter {
-        kind: io::ErrorKind,
-    }
-
-    impl io::Write for FailingWriter {
-        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
-            Err(io::Error::from(self.kind))
-        }
-
-        fn flush(&mut self) -> io::Result<()> {
-            Ok(())
-        }
-    }
-
-    #[test]
-    fn profile_setup_disables_profiling_when_file_cannot_be_created() {
-        let setup = setup_profile_file::<tracing_subscriber::Registry>(".");
-
-        assert!(setup.layer.is_none());
-        assert!(setup.guard.is_none());
-        assert!(matches!(
-            setup.warning.as_deref(),
-            Some(warning) if warning.contains("profiling disabled")
-        ));
-    }
-
-    #[test]
-    fn write_error_chain_writes_header_and_causes() {
-        let first = io::Error::other("first");
-        let second = io::Error::other("second");
-        let causes: [&dyn std::error::Error; 2] = [&first, &second];
-
-        let mut output = Vec::new();
-        write_error_chain(&mut output, causes).expect("write should succeed");
-
-        let output = String::from_utf8(output).expect("valid UTF-8");
-        assert!(output.contains("Karva failed"));
-        assert!(output.contains("Cause:"));
-        assert!(output.contains("first"));
-        assert!(output.contains("second"));
-    }
-
-    #[test]
-    fn write_error_chain_propagates_write_failures() {
-        let cause = io::Error::other("cause");
-        let causes: [&dyn std::error::Error; 1] = [&cause];
-        let mut writer = FailingWriter {
-            kind: io::ErrorKind::PermissionDenied,
-        };
-
-        let err = write_error_chain(&mut writer, causes).expect_err("write should fail");
-
-        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
-    }
-
-    #[test]
-    fn error_chain_contains_broken_pipe_detects_io_cause() {
-        let cause = io::Error::from(io::ErrorKind::BrokenPipe);
-        let causes: [&dyn std::error::Error; 1] = [&cause];
-
-        assert!(error_chain_contains_broken_pipe(causes));
     }
 }

--- a/crates/karva_logging/src/lib.rs
+++ b/crates/karva_logging/src/lib.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 use std::fs::File;
-use std::io::{self, BufWriter};
+use std::io::BufWriter;
 use std::path::Path;
 
 use colored::Colorize;

--- a/crates/karva_logging/src/lib.rs
+++ b/crates/karva_logging/src/lib.rs
@@ -34,14 +34,23 @@ pub fn error_chain_contains_broken_pipe<'a>(
     })
 }
 
-/// Writes Karva's top-level failure heading followed by each causal error.
+/// Writes Karva's top-level failure heading followed by each distinct causal error.
 pub fn write_error_chain<'a>(
     writer: &mut impl io::Write,
     causes: impl IntoIterator<Item = &'a (dyn std::error::Error + 'static)>,
 ) -> io::Result<()> {
     writeln!(writer, "{}", "Karva failed".red().bold())?;
+    let mut previous = None;
     for cause in causes {
+        let cause = cause.to_string();
+        if previous
+            .as_ref()
+            .is_some_and(|previous: &String| previous.ends_with(&cause))
+        {
+            continue;
+        }
         writeln!(writer, "  {} {cause}", "Cause:".bold())?;
+        previous = Some(cause);
     }
     Ok(())
 }

--- a/crates/karva_metadata/src/environment.rs
+++ b/crates/karva_metadata/src/environment.rs
@@ -1,0 +1,190 @@
+//! Profile-scoped environment variable configuration.
+
+use std::fmt;
+
+use serde::de::{self, MapAccess, Visitor};
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Validated environment variable name safe to pass to worker processes.
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(transparent)]
+pub struct EnvironmentVariableName(String);
+
+impl EnvironmentVariableName {
+    /// Returns the configured name.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for EnvironmentVariableName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let name = String::deserialize(deserializer)?;
+        if name.is_empty() {
+            return Err(de::Error::custom(
+                "environment variable name cannot be empty",
+            ));
+        }
+        if name.contains(['=', '\0']) {
+            return Err(de::Error::custom(format!(
+                "environment variable name `{name}` cannot contain `=` or NUL"
+            )));
+        }
+        let uppercase = name.to_ascii_uppercase();
+        if uppercase == "KARVA" || uppercase.starts_with("KARVA_") {
+            return Err(de::Error::custom(format!(
+                "environment variable `{name}` is reserved by Karva"
+            )));
+        }
+        Ok(Self(name))
+    }
+}
+
+/// Operation applied to one worker environment variable before Python starts.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum EnvironmentVariable {
+    /// Always set the configured value.
+    Set(String),
+
+    /// Set the configured value only when the invoking environment omits it.
+    Preserve(String),
+
+    /// Remove the variable from the worker environment.
+    Unset,
+}
+
+impl Serialize for EnvironmentVariable {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Set(value) => serializer.serialize_str(value),
+            Self::Preserve(value) => {
+                let mut map = serializer.serialize_map(Some(2))?;
+                map.serialize_entry("value", value)?;
+                map.serialize_entry("preserve", &true)?;
+                map.end()
+            }
+            Self::Unset => {
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry("unset", &true)?;
+                map.end()
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for EnvironmentVariable {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct EnvironmentVariableVisitor;
+
+        impl<'de> Visitor<'de> for EnvironmentVariableVisitor {
+            type Value = EnvironmentVariable;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str(
+                    "a string, `{ value = \"...\", preserve = true }`, or `{ unset = true }`",
+                )
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                validate_value(value)?;
+                Ok(EnvironmentVariable::Set(value.to_string()))
+            }
+
+            fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                validate_value(&value)?;
+                Ok(EnvironmentVariable::Set(value))
+            }
+
+            fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                let mut value = None;
+                let mut preserve = None;
+                let mut unset = None;
+
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "value" => value = Some(map.next_value::<String>()?),
+                        "preserve" => preserve = Some(map.next_value::<bool>()?),
+                        "unset" => unset = Some(map.next_value::<bool>()?),
+                        _ => {
+                            return Err(de::Error::unknown_field(
+                                &key,
+                                &["value", "preserve", "unset"],
+                            ));
+                        }
+                    }
+                }
+
+                match (value, preserve, unset) {
+                    (Some(value), Some(true), None) => {
+                        validate_value(&value)?;
+                        Ok(EnvironmentVariable::Preserve(value))
+                    }
+                    (None, None, Some(true)) => Ok(EnvironmentVariable::Unset),
+                    _ => Err(de::Error::custom(
+                        "expected exactly `{ value = \"...\", preserve = true }` or `{ unset = true }`",
+                    )),
+                }
+            }
+        }
+
+        deserializer.deserialize_any(EnvironmentVariableVisitor)
+    }
+}
+
+fn validate_value<E: de::Error>(value: &str) -> Result<(), E> {
+    if value.contains('\0') {
+        return Err(E::custom("environment variable value cannot contain NUL"));
+    }
+    Ok(())
+}
+
+#[cfg(feature = "schemars")]
+impl schemars::JsonSchema for EnvironmentVariable {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "EnvironmentVariable".into()
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        let string = generator.subschema_for::<String>();
+        schemars::json_schema!({
+            "oneOf": [
+                string,
+                {
+                    "type": "object",
+                    "properties": {
+                        "value": { "type": "string" },
+                        "preserve": { "const": true }
+                    },
+                    "required": ["value", "preserve"],
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "properties": { "unset": { "const": true } },
+                    "required": ["unset"],
+                    "additionalProperties": false
+                }
+            ]
+        })
+    }
+}

--- a/crates/karva_metadata/src/environment.rs
+++ b/crates/karva_metadata/src/environment.rs
@@ -188,3 +188,78 @@ impl schemars::JsonSchema for EnvironmentVariable {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use serde::de::value::{Error, StrDeserializer};
+
+    use super::*;
+
+    #[rstest::rstest]
+    #[case(r#""test""#, EnvironmentVariable::Set("test".to_string()))]
+    #[case(
+        r#"{ value = "test", preserve = true }"#,
+        EnvironmentVariable::Preserve("test".to_string())
+    )]
+    #[case(r"{ unset = true }", EnvironmentVariable::Unset)]
+    fn parses_operation(#[case] input: &str, #[case] expected: EnvironmentVariable) {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            variable: EnvironmentVariable,
+        }
+
+        let parsed: Wrapper =
+            toml::from_str(&format!("variable = {input}")).expect("valid operation");
+
+        assert_eq!(parsed.variable, expected);
+    }
+
+    #[rstest::rstest]
+    #[case("{}")]
+    #[case(r#"{ value = "test" }"#)]
+    #[case(r#"{ value = "test", preserve = false }"#)]
+    #[case("{ preserve = true }")]
+    #[case("{ unset = false }")]
+    #[case(r#"{ value = "test", preserve = true, unset = true }"#)]
+    #[case("{ unknown = true }")]
+    fn rejects_invalid_operation(#[case] input: &str) {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(rename = "variable")]
+            _variable: EnvironmentVariable,
+        }
+
+        assert!(toml::from_str::<Wrapper>(&format!("variable = {input}")).is_err());
+    }
+
+    #[rstest::rstest]
+    #[case("APP_ENV")]
+    #[case("lowercase")]
+    #[case("name-with-dashes")]
+    fn accepts_valid_name(#[case] input: &str) {
+        let name = EnvironmentVariableName::deserialize(StrDeserializer::<Error>::new(input))
+            .expect("valid environment variable name");
+
+        assert_eq!(name.as_str(), input);
+    }
+
+    #[rstest::rstest]
+    #[case("")]
+    #[case("HAS=EQUALS")]
+    #[case("HAS\0NUL")]
+    #[case("KARVA")]
+    #[case("KARVA_RUN_ID")]
+    #[case("karva_worker_id")]
+    fn rejects_invalid_name(#[case] input: &str) {
+        assert!(
+            EnvironmentVariableName::deserialize(StrDeserializer::<Error>::new(input)).is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_nul_value() {
+        assert!(
+            EnvironmentVariable::deserialize(StrDeserializer::<Error>::new("has\0nul")).is_err()
+        );
+    }
+}

--- a/crates/karva_metadata/src/lib.rs
+++ b/crates/karva_metadata/src/lib.rs
@@ -5,12 +5,14 @@ use fs_err as fs;
 use ruff_python_ast::PythonVersion;
 use thiserror::Error;
 
+mod environment;
 pub mod filter;
 mod max_fail;
 mod options;
 mod pyproject;
 mod settings;
 
+pub use environment::{EnvironmentVariable, EnvironmentVariableName};
 pub use max_fail::MaxFail;
 pub use options::{
     Config, CovReport, CoverageOptions, IncompatibleVersionError, JunitOptions, Options,

--- a/crates/karva_metadata/src/lib.rs
+++ b/crates/karva_metadata/src/lib.rs
@@ -335,7 +335,7 @@ pub enum ProjectMetadataError {
     NotADirectory(Utf8PathBuf),
 
     /// A discovered `pyproject.toml` could not be loaded.
-    #[error("{path} is not a valid `pyproject.toml`: {source}")]
+    #[error("{path} is not a valid `pyproject.toml`")]
     InvalidPyProject {
         /// Parsing or filesystem failure.
         source: Box<PyProjectError>,
@@ -345,7 +345,7 @@ pub enum ProjectMetadataError {
     },
 
     /// An explicit or discovered `karva.toml` could not be loaded.
-    #[error("{path} is not a valid `karva.toml`: {source}")]
+    #[error("{path} is not a valid `karva.toml`")]
     InvalidKarvaToml {
         /// Parsing, validation, or filesystem failure.
         source: Box<KarvaTomlError>,
@@ -355,7 +355,7 @@ pub enum ProjectMetadataError {
     },
 
     /// Running Karva version violates configured `required-version`.
-    #[error("{path}: {source}")]
+    #[error("configuration at {path} is incompatible with this Karva version")]
     IncompatibleVersion {
         /// Configuration path declaring requirement.
         path: Utf8PathBuf,

--- a/crates/karva_metadata/src/options/config.rs
+++ b/crates/karva_metadata/src/options/config.rs
@@ -205,7 +205,7 @@ pub enum IncompatibleVersionError {
         installed: Version,
     },
     /// Build supplied a version string that is not valid semantic versioning.
-    #[error("internal error: failed to parse installed karva {version}: {source}")]
+    #[error("internal error: failed to parse installed karva {version}")]
     InvalidInstalledVersion {
         /// Invalid build version.
         version: String,
@@ -224,7 +224,7 @@ pub enum KarvaTomlError {
     TomlSyntax(#[from] toml::de::Error),
 
     /// Configuration file could not be read.
-    #[error("Failed to read `{path}`: {source}")]
+    #[error("Failed to read `{path}`")]
     FileReadError {
         /// Underlying filesystem failure.
         #[source]

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -3,6 +3,8 @@
 mod config;
 mod overrides;
 
+use std::collections::BTreeMap;
+
 use karva_combine::Combine;
 use karva_logging::{FinalStatusLevel, StatusLevel};
 use karva_macros::{Combine, OptionsMetadata};
@@ -24,12 +26,30 @@ use crate::settings::{
     SlowTimeoutSecs, SrcSettings, TerminalSettings, TerminationGracePeriodSecs, TestSettings,
     TestTimeoutSecs,
 };
+use crate::{EnvironmentVariable, EnvironmentVariableName};
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, OptionsMetadata)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 /// Configuration groups combined across defaults, profiles, environment, and CLI.
 pub struct Options {
+    /// Environment variables applied to test workers before Python imports any
+    /// test modules or fixtures. Strings always set values. Use
+    /// `{ value = "...", preserve = true }` to keep an existing value, or
+    /// `{ unset = true }` to remove one. Karva's own variables are reserved.
+    #[option(
+        default = r#"{}"#,
+        value_type = "table",
+        example = r#"
+            [tool.karva.profile.default.env]
+            APP_ENV = "test"
+            CACHE_DIR = { value = ".cache/tests", preserve = true }
+            LIVE_API_TOKEN = { unset = true }
+        "#
+    )]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub env: BTreeMap<EnvironmentVariableName, EnvironmentVariable>,
+
     /// Source discovery overrides.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[option_group]
@@ -68,6 +88,7 @@ pub struct Options {
 
 impl Combine for Options {
     fn combine_with(&mut self, other: Self) {
+        Combine::combine_with(&mut self.env, other.env);
         Combine::combine_with(&mut self.src, other.src);
         Combine::combine_with(&mut self.terminal, other.terminal);
         Combine::combine_with(&mut self.test, other.test);
@@ -84,6 +105,7 @@ impl Options {
     /// Resolves sparse values into complete runtime settings and compiled overrides.
     pub fn to_settings(&self) -> ProjectSettings {
         ProjectSettings {
+            env: self.env.clone(),
             terminal: self.terminal.clone().unwrap_or_default().to_settings(),
             src: self.src.clone().unwrap_or_default().to_settings(),
             test: self.test.clone().unwrap_or_default().to_settings(),

--- a/crates/karva_metadata/src/pyproject.rs
+++ b/crates/karva_metadata/src/pyproject.rs
@@ -28,7 +28,7 @@ pub enum PyProjectError {
     TomlSyntax(#[from] toml::de::Error),
 
     /// File could not be read from disk.
-    #[error("Failed to read `{path}`: {source}")]
+    #[error("Failed to read `{path}`")]
     FileReadError {
         /// Underlying filesystem failure.
         #[source]

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 use karva_combine::Combine;
@@ -8,6 +9,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use crate::filter::{EvalContext, FiltersetSet, ValidatedFilter};
 use crate::max_fail::MaxFail;
 use crate::options::{CovReport, OutputFormat};
+use crate::{EnvironmentVariable, EnvironmentVariableName};
 
 /// Project-relative native coverage artifact used when no path is configured.
 pub const DEFAULT_COVERAGE_DATA_FILE: &str = ".karva/coverage/data.json";
@@ -459,6 +461,8 @@ impl Combine for CoveragePrecision {
 #[serde(rename_all = "kebab-case")]
 /// Fully resolved settings after configuration profiles and CLI overrides combine.
 pub struct ProjectSettings {
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub(super) env: BTreeMap<EnvironmentVariableName, EnvironmentVariable>,
     pub(super) src: SrcSettings,
     pub(super) terminal: TerminalSettings,
     pub(super) test: TestSettings,
@@ -508,6 +512,11 @@ impl OverrideSettings {
 }
 
 impl ProjectSettings {
+    /// Returns environment changes to apply to every worker process.
+    pub fn env(&self) -> &BTreeMap<EnvironmentVariableName, EnvironmentVariable> {
+        &self.env
+    }
+
     pub fn terminal(&self) -> &TerminalSettings {
         &self.terminal
     }

--- a/crates/karva_runner/src/worker_args.rs
+++ b/crates/karva_runner/src/worker_args.rs
@@ -5,7 +5,7 @@ use camino::Utf8PathBuf;
 use karva_cache::{RunCache, RunHash};
 use karva_cli::SubTestCommand;
 use karva_logging::TerminalColor;
-use karva_metadata::ProjectSettings;
+use karva_metadata::{EnvironmentVariable, ProjectSettings};
 use karva_project::Project;
 use karva_static::{EnvVars, PythonEnvVars, WorkerEnvVars};
 
@@ -75,6 +75,22 @@ pub fn worker_command(spawn: &WorkerSpawn, worker_id: usize, partition: &Partiti
             cmd.env(EnvVars::KARVA_SNAPSHOT_UPDATE, "0");
         }
         None => {}
+    }
+
+    for (name, variable) in spawn.project.settings().env() {
+        match variable {
+            EnvironmentVariable::Set(value) => {
+                cmd.env(name.as_str(), value);
+            }
+            EnvironmentVariable::Preserve(value) => {
+                if std::env::var_os(name.as_str()).is_none() {
+                    cmd.env(name.as_str(), value);
+                }
+            }
+            EnvironmentVariable::Unset => {
+                cmd.env_remove(name.as_str());
+            }
+        }
     }
 
     for path in partition.tests() {

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -1,8 +1,9 @@
-use std::ffi::OsString;
+use std::{ffi::OsString, io};
 
 use anyhow::Context as _;
 use camino::Utf8PathBuf;
 use clap::Parser;
+use colored::Colorize;
 use fs_err as fs;
 use karva_cache::{RunCache, RunHash};
 use karva_cli::{ExitStatus, SubTestCommand, Verbosity};
@@ -50,16 +51,32 @@ impl Args {
 /// Runs one worker invocation, translating broken pipes into successful exits.
 pub fn karva_worker_main(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> ExitStatus {
     run(f).unwrap_or_else(|error| {
-        if karva_logging::error_chain_contains_broken_pipe(error.chain()) {
+        use io::Write;
+
+        // Exit "gracefully" on broken pipe errors.
+        //
+        // See: https://github.com/BurntSushi/ripgrep/blob/bf63fe8f258afc09bae6caa48f0ae35eaf115005/crates/core/main.rs#L47C1-L61C14
+        if error.chain().any(|cause| {
+            cause
+                .downcast_ref::<io::Error>()
+                .is_some_and(|ioerr| ioerr.kind() == io::ErrorKind::BrokenPipe)
+        }) {
             return ExitStatus::Success;
         }
 
-        let mut stderr = std::io::stderr().lock();
-        if let Err(err) = karva_logging::write_error_chain(&mut stderr, error.chain()) {
-            if err.kind() == std::io::ErrorKind::BrokenPipe {
-                return ExitStatus::Success;
-            }
+        // Use `writeln` instead of `eprintln` to avoid panicking when the stderr pipe is broken.
+        let mut stderr = io::stderr().lock();
+
+        // This communicates that this isn't a linter error but karva itself hard-errored for
+        // some reason (e.g. failed to resolve the configuration)
+        writeln!(stderr, "{}", "karva failed".red().bold()).ok();
+        // Currently we generally only see one error, but e.g. with io errors when resolving
+        // the configuration it is help to chain errors ("resolving configuration failed" ->
+        // "failed to read file: subdir/pyproject.toml")
+        for cause in error.chain() {
+            writeln!(stderr, "  {} {cause}", "Cause:".bold()).ok();
         }
+
         ExitStatus::Error
     })
 }

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -35,6 +35,28 @@ required-version = ">=0.5.0"
 
 Configuration groups combined across defaults, profiles, environment, and CLI.
 
+## `env`
+
+Environment variables applied to test workers before Python imports any
+test modules or fixtures. Strings always set values. Use
+`{ value = "...", preserve = true }` to keep an existing value, or
+`{ unset = true }` to remove one. Karva's own variables are reserved.
+
+**Default value**: `{}`
+
+**Type**: `table`
+
+**Example usage** (`pyproject.toml`):
+
+```toml
+[tool.karva.profile.default.env]
+APP_ENV = "test"
+CACHE_DIR = { value = ".cache/tests", preserve = true }
+LIVE_API_TOKEN = { unset = true }
+```
+
+---
+
 ## `coverage`
 
 Controls measured Python sources and coverage report generation.

--- a/karva.schema.json
+++ b/karva.schema.json
@@ -231,6 +231,41 @@
       "format": "uint",
       "minimum": 0
     },
+    "EnvironmentVariable": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "preserve": {
+              "const": true
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "value",
+            "preserve"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "unset": {
+              "const": true
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "unset"
+          ]
+        }
+      ]
+    },
     "FailSlowSecs": {
       "description": "A per-test duration budget expressed in seconds.\n\nWraps `f64` for the same reason as [`SlowTimeoutSecs`]. Unlike\n[`SlowTimeoutSecs`] (informational) or [`TestTimeoutSecs`] (kills the\ntest mid-flight), a test exceeding this budget is allowed to finish its\nfull lifecycle — including fixture teardown — and is then reported as a\nfailure (see `TestSettings::fail_slow`).",
       "type": "number",
@@ -397,6 +432,13 @@
               "type": "null"
             }
           ]
+        },
+        "env": {
+          "description": "Environment variables applied to test workers before Python imports any\ntest modules or fixtures. Strings always set values. Use\n`{ value = \"...\", preserve = true }` to keep an existing value, or\n`{ unset = true }` to remove one. Karva's own variables are reserved.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/EnvironmentVariable"
+          }
         },
         "junit": {
           "description": "`JUnit` report overrides.",


### PR DESCRIPTION
## Summary

Add profile-scoped worker environment configuration with typed set, preserve, and unset operations. Profiles merge individual variables, reserved `KARVA*` names fail during configuration parsing, and values apply before Python imports without mutating the parent process. `show-config`, generated docs, and JSON schema now expose the section.

Closes #953.

## Test Plan

`just test`, workspace Clippy with warnings denied, and `uvx prek run -a`.