### PR TITLE
Simplify seeded shuffle integration tests

### DIFF
--- a/crates/karva/tests/it/common/mod.rs
+++ b/crates/karva/tests/it/common/mod.rs
@@ -79,6 +79,7 @@ impl TestContext {
         settings.add_filter(r"[-─]{30,}", "[LONG-LINE]");
         settings.add_filter(r"karva \d+\.\d+\.\d+[a-zA-Z0-9._-]*", "karva [VERSION]");
         settings.add_filter(r"karva\.exe", "karva");
+        settings.add_filter(r"Random seed: \d+", "Random seed: [SEED]");
         settings.add_filter(
             r"(?:File exists \(os error 17\)|Cannot create a file when that file already exists\. \(os error 183\))",
             "[FILE EXISTS]",

--- a/crates/karva/tests/it/shuffle.rs
+++ b/crates/karva/tests/it/shuffle.rs
@@ -1,5 +1,3 @@
-use std::process::Output;
-
 use insta::assert_snapshot;
 use insta_cmd::assert_cmd_snapshot;
 use serde_json::Value;
@@ -16,47 +14,6 @@ def _record(name):
         output.write(f"{name}\n")
 "#;
 
-struct ShuffledRun {
-    output: Output,
-    seed: u64,
-    orders: Vec<Vec<String>>,
-}
-
-fn snapshot(output: &Output, worker_orders: &[Vec<String>]) -> String {
-    let stdout = String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .map(|line| {
-            line.strip_prefix("Random seed: ")
-                .map_or(line, |_| "Random seed: [SEED]")
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
-    let output = format!(
-        "success: {}\nexit_code: {}\n----- stdout -----\n{stdout}\n----- stderr -----\n{}",
-        output.status.success(),
-        output.status.code().map_or(-1, |code| code),
-        String::from_utf8_lossy(&output.stderr),
-    );
-    let orders = worker_orders
-        .iter()
-        .enumerate()
-        .map(|(worker, orders)| format!("worker {worker}: {orders:?}"))
-        .collect::<Vec<_>>()
-        .join("\n");
-    if orders.is_empty() {
-        output
-    } else {
-        format!("{output}\n----- worker orders -----\n{orders}")
-    }
-}
-
-fn snapshots(runs: &[(&str, &Output, &[Vec<String>])]) -> String {
-    runs.iter()
-        .map(|(label, output, orders)| format!("{label}:\n{}", snapshot(output, orders)))
-        .collect::<Vec<_>>()
-        .join("\n\n")
-}
-
 fn recording_tests(names: &[&str]) -> String {
     let tests = names
         .iter()
@@ -66,55 +23,6 @@ fn recording_tests(names: &[&str]) -> String {
     format!("{RECORDER}\n{tests}\n")
 }
 
-fn run_shuffled(
-    context: &TestContext,
-    workers: usize,
-    seed: Option<u64>,
-    args: &[&str],
-) -> ShuffledRun {
-    for worker in 0..workers {
-        context.write_file(format!("order-{worker}.txt"), "");
-    }
-    let mut command = if workers == 1 {
-        context.command_no_parallel()
-    } else {
-        let mut command = context.command();
-        command.arg(format!("--num-workers={workers}"));
-        command
-    };
-    command.args(["--shuffle", "--status-level=none"]);
-    if let Some(seed) = seed {
-        command.arg(format!("--random-seed={seed}"));
-    }
-    command.args(args);
-
-    let output = command.output().expect("run shuffled tests");
-    let actual_seed = String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .find_map(|line| line.strip_prefix("Random seed: "))
-        .expect("seed should be printed")
-        .parse::<u64>()
-        .expect("seed should be a u64");
-    if let Some(seed) = seed {
-        assert_eq!(actual_seed, seed);
-    }
-
-    let orders = (0..workers)
-        .map(|worker| {
-            context
-                .read_file(format!("order-{worker}.txt"))
-                .lines()
-                .map(str::to_string)
-                .collect()
-        })
-        .collect();
-    ShuffledRun {
-        output,
-        seed: actual_seed,
-        orders,
-    }
-}
-
 #[test]
 fn generated_seed_reproduces_single_worker_order() {
     let context = TestContext::with_file(
@@ -122,37 +30,42 @@ fn generated_seed_reproduces_single_worker_order() {
         &recording_tests(&["a", "b", "c", "d", "e", "f"]),
     );
 
-    let first = run_shuffled(&context, 1, None, &[]);
-    let repeated = run_shuffled(&context, 1, None, &["--random-seed=last"]);
-
-    assert_snapshot!(
-        snapshots(&[
-            ("generated", &first.output, &[]),
-            ("replayed", &repeated.output, &[]),
-        ]),
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .args(["--shuffle", "--status-level=none"]),
         @"
-    generated:
     success: true
     exit_code: 0
     ----- stdout -----
     Random seed: [SEED]
     ────────────
          Summary [TIME] 6 tests run: 6 passed, 0 skipped
-    ----- stderr -----
 
-
-    replayed:
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    Random seed: [SEED]
-    ────────────
-         Summary [TIME] 6 tests run: 6 passed, 0 skipped
     ----- stderr -----
     "
     );
-    assert_eq!(first.orders, repeated.orders);
-    assert_eq!(first.seed, repeated.seed);
+    let generated_order = context.read_file("order-0.txt");
+
+    context.write_file("order-0.txt", "");
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
+            "--shuffle",
+            "--random-seed=last",
+            "--status-level=none",
+        ]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Random seed: [SEED]
+    ────────────
+         Summary [TIME] 6 tests run: 6 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+    assert_eq!(context.read_file("order-0.txt"), generated_order);
 }
 
 #[test]
@@ -202,42 +115,63 @@ fn parallel_worker_assignment_and_order_are_reproducible() {
         &recording_tests(&["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]),
     );
 
-    let first = run_shuffled(&context, 2, Some(SEED), &[]);
-    let repeated = run_shuffled(&context, 2, Some(SEED), &[]);
-
-    assert_snapshot!(
-        snapshots(&[
-            ("first", &first.output, &first.orders),
-            ("replayed", &repeated.output, &repeated.orders),
+    assert_cmd_snapshot!(
+        context.command().args([
+            "--num-workers=2",
+            "--shuffle",
+            "--random-seed=170938",
+            "--status-level=none",
         ]),
-        @r#"
-    first:
+        @"
     success: true
     exit_code: 0
     ----- stdout -----
     Random seed: [SEED]
     ────────────
          Summary [TIME] 10 tests run: 10 passed, 0 skipped
+
     ----- stderr -----
-
-    ----- worker orders -----
-    worker 0: ["d", "e", "h", "i"]
-    worker 1: ["a", "b", "c", "f", "g", "j"]
-
-    replayed:
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    Random seed: [SEED]
-    ────────────
-         Summary [TIME] 10 tests run: 10 passed, 0 skipped
-    ----- stderr -----
-
-    ----- worker orders -----
-    worker 0: ["d", "e", "h", "i"]
-    worker 1: ["a", "b", "c", "f", "g", "j"]
-    "#
+    "
     );
+    let first_worker_0 = context.read_file("order-0.txt");
+    let first_worker_1 = context.read_file("order-1.txt");
+    assert_snapshot!(first_worker_0, @"
+    d
+    e
+    h
+    i
+    ");
+    assert_snapshot!(first_worker_1, @"
+    a
+    b
+    c
+    f
+    g
+    j
+    ");
+
+    context.write_file("order-0.txt", "");
+    context.write_file("order-1.txt", "");
+    assert_cmd_snapshot!(
+        context.command().args([
+            "--num-workers=2",
+            "--shuffle",
+            "--random-seed=170938",
+            "--status-level=none",
+        ]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Random seed: [SEED]
+    ────────────
+         Summary [TIME] 10 tests run: 10 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+    assert_eq!(context.read_file("order-0.txt"), first_worker_0);
+    assert_eq!(context.read_file("order-1.txt"), first_worker_1);
 }
 
 #[test]
@@ -247,44 +181,54 @@ fn filtering_precedes_seeded_ordering() {
         &recording_tests(&["drop_a", "keep_a", "drop_b", "keep_b", "drop_c", "keep_c"]),
     );
 
-    let filtered = run_shuffled(&context, 1, Some(SEED), &["--filter=test(~keep)"]);
-    context.write_file(
-        "test_order.py",
-        &recording_tests(&["keep_a", "keep_b", "keep_c"]),
-    );
-    let selected = run_shuffled(&context, 1, Some(SEED), &[]);
-
-    assert_snapshot!(
-        snapshots(&[
-            ("filtered", &filtered.output, &filtered.orders),
-            ("selected", &selected.output, &selected.orders),
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
+            "--shuffle",
+            "--random-seed=170938",
+            "--status-level=none",
+            "--filter=test(~keep)",
         ]),
-        @r#"
-    filtered:
+        @"
     success: true
     exit_code: 0
     ----- stdout -----
     Random seed: [SEED]
     ────────────
          Summary [TIME] 6 tests run: 3 passed, 3 skipped
+
     ----- stderr -----
+    "
+    );
+    let filtered_order = context.read_file("order-0.txt");
+    assert_snapshot!(filtered_order, @"
+    keep_a
+    keep_b
+    keep_c
+    ");
 
-    ----- worker orders -----
-    worker 0: ["keep_a", "keep_b", "keep_c"]
-
-    selected:
+    context.write_file(
+        "test_order.py",
+        &recording_tests(&["keep_a", "keep_b", "keep_c"]),
+    );
+    context.write_file("order-0.txt", "");
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
+            "--shuffle",
+            "--random-seed=170938",
+            "--status-level=none",
+        ]),
+        @"
     success: true
     exit_code: 0
     ----- stdout -----
     Random seed: [SEED]
     ────────────
          Summary [TIME] 3 tests run: 3 passed, 0 skipped
-    ----- stderr -----
 
-    ----- worker orders -----
-    worker 0: ["keep_a", "keep_b", "keep_c"]
-    "#
+    ----- stderr -----
+    "
     );
+    assert_eq!(context.read_file("order-0.txt"), filtered_order);
 }
 
 #[test]
@@ -294,20 +238,29 @@ fn partition_selection_precedes_seeded_ordering() {
         &recording_tests(&["a", "b", "c", "d", "e", "f"]),
     );
 
-    let run = run_shuffled(&context, 1, Some(170_939), &["--partition=slice:2/2"]);
-
-    assert_snapshot!(snapshot(&run.output, &run.orders), @r#"
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
+            "--shuffle",
+            "--random-seed=170939",
+            "--status-level=none",
+            "--partition=slice:2/2",
+        ]),
+        @"
     success: true
     exit_code: 0
     ----- stdout -----
     Random seed: [SEED]
     ────────────
          Summary [TIME] 3 tests run: 3 passed, 0 skipped
-    ----- stderr -----
 
-    ----- worker orders -----
-    worker 0: ["b", "d", "f"]
-    "#);
+    ----- stderr -----
+    "
+    );
+    assert_snapshot!(context.read_file("order-0.txt"), @"
+    b
+    d
+    f
+    ");
 }
 
 #[test]
@@ -329,9 +282,14 @@ def test_z(): _record("z")
         ),
     );
 
-    let run = run_shuffled(&context, 1, Some(SEED), &["--retry=1"]);
-
-    assert_snapshot!(snapshot(&run.output, &run.orders), @r#"
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
+            "--shuffle",
+            "--random-seed=170938",
+            "--status-level=none",
+            "--retry=1",
+        ]),
+        @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -339,11 +297,16 @@ def test_z(): _record("z")
     ────────────
          Summary [TIME] 3 tests run: 3 passed (1 flaky), 0 skipped
        FLAKY 2/2 [TIME] test_order::test_flaky
-    ----- stderr -----
 
-    ----- worker orders -----
-    worker 0: ["a", "flaky:1", "flaky:2", "z"]
-    "#);
+    ----- stderr -----
+    "
+    );
+    assert_snapshot!(context.read_file("order-0.txt"), @"
+    a
+    flaky:1
+    flaky:2
+    z
+    ");
 }
 
 #[test]
@@ -363,48 +326,46 @@ status-level = "none"
         ),
     ]);
 
-    let mut json_command = context.command_no_parallel();
-    json_command.arg("--result-output=results.json");
-    let json_output = json_command.output().expect("write JSON report");
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .arg("--result-output=results.json"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Random seed: [SEED]
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
     let json: Value =
         serde_json::from_str(&context.read_file("results.json")).expect("JSON report should parse");
+    assert_eq!(json["random_seed"], SEED);
 
-    let mut jsonl_command = context.command_no_parallel();
-    jsonl_command.args(["--result-output=results.jsonl", "--result-format=jsonl"]);
-    let jsonl_output = jsonl_command.output().expect("write JSONL report");
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
+            "--result-output=results.jsonl",
+            "--result-format=jsonl",
+        ]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Random seed: [SEED]
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
     let finished: Value = context
         .read_file("results.jsonl")
         .lines()
         .map(|line| serde_json::from_str(line).expect("JSONL record should parse"))
         .find(|record: &Value| record["type"] == "run_finished")
         .expect("run_finished record should exist");
-
-    assert_snapshot!(
-        snapshots(&[
-            ("json", &json_output, &[]),
-            ("jsonl", &jsonl_output, &[]),
-        ]),
-        @"
-    json:
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    Random seed: [SEED]
-    ────────────
-         Summary [TIME] 1 test run: 1 passed, 0 skipped
-    ----- stderr -----
-
-
-    jsonl:
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    Random seed: [SEED]
-    ────────────
-         Summary [TIME] 1 test run: 1 passed, 0 skipped
-    ----- stderr -----
-    "
-    );
-    assert_eq!(json["random_seed"], SEED);
     assert_eq!(finished["random_seed"], SEED);
 }


### PR DESCRIPTION
## Summary

Replace custom shuffled-run and command-output formatting with direct insta-cmd snapshots, while snapshotting worker order files separately. Preserve seed replay, worker assignment, filtering, partitioning, retry, and result-report coverage. Closes #1209.

## Test Plan

`just test -p karva shuffle` and `uvx prek run -a`.