### PR TITLE
Improve generated configuration documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Run the documentation generator after changing configuration options, CLI
 arguments, or environment variable definitions:
 
 ```sh
-cargo run -p karva_dev generate-all
+cargo dev generate-all
 ```
 
 Files under `docs/reference/` and `docs/configuration/configuration.md` are

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,6 +1146,7 @@ dependencies = [
  "markdown",
  "pretty_assertions",
  "ruff_options_metadata",
+ "ruff_python_trivia",
  "schemars",
  "serde_json",
 ]

--- a/crates/karva_dev/Cargo.toml
+++ b/crates/karva_dev/Cargo.toml
@@ -24,6 +24,7 @@ itertools = { workspace = true }
 markdown = { workspace = true }
 pretty_assertions = { workspace = true }
 ruff_options_metadata = { workspace = true }
+ruff_python_trivia = { workspace = true }
 schemars = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/karva_dev/src/generate_cli_reference.rs
+++ b/crates/karva_dev/src/generate_cli_reference.rs
@@ -1,33 +1,30 @@
 //! Generate a Markdown-compatible reference for the karva command-line interface.
 use std::cmp::max;
 
-use anyhow::Result;
 use clap::{Command, CommandFactory};
 use itertools::Itertools;
 use karva_cli::Args as Cli;
 
 use crate::{Mode, apply_mode};
 
+const FILE_NAME: &str = "docs/reference/cli.md";
+const HEADER: &str = "<!-- WARNING: This file is auto-generated (cargo dev generate-all). Edit the doc comments in 'crates/karva/src/args.rs' if you want to change anything here. -->\n\n# CLI Reference\n\n";
 const SHOW_HIDDEN_COMMANDS: &[&str] = &["generate-shell-completion"];
-
-fn render_html(markdown_text: &str) -> String {
-    markdown::to_html(markdown_text)
-        .replace('[', "&#91;")
-        .replace(']', "&#93;")
-}
 
 #[derive(clap::Args)]
 pub struct Args {
+    /// Write the generated reference to stdout (rather than to `docs/reference/cli.md`).
     #[arg(long, default_value_t, value_enum)]
     pub mode: Mode,
 }
 
-pub fn main(args: &Args) -> Result<()> {
-    apply_mode(args.mode, "docs/reference/cli.md", &generate())
+pub fn main(args: &Args) -> anyhow::Result<()> {
+    apply_mode(args.mode, FILE_NAME, &generate())
 }
 
 fn generate() -> String {
     let mut output = String::new();
+    output.push_str(HEADER);
 
     let mut karva = Cli::command();
 
@@ -36,12 +33,15 @@ fn generate() -> String {
     karva.build();
 
     let mut parents = Vec::new();
-
-    output.push_str("<!-- WARNING: This file is auto-generated (cargo run -p karva_dev generate-all). Edit the doc comments in 'crates/karva/src/args.rs' if you want to change anything here. -->\n\n");
-    output.push_str("# CLI Reference\n\n");
     generate_command(&mut output, &karva, &mut parents);
 
     output
+}
+
+fn render_html(markdown_text: &str) -> String {
+    markdown::to_html(markdown_text)
+        .replace('[', "&#91;")
+        .replace(']', "&#93;")
 }
 
 #[expect(clippy::format_push_string)]
@@ -279,10 +279,10 @@ fn emit_possible_options(opt: &clap::Arg, output: &mut String) {
 
 #[cfg(test)]
 mod tests {
-
     use anyhow::Result;
 
-    use super::{Args, Mode, main};
+    use super::{Args, main};
+    use crate::Mode;
 
     #[test]
     #[cfg(unix)]

--- a/crates/karva_dev/src/generate_env_vars.rs
+++ b/crates/karva_dev/src/generate_env_vars.rs
@@ -7,17 +7,16 @@ use karva_static::{EnvVarDoc, EnvVars, WorkerEnvVars};
 
 use crate::{Mode, apply_mode};
 
+const FILE_NAME: &str = "docs/reference/env-vars.md";
+const HEADER: &str = "<!-- WARNING: This file is auto-generated (cargo dev generate-all). Update the doc comments on the env-var structs in 'crates/karva_static/src/lib.rs' if you want to change anything here. -->\n\n# Environment Variables\n\nThis page lists every environment variable that Karva reads from the \
+environment, plus the variables the worker exposes to running tests.\n\n";
+
 #[derive(clap::Args)]
 pub struct Args {
     /// Write the generated reference to stdout (rather than to `docs/reference/env-vars.md`).
     #[arg(long, default_value_t, value_enum)]
     pub mode: Mode,
 }
-
-const FILE_NAME: &str = "docs/reference/env-vars.md";
-
-const HEADER: &str = "<!-- WARNING: This file is auto-generated (cargo run -p karva_dev generate-all). Update the doc comments on the env-var structs in 'crates/karva_static/src/lib.rs' if you want to change anything here. -->\n\n# Environment Variables\n\nThis page lists every environment variable that Karva reads from the \
-environment, plus the variables the worker exposes to running tests.\n\n";
 
 pub fn main(args: &Args) -> anyhow::Result<()> {
     apply_mode(args.mode, FILE_NAME, &generate())

--- a/crates/karva_dev/src/generate_options.rs
+++ b/crates/karva_dev/src/generate_options.rs
@@ -3,7 +3,7 @@
 use std::fmt::Write;
 
 use itertools::Itertools;
-use karva_metadata::Options;
+use karva_metadata::{Config, Options};
 use ruff_options_metadata::{OptionField, OptionSet, OptionsMetadata, Visit};
 
 use crate::{Mode, apply_mode};
@@ -19,21 +19,28 @@ pub fn main(args: &Args) -> anyhow::Result<()> {
     let mut output = String::new();
 
     output.push_str(
-        "<!-- WARNING: This file is auto-generated (cargo dev generate-all). Update the doc comments on the 'Options' struct in 'crates/karva_project/src/metadata/options.rs' if you want to change anything here. -->\n\n",
+        "<!-- WARNING: This file is auto-generated (cargo run -p karva_dev generate-all). Update the doc comments on 'Config' and 'Options' in 'crates/karva_metadata/src/options/' if you want to change anything here. -->\n\n",
     );
 
     generate_set(
         &mut output,
+        Set::Toplevel(Config::metadata()),
+        &mut Vec::new(),
+        Root::Config,
+    );
+    generate_set(
+        &mut output,
         Set::Toplevel(Options::metadata()),
         &mut Vec::new(),
+        Root::Profile,
     );
 
     apply_mode(args.mode, "docs/configuration/configuration.md", &output)
 }
 
-fn generate_set(output: &mut String, set: Set, parents: &mut Vec<Set>) {
-    match &set {
-        Set::Toplevel(_) => {
+fn generate_set(output: &mut String, set: Set, parents: &mut Vec<Set>, root: Root) {
+    match (&set, root) {
+        (Set::Toplevel(_), Root::Config) => {
             output.push_str("# Configuration\n\n");
             output.push_str(
                 "Karva is configured through `karva.toml` (or the `[tool.karva]` table in \
@@ -41,13 +48,12 @@ fn generate_set(output: &mut String, set: Set, parents: &mut Vec<Set>) {
                  see [Profiles](profiles.md) for how to define and select profiles.\n\n",
             );
             output.push_str(
-                "The reference below documents every field supported inside a profile. Examples \
+                "The reference below documents every project and profile field. Profile examples \
                  target the implicit `default` profile.\n\n",
             );
-            emit_required_version_section(output);
-            emit_tags_section(output);
         }
-        Set::Named { name, .. } => {
+        (Set::Toplevel(_), Root::Profile) => {}
+        (Set::Named { name, .. }, _) => {
             let title = parents
                 .iter()
                 .filter_map(|set| set.name())
@@ -75,7 +81,7 @@ fn generate_set(output: &mut String, set: Set, parents: &mut Vec<Set>) {
 
     // Generate the fields.
     for (name, field) in &fields {
-        emit_field(output, name, field, parents.as_slice());
+        emit_field(output, name, field, parents.as_slice(), root);
         output.push_str("---\n\n");
     }
 
@@ -88,6 +94,7 @@ fn generate_set(output: &mut String, set: Set, parents: &mut Vec<Set>) {
                 set: *sub_set,
             },
             parents,
+            root,
         );
     }
 
@@ -110,57 +117,18 @@ impl Set {
 
     fn metadata(&self) -> &OptionSet {
         match self {
-            Self::Toplevel(set) => set,
-            Self::Named { set, .. } => set,
+            Self::Toplevel(set) | Self::Named { set, .. } => set,
         }
     }
 }
 
-/// `required-version` lives at the root of `Config`, not inside any profile,
-/// so the metadata-driven walker does not pick it up. Emit a hand-rolled
-/// section for it just below the intro paragraph instead.
-fn emit_required_version_section(output: &mut String) {
-    output.push_str("## `required-version`\n\n");
-    output.push_str(
-        "A SemVer requirement that the running karva binary must satisfy.\n\n\
-         If the installed karva version does not match the requirement, karva exits with a \
-         clear error before running any tests. This prevents confusing failures when CI or \
-         other contributors run with an older version that does not support features used \
-         elsewhere in the configuration.\n\n\
-         `required-version` is a top-level field, not part of any profile.\n\n",
-    );
-    output.push_str("**Default value**: `null`\n\n");
-    output.push_str("**Type**: SemVer requirement (`string`)\n\n");
-    output.push_str("**Example usage** (`karva.toml`):\n\n");
-    output.push_str("```toml\nrequired-version = \">=0.5.0\"\n```\n\n");
-    output.push_str("The same field in `pyproject.toml` lives under `[tool.karva]`:\n\n");
-    output.push_str("```toml\n[tool.karva]\nrequired-version = \">=0.5.0\"\n```\n\n");
-    output.push_str("---\n\n");
+#[derive(Debug, Copy, Clone)]
+enum Root {
+    Config,
+    Profile,
 }
 
-/// `[tags]` is project-wide rather than profile-specific, so emit it beside
-/// `required-version` instead of routing it through profile metadata.
-fn emit_tags_section(output: &mut String) {
-    output.push_str("## `tags`\n\n");
-    output.push_str(
-        "Project-wide custom tag registry. Each key is a tag name and each value is an optional \
-         description for project documentation. Use an empty string when no description is needed.\n\n\
-         Enable [`strict-tags`](#strict-tags) in a profile to reject custom tags absent from this table.\n\n",
-    );
-    output.push_str("**Default value**: `{}`\n\n");
-    output.push_str("**Type**: `table`\n\n");
-    output.push_str("**Example usage** (`karva.toml`):\n\n");
-    output.push_str(
-        "```toml\n[tags]\nintegration = \"Uses an external service\"\nslow = \"\"\n```\n\n",
-    );
-    output.push_str("The same table in `pyproject.toml` lives under `[tool.karva.tags]`:\n\n");
-    output.push_str(
-        "```toml\n[tool.karva.tags]\nintegration = \"Uses an external service\"\nslow = \"\"\n```\n\n",
-    );
-    output.push_str("---\n\n");
-}
-
-fn emit_field(output: &mut String, name: &str, field: &OptionField, parents: &[Set]) {
+fn emit_field(output: &mut String, name: &str, field: &OptionField, parents: &[Set], root: Root) {
     let header_level = "#".repeat(parents.len() + 1);
 
     let _ = writeln!(output, "{header_level} `{name}`");
@@ -196,6 +164,7 @@ fn emit_field(output: &mut String, name: &str, field: &OptionField, parents: &[S
             field.scope,
             field.example,
             parents,
+            root,
             ConfigurationFile::PyprojectToml,
         ),
         field.example,
@@ -218,13 +187,14 @@ fn format_header(
     scope: Option<&str>,
     example: &str,
     parents: &[Set],
+    root: Root,
     configuration: ConfigurationFile,
 ) -> String {
-    // All option groups live under `[profile.<name>]` (nextest-style). The
-    // generated examples target the implicit `default` profile.
-    let parent_path = match configuration {
-        ConfigurationFile::PyprojectToml => "tool.karva.profile.default",
-        ConfigurationFile::KarvaToml => "profile.default",
+    let parent_path = match (root, configuration) {
+        (Root::Config, ConfigurationFile::PyprojectToml) => "tool.karva",
+        (Root::Config, ConfigurationFile::KarvaToml) => "",
+        (Root::Profile, ConfigurationFile::PyprojectToml) => "tool.karva.profile.default",
+        (Root::Profile, ConfigurationFile::KarvaToml) => "profile.default",
     };
 
     let header = std::iter::once(parent_path)

--- a/crates/karva_dev/src/generate_options.rs
+++ b/crates/karva_dev/src/generate_options.rs
@@ -1,26 +1,31 @@
 //! Generate a Markdown-compatible listing of configuration options for `pyproject.toml`.
 
-use std::fmt::Write;
+use std::{borrow::Cow, fmt::Write};
 
 use itertools::Itertools;
 use karva_metadata::{Config, Options};
 use ruff_options_metadata::{OptionField, OptionSet, OptionsMetadata, Visit};
+use ruff_python_trivia::textwrap;
 
 use crate::{Mode, apply_mode};
 
+const FILE_NAME: &str = "docs/configuration/configuration.md";
+const HEADER: &str = "<!-- WARNING: This file is auto-generated (cargo dev generate-all). Update the doc comments on 'Config' and 'Options' in 'crates/karva_metadata/src/options/' if you want to change anything here. -->\n\n# Configuration\n\nKarva is configured through `karva.toml` (or the `[tool.karva]` table in `pyproject.toml`). All option groups live under a `[profile.<name>]` section; see [Profiles](profiles.md) for how to define and select profiles.\n\nThe reference below documents every project and profile field. Profile examples target the implicit `default` profile.\n\n";
+
 #[derive(clap::Args)]
 pub struct Args {
-    /// Write the generated table to stdout (rather than to `docs/configuration/configuration.md`).
+    /// Write the generated reference to stdout (rather than to `docs/configuration/configuration.md`).
     #[arg(long, default_value_t, value_enum)]
     pub mode: Mode,
 }
 
 pub fn main(args: &Args) -> anyhow::Result<()> {
-    let mut output = String::new();
+    apply_mode(args.mode, FILE_NAME, &generate())
+}
 
-    output.push_str(
-        "<!-- WARNING: This file is auto-generated (cargo run -p karva_dev generate-all). Update the doc comments on 'Config' and 'Options' in 'crates/karva_metadata/src/options/' if you want to change anything here. -->\n\n",
-    );
+fn generate() -> String {
+    let mut output = String::new();
+    output.push_str(HEADER);
 
     generate_set(
         &mut output,
@@ -35,31 +40,22 @@ pub fn main(args: &Args) -> anyhow::Result<()> {
         Root::Profile,
     );
 
-    apply_mode(args.mode, "docs/configuration/configuration.md", &output)
+    output
 }
 
 fn generate_set(output: &mut String, set: Set, parents: &mut Vec<Set>, root: Root) {
-    match (&set, root) {
-        (Set::Toplevel(_), Root::Config) => {
-            output.push_str("# Configuration\n\n");
-            output.push_str(
-                "Karva is configured through `karva.toml` (or the `[tool.karva]` table in \
-                 `pyproject.toml`). All option groups live under a `[profile.<name>]` section; \
-                 see [Profiles](profiles.md) for how to define and select profiles.\n\n",
-            );
-            output.push_str(
-                "The reference below documents every project and profile field. Profile examples \
-                 target the implicit `default` profile.\n\n",
-            );
+    match &set {
+        Set::Toplevel(_) => {
+            let _ = writeln!(output, "## {}\n", root.name());
         }
-        (Set::Toplevel(_), Root::Profile) => {}
-        (Set::Named { name, .. }, _) => {
+        Set::Named { name, .. } => {
             let title = parents
                 .iter()
                 .filter_map(|set| set.name())
                 .chain(std::iter::once(name.as_str()))
                 .join(".");
-            let _ = writeln!(output, "## `{title}`\n");
+            let header_level = "#".repeat(parents.len() + 2);
+            let _ = writeln!(output, "{header_level} `{title}`\n");
         }
     }
 
@@ -128,8 +124,17 @@ enum Root {
     Profile,
 }
 
+impl Root {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Config => "Global",
+            Self::Profile => "Profiles",
+        }
+    }
+}
+
 fn emit_field(output: &mut String, name: &str, field: &OptionField, parents: &[Set], root: Root) {
-    let header_level = "#".repeat(parents.len() + 1);
+    let header_level = "#".repeat(parents.len() + 2);
 
     let _ = writeln!(output, "{header_level} `{name}`");
 
@@ -158,63 +163,77 @@ fn emit_field(output: &mut String, name: &str, field: &OptionField, parents: &[S
     output.push('\n');
     let _ = writeln!(output, "**Type**: `{}`", field.value_type);
     output.push('\n');
-    output.push_str("**Example usage** (`pyproject.toml`):\n\n");
-    output.push_str(&format_example(
-        &format_header(
+    output.push_str("**Example usage**:\n\n");
+
+    for configuration_file in [
+        ConfigurationFile::KarvaToml,
+        ConfigurationFile::PyprojectToml,
+    ] {
+        let (header, example) = format_snippet(
             field.scope,
             field.example,
             parents,
             root,
-            ConfigurationFile::PyprojectToml,
-        ),
-        field.example,
-    ));
-    output.push('\n');
+            configuration_file,
+        );
+        output.push_str(&format_tab(configuration_file.name(), &header, &example));
+
+        output.push('\n');
+    }
 }
 
-fn format_example(header: &str, content: &str) -> String {
-    if header.is_empty() {
-        format!("```toml\n{content}\n```\n")
+fn format_tab(tab_name: &str, header: &str, content: &str) -> String {
+    let header = if header.is_empty() {
+        String::new()
     } else {
-        format!("```toml\n{header}\n{content}\n```\n")
-    }
+        format!("\n    {header}")
+    };
+    format!(
+        "=== \"{}\"\n\n    ```toml{}\n{}\n    ```\n",
+        tab_name,
+        header,
+        textwrap::indent(content, "    ")
+    )
 }
 
 /// Format the TOML header for the example usage for a given option.
 ///
 /// For example: `[tool.karva.profile.default.src]`.
-fn format_header(
+fn format_snippet<'a>(
     scope: Option<&str>,
-    example: &str,
+    example: &'a str,
     parents: &[Set],
     root: Root,
     configuration: ConfigurationFile,
-) -> String {
-    let parent_path = match (root, configuration) {
-        (Root::Config, ConfigurationFile::PyprojectToml) => "tool.karva",
-        (Root::Config, ConfigurationFile::KarvaToml) => "",
-        (Root::Profile, ConfigurationFile::PyprojectToml) => "tool.karva.profile.default",
-        (Root::Profile, ConfigurationFile::KarvaToml) => "profile.default",
-    };
+) -> (String, Cow<'a, str>) {
+    let mut example = Cow::Borrowed(example);
 
-    let header = std::iter::once(parent_path)
+    let header = configuration
+        .parent_table(root)
+        .into_iter()
         .chain(parents.iter().filter_map(|parent| parent.name()))
         .chain(scope)
         .join(".");
 
+    // Rewrite examples starting with `[tool.karva]` or `[[tool.karva]]` to their `karva.toml` equivalent.
+    if matches!(configuration, ConfigurationFile::KarvaToml) {
+        example = example.replace("[tool.karva.", "[").into();
+    }
+
     // Ex) `[[tool.karva.xx]]`
     if example.starts_with(&format!("[[{header}")) {
-        return String::new();
+        return (String::new(), example);
     }
-    // Ex) `[tool.karva.rules]`
+
+    // Ex) `[tool.karva.tags]`
     if example.starts_with(&format!("[{header}")) {
-        return String::new();
+        return (String::new(), example);
     }
 
     if header.is_empty() {
-        String::new()
+        (String::new(), example)
     } else {
-        format!("[{header}]")
+        (format!("[{header}]"), example)
     }
 }
 
@@ -237,8 +256,25 @@ impl Visit for CollectOptionsVisitor {
 #[derive(Debug, Copy, Clone)]
 enum ConfigurationFile {
     PyprojectToml,
-    #[expect(dead_code)]
     KarvaToml,
+}
+
+impl ConfigurationFile {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::PyprojectToml => "pyproject.toml",
+            Self::KarvaToml => "karva.toml",
+        }
+    }
+
+    const fn parent_table(self, root: Root) -> Option<&'static str> {
+        match (self, root) {
+            (Self::PyprojectToml, Root::Config) => Some("tool.karva"),
+            (Self::KarvaToml, Root::Config) => None,
+            (Self::PyprojectToml, Root::Profile) => Some("tool.karva.profile.default"),
+            (Self::KarvaToml, Root::Profile) => Some("profile.default"),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/karva_dev/src/main.rs
+++ b/crates/karva_dev/src/main.rs
@@ -1,6 +1,6 @@
 //! This crate implements an internal CLI for developers of Karva.
 //!
-//! Within the Karva repository you can run it with `cargo run -p karva_dev`.
+//! Within the Karva repository you can run it with `cargo dev`.
 
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
@@ -19,7 +19,7 @@ mod generate_options;
 
 const ROOT_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../");
 
-const REGENERATE_ALL_COMMAND: &str = "cargo run -p karva_dev generate-all";
+const REGENERATE_ALL_COMMAND: &str = "cargo dev generate-all";
 
 #[derive(Copy, Clone, PartialEq, Eq, clap::ValueEnum, Default)]
 pub(crate) enum Mode {

--- a/crates/karva_metadata/src/options/config.rs
+++ b/crates/karva_metadata/src/options/config.rs
@@ -37,7 +37,12 @@ pub struct Config {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     required_version: Option<VersionReq>,
 
-    /// Project-wide custom tag registry. Empty descriptions are allowed.
+    /// Project-wide custom tag registry. Each key is a tag name and each value
+    /// is an optional description for project documentation. Empty descriptions
+    /// are allowed.
+    ///
+    /// Enable [`strict-tags`](#strict-tags) in a profile to reject custom tags
+    /// absent from this table.
     #[option(
         default = r#"{}"#,
         value_type = "table",

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1,4 +1,4 @@
-<!-- WARNING: This file is auto-generated (cargo run -p karva_dev generate-all). Update the doc comments on 'Config' and 'Options' in 'crates/karva_metadata/src/options/' if you want to change anything here. -->
+<!-- WARNING: This file is auto-generated (cargo dev generate-all). Update the doc comments on 'Config' and 'Options' in 'crates/karva_metadata/src/options/' if you want to change anything here. -->
 
 # Configuration
 
@@ -6,13 +6,15 @@ Karva is configured through `karva.toml` (or the `[tool.karva]` table in `pyproj
 
 The reference below documents every project and profile field. Profile examples target the implicit `default` profile.
 
+## Global
+
 File-level configuration: a collection of named profiles.
 
 Every option group lives inside `[profile.<name>]`. The implicit `default`
 profile is always available; named profiles inherit from it and can
 override individual fields.
 
-## `required-version`
+### `required-version`
 
 `SemVer` requirement that the running karva binary must satisfy.
 
@@ -25,16 +27,24 @@ version.
 
 **Type**: `string`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva]
-required-version = ">=0.5.0"
-```
+=== "karva.toml"
+
+    ```toml
+    required-version = ">=0.5.0"
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva]
+    required-version = ">=0.5.0"
+    ```
 
 ---
 
-## `tags`
+### `tags`
 
 Project-wide custom tag registry. Each key is a tag name and each value
 is an optional description for project documentation. Empty descriptions
@@ -47,19 +57,31 @@ absent from this table.
 
 **Type**: `table`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.tags]
-integration = "Uses an external service"
-slow = ""
-```
+=== "karva.toml"
+
+    ```toml
+    [tags]
+    integration = "Uses an external service"
+    slow = ""
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.tags]
+    integration = "Uses an external service"
+    slow = ""
+    ```
 
 ---
 
+## Profiles
+
 Configuration groups combined across defaults, profiles, environment, and CLI.
 
-## `env`
+### `env`
 
 Environment variables applied to test workers before Python imports any
 test modules or fixtures. Strings always set values. Use
@@ -70,22 +92,33 @@ test modules or fixtures. Strings always set values. Use
 
 **Type**: `table`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.env]
-APP_ENV = "test"
-CACHE_DIR = { value = ".cache/tests", preserve = true }
-LIVE_API_TOKEN = { unset = true }
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.env]
+    APP_ENV = "test"
+    CACHE_DIR = { value = ".cache/tests", preserve = true }
+    LIVE_API_TOKEN = { unset = true }
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.env]
+    APP_ENV = "test"
+    CACHE_DIR = { value = ".cache/tests", preserve = true }
+    LIVE_API_TOKEN = { unset = true }
+    ```
 
 ---
 
-## `coverage`
+### `coverage`
 
 Controls measured Python sources and coverage report generation.
 
-### `append`
+#### `append`
 
 Add a test run to compatible native data instead of replacing it.
 
@@ -93,16 +126,25 @@ Add a test run to compatible native data instead of replacing it.
 
 **Type**: `true | false`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.coverage]
-append = true
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.coverage]
+    append = true
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.coverage]
+    append = true
+    ```
 
 ---
 
-### `branch`
+#### `branch`
 
 Whether to measure branch coverage in addition to line coverage.
 
@@ -110,16 +152,25 @@ Whether to measure branch coverage in addition to line coverage.
 
 **Type**: `true | false`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.coverage]
-branch = true
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.coverage]
+    branch = true
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.coverage]
+    branch = true
+    ```
 
 ---
 
-### `context`
+#### `context`
 
 Static context component attached to every observation in the run.
 
@@ -127,16 +178,25 @@ Static context component attached to every observation in the run.
 
 **Type**: `str`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.coverage]
-context = "python=3.14"
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.coverage]
+    context = "python=3.14"
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.coverage]
+    context = "python=3.14"
+    ```
 
 ---
 
-### `contexts`
+#### `contexts`
 
 Include execution attributed to contexts matching these regular expressions.
 
@@ -144,16 +204,25 @@ Include execution attributed to contexts matching these regular expressions.
 
 **Type**: `list[str]`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.coverage]
-contexts = ["python=3\\.14", "test_checkout"]
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.coverage]
+    contexts = ["python=3\\.14", "test_checkout"]
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.coverage]
+    contexts = ["python=3\\.14", "test_checkout"]
+    ```
 
 ---
 
-### `data-file`
+#### `data-file`
 
 Native coverage artifact read and written by coverage commands.
 
@@ -163,16 +232,25 @@ Relative paths are resolved from the project root.
 
 **Type**: `path`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.coverage]
-data-file = ".karva/coverage/data.json"
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.coverage]
+    data-file = ".karva/coverage/data.json"
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.coverage]
+    data-file = ".karva/coverage/data.json"
+    ```
 
 ---
 
-### `exclude-lines`
+#### `exclude-lines`
 
 Regular expressions excluding matching source lines or whole clauses.
 
@@ -180,16 +258,25 @@ Regular expressions excluding matching source lines or whole clauses.
 
 **Type**: `list[str]`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.coverage]
-exclude-lines = ["if TYPE_CHECKING:"]
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.coverage]
+    exclude-lines = ["if TYPE_CHECKING:"]
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.coverage]
+    exclude-lines = ["if TYPE_CHECKING:"]
+    ```
 
 ---
 
-### `fail-under`
+#### `fail-under`
 
 Minimum total coverage percentage required for the run to succeed.
 
@@ -202,16 +289,25 @@ already non-zero).
 
 **Type**: `float (0..=100)`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.coverage]
-fail-under = 90
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.coverage]
+    fail-under = 90
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.coverage]
+    fail-under = 90
+    ```
 
 ---
 
-### `include`
+#### `include`
 
 Include only coverage report files matching these globs.
 
@@ -223,16 +319,25 @@ under the configured coverage sources are included unless omitted.
 
 **Type**: `list[str]`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.coverage]
-include = ["src/**"]
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.coverage]
+    include = ["src/**"]
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.coverage]
+    include = ["src/**"]
+    ```
 
 ---
 
-### `omit`
+#### `omit`
 
 Exclude coverage report files matching these globs.
 
@@ -244,16 +349,25 @@ applied after include filters.
 
 **Type**: `list[str]`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.coverage]
-omit = ["**/migrations/*"]
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.coverage]
+    omit = ["**/migrations/*"]
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.coverage]
+    omit = ["**/migrations/*"]
+    ```
 
 ---
 
-### `partial-branches`
+#### `partial-branches`
 
 Regular expressions marking intentionally partial branch lines.
 
@@ -261,16 +375,25 @@ Regular expressions marking intentionally partial branch lines.
 
 **Type**: `list[str]`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.coverage]
-partial-branches = ["if platform.system"]
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.coverage]
+    partial-branches = ["if platform.system"]
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.coverage]
+    partial-branches = ["if platform.system"]
+    ```
 
 ---
 
-### `path-aliases`
+#### `path-aliases`
 
 Ordered `FROM=TO` path mappings applied when native artifacts are read.
 
@@ -281,16 +404,25 @@ or artifacts produced under a different CI checkout layout.
 
 **Type**: `list[str]`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.coverage]
-path-aliases = ["/workspace=.", "C:/repo=."]
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.coverage]
+    path-aliases = ["/workspace=.", "C:/repo=."]
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.coverage]
+    path-aliases = ["/workspace=.", "C:/repo=."]
+    ```
 
 ---
 
-### `precision`
+#### `precision`
 
 Decimal places shown in coverage percentages.
 
@@ -298,16 +430,25 @@ Decimal places shown in coverage percentages.
 
 **Type**: `non-negative integer`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.coverage]
-precision = 2
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.coverage]
+    precision = 2
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.coverage]
+    precision = 2
+    ```
 
 ---
 
-### `report`
+#### `report`
 
 Coverage report type.
 
@@ -319,16 +460,25 @@ uncovered line numbers per file. `none` persists native data only.
 
 **Type**: `none | term | term-missing | xml | json | html | lcov`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.coverage]
-report = "term-missing"
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.coverage]
+    report = "term-missing"
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.coverage]
+    report = "term-missing"
+    ```
 
 ---
 
-### `report-path`
+#### `report-path`
 
 Optional output path for machine-readable coverage reports.
 
@@ -341,16 +491,25 @@ project root.
 
 **Type**: `path`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.coverage]
-report-path = "build/coverage.xml"
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.coverage]
+    report-path = "build/coverage.xml"
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.coverage]
+    report-path = "build/coverage.xml"
+    ```
 
 ---
 
-### `sources`
+#### `sources`
 
 Source paths or importable Python names to measure coverage for.
 
@@ -362,20 +521,29 @@ working directory, matching pytest-cov's bare `--cov`.
 
 **Type**: `list[str]`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.coverage]
-sources = ["src"]
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.coverage]
+    sources = ["src"]
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.coverage]
+    sources = ["src"]
+    ```
 
 ---
 
-## `junit`
+### `junit`
 
 Controls `JUnit` XML output, captured streams, and flaky-test representation.
 
-### `flaky-fail-status`
+#### `flaky-fail-status`
 
 How flaky tests configured to fail are represented in `JUnit`.
 
@@ -383,16 +551,25 @@ How flaky tests configured to fail are represented in `JUnit`.
 
 **Type**: `failure | success`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.junit]
-flaky-fail-status = "success"
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.junit]
+    flaky-fail-status = "success"
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.junit]
+    flaky-fail-status = "success"
+    ```
 
 ---
 
-### `path`
+#### `path`
 
 Output path for the `JUnit` XML report.
 
@@ -402,16 +579,25 @@ When unset, no `JUnit` report is written.
 
 **Type**: `path`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.junit]
-path = "reports/test-results.xml"
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.junit]
+    path = "reports/test-results.xml"
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.junit]
+    path = "reports/test-results.xml"
+    ```
 
 ---
 
-### `report-name`
+#### `report-name`
 
 Name of the top-level `JUnit` test suite collection.
 
@@ -419,16 +605,25 @@ Name of the top-level `JUnit` test suite collection.
 
 **Type**: `string`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.junit]
-report-name = "karva-tests"
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.junit]
+    report-name = "karva-tests"
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.junit]
+    report-name = "karva-tests"
+    ```
 
 ---
 
-### `store-failure-output`
+#### `store-failure-output`
 
 Whether to include captured stdout and stderr for failing tests.
 
@@ -436,16 +631,25 @@ Whether to include captured stdout and stderr for failing tests.
 
 **Type**: `true | false`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.junit]
-store-failure-output = true
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.junit]
+    store-failure-output = true
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.junit]
+    store-failure-output = true
+    ```
 
 ---
 
-### `store-success-output`
+#### `store-success-output`
 
 Whether to include captured stdout and stderr for passing tests.
 
@@ -453,20 +657,29 @@ Whether to include captured stdout and stderr for passing tests.
 
 **Type**: `true | false`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.junit]
-store-success-output = true
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.junit]
+    store-success-output = true
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.junit]
+    store-success-output = true
+    ```
 
 ---
 
-## `src`
+### `src`
 
 Controls test-path discovery and whether filesystem ignore rules are honored.
 
-### `include`
+#### `include`
 
 A list of files and directories to check.
 Including a file or directory will make it so that it (and its contents)
@@ -481,16 +694,25 @@ it checks the project root.
 
 **Type**: `list[str]`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.src]
-include = ["tests"]
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.src]
+    include = ["tests"]
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.src]
+    include = ["tests"]
+    ```
 
 ---
 
-### `respect-ignore-files`
+#### `respect-ignore-files`
 
 Whether to automatically exclude files that are ignored by `.ignore`,
 `.gitignore`, `.git/info/exclude`, and global `gitignore` files.
@@ -500,20 +722,29 @@ Enabled by default.
 
 **Type**: `bool`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.src]
-respect-ignore-files = false
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.src]
+    respect-ignore-files = false
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.src]
+    respect-ignore-files = false
+    ```
 
 ---
 
-## `terminal`
+### `terminal`
 
 Controls diagnostic formatting, captured output, and displayed test statuses.
 
-### `final-status-level`
+#### `final-status-level`
 
 Test summary information to display at the end of the run.
 
@@ -526,16 +757,25 @@ Defaults to `pass`.
 
 **Type**: `none | fail | retry | slow | pass | skip | all`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.terminal]
-final-status-level = "fail"
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.terminal]
+    final-status-level = "fail"
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.terminal]
+    final-status-level = "fail"
+    ```
 
 ---
 
-### `output-format`
+#### `output-format`
 
 The format to use for printing diagnostic messages.
 
@@ -545,16 +785,25 @@ Defaults to `full`.
 
 **Type**: `full | concise`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.terminal]
-output-format = "concise"
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.terminal]
+    output-format = "concise"
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.terminal]
+    output-format = "concise"
+    ```
 
 ---
 
-### `show-python-output`
+#### `show-python-output`
 
 Whether to show the python output.
 
@@ -564,16 +813,25 @@ This is the output the `print` goes to etc.
 
 **Type**: `true | false`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.terminal]
-show-python-output = false
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.terminal]
+    show-python-output = false
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.terminal]
+    show-python-output = false
+    ```
 
 ---
 
-### `status-level`
+#### `status-level`
 
 Test result statuses to display during the run.
 
@@ -588,20 +846,29 @@ Defaults to `pass`.
 
 **Type**: `none | fail | retry | slow | pass | skip | all`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.terminal]
-status-level = "fail"
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.terminal]
+    status-level = "fail"
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.terminal]
+    status-level = "fail"
+    ```
 
 ---
 
-## `test`
+### `test`
 
 Controls test selection, retries, timeouts, and failure policies.
 
-### `fail-fast`
+#### `fail-fast`
 
 Whether to stop at the first test failure.
 
@@ -615,16 +882,25 @@ Defaults to `false`.
 
 **Type**: `true | false`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.test]
-fail-fast = true
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.test]
+    fail-fast = true
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.test]
+    fail-fast = true
+    ```
 
 ---
 
-### `fail-slow`
+#### `fail-slow`
 
 Duration budget (in seconds) for a test's full lifecycle (fixture
 setup, the test call, and fixture teardown).
@@ -647,16 +923,25 @@ applied to the test.
 
 **Type**: `float (seconds)`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.test]
-fail-slow = 0.25
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.test]
+    fail-slow = 0.25
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.test]
+    fail-slow = 0.25
+    ```
 
 ---
 
-### `flaky-result`
+#### `flaky-result`
 
 Whether tests that pass only after a retry should fail the run.
 
@@ -664,16 +949,25 @@ Whether tests that pass only after a retry should fail the run.
 
 **Type**: `pass | fail`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.test]
-flaky-result = "fail"
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.test]
+    flaky-result = "fail"
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.test]
+    flaky-result = "fail"
+    ```
 
 ---
 
-### `max-fail`
+#### `max-fail`
 
 Stop scheduling new tests once this many tests have failed.
 
@@ -688,16 +982,25 @@ When both [`fail_fast`](#fail-fast) and `max-fail` are set,
 
 **Type**: `positive integer`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.test]
-max-fail = 3
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.test]
+    max-fail = 3
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.test]
+    max-fail = 3
+    ```
 
 ---
 
-### `no-tests`
+#### `no-tests`
 
 Configures behavior when no tests are found to run.
 
@@ -709,16 +1012,25 @@ passes silently when filters were given. Use `fail` to always fail,
 
 **Type**: `auto | pass | warn | fail`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.test]
-no-tests = "warn"
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.test]
+    no-tests = "warn"
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.test]
+    no-tests = "warn"
+    ```
 
 ---
 
-### `random-seed`
+#### `random-seed`
 
 Seed used to randomize test order when [`shuffle`](#shuffle) is enabled.
 
@@ -729,16 +1041,25 @@ seed does not enable shuffling by itself.
 
 **Type**: `u64`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.test]
-random-seed = 170938
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.test]
+    random-seed = 170938
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.test]
+    random-seed = 170938
+    ```
 
 ---
 
-### `retry`
+#### `retry`
 
 When set, we will retry failed tests up to this number of times.
 
@@ -746,16 +1067,25 @@ When set, we will retry failed tests up to this number of times.
 
 **Type**: `u32`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.test]
-retry = 3
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.test]
+    retry = 3
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.test]
+    retry = 3
+    ```
 
 ---
 
-### `run-timeout`
+#### `run-timeout`
 
 Wall-clock limit (in seconds) for the entire run.
 
@@ -770,16 +1100,25 @@ Defaults to unset, which lets the run take as long as it needs.
 
 **Type**: `float (seconds)`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.test]
-run-timeout = 1800.0
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.test]
+    run-timeout = 1800.0
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.test]
+    run-timeout = 1800.0
+    ```
 
 ---
 
-### `shuffle`
+#### `shuffle`
 
 Use seeded randomized ordering instead of duration-aware scheduling.
 
@@ -790,16 +1129,25 @@ run so the same order can be reproduced.
 
 **Type**: `true | false`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.test]
-shuffle = true
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.test]
+    shuffle = true
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.test]
+    shuffle = true
+    ```
 
 ---
 
-### `slow-timeout`
+#### `slow-timeout`
 
 Threshold (in seconds) after which a test is flagged as slow.
 
@@ -814,16 +1162,25 @@ Defaults to unset, which disables slow-test detection.
 
 **Type**: `float (seconds)`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.test]
-slow-timeout = 60.0
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.test]
+    slow-timeout = 60.0
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.test]
+    slow-timeout = 60.0
+    ```
 
 ---
 
-### `strict-tags`
+#### `strict-tags`
 
 Reject custom tags that are absent from the project-wide `[tags]` registry.
 Built-in Karva tags and pytest marks remain available without registration.
@@ -832,16 +1189,25 @@ Built-in Karva tags and pytest marks remain available without registration.
 
 **Type**: `true | false`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.test]
-strict-tags = true
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.test]
+    strict-tags = true
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.test]
+    strict-tags = true
+    ```
 
 ---
 
-### `termination-grace-period`
+#### `termination-grace-period`
 
 Grace period (in seconds) between graceful worker termination and
 force-kill.
@@ -856,16 +1222,25 @@ Defaults to 10 seconds.
 
 **Type**: `float (seconds)`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.test]
-termination-grace-period = 10.0
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.test]
+    termination-grace-period = 10.0
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.test]
+    termination-grace-period = 10.0
+    ```
 
 ---
 
-### `test-function-prefix`
+#### `test-function-prefix`
 
 The prefix to use for test functions.
 
@@ -875,16 +1250,25 @@ Defaults to `test`.
 
 **Type**: `string`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.test]
-test-function-prefix = "test"
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.test]
+    test-function-prefix = "test"
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.test]
+    test-function-prefix = "test"
+    ```
 
 ---
 
-### `timeout`
+#### `timeout`
 
 Hard per-test timeout (in seconds).
 
@@ -900,16 +1284,25 @@ applied to the test.
 
 **Type**: `float (seconds)`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.test]
-timeout = 120.0
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.test]
+    timeout = 120.0
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.test]
+    timeout = 120.0
+    ```
 
 ---
 
-### `try-import-fixtures`
+#### `try-import-fixtures`
 
 When set, we will try to import functions in each test file as well as parsing the ast to find them.
 
@@ -919,12 +1312,21 @@ This is often slower, so it is not recommended for most projects.
 
 **Type**: `true | false`
 
-**Example usage** (`pyproject.toml`):
+**Example usage**:
 
-```toml
-[tool.karva.profile.default.test]
-try-import-fixtures = true
-```
+=== "karva.toml"
+
+    ```toml
+    [profile.default.test]
+    try-import-fixtures = true
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.test]
+    try-import-fixtures = true
+    ```
 
 ---
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1,30 +1,31 @@
-<!-- WARNING: This file is auto-generated (cargo dev generate-all). Update the doc comments on the 'Options' struct in 'crates/karva_project/src/metadata/options.rs' if you want to change anything here. -->
+<!-- WARNING: This file is auto-generated (cargo run -p karva_dev generate-all). Update the doc comments on 'Config' and 'Options' in 'crates/karva_metadata/src/options/' if you want to change anything here. -->
 
 # Configuration
 
 Karva is configured through `karva.toml` (or the `[tool.karva]` table in `pyproject.toml`). All option groups live under a `[profile.<name>]` section; see [Profiles](profiles.md) for how to define and select profiles.
 
-The reference below documents every field supported inside a profile. Examples target the implicit `default` profile.
+The reference below documents every project and profile field. Profile examples target the implicit `default` profile.
+
+File-level configuration: a collection of named profiles.
+
+Every option group lives inside `[profile.<name>]`. The implicit `default`
+profile is always available; named profiles inherit from it and can
+override individual fields.
 
 ## `required-version`
 
-A SemVer requirement that the running karva binary must satisfy.
+`SemVer` requirement that the running karva binary must satisfy.
 
-If the installed karva version does not match the requirement, karva exits with a clear error before running any tests. This prevents confusing failures when CI or other contributors run with an older version that does not support features used elsewhere in the configuration.
-
-`required-version` is a top-level field, not part of any profile.
+When set, karva refuses to run if the installed version does not
+match the requirement. This is useful in CI and for shared
+repositories where every developer should be on a known-good
+version.
 
 **Default value**: `null`
 
-**Type**: SemVer requirement (`string`)
+**Type**: `string`
 
-**Example usage** (`karva.toml`):
-
-```toml
-required-version = ">=0.5.0"
-```
-
-The same field in `pyproject.toml` lives under `[tool.karva]`:
+**Example usage** (`pyproject.toml`):
 
 ```toml
 [tool.karva]
@@ -35,23 +36,18 @@ required-version = ">=0.5.0"
 
 ## `tags`
 
-Project-wide custom tag registry. Each key is a tag name and each value is an optional description for project documentation. Use an empty string when no description is needed.
+Project-wide custom tag registry. Each key is a tag name and each value
+is an optional description for project documentation. Empty descriptions
+are allowed.
 
-Enable [`strict-tags`](#strict-tags) in a profile to reject custom tags absent from this table.
+Enable [`strict-tags`](#strict-tags) in a profile to reject custom tags
+absent from this table.
 
 **Default value**: `{}`
 
 **Type**: `table`
 
-**Example usage** (`karva.toml`):
-
-```toml
-[tags]
-integration = "Uses an external service"
-slow = ""
-```
-
-The same table in `pyproject.toml` lives under `[tool.karva.tags]`:
+**Example usage** (`pyproject.toml`):
 
 ```toml
 [tool.karva.tags]

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,4 +1,4 @@
-<!-- WARNING: This file is auto-generated (cargo run -p karva_dev generate-all). Edit the doc comments in 'crates/karva/src/args.rs' if you want to change anything here. -->
+<!-- WARNING: This file is auto-generated (cargo dev generate-all). Edit the doc comments in 'crates/karva/src/args.rs' if you want to change anything here. -->
 
 # CLI Reference
 

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -1,4 +1,4 @@
-<!-- WARNING: This file is auto-generated (cargo run -p karva_dev generate-all). Update the doc comments on the env-var structs in 'crates/karva_static/src/lib.rs' if you want to change anything here. -->
+<!-- WARNING: This file is auto-generated (cargo dev generate-all). Update the doc comments on the env-var structs in 'crates/karva_static/src/lib.rs' if you want to change anything here. -->
 
 # Environment Variables
 

--- a/karva.schema.json
+++ b/karva.schema.json
@@ -25,7 +25,7 @@
       ]
     },
     "tags": {
-      "description": "Project-wide custom tag registry. Empty descriptions are allowed.",
+      "description": "Project-wide custom tag registry. Each key is a tag name and each value\nis an optional description for project documentation. Empty descriptions\nare allowed.\n\nEnable [`strict-tags`](#strict-tags) in a profile to reject custom tags\nabsent from this table.",
       "type": "object",
       "additionalProperties": {
         "type": "string"


### PR DESCRIPTION
## Summary

Generate top-level configuration reference sections from `Config` metadata alongside profile `Options` metadata, removing the hand-written emitters. Present `karva.toml` and `pyproject.toml` examples in tabs under distinct Global and Profiles sections, align the three documentation generators around shared file/header constants, and standardize regeneration on `cargo dev generate-all`.

<img width="959" height="1309" alt="image" src="https://github.com/user-attachments/assets/250726cb-27a1-4698-8d86-642011aedc9a" />


## Test Plan

`just test -p karva_dev`; `uv run --isolated --only-group docs zensical build`; `uvx prek run -a`