### PR TITLE
Seed Python randomness independently per test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1333,6 +1333,7 @@ dependencies = [
  "ruff_python_stdlib",
  "ruff_source_file",
  "ruff_text_size",
+ "siphasher",
  "thiserror",
  "tracing",
 ]

--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -97,24 +97,23 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
     FiltersetSet::new(&sub_command.filter_expressions).context("invalid `--filter` expression")?;
 
     let cache_dir = project.cwd().join(CACHE_DIR);
-    let (random_seed, generated_random_seed) = if project.settings().test().shuffle {
-        match random_seed_selection {
-            Some(RandomSeed::Last) => {
-                if no_cache {
-                    anyhow::bail!("`--random-seed=last` cannot be used with `--no-cache`");
-                }
-                let seed = read_random_seed(&cache_dir)?
-                    .context("No generated random seed found; run with `--shuffle` first")?;
-                (Some(seed), false)
+    let (random_seed, generated_random_seed) = match random_seed_selection {
+        Some(RandomSeed::Last) => {
+            if no_cache {
+                anyhow::bail!("`--random-seed=last` cannot be used with `--no-cache`");
             }
-            Some(RandomSeed::Value(seed)) => (Some(seed), false),
-            None => match project.settings().test().random_seed {
-                Some(seed) => (Some(seed), false),
-                None => (Some(karva_runner::generate_random_seed()), true),
-            },
+            let seed = read_random_seed(&cache_dir)?
+                .context("No generated random seed found; run with `--shuffle` first")?;
+            (Some(seed), false)
         }
-    } else {
-        (None, false)
+        Some(RandomSeed::Value(seed)) => (Some(seed), false),
+        None => match project.settings().test().random_seed {
+            Some(seed) => (Some(seed), false),
+            None if project.settings().test().shuffle => {
+                (Some(karva_runner::generate_random_seed()), true)
+            }
+            None => (None, false),
+        },
     };
     if generated_random_seed
         && !no_cache
@@ -134,10 +133,13 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
         last_failed,
         profile,
         partition,
-        test_ordering: random_seed.map_or(
-            karva_runner::TestOrdering::RandomizeUnmeasured,
-            karva_runner::TestOrdering::SeededShuffle,
-        ),
+        random_seed,
+        test_ordering: random_seed
+            .filter(|_| project.settings().test().shuffle)
+            .map_or(
+                karva_runner::TestOrdering::RandomizeUnmeasured,
+                karva_runner::TestOrdering::SeededShuffle,
+            ),
     };
 
     if watch {
@@ -500,6 +502,7 @@ fn write_test_failures_block(
                 if other.captured_output().is_none()
                     && other.outcome().diagnostic() == Some(diagnostic)
                     && other.outcome().related_diagnostics() == case.outcome().related_diagnostics()
+                    && other.random_seeds() == case.random_seeds()
                 {
                     emitted[other_index] = true;
                     write_test_failure_header(stdout, other)?;
@@ -510,6 +513,17 @@ fn write_test_failures_block(
         write_rendered_diagnostic(stdout, diagnostic.rendered_for_terminal())?;
         for diagnostic in case.outcome().related_diagnostics() {
             write_rendered_diagnostic(stdout, diagnostic.rendered_for_terminal())?;
+        }
+        if let Some(seeds) = case.random_seeds() {
+            writeln!(stdout, "Random seed: {}", seeds.base())?;
+            writeln!(
+                stdout,
+                "Phase seeds: setup={}, call={}, teardown={}",
+                seeds.setup(),
+                seeds.call(),
+                seeds.teardown()
+            )?;
+            writeln!(stdout)?;
         }
         if let Some(output) = case.captured_output() {
             write_captured_stream(stdout, "stdout", output.stdout())?;

--- a/crates/karva/src/commands/test/result_report.rs
+++ b/crates/karva/src/commands/test/result_report.rs
@@ -6,7 +6,7 @@ use karva_cache::AggregatedResults;
 use karva_cli::ResultFormat;
 use karva_diagnostic::{
     CapturedTestOutput, FixtureFailure, RenderedDiagnostic, TestCaseAttempt, TestCaseOutcome,
-    TestCaseResult, TestCaseRetry,
+    TestCaseResult, TestCaseRetry, TestRandomSeeds,
 };
 use karva_project::path::absolute;
 use serde::Serialize;
@@ -117,7 +117,7 @@ struct RunReport<'a> {
 
     status: RunStatus,
 
-    /// Seed controlling randomized ordering, omitted when shuffling is disabled.
+    /// Base seed controlling Python randomness and optional shuffled ordering.
     #[serde(skip_serializing_if = "Option::is_none")]
     random_seed: Option<u64>,
 
@@ -224,6 +224,8 @@ struct TestReport<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     retry: Option<RetryReport>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    random_seeds: Option<TestRandomSeeds>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     captured_output: Option<CapturedOutputReport<'a>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     diagnostic: Option<DiagnosticReport<'a>>,
@@ -259,6 +261,7 @@ impl<'a> TestReport<'a> {
             skip_reason,
             flaky,
             retry,
+            random_seeds: case.random_seeds(),
             captured_output: case.captured_output().map(CapturedOutputReport::new),
             diagnostic: diagnostic.map(DiagnosticReport::new),
             fixture_failures: (!case.outcome().fixture_failures().is_empty())
@@ -402,7 +405,7 @@ impl<'a> DiagnosticReport<'a> {
 struct RunFinishedRecord {
     status: RunStatus,
 
-    /// Seed controlling randomized ordering, omitted when shuffling is disabled.
+    /// Base seed controlling Python randomness and optional shuffled ordering.
     #[serde(skip_serializing_if = "Option::is_none")]
     random_seed: Option<u64>,
 

--- a/crates/karva/tests/it/main.rs
+++ b/crates/karva/tests/it/main.rs
@@ -14,6 +14,7 @@ mod filterset;
 mod junit;
 mod last_failed;
 mod partition;
+mod random_seed;
 mod result_report;
 mod run_ignored;
 mod run_timeout;

--- a/crates/karva/tests/it/random_seed.rs
+++ b/crates/karva/tests/it/random_seed.rs
@@ -1,0 +1,275 @@
+use std::process::Output;
+
+use insta::assert_snapshot;
+use insta_cmd::assert_cmd_snapshot;
+use rstest::rstest;
+use serde_json::{Value, json};
+
+use crate::common::TestContext;
+
+#[test]
+fn lifecycle_seeds_repeat_across_retries() {
+    let context = TestContext::with_file(
+        "test_random.py",
+        r#"
+        import os
+        import random
+
+        import karva
+
+        def record(phase):
+            with open("random.log", "a", encoding="utf-8") as output:
+                output.write(f"{phase}:{os.environ['KARVA_RANDOM_SEED']}:{random.random()}\n")
+
+        @karva.fixture
+        def seeded_fixture():
+            record("setup")
+            yield
+            record("teardown")
+
+        def test_random(seeded_fixture):
+            record("call")
+            random.seed(17)
+            assert random.random() == 0.5219839097124932
+            assert os.environ["KARVA_ATTEMPT"] == "2"
+        "#,
+    );
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
+            "--random-seed=170938",
+            "--retry=1",
+            "--status-level=none",
+        ]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Random seed: 170938
+    ────────────
+         Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test_random::test_random(seeded_fixture=None)
+
+    ----- stderr -----
+    "
+    );
+    assert_snapshot!(context.read_file("random.log"), @"
+    setup:7516306709688983817:0.2703726869595934
+    call:7421003177346115495:0.5671970256751211
+    teardown:9017368182005858673:0.7917082330962069
+    setup:7516306709688983817:0.2703726869595934
+    call:7421003177346115495:0.5671970256751211
+    teardown:9017368182005858673:0.7917082330962069
+    ");
+}
+
+#[test]
+fn seeds_do_not_depend_on_scheduling_or_selection() {
+    let context = TestContext::with_file(
+        "test_random.py",
+        r#"
+        import os
+        import random
+
+        def test_keep():
+            with open("observed.txt", "w", encoding="utf-8") as output:
+                output.write(f"{os.environ['KARVA_RANDOM_SEED']}:{random.random()}")
+
+        def test_noise_1(): pass
+        def test_noise_2(): pass
+        def test_noise_3(): pass
+        def test_noise_4(): pass
+        def test_noise_5(): pass
+        def test_noise_6(): pass
+        def test_noise_7(): pass
+        def test_noise_8(): pass
+        def test_noise_9(): pass
+        "#,
+    );
+
+    let serial = run_observed(&context, &["--no-parallel"]);
+    let parallel = run_observed(&context, &["--num-workers=2", "--shuffle"]);
+    let filtered = run_observed(&context, &["--no-parallel", "--filter=test(~keep)"]);
+    let partitions = [
+        run_observed(&context, &["--no-parallel", "--partition=slice:1/2"]),
+        run_observed(&context, &["--no-parallel", "--partition=slice:2/2"]),
+    ];
+
+    assert_eq!(parallel, serial);
+    assert_eq!(filtered, serial);
+    assert_eq!(
+        partitions.iter().find(|value| !value.is_empty()),
+        Some(&serial)
+    );
+}
+
+fn run_observed(context: &TestContext, args: &[&str]) -> String {
+    context.write_file("observed.txt", "");
+    let output = context
+        .command()
+        .args(["--random-seed=170938", "--status-level=none"])
+        .args(args)
+        .output()
+        .expect("run seeded tests");
+    assert_success(&output);
+    context.read_file("observed.txt")
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn parametrized_variants_receive_distinct_seeds() {
+    let context = TestContext::with_file(
+        "test_random.py",
+        r#"
+        import os
+
+        import karva
+
+        @karva.tags.parametrize("value", ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2"])
+        def test_random(value):
+            with open(f"seed-{value[-1]}.txt", "w", encoding="utf-8") as output:
+                output.write(os.environ["KARVA_RANDOM_SEED"])
+        "#,
+    );
+
+    let output = context
+        .command_no_parallel()
+        .args(["--random-seed=170938", "--status-level=none"])
+        .output()
+        .expect("run parametrized tests");
+    assert_success(&output);
+
+    assert_ne!(
+        context.read_file("seed-1.txt"),
+        context.read_file("seed-2.txt")
+    );
+}
+
+#[test]
+fn failure_diagnostics_include_seeds() {
+    let context = TestContext::with_file(
+        "test_random.py",
+        r"
+        import random
+
+        def test_failure():
+            assert random.random() < 0
+        ",
+    );
+
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .args(["--random-seed=170938", "--status-level=none"]),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    Random seed: 170938
+
+    failures:
+
+    test_random::test_failure:
+
+    error[test-failure]: Test `test_failure` failed
+     --> test_random.py:4:5
+      |
+    4 | def test_failure():
+      |     ^^^^^^^^^^^^
+      |
+    info: Test failed here
+     --> test_random.py:5:5
+      |
+    5 |     assert random.random() < 0
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+
+    Random seed: 170938
+    Phase seeds: setup=6637454972422594998, call=2091077975967582004, teardown=15821255015519234932
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[rstest]
+fn reports_include_seeds(
+    #[values(("results.json", None), ("results.jsonl", Some("jsonl")))] report: (
+        &str,
+        Option<&str>,
+    ),
+) {
+    let context = TestContext::with_file("test_random.py", "def test_random(): pass");
+    let (path, format) = report;
+    let mut command = context.command_no_parallel();
+    command
+        .args(["--random-seed=170938", "--status-level=none"])
+        .arg(format!("--result-output={path}"));
+    if let Some(format) = format {
+        command.arg(format!("--result-format={format}"));
+    }
+
+    insta::allow_duplicates! {
+        assert_cmd_snapshot!(command, @"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+        Random seed: 170938
+        ────────────
+             Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+        ----- stderr -----
+        ");
+
+        let contents = context.read_file(path);
+        let report = if format.is_some() {
+            let records = contents
+                .lines()
+                .map(|line| serde_json::from_str::<Value>(line).expect("parse JSONL record"))
+                .collect::<Vec<_>>();
+            let test = records
+                .iter()
+                .find(|record| record["type"] == "test")
+                .expect("test record");
+            let finished = records
+                .iter()
+                .find(|record| record["type"] == "run_finished")
+                .expect("run_finished record");
+            json!({
+                "random_seed": finished["random_seed"],
+                "random_seeds": test["random_seeds"],
+            })
+        } else {
+            let document = serde_json::from_str::<Value>(&contents).expect("parse JSON report");
+            json!({
+                "random_seed": document["random_seed"],
+                "random_seeds": document["tests"][0]["random_seeds"],
+            })
+        };
+        assert_snapshot!(
+            serde_json::to_string_pretty(&report).expect("serialize report seeds"),
+            @r#"
+        {
+          "random_seed": 170938,
+          "random_seeds": {
+            "base": 170938,
+            "call": 7421003177346115495,
+            "setup": 7516306709688983817,
+            "teardown": 9017368182005858673
+          }
+        }
+        "#
+        );
+    }
+}

--- a/crates/karva/tests/it/random_seed.rs
+++ b/crates/karva/tests/it/random_seed.rs
@@ -1,5 +1,3 @@
-use std::process::Output;
-
 use insta::assert_snapshot;
 use insta_cmd::assert_cmd_snapshot;
 use rstest::rstest;
@@ -45,7 +43,7 @@ fn lifecycle_seeds_repeat_across_retries() {
     success: true
     exit_code: 0
     ----- stdout -----
-    Random seed: 170938
+    Random seed: [SEED]
     ────────────
          Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
        FLAKY 2/2 [TIME] test_random::test_random(seeded_fixture=None)
@@ -105,23 +103,26 @@ fn seeds_do_not_depend_on_scheduling_or_selection() {
 
 fn run_observed(context: &TestContext, args: &[&str]) -> String {
     context.write_file("observed.txt", "");
-    let output = context
-        .command()
+    let mut command = context.command();
+    command
         .args(["--random-seed=170938", "--status-level=none"])
-        .args(args)
-        .output()
-        .expect("run seeded tests");
-    assert_success(&output);
-    context.read_file("observed.txt")
-}
+        .args(args);
+    let mut settings = insta::Settings::clone_current();
+    settings.add_filter(r"\d+ tests? run: \d+ passed", "[TESTS]");
+    settings.add_filter(r"\d+ skipped", "[SKIPPED]");
+    insta::allow_duplicates! {
+        settings.bind(|| assert_cmd_snapshot!(command, @"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+        Random seed: [SEED]
+        ────────────
+             Summary [TIME] [TESTS], [SKIPPED]
 
-fn assert_success(output: &Output) {
-    assert!(
-        output.status.success(),
-        "stdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
-    );
+        ----- stderr -----
+        "));
+    }
+    context.read_file("observed.txt")
 }
 
 #[test]
@@ -140,12 +141,21 @@ fn parametrized_variants_receive_distinct_seeds() {
         "#,
     );
 
-    let output = context
-        .command_no_parallel()
-        .args(["--random-seed=170938", "--status-level=none"])
-        .output()
-        .expect("run parametrized tests");
-    assert_success(&output);
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .args(["--random-seed=170938", "--status-level=none"]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Random seed: [SEED]
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
 
     assert_ne!(
         context.read_file("seed-1.txt"),
@@ -173,7 +183,7 @@ fn failure_diagnostics_include_seeds() {
     success: false
     exit_code: 1
     ----- stdout -----
-    Random seed: 170938
+    Random seed: [SEED]
 
     failures:
 
@@ -192,7 +202,7 @@ fn failure_diagnostics_include_seeds() {
       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
 
-    Random seed: 170938
+    Random seed: [SEED]
     Phase seeds: setup=6637454972422594998, call=2091077975967582004, teardown=15821255015519234932
 
     ────────────
@@ -225,7 +235,7 @@ fn reports_include_seeds(
         success: true
         exit_code: 0
         ----- stdout -----
-        Random seed: 170938
+        Random seed: [SEED]
         ────────────
              Summary [TIME] 1 test run: 1 passed, 0 skipped
 

--- a/crates/karva_benchmark/src/lib.rs
+++ b/crates/karva_benchmark/src/lib.rs
@@ -434,6 +434,7 @@ pub fn try_run_project(project: &Project) -> Result<RunOutput> {
         last_failed: false,
         profile: None,
         partition: None,
+        random_seed: None,
         test_ordering: karva_runner::TestOrdering::Stable,
     };
 

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -1001,6 +1001,7 @@ mod tests {
                         stderr: "",
                     },
                 ),
+                random_seeds: None,
                 attempts: [],
             },
             TestCaseResult {
@@ -1016,6 +1017,7 @@ mod tests {
                         stderr: "worker 1 stderr\n",
                     },
                 ),
+                random_seeds: None,
                 attempts: [],
             },
         ]
@@ -1087,6 +1089,7 @@ mod tests {
                 duration: 42ms,
                 retry: None,
                 captured_output: None,
+                random_seeds: None,
                 attempts: [],
             },
             TestCaseResult {
@@ -1106,6 +1109,7 @@ mod tests {
                 duration: 24ms,
                 retry: None,
                 captured_output: None,
+                random_seeds: None,
                 attempts: [],
             },
         ]

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -378,7 +378,7 @@ pub struct TestCommand {
     #[clap(long, default_missing_value = "true", require_equals = true, num_args = 0..=1, help_heading = "Runner options")]
     shuffle: Option<bool>,
 
-    /// Seed used by `--shuffle`. Does not enable shuffling by itself.
+    /// Seed for Python randomness and, with `--shuffle`, test ordering.
     ///
     /// Pass `last` to reuse the most recently generated seed.
     #[clap(long, value_name = "SEED", help_heading = "Runner options")]

--- a/crates/karva_diagnostic/src/lib.rs
+++ b/crates/karva_diagnostic/src/lib.rs
@@ -8,9 +8,10 @@ mod traceback;
 pub use reporter::{DummyReporter, Reporter, TestCaseReporter};
 pub use result::{
     CapturedTestOutput, DisplayFlakyTests, FixtureFailure, FixtureUsage, FlakyTest,
-    IndividualTestResultKind, RenderedDiagnostic, TestCaseAttempt, TestCaseOutcome, TestCaseResult,
-    TestCaseRetry, TestExecutionAttempt, TestExecutionOutcome, TestExecutionResult, TestResultKind,
-    TestResultStats, TestRunResult, TestRunResultParts,
+    IndividualTestResultKind, RenderedDiagnostic, TestCaseArtifacts, TestCaseAttempt,
+    TestCaseOutcome, TestCaseResult, TestCaseRetry, TestExecutionAttempt, TestExecutionOutcome,
+    TestExecutionResult, TestRandomSeeds, TestResultKind, TestResultStats, TestRunResult,
+    TestRunResultParts,
 };
 
 #[cfg(feature = "traceback")]

--- a/crates/karva_diagnostic/src/result/case.rs
+++ b/crates/karva_diagnostic/src/result/case.rs
@@ -28,6 +28,8 @@ pub struct TestCaseResult<D = RenderedDiagnostic> {
     retry: Option<TestCaseRetry>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     captured_output: Option<CapturedTestOutput>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    random_seeds: Option<TestRandomSeeds>,
     #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
     attempts: Vec<TestCaseAttempt<D>>,
 }
@@ -38,8 +40,12 @@ impl<D> TestCaseResult<D> {
         test_case_name: &QualifiedTestName,
         outcome: TestCaseOutcome<D>,
         duration: Duration,
-        captured_output: Option<CapturedTestOutput>,
+        artifacts: TestCaseArtifacts,
     ) -> Self {
+        let TestCaseArtifacts {
+            captured_output,
+            random_seeds,
+        } = artifacts;
         let function_name = test_case_name.function_name();
         let module_name = function_name.module_path().module_name().to_string();
         let full_name = test_case_name.to_string();
@@ -56,6 +62,7 @@ impl<D> TestCaseResult<D> {
             duration,
             retry: None,
             captured_output,
+            random_seeds,
             attempts: Vec::new(),
         }
     }
@@ -66,10 +73,10 @@ impl<D> TestCaseResult<D> {
         outcome: TestCaseOutcome<D>,
         duration: Duration,
         retry: TestCaseRetry,
-        captured_output: Option<CapturedTestOutput>,
+        artifacts: TestCaseArtifacts,
         attempts: Vec<TestCaseAttempt<D>>,
     ) -> Self {
-        let mut result = Self::new(test_case_name, outcome, duration, captured_output);
+        let mut result = Self::new(test_case_name, outcome, duration, artifacts);
         result.retry = Some(retry);
         result.attempts = attempts;
         result
@@ -96,6 +103,7 @@ impl<D> TestCaseResult<D> {
             duration,
             retry: None,
             captured_output,
+            random_seeds: None,
             attempts: Vec::new(),
         }
     }
@@ -140,6 +148,10 @@ impl<D> TestCaseResult<D> {
         self.captured_output.as_ref()
     }
 
+    pub fn random_seeds(&self) -> Option<TestRandomSeeds> {
+        self.random_seeds
+    }
+
     pub fn attempts(&self) -> &[TestCaseAttempt<D>] {
         &self.attempts
     }
@@ -157,12 +169,74 @@ impl<D> TestCaseResult<D> {
             duration: self.duration,
             retry: self.retry,
             captured_output: self.captured_output,
+            random_seeds: self.random_seeds,
             attempts: self
                 .attempts
                 .into_iter()
                 .map(|attempt| attempt.try_map_diagnostic(&mut map))
                 .collect::<Result<Vec<_>, _>>()?,
         })
+    }
+}
+
+#[derive(Default)]
+/// Output and reproducibility metadata produced while executing one test.
+pub struct TestCaseArtifacts {
+    captured_output: Option<CapturedTestOutput>,
+    random_seeds: Option<TestRandomSeeds>,
+}
+
+impl TestCaseArtifacts {
+    /// Groups captured output with the seeds that produced the test result.
+    pub const fn new(
+        captured_output: Option<CapturedTestOutput>,
+        random_seeds: Option<TestRandomSeeds>,
+    ) -> Self {
+        Self {
+            captured_output,
+            random_seeds,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+/// Stable seeds assigned to one test variant's lifecycle phases.
+pub struct TestRandomSeeds {
+    base: u64,
+    setup: u64,
+    call: u64,
+    teardown: u64,
+}
+
+impl TestRandomSeeds {
+    /// Records the base seed and its derived phase seeds.
+    pub const fn new(base: u64, setup: u64, call: u64, teardown: u64) -> Self {
+        Self {
+            base,
+            setup,
+            call,
+            teardown,
+        }
+    }
+
+    /// Base seed selected for the run.
+    pub const fn base(self) -> u64 {
+        self.base
+    }
+
+    /// Seed applied before fixture setup.
+    pub const fn setup(self) -> u64 {
+        self.setup
+    }
+
+    /// Seed applied before the test call.
+    pub const fn call(self) -> u64 {
+        self.call
+    }
+
+    /// Seed applied before fixture teardown.
+    pub const fn teardown(self) -> u64 {
+        self.teardown
     }
 }
 
@@ -499,8 +573,12 @@ mod tests {
             "value=1".to_string(),
         );
 
-        let result =
-            TestCaseResult::<()>::new(&name, TestCaseOutcome::Passed, Duration::ZERO, None);
+        let result = TestCaseResult::<()>::new(
+            &name,
+            TestCaseOutcome::Passed,
+            Duration::ZERO,
+            TestCaseArtifacts::default(),
+        );
 
         assert_eq!(result.module_name(), "tests.test");
         assert_eq!(result.name(), "test_example(value=1)");

--- a/crates/karva_diagnostic/src/result/mod.rs
+++ b/crates/karva_diagnostic/src/result/mod.rs
@@ -15,8 +15,9 @@ use ruff_db::diagnostic::Diagnostic;
 use crate::reporter::Reporter;
 
 pub use case::{
-    FixtureFailure, FixtureUsage, TestCaseAttempt, TestCaseOutcome, TestCaseResult, TestCaseRetry,
-    TestExecutionAttempt, TestExecutionOutcome, TestExecutionResult,
+    FixtureFailure, FixtureUsage, TestCaseArtifacts, TestCaseAttempt, TestCaseOutcome,
+    TestCaseResult, TestCaseRetry, TestExecutionAttempt, TestExecutionOutcome, TestExecutionResult,
+    TestRandomSeeds,
 };
 pub use diagnostic::RenderedDiagnostic;
 pub use flaky::{DisplayFlakyTests, FlakyTest};
@@ -100,7 +101,7 @@ impl TestRunResult {
         test_case_name: &QualifiedTestName,
         outcome: TestExecutionOutcome,
         duration: std::time::Duration,
-        captured_output: Option<CapturedTestOutput>,
+        artifacts: TestCaseArtifacts,
         reporter: Option<&dyn Reporter>,
     ) {
         let result = outcome.result_kind();
@@ -111,7 +112,7 @@ impl TestRunResult {
             test_case_name,
             outcome,
             duration,
-            captured_output,
+            artifacts,
         ));
 
         if matches!(
@@ -143,7 +144,7 @@ impl TestRunResult {
         outcome: TestExecutionOutcome,
         duration: std::time::Duration,
         retry: TestCaseRetry,
-        captured_output: Option<CapturedTestOutput>,
+        artifacts: TestCaseArtifacts,
         attempts: Vec<TestExecutionAttempt>,
     ) {
         let result = outcome.result_kind();
@@ -155,7 +156,7 @@ impl TestRunResult {
             outcome,
             duration,
             retry,
-            captured_output,
+            artifacts,
             attempts,
         ));
 

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -480,10 +480,11 @@ pub struct TestOptions {
     )]
     pub shuffle: Option<bool>,
 
-    /// Seed used to randomize test order when [`shuffle`](#shuffle) is enabled.
+    /// Base seed for Python randomness and optional shuffled ordering.
     ///
-    /// When omitted, Karva generates and prints a seed for the run. Setting a
-    /// seed does not enable shuffling by itself.
+    /// Karva derives distinct setup, call, and teardown seeds for each test.
+    /// When [`shuffle`](#shuffle) is enabled, the same base seed also controls
+    /// ordering. Without either setting, runs use Python's default randomness.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[option(
         default = r#"null"#,

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -470,6 +470,9 @@ pub struct ParallelTestConfig {
     /// When set, restrict the run to the selected slice of collected tests.
     pub partition: Option<PartitionSelection>,
 
+    /// Base seed forwarded to workers for Python standard-library randomness.
+    pub random_seed: Option<u64>,
+
     /// Ordering strategy for partition inputs.
     pub test_ordering: TestOrdering,
 }
@@ -685,6 +688,7 @@ pub fn run_parallel_tests(
         args,
         num_workers,
         profile: config.profile.as_deref().unwrap_or("default"),
+        random_seed: config.random_seed,
         worker_binary: &worker_binary,
         coverage_enabled: !project.settings().coverage().sources.is_empty(),
     };

--- a/crates/karva_runner/src/worker_args.rs
+++ b/crates/karva_runner/src/worker_args.rs
@@ -34,6 +34,9 @@ pub struct WorkerSpawn<'a> {
     /// Resolved configuration profile propagated through `KARVA_PROFILE`.
     pub profile: &'a str,
 
+    /// Base seed for Python standard-library randomness.
+    pub random_seed: Option<u64>,
+
     /// Executable selected for the worker subprocess.
     pub worker_binary: &'a Utf8PathBuf,
 
@@ -95,6 +98,10 @@ pub fn worker_command(spawn: &WorkerSpawn, worker_id: usize, partition: &Partiti
 
     for path in partition.tests() {
         cmd.arg(path);
+    }
+
+    if let Some(seed) = spawn.random_seed {
+        cmd.arg("--random-seed").arg(seed.to_string());
     }
 
     cmd.args(inner_cli_args(spawn.project.settings(), spawn.args));

--- a/crates/karva_static/src/lib.rs
+++ b/crates/karva_static/src/lib.rs
@@ -161,6 +161,10 @@ env_vars! {
         /// (`retries + 1`). Always set.
         pub const KARVA_TOTAL_ATTEMPTS: &'static str = "KARVA_TOTAL_ATTEMPTS";
 
+        /// Seed applied to Python's standard-library `random` module for the
+        /// current setup, call, or teardown phase. Updated before each phase.
+        pub const KARVA_RANDOM_SEED: &'static str = "KARVA_RANDOM_SEED";
+
         /// Name of the active configuration profile, e.g. `"default"` or
         /// whatever was passed to `--profile` / `KARVA_PROFILE`.
         pub const KARVA_PROFILE: &'static str = "KARVA_PROFILE";

--- a/crates/karva_test_semantic/Cargo.toml
+++ b/crates/karva_test_semantic/Cargo.toml
@@ -31,6 +31,7 @@ ruff_python_parser = { workspace = true }
 ruff_python_stdlib = { workspace = true }
 ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }
+siphasher = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/karva_test_semantic/src/context.rs
+++ b/crates/karva_test_semantic/src/context.rs
@@ -1,7 +1,7 @@
 use camino::Utf8Path;
 use karva_collector::CollectionSettings;
 use karva_diagnostic::{
-    CapturedTestOutput, IndividualTestResultKind, Reporter, TestCaseRetry, TestExecutionAttempt,
+    IndividualTestResultKind, Reporter, TestCaseArtifacts, TestCaseRetry, TestExecutionAttempt,
     TestExecutionOutcome, TestRunResult,
 };
 use karva_metadata::ProjectSettings;
@@ -25,6 +25,9 @@ pub struct Context<'a> {
 
     /// Whether diagnostics should include the full Python call chain.
     verbose: bool,
+
+    /// Base seed for Python standard-library randomness.
+    random_seed: Option<u64>,
 }
 
 /// Mutable result state owned by the active execution path.
@@ -40,6 +43,7 @@ impl<'a> Context<'a> {
         python_version: PythonVersion,
         reporter: &'a dyn Reporter,
         verbose: bool,
+        random_seed: Option<u64>,
     ) -> Self {
         Self {
             cwd,
@@ -47,6 +51,7 @@ impl<'a> Context<'a> {
             python_version,
             reporter,
             verbose,
+            random_seed,
         }
     }
 
@@ -60,6 +65,10 @@ impl<'a> Context<'a> {
 
     pub(super) fn is_verbose(&self) -> bool {
         self.verbose
+    }
+
+    pub(super) fn random_seed(&self) -> Option<u64> {
+        self.random_seed
     }
 
     pub(super) fn collection_settings(&'a self) -> CollectionSettings<'a> {
@@ -104,7 +113,7 @@ impl RunState {
         test_case_name: &QualifiedTestName,
         outcome: TestExecutionOutcome,
         duration: std::time::Duration,
-        captured_output: Option<CapturedTestOutput>,
+        artifacts: TestCaseArtifacts,
     ) -> bool {
         let passed = !outcome.is_non_success();
 
@@ -112,7 +121,7 @@ impl RunState {
             test_case_name,
             outcome,
             duration,
-            captured_output,
+            artifacts,
             Some(context.reporter),
         );
 
@@ -134,7 +143,7 @@ impl RunState {
             &name,
             TestExecutionOutcome::Skipped { reason },
             std::time::Duration::ZERO,
-            None,
+            TestCaseArtifacts::default(),
         );
     }
 
@@ -181,7 +190,7 @@ impl RunState {
         outcome: TestExecutionOutcome,
         duration: std::time::Duration,
         retry: TestCaseRetry,
-        captured_output: Option<CapturedTestOutput>,
+        artifacts: TestCaseArtifacts,
         attempts: Vec<TestExecutionAttempt>,
     ) -> bool {
         let passed = !outcome.is_non_success() && !retry.is_flaky_failure();
@@ -190,7 +199,7 @@ impl RunState {
             outcome,
             duration,
             retry,
-            captured_output,
+            artifacts,
             attempts,
         );
         passed

--- a/crates/karva_test_semantic/src/lib.rs
+++ b/crates/karva_test_semantic/src/lib.rs
@@ -27,6 +27,23 @@ use crate::discovery::{DiscoveryIssue, StandardDiscoverer};
 use crate::py_attach::attach_with_output;
 use crate::runner::PackageRunner;
 
+/// Worker-local options that do not belong to project configuration.
+#[derive(Clone, Copy)]
+pub struct TestRunOptions {
+    verbose: bool,
+    random_seed: Option<u64>,
+}
+
+impl TestRunOptions {
+    /// Creates execution options for one worker run.
+    pub const fn new(verbose: bool, random_seed: Option<u64>) -> Self {
+        Self {
+            verbose,
+            random_seed,
+        }
+    }
+}
+
 /// Runs discovery and execution inside one interpreter attachment.
 ///
 /// Coverage startup or persistence failures are logged but do not discard test results.
@@ -37,9 +54,20 @@ pub fn run_tests(
     reporter: &dyn Reporter,
     test_paths: Vec<Result<TestPath, TestPathError>>,
     coverage: Option<&CoverageConfig>,
-    verbose: bool,
+    options: TestRunOptions,
 ) -> TestRunResult {
-    let context = Context::new(cwd, settings, python_version, reporter, verbose);
+    let TestRunOptions {
+        verbose,
+        random_seed,
+    } = options;
+    let context = Context::new(
+        cwd,
+        settings,
+        python_version,
+        reporter,
+        verbose,
+        random_seed,
+    );
     let mut state = RunState::default();
 
     attach_with_output(settings.terminal().show_python_output, |py| {

--- a/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
@@ -251,6 +251,24 @@ pub(super) struct PreparedFixtures {
     pub(super) test_finalizers: Vec<Finalizer>,
 }
 
+impl PreparedFixtures {
+    /// Retains parameters for identity and reporting when setup cannot start.
+    pub(super) fn from_params(py: Python<'_>, params: HashMap<String, Arc<Py<PyAny>>>) -> Self {
+        let mut function_arguments = FixtureArguments::default();
+        for (key, value) in params {
+            function_arguments.insert(
+                key,
+                Arc::try_unwrap(value).unwrap_or_else(|arc| (*arc).clone_ref(py)),
+            );
+        }
+        Self {
+            function_arguments,
+            setup_result: Ok(()),
+            test_finalizers: Vec::new(),
+        }
+    }
+}
+
 /// Raw fixture call error paired with its relationship to the blocked test.
 struct PreparedFixtureFailure {
     /// Python call failure and source context for diagnostic rendering.

--- a/crates/karva_test_semantic/src/runner/package_runner/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/mod.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 
 use karva_coverage::CoverageSession;
+use karva_diagnostic::TestCaseArtifacts;
 use karva_python_semantic::QualifiedTestName;
 use pyo3::prelude::*;
 
@@ -86,7 +87,7 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
             &QualifiedTestName::new(test.name().clone()),
             error.into_outcome(),
             std::time::Duration::ZERO,
-            None,
+            TestCaseArtifacts::default(),
         );
         self.record_outcome(false);
     }

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/attempt.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/attempt.rs
@@ -6,8 +6,9 @@ use karva_coverage::CoveragePhase;
 use karva_diagnostic::{CapturedTestOutput, TestExecutionAttempt, TestExecutionOutcome};
 use pyo3::prelude::*;
 
+use crate::diagnostic::test_failure_diagnostic;
 use crate::extensions::functions::snapshot::set_snapshot_context;
-use crate::utils::{run_coroutine, run_test_with_timeout};
+use crate::utils::{run_coroutine, run_test_with_timeout, set_random_seed};
 
 use super::{VariantRunner, VariantSettings, finish_output_capture};
 use crate::output_capture::PythonOutputCapture;
@@ -37,31 +38,51 @@ impl VariantRunner<'_, '_, '_, '_, '_> {
                 },
             setup_duration,
             output_capture,
+            random_seed_error,
         } = prepared;
 
-        let body = match setup_result {
-            Ok(()) => self.execute_test_body(
-                settings,
-                function,
-                test_name_env_result,
-                attempt_env_result,
-                &function_arguments,
-            ),
-            Err(error) => AttemptBody {
-                outcome: error
-                    .into_test_error(self.py, self.package_runner.context.is_verbose())
-                    .into_outcome(),
-                call_duration: Duration::ZERO,
-                retryable: true,
+        let body = match random_seed_error {
+            Some(error) => self.classify_seed_error(error, &function_arguments),
+            None => match setup_result {
+                Ok(()) => self.execute_test_body(
+                    settings,
+                    function,
+                    test_name_env_result,
+                    attempt_env_result,
+                    &function_arguments,
+                ),
+                Err(error) => AttemptBody {
+                    outcome: error
+                        .into_test_error(self.py, self.package_runner.context.is_verbose())
+                        .into_outcome(),
+                    call_duration: Duration::ZERO,
+                    retryable: true,
+                },
             },
         };
 
         let skipped = body.outcome.is_skipped();
         self.set_coverage_context(&settings.qualified_name, CoveragePhase::Teardown);
         let teardown_start = Instant::now();
-        let finalizer_diagnostics = self
-            .package_runner
-            .clean_up_test_attempt(self.py, test_finalizers);
+        let mut finalizer_diagnostics = settings
+            .random_seeds
+            .and_then(|seeds| set_random_seed(self.py, seeds.teardown()).err())
+            .map(|error| {
+                test_failure_diagnostic(
+                    self.py,
+                    self.test.source_file(),
+                    self.test.statement(),
+                    &function_arguments,
+                    &error,
+                    self.package_runner.context.is_verbose(),
+                )
+            })
+            .into_iter()
+            .collect::<Vec<_>>();
+        finalizer_diagnostics.extend(
+            self.package_runner
+                .clean_up_test_attempt(self.py, test_finalizers),
+        );
         let teardown_failed = !finalizer_diagnostics.is_empty();
         let phases = PhaseDurations {
             setup: setup_duration,
@@ -106,19 +127,23 @@ impl VariantRunner<'_, '_, '_, '_, '_> {
         function_arguments: &crate::runner::FixtureArguments,
     ) -> AttemptBody {
         set_snapshot_context(settings.snapshot_context.clone());
-        let prepared_call = attempt_env_result.and_then(|()| {
-            if let Err(error) = test_name_env_result {
-                return Err(error.clone_ref(self.py));
-            }
-            if let Err(error) = &settings.async_patch_result {
-                return Err(error.clone_ref(self.py));
-            }
-            if function_arguments.is_empty() || settings.timeout_seconds.is_some() {
-                Ok(None)
-            } else {
-                function_arguments.to_kwargs(self.py).map(Some)
-            }
-        });
+        let prepared_call = settings
+            .random_seeds
+            .map_or(Ok(()), |seeds| set_random_seed(self.py, seeds.call()))
+            .and(attempt_env_result)
+            .and_then(|()| {
+                if let Err(error) = test_name_env_result {
+                    return Err(error.clone_ref(self.py));
+                }
+                if let Err(error) = &settings.async_patch_result {
+                    return Err(error.clone_ref(self.py));
+                }
+                if function_arguments.is_empty() || settings.timeout_seconds.is_some() {
+                    Ok(None)
+                } else {
+                    function_arguments.to_kwargs(self.py).map(Some)
+                }
+            });
         let (test_result, call_duration) = match prepared_call {
             Ok(keyword_arguments) => {
                 let call_start = Instant::now();
@@ -169,6 +194,30 @@ impl VariantRunner<'_, '_, '_, '_, '_> {
             retryable: result.retryable,
         }
     }
+
+    fn classify_seed_error(
+        &self,
+        error: PyErr,
+        function_arguments: &crate::runner::FixtureArguments,
+    ) -> AttemptBody {
+        let result = classify_test_result(
+            self.py,
+            Err(error),
+            &OutcomeContext {
+                name: self.test.name(),
+                source_file: self.test.source_file(),
+                stmt_function_def: self.test.statement(),
+                function_arguments,
+                expect_fail_tag: None,
+                verbose: self.package_runner.context.is_verbose(),
+            },
+        );
+        AttemptBody {
+            outcome: result.outcome,
+            call_duration: Duration::ZERO,
+            retryable: false,
+        }
+    }
 }
 
 /// Test-body result before common teardown and duration policy are applied.
@@ -191,6 +240,8 @@ pub(super) struct PreparedTestAttempt {
     pub(super) setup_duration: Duration,
     /// Python stdout and stderr capture spanning setup, call, and teardown.
     pub(super) output_capture: Option<PythonOutputCapture>,
+    /// Failure while applying the setup phase seed.
+    pub(super) random_seed_error: Option<PyErr>,
 }
 
 /// Completed call lifecycle plus retry decision.

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
@@ -1,12 +1,15 @@
 //! Orchestration and reporting for one concrete test variant.
 
 use std::collections::HashMap;
+use std::fmt::Write as _;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use karva_coverage::CoveragePhase;
-use karva_diagnostic::{CapturedTestOutput, TestCaseRetry, TestExecutionOutcome};
+use karva_diagnostic::{
+    CapturedTestOutput, TestCaseArtifacts, TestCaseRetry, TestExecutionOutcome, TestRandomSeeds,
+};
 use karva_metadata::filter::EvalContext;
 use karva_metadata::{FlakyResult, JunitFlakyFailStatus, RunIgnoredMode};
 use karva_python_semantic::QualifiedTestName;
@@ -21,9 +24,13 @@ use crate::extensions::tags::timeout::TimeoutTag;
 use crate::output_capture::PythonOutputCapture;
 use crate::runner::fixture_arguments::FixtureArguments;
 use crate::runner::test_iterator::TestVariant;
-use crate::utils::{set_attempt_env, set_test_name_env, test_parameters};
+use crate::utils::{
+    display_value, set_attempt_env, set_random_seed, set_test_name_env, test_parameters,
+    test_random_seeds,
+};
 
 use super::PackageRunner;
+use super::fixture::PreparedFixtures;
 
 mod attempt;
 
@@ -117,10 +124,12 @@ impl<'runner, 'context, 'settings, 'test, 'py>
         }
 
         let retry_params = self.params.clone();
+        let random_seeds = self.random_seeds();
         let first_params = std::mem::take(&mut self.params);
         self.begin_pending_coverage_setup();
-        let first_attempt = self.prepare_attempt(first_params, self.start_output_capture());
-        let settings = self.settings(&first_attempt.fixtures.function_arguments);
+        let first_attempt =
+            self.prepare_attempt(first_params, self.start_output_capture(), random_seeds);
+        let settings = self.settings(&first_attempt.fixtures.function_arguments, random_seeds);
         self.resolve_pending_coverage_setup(&settings.qualified_name);
         let function = self.test.py_function.clone_ref(self.py);
         let test_name_env_result =
@@ -175,20 +184,28 @@ impl<'runner, 'context, 'settings, 'test, 'py>
         &mut self,
         params: HashMap<String, Arc<Py<PyAny>>>,
         output_capture: Option<PythonOutputCapture>,
+        random_seeds: Option<TestRandomSeeds>,
     ) -> PreparedTestAttempt {
         let setup_start = Instant::now();
-        let fixtures = self.package_runner.prepare_test_fixtures(
-            self.py,
-            &self.fixture_plan,
-            &self.fixture_dependencies,
-            &self.use_fixture_dependencies,
-            &self.auto_use_fixtures,
-            params,
-        );
+        let random_seed_error =
+            random_seeds.and_then(|seeds| set_random_seed(self.py, seeds.setup()).err());
+        let fixtures = if random_seed_error.is_some() {
+            PreparedFixtures::from_params(self.py, params)
+        } else {
+            self.package_runner.prepare_test_fixtures(
+                self.py,
+                &self.fixture_plan,
+                &self.fixture_dependencies,
+                &self.use_fixture_dependencies,
+                &self.auto_use_fixtures,
+                params,
+            )
+        };
         PreparedTestAttempt {
             fixtures,
             setup_duration: setup_start.elapsed(),
             output_capture,
+            random_seed_error,
         }
     }
 
@@ -199,11 +216,15 @@ impl<'runner, 'context, 'settings, 'test, 'py>
         settings: &VariantSettings,
     ) -> PreparedTestAttempt {
         self.set_coverage_context(&settings.qualified_name, CoveragePhase::Setup);
-        self.prepare_attempt(params, self.start_output_capture())
+        self.prepare_attempt(params, self.start_output_capture(), settings.random_seeds)
     }
 
     /// Derives identity and execution policy after first fixture setup.
-    fn settings(&self, function_arguments: &FixtureArguments) -> VariantSettings {
+    fn settings(
+        &self,
+        function_arguments: &FixtureArguments,
+        random_seeds: Option<TestRandomSeeds>,
+    ) -> VariantSettings {
         let name = self.test.name();
         let fixture_names = self
             .fixture_dependencies
@@ -316,7 +337,29 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             max_attempts,
             flaky_result,
             junit_flaky_fail_status,
+            random_seeds,
         }
+    }
+
+    /// Derives seed identity from collection-time parameters, before fixtures run.
+    fn random_seeds(&self) -> Option<TestRandomSeeds> {
+        let base = self.package_runner.context.random_seed()?;
+        let mut arguments = FixtureArguments::default();
+        for (name, value) in &self.params {
+            arguments.insert(name.clone(), value.as_ref().clone_ref(self.py));
+        }
+        let mut identity = self.test.name().to_string();
+        if let Some(id) = &self.id {
+            let _ = write!(identity, "\0id:{}:{id}", id.len());
+        } else {
+            for (name, value) in
+                arguments.iter_in_signature_order(&self.test.statement().parameters)
+            {
+                let value = display_value(value.bind(self.py));
+                let _ = write!(identity, "\0{}:{name}{}:{value}", name.len(), value.len());
+            }
+        }
+        Some(test_random_seeds(base, &identity))
     }
 
     /// Registers final outcome after all retries and returns pass/fail status.
@@ -368,7 +411,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
                 &settings.qualified_test_name,
                 final_attempt.outcome,
                 total_duration,
-                captured_output,
+                TestCaseArtifacts::new(captured_output, settings.random_seeds),
             )
         } else {
             let final_attempt_number = final_attempt.attempt;
@@ -388,7 +431,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
                 total_duration,
                 TestCaseRetry::new(final_attempt_number, settings.max_attempts)
                     .with_failure_policy(flaky_failure, junit_flaky_failure),
-                captured_output,
+                TestCaseArtifacts::new(captured_output, settings.random_seeds),
                 execution_attempts,
             )
         }
@@ -418,7 +461,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
                     &qualified,
                     TestExecutionOutcome::Skipped { reason: None },
                     Duration::ZERO,
-                    None,
+                    TestCaseArtifacts::default(),
                 ));
             }
         }
@@ -439,7 +482,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             &qualified,
             TestExecutionOutcome::Skipped { reason },
             Duration::ZERO,
-            None,
+            TestCaseArtifacts::default(),
         ))
     }
 
@@ -519,6 +562,8 @@ struct VariantSettings {
     flaky_result: FlakyResult,
     /// How a flaky failure appears in `JUnit`.
     junit_flaky_fail_status: JunitFlakyFailStatus,
+    /// Seeds reapplied at each lifecycle boundary and reused by retries.
+    random_seeds: Option<TestRandomSeeds>,
 }
 
 /// Finishes best-effort Python output capture.

--- a/crates/karva_test_semantic/src/utils.rs
+++ b/crates/karva_test_semantic/src/utils.rs
@@ -1,12 +1,15 @@
 use std::fmt::Write;
+use std::hash::{Hash, Hasher};
 
 use camino::Utf8Path;
+use karva_diagnostic::TestRandomSeeds;
 use karva_static::WorkerEnvVars;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3::types::{PyAnyMethods, PyCFunction, PyDict, PyString, PyTuple};
 use pyo3::{PyResult, Python};
 use ruff_python_ast::Parameters;
+use siphasher::sip::SipHasher13;
 
 use crate::extensions::functions::snapshot::{
     SnapshotContext, capture_snapshot_thread_state, set_snapshot_thread_state,
@@ -219,6 +222,31 @@ pub fn set_test_name_env(py: Python<'_>, qualified_name: &str) -> PyResult<()> {
     let environ = py.import("os")?.getattr("environ")?;
     environ.set_item(WorkerEnvVars::KARVA_TEST_NAME, qualified_name)?;
     Ok(())
+}
+
+/// Seeds Python's standard-library PRNG and exposes the active phase seed.
+pub fn set_random_seed(py: Python<'_>, seed: u64) -> PyResult<()> {
+    py.import("random")?.call_method1("seed", (seed,))?;
+    let environ = py.import("os")?.getattr("environ")?;
+    environ.set_item(WorkerEnvVars::KARVA_RANDOM_SEED, seed.to_string())?;
+    Ok(())
+}
+
+/// Derives stable, distinct lifecycle seeds from one run seed and test identity.
+pub fn test_random_seeds(base: u64, test_identity: &str) -> TestRandomSeeds {
+    TestRandomSeeds::new(
+        base,
+        phase_random_seed(base, test_identity, 0),
+        phase_random_seed(base, test_identity, 1),
+        phase_random_seed(base, test_identity, 2),
+    )
+}
+
+fn phase_random_seed(base: u64, test_identity: &str, phase: u8) -> u64 {
+    let mut hasher = SipHasher13::new_with_keys(base, base ^ 0x9e37_79b9_7f4a_7c15);
+    test_identity.hash(&mut hasher);
+    phase.hash(&mut hasher);
+    hasher.finish()
 }
 
 /// Formats Python values for test identity, quoting strings and escaping NUL bytes.

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -36,6 +36,10 @@ struct Args {
     #[arg(long)]
     worker_id: usize,
 
+    /// Base seed for Python standard-library randomness.
+    #[arg(long)]
+    random_seed: Option<u64>,
+
     /// Shared test execution options inherited from the main CLI.
     #[clap(flatten)]
     sub_command: SubTestCommand,
@@ -162,6 +166,8 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
         )
     };
 
+    let run_options =
+        karva_test_semantic::TestRunOptions::new(!verbosity.is_default(), args.random_seed);
     let result = karva_test_semantic::run_tests(
         &cwd,
         &settings,
@@ -169,7 +175,7 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
         reporter.as_ref(),
         test_paths,
         coverage.as_ref(),
-        !verbosity.is_default(),
+        run_options,
     );
 
     let diagnostic_format = settings.terminal().output_format.into();

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1032,10 +1032,11 @@ passes silently when filters were given. Use `fail` to always fail,
 
 #### `random-seed`
 
-Seed used to randomize test order when [`shuffle`](#shuffle) is enabled.
+Base seed for Python randomness and optional shuffled ordering.
 
-When omitted, Karva generates and prints a seed for the run. Setting a
-seed does not enable shuffling by itself.
+Karva derives distinct setup, call, and teardown seeds for each test.
+When [`shuffle`](#shuffle) is enabled, the same base seed also controls
+ordering. Without either setting, runs use Python's default randomness.
 
 **Default value**: `null`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -146,7 +146,7 @@ karva test [OPTIONS] [PATH]...
 </dd><dt id="karva-test--profile"><a href="#karva-test--profile"><code>--profile</code></a>, <code>-P</code> <i>name</i></dt><dd><p>Configuration profile to use.</p>
 <p>Profiles are defined as <code>&#91;profile.&lt;name&gt;&#93;</code> sections in <code>karva.toml</code> (or <code>&#91;tool.karva.profile.&lt;name&gt;&#93;</code> in <code>pyproject.toml</code>) and may override <code>env</code>, <code>src</code>, <code>terminal</code>, <code>test</code>, <code>coverage</code>, <code>junit</code>, and <code>overrides</code>. The selected profile is layered on top of any <code>&#91;profile.default&#93;</code> overrides, which themselves layer on top of Karva's built-in defaults.</p>
 <p>Defaults to <code>default</code>.</p>
-<p>May also be set with the <code>KARVA_PROFILE</code> environment variable.</p></dd><dt id="karva-test--random-seed"><a href="#karva-test--random-seed"><code>--random-seed</code></a> <i>seed</i></dt><dd><p>Seed used by <code>--shuffle</code>. Does not enable shuffling by itself.</p>
+<p>May also be set with the <code>KARVA_PROFILE</code> environment variable.</p></dd><dt id="karva-test--random-seed"><a href="#karva-test--random-seed"><code>--random-seed</code></a> <i>seed</i></dt><dd><p>Seed for Python randomness and, with <code>--shuffle</code>, test ordering.</p>
 <p>Pass <code>last</code> to reuse the most recently generated seed.</p>
 </dd><dt id="karva-test--result-format"><a href="#karva-test--result-format"><code>--result-format</code></a> <i>format</i></dt><dd><p>Machine-readable test result format</p>
 <p>Possible values:</p>

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -106,6 +106,11 @@ set; `"1"` when no retries are configured.
 The total number of attempts allowed for the currently running test
 (`retries + 1`). Always set.
 
+### `KARVA_RANDOM_SEED`
+
+Seed applied to Python's standard-library `random` module for the
+current setup, call, or teardown phase. Updated before each phase.
+
 ### `KARVA_PROFILE`
 
 Name of the active configuration profile, e.g. `"default"` or

--- a/docs/usage/running-tests/reports.md
+++ b/docs/usage/running-tests/reports.md
@@ -54,7 +54,8 @@ names, status, duration, skip reason, captured output, diagnostics, and retry
 attempts when applicable. Collection and import diagnostics that do not belong
 to one test are stored separately as run diagnostics.
 
-Seeded shuffled runs include `random_seed` in the top-level run metadata.
+Seeded runs include `random_seed` in the top-level run metadata and the base,
+setup, call, and teardown values under `random_seeds` on each executed test.
 
 Result output is plain text without ANSI styling, regardless of terminal color
 settings.
@@ -72,5 +73,5 @@ uv run karva test \
 Karva writes a `test` record for each test, a `run_diagnostic` record for each
 unattached collection or import diagnostic, then one `run_finished` record
 with final status and aggregate statistics. Every line includes the schema
-version and record type. Seeded shuffled runs include `random_seed` on the
-`run_finished` record.
+version and record type. Seeded runs include `random_seed` on the
+`run_finished` record and `random_seeds` on each `test` record.

--- a/docs/usage/running-tests/shuffle.md
+++ b/docs/usage/running-tests/shuffle.md
@@ -21,7 +21,8 @@ Karva prints the generated seed before running tests:
 Random seed: 170938
 ```
 
-Pass that seed to reproduce the same worker assignment and per-worker order:
+Pass that seed to reproduce the same worker assignment, per-worker order, and
+Python standard-library randomness:
 
 ```bash
 uv run karva test --shuffle --random-seed 170938
@@ -39,8 +40,22 @@ shuffle = true
 random-seed = 170938
 ```
 
-`random-seed` does not enable shuffling by itself. Leave it unset to generate a
-new seed for each invocation.
+`random-seed` does not enable shuffling by itself. It still seeds Python
+randomness when shuffling is disabled. Leave it unset with `shuffle = true` to
+generate a new seed for each invocation.
+
+## Python randomness
+
+When a random seed is set, Karva derives distinct deterministic seeds for each
+test's function-scoped fixture setup, test call, and fixture teardown. It
+reapplies the same phase seeds on retries, independent of worker count,
+selection, partition, or ordering. The active phase seed is available to test
+code as `KARVA_RANDOM_SEED`.
+
+Calling `random.seed()` inside a fixture or test remains under user control for
+the rest of that phase. Karva does not change `secrets`, `random.SystemRandom`,
+or operating-system entropy. Support for third-party random generators is out
+of scope.
 
 Use the most recently generated seed again without copying it from output:
 
@@ -65,5 +80,6 @@ keep the normal duration-aware scheduler.
 Watch mode chooses one generated or configured seed when the session starts and
 reuses it for every rerun. File changes can still change the collected test set.
 
-JSON reports include `random_seed` at the run level. JSONL reports include it
-on the final `run_finished` record.
+JSON reports include `random_seed` at the run level and `random_seeds` on each
+executed test. JSONL reports include the same fields on `run_finished` and
+`test` records.

--- a/karva.schema.json
+++ b/karva.schema.json
@@ -794,7 +794,7 @@
           ]
         },
         "random-seed": {
-          "description": "Seed used to randomize test order when [`shuffle`](#shuffle) is enabled.\n\nWhen omitted, Karva generates and prints a seed for the run. Setting a\nseed does not enable shuffling by itself.",
+          "description": "Base seed for Python randomness and optional shuffled ordering.\n\nKarva derives distinct setup, call, and teardown seeds for each test.\nWhen [`shuffle`](#shuffle) is enabled, the same base seed also controls\nordering. Without either setting, runs use Python's default randomness.",
           "type": [
             "integer",
             "null"


### PR DESCRIPTION
## Summary

Seeds Python's standard-library `random` module independently for each test's fixture setup, call, and teardown. Stable phase seeds derived from the run seed and test identity make random data independent of workers, selection, ordering, and retries; failure output, `KARVA_RANDOM_SEED`, and JSON/JSONL reports expose the values needed to reproduce a failure.

#1215 independently added last-generated-seed replay and is now in `main`. Together these changes complete the requested random-seed behavior.

Closes #981.

## Test plan

`just test -p karva random_seed`, `just test -p karva generated_seed_reproduces_single_worker_order`, `just test -p karva_dev cli_reference_is_up_to_date`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo hawk check -D warnings -D hawk::unnecessary_crate_visibility`, and `uvx prek run -a`.