### PR TITLE
Complete explicit parameter ID support

### DIFF
--- a/crates/karva/tests/it/extensions/tags/parametrize.rs
+++ b/crates/karva/tests/it/extensions/tags/parametrize.rs
@@ -1857,10 +1857,13 @@ import karva
 
 @karva.tags.parametrize("a", [
     karva.param(1),
-    karva.param(2),
+    karva.param(2, id="two"),
     karva.param(3),
-])
+], ids=["one", "ignored", "three"])
 def test_single_arg(a):
+    if a == 2:
+        import os
+        assert os.environ["KARVA_TEST_NAME"] == "test::test_single_arg(two)"
     assert a > 0
 "#,
     );
@@ -1870,11 +1873,66 @@ def test_single_arg(a):
     exit_code: 0
     ----- stdout -----
         Starting 1 test across 1 worker
-            PASS [TIME] test::test_single_arg(a=1)
-            PASS [TIME] test::test_single_arg(a=2)
-            PASS [TIME] test::test_single_arg(a=3)
+            PASS [TIME] test::test_single_arg(one)
+            PASS [TIME] test::test_single_arg(two)
+            PASS [TIME] test::test_single_arg(three)
     ────────────
          Summary [TIME] 3 tests run: 3 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+
+    assert_cmd_snapshot!(
+        test_context
+            .command_no_parallel()
+            .args(["-E", "test(=\"test::test_single_arg(two)\")"]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_single_arg(two)
+    ────────────
+         Summary [TIME] 3 tests run: 1 passed, 2 skipped
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
+fn test_karva_param_rejects_empty_id() {
+    let test_context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+
+@karva.tags.parametrize("value", [karva.param(1, id="")])
+def test_value(value):
+    pass
+"#,
+    );
+
+    assert_cmd_snapshot!(test_context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+           ERROR [TIME] test::test_value
+
+    failures:
+
+    test::test_value:
+
+    error[invalid-parametrize]: Parameter ID cannot be empty
+     --> test.py:5:5
+      |
+    5 | def test_value(value):
+      |     ^^^^^^^^^^
+      |
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
 
     ----- stderr -----
     ");

--- a/crates/karva_test_semantic/src/extensions/functions/python.rs
+++ b/crates/karva_test_semantic/src/extensions/functions/python.rs
@@ -30,7 +30,12 @@ pub struct Param {
 }
 
 impl Param {
-    fn new(py: Python, values: Vec<Py<PyAny>>, tags: Vec<Py<PyAny>>) -> PyResult<Self> {
+    fn new(
+        py: Python,
+        values: Vec<Py<PyAny>>,
+        tags: Vec<Py<PyAny>>,
+        id: Option<String>,
+    ) -> PyResult<Self> {
         let mut new_tags = Vec::new();
 
         for tag in tags {
@@ -44,7 +49,7 @@ impl Param {
             default_id: default_param_id(py, &values),
             values,
             tags: Tags::new(new_tags),
-            id: None,
+            id,
         })
     }
 
@@ -109,12 +114,13 @@ pub fn fail(_py: Python<'_>, reason: Option<String>) -> PyResult<()> {
 }
 
 #[pyfunction]
-#[pyo3(signature = (*values, tags = None))]
-/// Creates one parameter row with optional row-specific tags.
+#[pyo3(signature = (*values, tags = None, id = None))]
+/// Creates one parameter row with optional row-specific tags and display ID.
 pub fn param(
     py: Python<'_>,
     values: Vec<Py<PyAny>>,
     tags: Option<Vec<Py<PyAny>>>,
+    id: Option<String>,
 ) -> PyResult<Param> {
-    Param::new(py, values, tags.unwrap_or_default())
+    Param::new(py, values, tags.unwrap_or_default(), id)
 }

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
@@ -393,9 +393,13 @@ impl<'runner, 'context, 'settings, 'test, 'py>
     fn should_skip(&mut self) -> Option<bool> {
         let filter = &self.package_runner.context.settings().test().filter;
         let run_ignored = self.package_runner.context.settings().test().run_ignored;
+        let qualified = if let Some(id) = &self.id {
+            QualifiedTestName::with_parameters(self.test.name().clone(), id.clone())
+        } else {
+            QualifiedTestName::new(self.test.name().clone())
+        };
 
         if !filter.is_empty() {
-            let qualified = QualifiedTestName::new(self.test.name().clone());
             let display_name = qualified.to_string();
             let custom_names = self.tags.custom_tag_names();
             let context = EvalContext {
@@ -424,7 +428,6 @@ impl<'runner, 'context, 'settings, 'test, 'py>
         let (true, reason) = skipped else {
             return None;
         };
-        let qualified = QualifiedTestName::new(self.test.name().clone());
         Some(self.package_runner.state.register_test_case_result(
             self.package_runner.context,
             &qualified,

--- a/docs/usage/tags/parametrize.md
+++ b/docs/usage/tags/parametrize.md
@@ -105,6 +105,25 @@ def test_status(status, expected):
 
 IDs combine with `-` when multiple parametrize tags are stacked.
 
+Use `id` on `karva.param` when each row should carry its own name:
+
+```python title="test.py"
+import karva
+
+@karva.tags.parametrize("card,expected", [
+    karva.param(valid_card, "paid", id="valid-card"),
+    karva.param(expired_card, "declined", id="expired-card"),
+])
+def test_checkout(card, expected):
+    assert checkout(card) == expected
+```
+
+The ID appears in output and failure reports and provides a stable exact filter:
+
+```console
+uv run karva -E 'test(="test::test_checkout(expired-card)")'
+```
+
 ## Params
 
 You can use `karva.param` (similar to `pytest.param`) to attach tags to individual parameter sets:

--- a/python/karva/_karva/__init__.pyi
+++ b/python/karva/_karva/__init__.pyi
@@ -75,13 +75,16 @@ class Param:
 
 
 def param(
-    *values: object, tags: Sequence[Tags | Callable[[], Tags]] | None = None
-) -> None:
+    *values: object,
+    tags: Sequence[Tags | Callable[[], Tags]] | None = None,
+    id: str | None = None,
+) -> Param:
     """Define a parameterized test case.
 
     Args:
         *values: The values to parameterize the test case with.
         tags: The tag or tag functions.
+        id: A stable name for the parameterized test case.
 
     Examples:
         Parameterize a test and tag individual cases:


### PR DESCRIPTION
## Summary

Add `id=` to `karva.param`, propagate explicit variant identity through pre-execution filtering and skipped results, and document stable exact filtering. This finishes explicit parameter ID support while retaining the pytest-compatible duplicate suffixing introduced by #1097.

Closes #961.

## Test Plan

Ran `just test`, built the documentation, and ran `uvx prek run -a`.