### PR TITLE
Reuse the last generated random seed

### DIFF
--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -11,8 +11,10 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context as _, Result};
 use camino::Utf8PathBuf;
-use karva_cache::{AggregatedResults, DisplayFlakyTests};
-use karva_cli::{CovReport as CliCovReport, TestCommand};
+use karva_cache::{
+    AggregatedResults, CACHE_DIR, DisplayFlakyTests, read_random_seed, write_random_seed,
+};
+use karva_cli::{CovReport as CliCovReport, RandomSeed, TestCommand};
 use karva_logging::{Printer, Stdout, set_colored_override, setup_tracing};
 use karva_metadata::filter::FiltersetSet;
 use karva_metadata::{CovReport, NoTestsMode, ProjectMetadata, ProjectOptionsOverrides};
@@ -58,6 +60,7 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
     let last_failed = args.last_failed;
     let partition = args.partition;
     let no_cache = args.no_cache.unwrap_or(false);
+    let random_seed_selection = args.random_seed();
     let num_workers = if args.no_parallel.unwrap_or(false) || args.no_capture {
         1
     } else if let Some(num_workers) = args.num_workers {
@@ -93,13 +96,32 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
 
     FiltersetSet::new(&sub_command.filter_expressions).context("invalid `--filter` expression")?;
 
-    let random_seed = project.settings().test().shuffle.then(|| {
-        project
-            .settings()
-            .test()
-            .random_seed
-            .unwrap_or_else(karva_runner::generate_random_seed)
-    });
+    let cache_dir = project.cwd().join(CACHE_DIR);
+    let (random_seed, generated_random_seed) = if project.settings().test().shuffle {
+        match random_seed_selection {
+            Some(RandomSeed::Last) => {
+                if no_cache {
+                    anyhow::bail!("`--random-seed=last` cannot be used with `--no-cache`");
+                }
+                let seed = read_random_seed(&cache_dir)?
+                    .context("No generated random seed found; run with `--shuffle` first")?;
+                (Some(seed), false)
+            }
+            Some(RandomSeed::Value(seed)) => (Some(seed), false),
+            None => match project.settings().test().random_seed {
+                Some(seed) => (Some(seed), false),
+                None => (Some(karva_runner::generate_random_seed()), true),
+            },
+        }
+    } else {
+        (None, false)
+    };
+    if generated_random_seed
+        && !no_cache
+        && let Some(seed) = random_seed
+    {
+        write_random_seed(&cache_dir, seed)?;
+    }
     if let Some(seed) = random_seed {
         let mut stdout = printer.stream_for_message().lock();
         writeln!(stdout, "Random seed: {seed}")?;

--- a/crates/karva/tests/it/shuffle.rs
+++ b/crates/karva/tests/it/shuffle.rs
@@ -1,6 +1,7 @@
 use std::process::Output;
 
 use insta::assert_snapshot;
+use insta_cmd::assert_cmd_snapshot;
 use serde_json::Value;
 
 use crate::common::TestContext;
@@ -122,7 +123,7 @@ fn generated_seed_reproduces_single_worker_order() {
     );
 
     let first = run_shuffled(&context, 1, None, &[]);
-    let repeated = run_shuffled(&context, 1, Some(first.seed), &[]);
+    let repeated = run_shuffled(&context, 1, None, &["--random-seed=last"]);
 
     assert_snapshot!(
         snapshots(&[
@@ -151,6 +152,47 @@ fn generated_seed_reproduces_single_worker_order() {
     "
     );
     assert_eq!(first.orders, repeated.orders);
+    assert_eq!(first.seed, repeated.seed);
+}
+
+#[test]
+fn last_seed_requires_a_generated_seed() {
+    let context = TestContext::with_file("test_pass.py", "def test_pass(): pass");
+
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .args(["--shuffle", "--random-seed=last"]),
+        @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    karva failed
+      Cause: No generated random seed found; run with `--shuffle` first
+    "
+    );
+}
+
+#[test]
+fn last_seed_requires_cache() {
+    let context = TestContext::with_file("test_pass.py", "def test_pass(): pass");
+
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .args(["--shuffle", "--random-seed=last", "--no-cache"]),
+        @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    karva failed
+      Cause: `--random-seed=last` cannot be used with `--no-cache`
+    "
+    );
 }
 
 #[test]

--- a/crates/karva_cache/src/artifact.rs
+++ b/crates/karva_cache/src/artifact.rs
@@ -28,6 +28,8 @@ pub enum CacheFile {
     FailFastSignal,
     /// Cache-root JSON: list of last-run failed test names.
     LastFailed,
+    /// Cache-root JSON: most recently generated random seed.
+    RandomSeed,
     /// Per-worker JSON: name + start time of the test currently executing,
     /// or empty/absent when the worker is between tests. Used by the
     /// orchestrator to render per-test `SIGINT` lines on Ctrl+C.
@@ -43,6 +45,7 @@ impl CacheFile {
             Self::Coverage => "coverage.json",
             Self::FailFastSignal => "fail-fast",
             Self::LastFailed => "last-failed.json",
+            Self::RandomSeed => "random-seed.json",
             Self::CurrentTest => "current_test.json",
         }
     }

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -297,6 +297,17 @@ pub fn read_last_failed(cache_dir: &Utf8Path) -> Result<Vec<String>> {
     Ok(read_json::<Vec<String>>(cache_dir, CacheFile::LastFailed)?.unwrap_or_default())
 }
 
+/// Persists the most recently generated random seed.
+pub fn write_random_seed(cache_dir: &Utf8Path, seed: u64) -> Result<()> {
+    fs::create_dir_all(cache_dir)?;
+    write_json(cache_dir, CacheFile::RandomSeed, &seed)
+}
+
+/// Reads the most recently generated random seed.
+pub fn read_random_seed(cache_dir: &Utf8Path) -> Result<Option<u64>> {
+    read_json(cache_dir, CacheFile::RandomSeed)
+}
+
 /// Lists subdirectories of `parent` whose name starts with `prefix`.
 ///
 /// Returns an empty vec if `parent` does not exist. Non-UTF-8 entries and
@@ -639,6 +650,19 @@ mod tests {
 
         let read = read_last_failed(&cache_dir).unwrap();
         assert!(read.is_empty());
+    }
+
+    #[test]
+    fn random_seed_roundtrips() {
+        let tmp = tempfile::tempdir().expect("create temp directory");
+        let cache_dir = Utf8PathBuf::try_from(tmp.path().to_path_buf()).expect("UTF-8 temp path");
+
+        write_random_seed(&cache_dir, 170_938).expect("write random seed");
+
+        assert_eq!(
+            read_random_seed(&cache_dir).expect("read random seed"),
+            Some(170_938)
+        );
     }
 
     #[test]

--- a/crates/karva_cache/src/lib.rs
+++ b/crates/karva_cache/src/lib.rs
@@ -7,7 +7,8 @@ pub(crate) mod hash;
 
 pub use cache::{
     AggregatedResults, CurrentTest, PruneResult, RunCache, clean_cache, prune_cache,
-    read_last_failed, read_recent_durations, write_last_failed,
+    read_last_failed, read_random_seed, read_recent_durations, write_last_failed,
+    write_random_seed,
 };
 pub use hash::RunHash;
 pub use karva_diagnostic::{DisplayFlakyTests, FlakyTest};

--- a/crates/karva_cli/src/lib.rs
+++ b/crates/karva_cli/src/lib.rs
@@ -30,7 +30,7 @@ pub use show_config::ShowConfigCommand;
 pub use snapshot::{
     SnapshotAction, SnapshotCommand, SnapshotDeleteArgs, SnapshotFilterArgs, SnapshotPruneArgs,
 };
-pub use test::{SubTestCommand, TestCommand};
+pub use test::{RandomSeed, SubTestCommand, TestCommand};
 pub use verbosity::Verbosity;
 
 const STYLES: Styles = Styles::styled()

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -371,8 +371,10 @@ pub struct TestCommand {
     shuffle: Option<bool>,
 
     /// Seed used by `--shuffle`. Does not enable shuffling by itself.
+    ///
+    /// Pass `last` to reuse the most recently generated seed.
     #[clap(long, value_name = "SEED", help_heading = "Runner options")]
-    random_seed: Option<u64>,
+    random_seed: Option<RandomSeed>,
 
     /// Number of parallel workers (default: number of CPU cores)
     #[clap(short = 'n', long, help_heading = "Runner options")]
@@ -473,6 +475,11 @@ impl TestCommand {
     pub fn verbosity(&self) -> &Verbosity {
         &self.sub_command.verbosity
     }
+
+    /// Returns the controller-side random seed selection.
+    pub fn random_seed(&self) -> Option<RandomSeed> {
+        self.random_seed
+    }
 }
 
 impl SubTestCommand {
@@ -567,7 +574,7 @@ impl TestCommand {
         let run_timeout = self.run_timeout;
         let termination_grace_period = self.termination_grace_period;
         let shuffle = self.shuffle;
-        let random_seed = self.random_seed;
+        let random_seed = self.random_seed.and_then(RandomSeed::value);
         let mut sub_command = self.sub_command;
         if self.no_capture {
             sub_command.show_output = Some(true);
@@ -581,6 +588,39 @@ impl TestCommand {
                 termination_grace_period.map(TerminationGracePeriodSecs);
         }
         options
+    }
+}
+
+/// User selection for the run's base random seed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RandomSeed {
+    /// A concrete reproducible seed.
+    Value(u64),
+
+    /// The most recently generated seed stored in Karva's cache.
+    Last,
+}
+
+impl RandomSeed {
+    /// Returns the concrete value, or `None` for [`Self::Last`].
+    const fn value(self) -> Option<u64> {
+        match self {
+            Self::Value(value) => Some(value),
+            Self::Last => None,
+        }
+    }
+}
+
+impl std::str::FromStr for RandomSeed {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value == "last" {
+            return Ok(Self::Last);
+        }
+        value.parse().map(Self::Value).map_err(|error| {
+            format!("`{value}` is not a valid random seed; expected an integer or `last`: {error}")
+        })
     }
 }
 
@@ -627,7 +667,14 @@ mod tests {
     use camino::Utf8PathBuf;
     use clap::Parser as _;
 
-    use super::{CovReport, TestCommand, parse_cov_report};
+    use super::{CovReport, RandomSeed, TestCommand, parse_cov_report};
+
+    #[test]
+    fn random_seed_accepts_last_generated_seed() {
+        let command = TestCommand::parse_from(["karva-test", "--random-seed=last"]);
+
+        assert_eq!(command.random_seed(), Some(RandomSeed::Last));
+    }
 
     #[test]
     fn optional_bool_flags_accept_equals_false() {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -146,7 +146,8 @@ karva test [OPTIONS] [PATH]...
 </dd><dt id="karva-test--profile"><a href="#karva-test--profile"><code>--profile</code></a>, <code>-P</code> <i>name</i></dt><dd><p>Configuration profile to use.</p>
 <p>Profiles are defined as <code>&#91;profile.&lt;name&gt;&#93;</code> sections in <code>karva.toml</code> (or <code>&#91;tool.karva.profile.&lt;name&gt;&#93;</code> in <code>pyproject.toml</code>) and may override any of the <code>&#91;src&#93;</code>, <code>&#91;terminal&#93;</code>, and <code>&#91;test&#93;</code> settings. The selected profile is layered on top of any <code>&#91;profile.default&#93;</code> overrides, which themselves layer on top of the top-level options.</p>
 <p>Defaults to <code>default</code>.</p>
-<p>May also be set with the <code>KARVA_PROFILE</code> environment variable.</p></dd><dt id="karva-test--random-seed"><a href="#karva-test--random-seed"><code>--random-seed</code></a> <i>seed</i></dt><dd><p>Seed used by <code>--shuffle</code>. Does not enable shuffling by itself</p>
+<p>May also be set with the <code>KARVA_PROFILE</code> environment variable.</p></dd><dt id="karva-test--random-seed"><a href="#karva-test--random-seed"><code>--random-seed</code></a> <i>seed</i></dt><dd><p>Seed used by <code>--shuffle</code>. Does not enable shuffling by itself.</p>
+<p>Pass <code>last</code> to reuse the most recently generated seed.</p>
 </dd><dt id="karva-test--result-format"><a href="#karva-test--result-format"><code>--result-format</code></a> <i>format</i></dt><dd><p>Machine-readable test result format</p>
 <p>Possible values:</p>
 <ul>

--- a/docs/usage/running-tests/shuffle.md
+++ b/docs/usage/running-tests/shuffle.md
@@ -42,6 +42,15 @@ random-seed = 170938
 `random-seed` does not enable shuffling by itself. Leave it unset to generate a
 new seed for each invocation.
 
+Use the most recently generated seed again without copying it from output:
+
+```bash
+uv run karva test --shuffle --random-seed last
+```
+
+Karva stores that seed in `.karva_cache/random-seed.json`. `last` is a CLI-only
+selector; configuration files accept integer seeds.
+
 ## Selection and scheduling
 
 Karva applies test selection before seeded ordering. `--last-failed` narrows the


### PR DESCRIPTION
## Summary

Persists the most recently generated shuffle seed and adds `--random-seed=last` to replay it without copying the value from output. Missing or disabled caches produce direct errors. This is independent of #1213 and targets `main` on its own.

## Test plan

`just test -p karva generated_seed_reproduces_single_worker_order`, `just test -p karva_cache random_seed_roundtrips`, `just test -p karva_cli random_seed_accepts_last_generated_seed`, `cargo hawk check -D warnings -D hawk::unnecessary_crate_visibility`, and `uvx prek run -a`.