### PR TITLE
Remove obsolete benchmark Cargo alias

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,5 @@
 [alias]
 dev = "run --package karva_dev --bin karva_dev"
-benchmark = "bench -p karva_benchmark --bench karva_benchmark_walltime --"
 
 # Statically link the C runtime so Windows wheels do not depend on the
 # shared/dynamic MSVC runtime.


### PR DESCRIPTION
## Summary

Remove the obsolete Cargo `benchmark` alias, which references the removed `karva_benchmark_walltime` bench target.

## Test Plan

`uvx prek run -a`