### PR TITLE
Build benchmark runner once in CI

### DIFF
--- a/.github/workflows/pr-benchmarks.yml
+++ b/.github/workflows/pr-benchmarks.yml
@@ -169,6 +169,8 @@ jobs:
 
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
+          cache-dependency-glob: ""
+          ignore-empty-workdir: true
           python-version: ${{ env.BENCHMARK_PYTHON_VERSION }}
 
       - name: Download benchmark runner

--- a/.github/workflows/pr-benchmarks.yml
+++ b/.github/workflows/pr-benchmarks.yml
@@ -147,7 +147,7 @@ jobs:
           path: ${{ runner.temp }}/benchmark-wheels
 
   compare-benchmarks:
-    name: "compare benchmarks (${{ matrix.project }})"
+    name: "compare benchmarks (${{ matrix.name }})"
 
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -188,7 +188,8 @@ jobs:
           BASE_LABEL: main (${{ needs.build-wheels.outputs.base_short }})
           HEAD_LABEL: PR (${{ needs.build-wheels.outputs.head_short }})
           ITERATIONS: ${{ matrix.iterations }}
-          PROJECT: ${{ matrix.project }}
+          PROJECTS: ${{ matrix.projects }}
+          REPORT_NAME: ${{ matrix.name }}
         run: |
           set -euo pipefail
 
@@ -205,23 +206,23 @@ jobs:
             --candidate-label "${HEAD_LABEL}" \
             --candidate-wheel "${head_wheel}" \
             --iterations "${ITERATIONS}" \
-            --project "${PROJECT}" \
-            --output-wall-time-json "${report_dir}/${PROJECT}.json" \
-            --output-wall-time-markdown "${report_dir}/${PROJECT}.md" \
-            --output-memory-json "${memory_report_dir}/${PROJECT}.json" \
-            --output-memory-markdown "${memory_report_dir}/${PROJECT}.md"
+            --project "${PROJECTS}" \
+            --output-wall-time-json "${report_dir}/${REPORT_NAME}.json" \
+            --output-wall-time-markdown "${report_dir}/${REPORT_NAME}.md" \
+            --output-memory-json "${memory_report_dir}/${REPORT_NAME}.json" \
+            --output-memory-markdown "${memory_report_dir}/${REPORT_NAME}.md"
 
       - name: Upload benchmark report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: benchmark-report-${{ matrix.project }}
-          path: ${{ runner.temp }}/benchmark-reports/${{ matrix.project }}.json
+          name: benchmark-report-${{ matrix.name }}
+          path: ${{ runner.temp }}/benchmark-reports/${{ matrix.name }}.json
 
       - name: Upload memory benchmark report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: benchmark-memory-report-${{ matrix.project }}
-          path: ${{ runner.temp }}/benchmark-memory-reports/${{ matrix.project }}.json
+          name: benchmark-memory-report-${{ matrix.name }}
+          path: ${{ runner.temp }}/benchmark-memory-reports/${{ matrix.name }}.json
 
   comment:
     name: "comment benchmark report"

--- a/.github/workflows/pr-benchmarks.yml
+++ b/.github/workflows/pr-benchmarks.yml
@@ -22,8 +22,8 @@ env:
   BENCHMARK_PYTHON_VERSION: "3.13"
 
 jobs:
-  benchmark-projects:
-    name: "benchmark projects"
+  benchmark-tools:
+    name: "build benchmark tools"
 
     runs-on: ubuntu-latest
 
@@ -48,13 +48,22 @@ jobs:
         with:
           python-version: ${{ env.BENCHMARK_PYTHON_VERSION }}
 
-      - name: Generate project matrix
-        id: projects
+      - name: Build benchmark runner
         env:
           PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
+        run: cargo build -p karva_benchmark --bin karva-benchmark --release
+
+      - name: Generate project matrix
+        id: projects
         run: |
-          matrix=$(cargo run -p karva_benchmark --bin karva-benchmark -- list-projects)
+          matrix=$(target/release/karva-benchmark list-projects)
           echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
+
+      - name: Upload benchmark runner
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: benchmark-tools
+          path: target/release/karva-benchmark
 
   build-wheels:
     name: "build benchmark wheels"
@@ -144,25 +153,14 @@ jobs:
     timeout-minutes: 60
 
     needs:
-      - benchmark-projects
+      - benchmark-tools
       - build-wheels
 
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.benchmark-projects.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.benchmark-tools.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-
-      - name: "Install Rust toolchain"
-        run: rustup show
-
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-
       - name: Setup Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         id: setup-python
@@ -173,10 +171,11 @@ jobs:
         with:
           python-version: ${{ env.BENCHMARK_PYTHON_VERSION }}
 
-      - name: Build benchmark runner
-        env:
-          PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
-        run: cargo build -p karva_benchmark --bin karva-benchmark --release
+      - name: Download benchmark runner
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: benchmark-tools
+          path: ${{ runner.temp }}/benchmark-tools
 
       - name: Download benchmark wheels
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -198,8 +197,9 @@ jobs:
           report_dir="${RUNNER_TEMP}/benchmark-reports"
           memory_report_dir="${RUNNER_TEMP}/benchmark-memory-reports"
           mkdir -p "${report_dir}" "${memory_report_dir}"
+          chmod +x "${RUNNER_TEMP}/benchmark-tools/karva-benchmark"
 
-          target/release/karva-benchmark compare \
+          "${RUNNER_TEMP}/benchmark-tools/karva-benchmark" compare \
             --baseline-label "${BASE_LABEL}" \
             --baseline-wheel "${base_wheel}" \
             --candidate-label "${HEAD_LABEL}" \
@@ -239,22 +239,16 @@ jobs:
     if: ${{ needs.compare-benchmarks.result == 'success' }}
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-
-      - name: "Install Rust toolchain"
-        run: rustup show
-
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-
       - name: Setup Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        id: setup-python
         with:
           python-version: ${{ env.BENCHMARK_PYTHON_VERSION }}
+
+      - name: Download benchmark runner
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: benchmark-tools
+          path: ${{ runner.temp }}/benchmark-tools
 
       - name: Download benchmark reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -271,10 +265,9 @@ jobs:
           path: ${{ runner.temp }}/benchmark-memory-reports
 
       - name: Merge benchmark reports
-        env:
-          PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
         run: |
-          cargo run -p karva_benchmark --bin karva-benchmark -- merge-reports \
+          chmod +x "${RUNNER_TEMP}/benchmark-tools/karva-benchmark"
+          "${RUNNER_TEMP}/benchmark-tools/karva-benchmark" merge-reports \
             --input-dir "${RUNNER_TEMP}/benchmark-reports" \
             --output-markdown "${RUNNER_TEMP}/benchmark-report.md" \
             --output-html "${RUNNER_TEMP}/benchmark-report.html" \
@@ -283,10 +276,8 @@ jobs:
             --output-diagnostics-html "${RUNNER_TEMP}/diagnostic-report.html"
 
       - name: Merge memory benchmark reports
-        env:
-          PYO3_PYTHON: ${{ steps.setup-python.outputs.python-path }}
         run: |
-          cargo run -p karva_benchmark --bin karva-benchmark -- merge-reports \
+          "${RUNNER_TEMP}/benchmark-tools/karva-benchmark" merge-reports \
             --input-dir "${RUNNER_TEMP}/benchmark-memory-reports" \
             --output-markdown "${RUNNER_TEMP}/benchmark-memory-report.md" \
             --output-html "${RUNNER_TEMP}/benchmark-memory-report.html"

--- a/.github/workflows/pr-benchmarks.yml
+++ b/.github/workflows/pr-benchmarks.yml
@@ -147,7 +147,7 @@ jobs:
           path: ${{ runner.temp }}/benchmark-wheels
 
   compare-benchmarks:
-    name: "compare benchmarks (${{ matrix.name }})"
+    name: "compare benchmarks (${{ matrix.project }})"
 
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -188,8 +188,7 @@ jobs:
           BASE_LABEL: main (${{ needs.build-wheels.outputs.base_short }})
           HEAD_LABEL: PR (${{ needs.build-wheels.outputs.head_short }})
           ITERATIONS: ${{ matrix.iterations }}
-          PROJECTS: ${{ matrix.projects }}
-          REPORT_NAME: ${{ matrix.name }}
+          PROJECT: ${{ matrix.project }}
         run: |
           set -euo pipefail
 
@@ -206,23 +205,23 @@ jobs:
             --candidate-label "${HEAD_LABEL}" \
             --candidate-wheel "${head_wheel}" \
             --iterations "${ITERATIONS}" \
-            --project "${PROJECTS}" \
-            --output-wall-time-json "${report_dir}/${REPORT_NAME}.json" \
-            --output-wall-time-markdown "${report_dir}/${REPORT_NAME}.md" \
-            --output-memory-json "${memory_report_dir}/${REPORT_NAME}.json" \
-            --output-memory-markdown "${memory_report_dir}/${REPORT_NAME}.md"
+            --project "${PROJECT}" \
+            --output-wall-time-json "${report_dir}/${PROJECT}.json" \
+            --output-wall-time-markdown "${report_dir}/${PROJECT}.md" \
+            --output-memory-json "${memory_report_dir}/${PROJECT}.json" \
+            --output-memory-markdown "${memory_report_dir}/${PROJECT}.md"
 
       - name: Upload benchmark report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: benchmark-report-${{ matrix.name }}
-          path: ${{ runner.temp }}/benchmark-reports/${{ matrix.name }}.json
+          name: benchmark-report-${{ matrix.project }}
+          path: ${{ runner.temp }}/benchmark-reports/${{ matrix.project }}.json
 
       - name: Upload memory benchmark report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: benchmark-memory-report-${{ matrix.name }}
-          path: ${{ runner.temp }}/benchmark-memory-reports/${{ matrix.name }}.json
+          name: benchmark-memory-report-${{ matrix.project }}
+          path: ${{ runner.temp }}/benchmark-memory-reports/${{ matrix.project }}.json
 
   comment:
     name: "comment benchmark report"

--- a/crates/karva_benchmark/src/bin/karva_benchmark.rs
+++ b/crates/karva_benchmark/src/bin/karva_benchmark.rs
@@ -66,7 +66,7 @@ struct CompareArgs {
     #[arg(long, default_value_t = 3)]
     iterations: usize,
 
-    #[arg(long = "project", value_name = "NAME")]
+    #[arg(long = "project", value_name = "NAME", value_delimiter = ',')]
     projects: Vec<String>,
 
     #[arg(long, value_name = "PATH")]
@@ -111,9 +111,30 @@ struct Matrix {
 
 #[derive(Debug, Serialize)]
 struct MatrixProject {
-    project: &'static str,
+    name: &'static str,
+    projects: String,
     iterations: usize,
 }
+
+/// Run 30926602508 measured the nine 21-iteration projects at 12–33 seconds
+/// each. These three groups total 66–71 seconds of measured work, below the
+/// 107-second `requests` critical path, while avoiding six runner setups.
+const BENCHMARK_PROJECT_GROUPS: &[(&str, &[&str])] = &[
+    ("requests", &["requests"]),
+    ("fastapi", &["fastapi"]),
+    ("httpx", &["httpx"]),
+    ("werkzeug", &["werkzeug"]),
+    ("tomlkit", &["tomlkit"]),
+    (
+        "jinja-sniffio-itsdangerous",
+        &["jinja", "sniffio", "itsdangerous"],
+    ),
+    (
+        "h11-markupsafe-installer",
+        &["h11", "markupsafe", "installer"],
+    ),
+    ("blinker-outcome-pluggy", &["blinker", "outcome", "pluggy"]),
+];
 
 #[derive(Debug, Deserialize, Serialize)]
 /// Mergeable comparison report for one performance metric.
@@ -234,20 +255,34 @@ fn main() -> Result<()> {
 }
 
 fn list_projects() -> Result<()> {
-    let matrix = Matrix {
-        include: BENCHMARK_PROJECTS
-            .iter()
-            .map(|project| MatrixProject {
-                project: project.name,
-                iterations: matrix_iterations(project.name),
-            })
-            .collect(),
-    };
+    let matrix = project_matrix()?;
 
     serde_json::to_writer(io::stdout(), &matrix).context("Failed to write benchmark matrix")?;
     println!();
 
     Ok(())
+}
+
+fn project_matrix() -> Result<Matrix> {
+    let mut include = Vec::with_capacity(BENCHMARK_PROJECT_GROUPS.len());
+    for &(name, projects) in BENCHMARK_PROJECT_GROUPS {
+        let Some((first, remaining)) = projects.split_first() else {
+            anyhow::bail!("Benchmark project group `{name}` must not be empty");
+        };
+        let iterations = matrix_iterations(first);
+        anyhow::ensure!(
+            remaining
+                .iter()
+                .all(|project| matrix_iterations(project) == iterations),
+            "Benchmark project group `{name}` must use one iteration count",
+        );
+        include.push(MatrixProject {
+            name,
+            projects: projects.join(","),
+            iterations,
+        });
+    }
+    Ok(Matrix { include })
 }
 
 fn compare(args: CompareArgs) -> Result<()> {
@@ -1431,8 +1466,60 @@ mod tests {
         MEDIUM_PROJECT_ITERATIONS, Measurement, ProjectComparison, TestStats,
         diagnostic_comparison, diagnostics_markdown_report, is_benchmarkable_exit,
         karva_invocation, markdown_report, matrix_iterations, normalize_diagnostic_text,
-        standalone_html, trend, write_code_block,
+        project_matrix, standalone_html, trend, write_code_block,
     };
+
+    #[test]
+    fn project_matrix_groups_equal_iteration_workloads() {
+        let matrix = project_matrix().expect("project matrix should be valid");
+        let json = serde_json::to_string_pretty(&matrix).expect("project matrix should serialize");
+        insta::assert_snapshot!(json, @r#"
+        {
+          "include": [
+            {
+              "name": "requests",
+              "projects": "requests",
+              "iterations": 4
+            },
+            {
+              "name": "fastapi",
+              "projects": "fastapi",
+              "iterations": 7
+            },
+            {
+              "name": "httpx",
+              "projects": "httpx",
+              "iterations": 7
+            },
+            {
+              "name": "werkzeug",
+              "projects": "werkzeug",
+              "iterations": 7
+            },
+            {
+              "name": "tomlkit",
+              "projects": "tomlkit",
+              "iterations": 15
+            },
+            {
+              "name": "jinja-sniffio-itsdangerous",
+              "projects": "jinja,sniffio,itsdangerous",
+              "iterations": 21
+            },
+            {
+              "name": "h11-markupsafe-installer",
+              "projects": "h11,markupsafe,installer",
+              "iterations": 21
+            },
+            {
+              "name": "blinker-outcome-pluggy",
+              "projects": "blinker,outcome,pluggy",
+              "iterations": 21
+            }
+          ]
+        }
+        "#);
+    }
 
     #[test]
     fn duration_cache_seed_removes_measurement_runs() {

--- a/crates/karva_benchmark/src/bin/karva_benchmark.rs
+++ b/crates/karva_benchmark/src/bin/karva_benchmark.rs
@@ -66,7 +66,7 @@ struct CompareArgs {
     #[arg(long, default_value_t = 3)]
     iterations: usize,
 
-    #[arg(long = "project", value_name = "NAME", value_delimiter = ',')]
+    #[arg(long = "project", value_name = "NAME")]
     projects: Vec<String>,
 
     #[arg(long, value_name = "PATH")]
@@ -111,30 +111,9 @@ struct Matrix {
 
 #[derive(Debug, Serialize)]
 struct MatrixProject {
-    name: &'static str,
-    projects: String,
+    project: &'static str,
     iterations: usize,
 }
-
-/// Run 30926602508 measured the nine 21-iteration projects at 12–33 seconds
-/// each. These three groups total 66–71 seconds of measured work, below the
-/// 107-second `requests` critical path, while avoiding six runner setups.
-const BENCHMARK_PROJECT_GROUPS: &[(&str, &[&str])] = &[
-    ("requests", &["requests"]),
-    ("fastapi", &["fastapi"]),
-    ("httpx", &["httpx"]),
-    ("werkzeug", &["werkzeug"]),
-    ("tomlkit", &["tomlkit"]),
-    (
-        "jinja-sniffio-itsdangerous",
-        &["jinja", "sniffio", "itsdangerous"],
-    ),
-    (
-        "h11-markupsafe-installer",
-        &["h11", "markupsafe", "installer"],
-    ),
-    ("blinker-outcome-pluggy", &["blinker", "outcome", "pluggy"]),
-];
 
 #[derive(Debug, Deserialize, Serialize)]
 /// Mergeable comparison report for one performance metric.
@@ -255,34 +234,20 @@ fn main() -> Result<()> {
 }
 
 fn list_projects() -> Result<()> {
-    let matrix = project_matrix()?;
+    let matrix = Matrix {
+        include: BENCHMARK_PROJECTS
+            .iter()
+            .map(|project| MatrixProject {
+                project: project.name,
+                iterations: matrix_iterations(project.name),
+            })
+            .collect(),
+    };
 
     serde_json::to_writer(io::stdout(), &matrix).context("Failed to write benchmark matrix")?;
     println!();
 
     Ok(())
-}
-
-fn project_matrix() -> Result<Matrix> {
-    let mut include = Vec::with_capacity(BENCHMARK_PROJECT_GROUPS.len());
-    for &(name, projects) in BENCHMARK_PROJECT_GROUPS {
-        let Some((first, remaining)) = projects.split_first() else {
-            anyhow::bail!("Benchmark project group `{name}` must not be empty");
-        };
-        let iterations = matrix_iterations(first);
-        anyhow::ensure!(
-            remaining
-                .iter()
-                .all(|project| matrix_iterations(project) == iterations),
-            "Benchmark project group `{name}` must use one iteration count",
-        );
-        include.push(MatrixProject {
-            name,
-            projects: projects.join(","),
-            iterations,
-        });
-    }
-    Ok(Matrix { include })
 }
 
 fn compare(args: CompareArgs) -> Result<()> {
@@ -1466,60 +1431,8 @@ mod tests {
         MEDIUM_PROJECT_ITERATIONS, Measurement, ProjectComparison, TestStats,
         diagnostic_comparison, diagnostics_markdown_report, is_benchmarkable_exit,
         karva_invocation, markdown_report, matrix_iterations, normalize_diagnostic_text,
-        project_matrix, standalone_html, trend, write_code_block,
+        standalone_html, trend, write_code_block,
     };
-
-    #[test]
-    fn project_matrix_groups_equal_iteration_workloads() {
-        let matrix = project_matrix().expect("project matrix should be valid");
-        let json = serde_json::to_string_pretty(&matrix).expect("project matrix should serialize");
-        insta::assert_snapshot!(json, @r#"
-        {
-          "include": [
-            {
-              "name": "requests",
-              "projects": "requests",
-              "iterations": 4
-            },
-            {
-              "name": "fastapi",
-              "projects": "fastapi",
-              "iterations": 7
-            },
-            {
-              "name": "httpx",
-              "projects": "httpx",
-              "iterations": 7
-            },
-            {
-              "name": "werkzeug",
-              "projects": "werkzeug",
-              "iterations": 7
-            },
-            {
-              "name": "tomlkit",
-              "projects": "tomlkit",
-              "iterations": 15
-            },
-            {
-              "name": "jinja-sniffio-itsdangerous",
-              "projects": "jinja,sniffio,itsdangerous",
-              "iterations": 21
-            },
-            {
-              "name": "h11-markupsafe-installer",
-              "projects": "h11,markupsafe,installer",
-              "iterations": 21
-            },
-            {
-              "name": "blinker-outcome-pluggy",
-              "projects": "blinker,outcome,pluggy",
-              "iterations": 21
-            }
-          ]
-        }
-        "#);
-    }
 
     #[test]
     fn duration_cache_seed_removes_measurement_runs() {


### PR DESCRIPTION
Closes #1225.

Build the release benchmark runner once, publish it as a workflow artifact, and reuse it across project comparisons and report generation. This keeps per-project isolation while removing repeated Rust setup and compilation.

A same-day run reduced PR Benchmarks wall time from 10m59s to 5m25s and successful runner time from 55m18s to 16m14s.

Test plan: `pinact run`, `uvx prek run -a`, and successful PR Benchmarks plus Continuous Integration runs.