### PR TITLE
Replace Ruff diagnostics with annotate-snippets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,18 +12,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "annotate-snippets"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
+dependencies = [
+ "anstyle",
+ "unicode-width",
 ]
 
 [[package]]
@@ -81,15 +85,6 @@ name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
-
-[[package]]
-name = "arc-swap"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
-dependencies = [
- "rustversion",
-]
 
 [[package]]
 name = "argfile"
@@ -159,12 +154,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "boxcar"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
-
-[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,12 +169,6 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "camino"
@@ -226,17 +209,6 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
-name = "chacha20"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "rand_core 0.10.0",
-]
 
 [[package]]
 name = "chrono"
@@ -374,24 +346,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,15 +374,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,55 +388,6 @@ dependencies = [
  "dispatch2",
  "nix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "darling"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
-dependencies = [
- "darling_core",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
 ]
 
 [[package]]
@@ -591,27 +487,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
-name = "filetime"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -732,7 +611,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -758,18 +636,10 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash",
 ]
 
@@ -778,15 +648,6 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "hashlink"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
-dependencies = [
- "hashbrown 0.15.5",
-]
 
 [[package]]
 name = "heck"
@@ -823,12 +684,6 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "ignore"
@@ -911,24 +766,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
 
 [[package]]
-name = "intrusive-collections"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
-dependencies = [
- "memoffset",
-]
-
-[[package]]
-name = "inventory"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "is-macro"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,15 +775,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "is_executable"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baabb8b4867b26294d818bf3f651a454b6901431711abb96e296245888d6e8c4"
-dependencies = [
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1062,10 +890,6 @@ dependencies = [
  "insta",
  "karva_diagnostic",
  "karva_python_semantic",
- "ruff_db",
- "ruff_notebook",
- "ruff_source_file",
- "ruff_text_size",
  "serde",
  "serde_json",
  "tempfile",
@@ -1083,7 +907,6 @@ dependencies = [
  "karva_metadata",
  "karva_static",
  "karva_version",
- "ruff_db",
  "serde_json",
 ]
 
@@ -1156,6 +979,7 @@ dependencies = [
 name = "karva_diagnostic"
 version = "0.0.0"
 dependencies = [
+ "annotate-snippets",
  "camino",
  "colored",
  "fs-err",
@@ -1163,7 +987,6 @@ dependencies = [
  "karva_logging",
  "karva_python_semantic",
  "pyo3",
- "ruff_db",
  "ruff_source_file",
  "ruff_text_size",
  "serde",
@@ -1215,7 +1038,6 @@ dependencies = [
  "karva_version",
  "regex",
  "rstest",
- "ruff_db",
  "ruff_options_metadata",
  "ruff_python_ast",
  "ruff_python_stdlib",
@@ -1326,7 +1148,6 @@ dependencies = [
  "karva_snapshot",
  "karva_static",
  "pyo3",
- "ruff_db",
  "ruff_macros",
  "ruff_python_ast",
  "ruff_python_parser",
@@ -1360,7 +1181,6 @@ dependencies = [
  "karva_python_semantic",
  "karva_static",
  "karva_test_semantic",
- "ruff_db",
  "wild",
 ]
 
@@ -1419,7 +1239,6 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
- "redox_syscall 0.7.1",
 ]
 
 [[package]]
@@ -1427,15 +1246,6 @@ name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
-
-[[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -1485,25 +1295,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchit"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3eede3bdf92f3b4f9dc04072a9ce5ab557d5ec9038773bf9ffcd5588b3cc05b"
-
-[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mio"
@@ -1638,41 +1433,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall 0.5.18",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
-name = "path-slash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
-
-[[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
-
-[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1698,7 +1458,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -1882,18 +1642,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
-dependencies = [
- "chacha20",
- "getrandom 0.4.1",
- "rand_core 0.10.0",
+ "rand_core",
 ]
 
 [[package]]
@@ -1903,7 +1652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1913,30 +1662,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
-dependencies = [
- "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2035,64 +1760,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ruff_annotate_snippets"
-version = "0.1.0"
-source = "git+https://github.com/astral-sh/ruff/?branch=main#fb2b844c0a72b9ee4578f836f407938cc2ab1b79"
-dependencies = [
- "anstyle",
- "memchr",
- "unicode-width",
-]
-
-[[package]]
-name = "ruff_db"
-version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff/?branch=main#fb2b844c0a72b9ee4578f836f407938cc2ab1b79"
-dependencies = [
- "anstyle",
- "arc-swap",
- "camino",
- "dashmap",
- "dunce",
- "filetime",
- "get-size2",
- "glob",
- "is_executable",
- "matchit",
- "path-slash",
- "pathdiff",
- "ruff_annotate_snippets",
- "ruff_diagnostics",
- "ruff_memory_usage",
- "ruff_notebook",
- "ruff_python_ast",
- "ruff_python_parser",
- "ruff_python_trivia",
- "ruff_source_file",
- "ruff_text_size",
- "rustc-hash",
- "salsa",
- "similar 2.7.0",
- "supports-hyperlinks",
- "thiserror",
- "tracing",
- "ty_static",
- "web-time",
- "which",
- "zip",
-]
-
-[[package]]
-name = "ruff_diagnostics"
-version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff/?branch=main#fb2b844c0a72b9ee4578f836f407938cc2ab1b79"
-dependencies = [
- "get-size2",
- "is-macro",
- "ruff_text_size",
-]
-
-[[package]]
 name = "ruff_macros"
 version = "0.0.0"
 source = "git+https://github.com/astral-sh/ruff/?branch=main#fb2b844c0a72b9ee4578f836f407938cc2ab1b79"
@@ -2104,32 +1771,6 @@ dependencies = [
  "regex",
  "ruff_python_trivia",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "ruff_memory_usage"
-version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff/?branch=main#fb2b844c0a72b9ee4578f836f407938cc2ab1b79"
-dependencies = [
- "get-size2",
-]
-
-[[package]]
-name = "ruff_notebook"
-version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff/?branch=main#fb2b844c0a72b9ee4578f836f407938cc2ab1b79"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "rand 0.10.0",
- "ruff_diagnostics",
- "ruff_source_file",
- "ruff_text_size",
- "serde",
- "serde_json",
- "serde_with",
- "thiserror",
- "uuid",
 ]
 
 [[package]]
@@ -2200,10 +1841,8 @@ name = "ruff_source_file"
 version = "0.0.0"
 source = "git+https://github.com/astral-sh/ruff/?branch=main#fb2b844c0a72b9ee4578f836f407938cc2ab1b79"
 dependencies = [
- "get-size2",
  "memchr",
  "ruff_text_size",
- "serde",
 ]
 
 [[package]]
@@ -2212,7 +1851,6 @@ version = "0.0.0"
 source = "git+https://github.com/astral-sh/ruff/?branch=main#fb2b844c0a72b9ee4578f836f407938cc2ab1b79"
 dependencies = [
  "get-size2",
- "serde",
 ]
 
 [[package]]
@@ -2256,46 +1894,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "salsa"
-version = "0.26.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=53421c2fff87426fa0bb51cab06632b87646de13#53421c2fff87426fa0bb51cab06632b87646de13"
-dependencies = [
- "boxcar",
- "compact_str",
- "crossbeam-queue",
- "crossbeam-utils",
- "hashbrown 0.15.5",
- "hashlink",
- "indexmap",
- "intrusive-collections",
- "inventory",
- "parking_lot",
- "portable-atomic",
- "rustc-hash",
- "salsa-macro-rules",
- "salsa-macros",
- "smallvec",
- "thin-vec",
- "tracing",
-]
-
-[[package]]
-name = "salsa-macro-rules"
-version = "0.26.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=53421c2fff87426fa0bb51cab06632b87646de13#53421c2fff87426fa0bb51cab06632b87646de13"
-
-[[package]]
-name = "salsa-macros"
-version = "0.26.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=53421c2fff87426fa0bb51cab06632b87646de13#53421c2fff87426fa0bb51cab06632b87646de13"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
- "synstructure",
-]
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2328,12 +1926,6 @@ dependencies = [
  "serde_derive_internals",
  "syn 3.0.3",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -2409,28 +2001,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "3.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
-dependencies = [
- "serde_core",
- "serde_with_macros",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2500,12 +2070,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "supports-hyperlinks"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
-
-[[package]]
 name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2525,17 +2089,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -2566,12 +2119,6 @@ dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "thin-vec"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
 
 [[package]]
 name = "thiserror"
@@ -2760,14 +2307,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ty_static"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/ruff/?branch=main#fb2b844c0a72b9ee4578f836f407938cc2ab1b79"
-dependencies = [
- "ruff_macros",
-]
-
-[[package]]
 name = "unicode-id"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2819,7 +2358,7 @@ dependencies = [
  "getopts",
  "log",
  "phf_codegen",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -2836,7 +2375,6 @@ checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.1",
  "js-sys",
- "rand 0.10.0",
  "wasm-bindgen",
 ]
 
@@ -2966,16 +2504,6 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -3274,17 +2802,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "byteorder",
- "crc32fast",
- "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ karva_test_semantic = { path = "crates/karva_test_semantic" }
 karva_version = { path = "crates/karva_version" }
 karva_worker = { path = "crates/karva_worker" }
 
+annotate-snippets = { version = "0.11.5" }
 anyhow = { version = "1.0.102" }
 argfile = { version = "1.0.0" }
 camino = { version = "1.2", features = ["serde1"] }
@@ -60,9 +61,7 @@ pyo3 = { version = "0.29.0", features = ["abi3-py310"] }
 quote = { version = "1.0.45" }
 regex = { version = "1.12.3" }
 rstest = { version = "0.26" }
-ruff_db = { git = "https://github.com/astral-sh/ruff/", branch = "main" }
 ruff_macros = { git = "https://github.com/astral-sh/ruff/", branch = "main" }
-ruff_notebook = { git = "https://github.com/astral-sh/ruff/", branch = "main" }
 ruff_options_metadata = { git = "https://github.com/astral-sh/ruff/", branch = "main" }
 ruff_python_ast = { git = "https://github.com/astral-sh/ruff/", branch = "main" }
 ruff_python_parser = { git = "https://github.com/astral-sh/ruff/", branch = "main" }

--- a/crates/karva/tests/it/extensions/tags/parametrize.rs
+++ b/crates/karva/tests/it/extensions/tags/parametrize.rs
@@ -119,6 +119,9 @@ def test_value(left, right):
       |
     5 |     arg_values=[(1, 2), (3,)],
       |                         ^^^^ contains 1 value
+      |
+     ::: test.py:6:15
+      |
     6 |     arg_names=("left", "right"),
       |               ----------------- expects 2 values
       |
@@ -162,6 +165,9 @@ def test_value(left, right):
       |
     5 |     argvalues=[(1, 2), (3,)],
       |                        ^^^^ contains 1 value
+      |
+     ::: test.py:6:15
+      |
     6 |     argnames=("left," "right"),
       |               --------------- expects 2 values
       |
@@ -483,12 +489,15 @@ def test_value(value):
     test::test_value:
 
     error[invalid-parametrize]: Parameter `value` is parametrized more than once
-     --> test.py:6:9
+     --> test.py:7:9
+      |
+    7 |         "value",
+      |         ^^^^^^^ duplicate parameter
+      |
+     ::: test.py:6:9
       |
     6 |         "value",
       |         ------- first parametrized here
-    7 |         "value",
-      |         ^^^^^^^ duplicate parameter
       |
 
     ────────────
@@ -623,12 +632,15 @@ def test_value(value):
         test::test_value:
 
         error[invalid-parametrize]: Parameter `value` is parametrized more than once
-         --> test.py:5:14
+         --> test.py:6:14
+          |
+        6 | @parametrize("value", [2])
+          |              ^^^^^^^ duplicate parameter
+          |
+         ::: test.py:5:14
           |
         5 | @parametrize("value", [1])
           |              ------- first parametrized here
-        6 | @parametrize("value", [2])
-          |              ^^^^^^^ duplicate parameter
           |
 
         ────────────
@@ -673,6 +685,9 @@ def test_value(value):
           |
         5 | @parametrize("missing", [1])
           |              ^^^^^^^^^ not accepted by test
+          |
+         ::: test.py:6:15
+          |
         6 | def test_value(value):
           |               ------- available parameter
           |
@@ -716,6 +731,9 @@ def test_value(value):
       |
     6 | @cases(("value", "missing"), [(1, 2)])
       |                  ^^^^^^^^^ not accepted by test
+      |
+     ::: test.py:7:15
+      |
     7 | def test_value(value):
       |               ------- available parameter
       |
@@ -849,6 +867,9 @@ def test_value(value):
           |
         5 | @parametrize("", [1])
           |              ^^ empty parameter name
+          |
+         ::: test.py:6:15
+          |
         6 | def test_value(value):
           |               ------- available parameter
           |
@@ -895,6 +916,9 @@ def test_value(value):
           |
         5 | @parametrize("not valid", [1])
           |              ^^^^^^^^^^^ invalid parameter name
+          |
+         ::: test.py:6:15
+          |
         6 | def test_value(value):
           |               ------- available parameter
           |
@@ -954,6 +978,9 @@ def test_invalid(
        |
     12 |   @karva.tags.parametrize("", [1])
        |                           ^^ empty parameter name
+       |
+      ::: test.py:13:15
+       |
     13 |   def test_empty(
        |  _______________-
     14 | |     value,
@@ -968,6 +995,9 @@ def test_invalid(
        |
     18 |   @karva.tags.parametrize("not valid", [1])
        |                           ^^^^^^^^^^^ invalid parameter name
+       |
+      ::: test.py:19:17
+       |
     19 |   def test_invalid(
        |  _________________-
     20 | |     value: int = 1,
@@ -982,6 +1012,9 @@ def test_invalid(
       |
     4 |   @karva.tags.parametrize("missing", [1])
       |                           ^^^^^^^^^ not accepted by test
+      |
+     ::: test.py:5:17
+      |
     5 |   def test_unknown(
       |  _________________-
     6 | |     value,

--- a/crates/karva_cache/Cargo.toml
+++ b/crates/karva_cache/Cargo.toml
@@ -14,11 +14,9 @@ license.workspace = true
 karva_diagnostic = { workspace = true }
 karva_python_semantic = { workspace = true }
 
-annotate-snippets = { workspace = true }
 anyhow = { workspace = true }
 camino = { workspace = true }
 fs-err = { workspace = true }
-ruff_source_file = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
@@ -26,7 +24,6 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
-ruff_text_size = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/karva_cache/Cargo.toml
+++ b/crates/karva_cache/Cargo.toml
@@ -14,11 +14,11 @@ license.workspace = true
 karva_diagnostic = { workspace = true }
 karva_python_semantic = { workspace = true }
 
+annotate-snippets = { workspace = true }
 anyhow = { workspace = true }
 camino = { workspace = true }
 fs-err = { workspace = true }
-ruff_db = { workspace = true }
-ruff_notebook = { workspace = true }
+ruff_source_file = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
@@ -26,7 +26,6 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
-ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }
 
 [lints]

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -6,15 +6,13 @@ use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use fs_err as fs;
 use karva_diagnostic::{
-    FlakyTest, RenderedDiagnostic, TestCaseOutcome, TestCaseResult, TestResultKind,
-    TestResultStats, TestRunResult, TestRunResultParts,
+    DisplayDiagnosticConfig, FlakyTest, RenderedDiagnostic, TestCaseOutcome, TestCaseResult,
+    TestResultKind, TestResultStats, TestRunResult, TestRunResultParts, render_diagnostic,
 };
 use karva_python_semantic::TestCacheKey;
-use ruff_db::diagnostic::DisplayDiagnosticConfig;
 use serde::{Deserialize, Serialize};
 
 use crate::artifact::{CacheFile, read_json, read_text, write_json, write_text};
-use crate::diagnostics::render_diagnostic;
 use crate::{RUN_PREFIX, RunHash, WORKER_PREFIX, worker_folder};
 
 /// Snapshot of the test a worker is currently executing.
@@ -453,7 +451,7 @@ mod tests {
     use camino::Utf8PathBuf;
     use insta::assert_debug_snapshot;
     use karva_diagnostic::CapturedTestOutput;
-    use ruff_db::diagnostic::Severity;
+    use karva_diagnostic::Severity;
 
     use super::*;
 

--- a/crates/karva_cache/src/cache.rs
+++ b/crates/karva_cache/src/cache.rs
@@ -258,12 +258,14 @@ impl RunCache {
         } = result.into_parts();
         let run_diagnostics = run_diagnostics
             .iter()
-            .map(|diagnostic| render_diagnostic(diagnostic, cwd, config))
-            .collect::<Result<Vec<_>>>()?;
+            .map(|diagnostic| render_diagnostic(diagnostic, cwd, *config))
+            .collect::<Vec<_>>();
         let test_cases = test_cases
             .into_iter()
             .map(|case| {
-                case.try_map_diagnostic(|diagnostic| render_diagnostic(diagnostic, cwd, config))
+                case.try_map_diagnostic(|diagnostic| {
+                    Ok::<_, anyhow::Error>(render_diagnostic(diagnostic, cwd, *config))
+                })
             })
             .collect::<Result<Vec<TestCaseResult>>>()?;
 

--- a/crates/karva_cache/src/diagnostics.rs
+++ b/crates/karva_cache/src/diagnostics.rs
@@ -1,5 +1,4 @@
 use annotate_snippets::{Level, Renderer, Snippet};
-use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
 use karva_diagnostic::{Annotation, Diagnostic, RenderedDiagnostic, Severity};
 use ruff_source_file::SourceFile;
@@ -27,17 +26,17 @@ impl DisplayDiagnosticConfig {
 pub fn render_diagnostic(
     diagnostic: &Diagnostic,
     cwd: &Utf8Path,
-    config: &DisplayDiagnosticConfig,
-) -> Result<RenderedDiagnostic> {
+    config: DisplayDiagnosticConfig,
+) -> RenderedDiagnostic {
     let rendered = render(diagnostic, cwd, config.format, false);
     let colored_rendered = render(diagnostic, cwd, config.format, config.color);
-    Ok(RenderedDiagnostic::new(
+    RenderedDiagnostic::new(
         diagnostic.code(),
         diagnostic.severity(),
         diagnostic.primary_message(),
         rendered,
     )
-    .with_colored_rendered(colored_rendered))
+    .with_colored_rendered(colored_rendered)
 }
 
 fn render(
@@ -208,9 +207,8 @@ mod tests {
         let rendered = render_diagnostic(
             &diagnostic,
             &cwd,
-            &DisplayDiagnosticConfig::new(DiagnosticFormat::Full, false),
-        )
-        .expect("render diagnostic");
+            DisplayDiagnosticConfig::new(DiagnosticFormat::Full, false),
+        );
 
         assert_eq!(rendered.code(), "test-failure");
         assert_eq!(rendered.message(), "Test `test_example` failed");
@@ -229,9 +227,8 @@ mod tests {
         let rendered = render_diagnostic(
             &diagnostic,
             &cwd,
-            &DisplayDiagnosticConfig::new(DiagnosticFormat::Full, true),
-        )
-        .expect("render diagnostic");
+            DisplayDiagnosticConfig::new(DiagnosticFormat::Full, true),
+        );
 
         assert!(!rendered.rendered().contains('\u{1b}'));
         assert!(rendered.rendered_for_terminal().contains('\u{1b}'));

--- a/crates/karva_cache/src/diagnostics.rs
+++ b/crates/karva_cache/src/diagnostics.rs
@@ -1,32 +1,38 @@
-use std::path::Path;
+use annotate_snippets::{Level, Renderer, Snippet};
+use anyhow::Result;
+use camino::{Utf8Path, Utf8PathBuf};
+use karva_diagnostic::{Annotation, Diagnostic, RenderedDiagnostic, Severity};
+use ruff_source_file::SourceFile;
 
-use anyhow::{Result, bail};
-use camino::Utf8Path;
-use karva_diagnostic::RenderedDiagnostic;
-use ruff_db::diagnostic::{
-    Diagnostic, DisplayDiagnosticConfig, DummyFileResolver, FileResolver, Input, UnifiedFile,
-};
-use ruff_db::files::File;
-use ruff_notebook::NotebookIndex;
+/// Shape used when rendering diagnostics for users.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagnosticFormat {
+    Full,
+    Concise,
+}
 
-/// Karva creates diagnostics from `ruff_source_file::SourceFile` values, not
-/// from Ruff's ty/Salsa database. Validate that contract before entering
-/// Ruff's renderer so an unsupported span is reported as a cache write error
-/// instead of becoming a renderer panic.
+/// Terminal-specific diagnostic rendering settings.
+#[derive(Debug, Clone, Copy)]
+pub struct DisplayDiagnosticConfig {
+    format: DiagnosticFormat,
+    color: bool,
+}
+
+impl DisplayDiagnosticConfig {
+    pub fn new(format: DiagnosticFormat, color: bool) -> Self {
+        Self { format, color }
+    }
+}
+
 pub fn render_diagnostic(
     diagnostic: &Diagnostic,
     cwd: &Utf8Path,
     config: &DisplayDiagnosticConfig,
 ) -> Result<RenderedDiagnostic> {
-    ensure_source_file_spans(diagnostic)?;
-
-    let resolver = DiagnosticFileResolver::new(cwd);
-    let rendered = diagnostic
-        .display(&resolver, &config.clone().color(false))
-        .to_string();
-    let colored_rendered = diagnostic.display(&resolver, config).to_string();
+    let rendered = render(diagnostic, cwd, config.format, false);
+    let colored_rendered = render(diagnostic, cwd, config.format, config.color);
     Ok(RenderedDiagnostic::new(
-        diagnostic.id().as_str(),
+        diagnostic.code(),
         diagnostic.severity(),
         diagnostic.primary_message(),
         rendered,
@@ -34,69 +40,149 @@ pub fn render_diagnostic(
     .with_colored_rendered(colored_rendered))
 }
 
-fn ensure_source_file_spans(diagnostic: &Diagnostic) -> Result<()> {
-    for annotation in diagnostic
-        .primary_annotation()
-        .into_iter()
-        .chain(diagnostic.secondary_annotations())
-    {
-        ensure_source_file_span(annotation.get_span().file())?;
+fn render(
+    diagnostic: &Diagnostic,
+    cwd: &Utf8Path,
+    format: DiagnosticFormat,
+    color: bool,
+) -> String {
+    if format == DiagnosticFormat::Concise {
+        return render_concise(diagnostic, cwd);
     }
 
-    for sub_diagnostic in diagnostic.sub_diagnostics() {
-        for annotation in sub_diagnostic.annotations() {
-            ensure_source_file_span(annotation.get_span().file())?;
+    let mut rendered = render_message(
+        diagnostic.severity(),
+        Some(diagnostic.code()),
+        diagnostic.primary_message(),
+        diagnostic.annotations(),
+        cwd,
+        color,
+    );
+    for diagnostic in diagnostic.sub_diagnostics() {
+        rendered.push_str(&render_message(
+            diagnostic.severity(),
+            None,
+            diagnostic.message(),
+            diagnostic.annotations(),
+            cwd,
+            color,
+        ));
+    }
+    rendered.push('\n');
+    rendered
+}
+
+fn render_concise(diagnostic: &Diagnostic, cwd: &Utf8Path) -> String {
+    let severity = severity_name(diagnostic.severity());
+    if let Some(annotation) = diagnostic.primary_annotation() {
+        let span = annotation.span();
+        let location = span
+            .source_file()
+            .to_source_code()
+            .line_column(span.range().start());
+        format!(
+            "{}:{location}: {severity}[{}] {}\n",
+            display_path(span.source_file(), cwd),
+            diagnostic.code(),
+            diagnostic.concise_message()
+        )
+    } else {
+        format!(
+            "{severity}[{}] {}\n",
+            diagnostic.code(),
+            diagnostic.concise_message()
+        )
+    }
+}
+
+fn render_message(
+    severity: Severity,
+    code: Option<&str>,
+    message: &str,
+    annotations: &[Annotation],
+    cwd: &Utf8Path,
+    color: bool,
+) -> String {
+    let mut files: Vec<(&SourceFile, Vec<&Annotation>)> = Vec::new();
+    for annotation in annotations {
+        let source_file = annotation.span().source_file();
+        if let Some((_, file_annotations)) = files
+            .iter_mut()
+            .find(|(existing, _)| *existing == source_file)
+        {
+            file_annotations.push(annotation);
+        } else {
+            files.push((source_file, vec![annotation]));
         }
     }
+    for (_, annotations) in &mut files {
+        annotations.sort_by_key(|annotation| annotation.span().range().start());
+    }
 
-    Ok(())
+    let paths = files
+        .iter()
+        .map(|(source_file, _)| display_path(source_file, cwd).into_string())
+        .collect::<Vec<_>>();
+    let snippets = files
+        .iter()
+        .zip(&paths)
+        .map(|((source_file, annotations), path)| {
+            Snippet::source(source_file.source_text())
+                .origin(path)
+                .fold(true)
+                .annotations(annotations.iter().map(|annotation| {
+                    let range = annotation.span().range();
+                    let level = if annotation.is_primary() {
+                        Level::Error
+                    } else {
+                        Level::Warning
+                    };
+                    let rendered_annotation =
+                        level.span(usize::from(range.start())..usize::from(range.end()));
+                    if let Some(message) = annotation.message_text() {
+                        rendered_annotation.label(message)
+                    } else {
+                        rendered_annotation
+                    }
+                }))
+        });
+    let mut diagnostic = level(severity).title(message).snippets(snippets);
+    if let Some(code) = code {
+        diagnostic = diagnostic.id(code);
+    }
+    let renderer = if color {
+        Renderer::styled()
+    } else {
+        Renderer::plain()
+    };
+    format!("{}\n", renderer.render(diagnostic))
 }
 
-fn ensure_source_file_span(file: &UnifiedFile) -> Result<()> {
-    if matches!(file, UnifiedFile::Ty(_)) {
-        bail!("cannot render ty-backed diagnostics without a Ruff database");
-    }
-    Ok(())
+fn display_path(source_file: &SourceFile, cwd: &Utf8Path) -> Utf8PathBuf {
+    let path = Utf8Path::new(source_file.name());
+    path.strip_prefix(cwd).unwrap_or(path).to_path_buf()
 }
 
-struct DiagnosticFileResolver<'a> {
-    cwd: &'a Utf8Path,
-}
-
-impl<'a> DiagnosticFileResolver<'a> {
-    fn new(cwd: &'a Utf8Path) -> Self {
-        Self { cwd }
+fn level(severity: Severity) -> Level {
+    match severity {
+        Severity::Info => Level::Info,
+        Severity::Warning => Level::Warning,
+        Severity::Error | Severity::Fatal => Level::Error,
     }
 }
 
-impl FileResolver for DiagnosticFileResolver<'_> {
-    fn path(&self, file: File) -> &str {
-        DummyFileResolver.path(file)
-    }
-
-    fn input(&self, file: File) -> Input {
-        DummyFileResolver.input(file)
-    }
-
-    fn notebook_index(&self, _file: &UnifiedFile) -> Option<NotebookIndex> {
-        None
-    }
-
-    fn is_notebook(&self, _file: &UnifiedFile) -> bool {
-        false
-    }
-
-    fn current_directory(&self) -> &Path {
-        self.cwd.as_std_path()
+fn severity_name(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Info => "info",
+        Severity::Warning => "warning",
+        Severity::Error => "error",
+        Severity::Fatal => "fatal",
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use camino::Utf8PathBuf;
-    use ruff_db::diagnostic::{
-        Annotation, Diagnostic, DiagnosticId, DisplayDiagnosticConfig, LintName, Severity, Span,
-    };
+    use karva_diagnostic::{Annotation, Diagnostic, Severity, Span};
     use ruff_source_file::SourceFileBuilder;
     use ruff_text_size::{TextRange, TextSize};
 
@@ -104,14 +190,14 @@ mod tests {
 
     #[test]
     fn renders_source_file_diagnostics() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let cwd = Utf8PathBuf::try_from(temp_dir.path().to_path_buf()).unwrap();
-
+        let temp_dir = tempfile::tempdir().expect("create temporary directory");
+        let cwd =
+            Utf8PathBuf::try_from(temp_dir.path().to_path_buf()).expect("temporary path is UTF-8");
         let source = "def test_example():\n    assert False\n";
         let source_file =
             SourceFileBuilder::new(cwd.join("test_sample.py").as_str(), source).finish();
         let mut diagnostic = Diagnostic::new(
-            DiagnosticId::Lint(LintName::of("test-failure")),
+            "test-failure",
             Severity::Error,
             "Test `test_example` failed",
         );
@@ -119,8 +205,12 @@ mod tests {
             Span::from(source_file).with_range(TextRange::new(TextSize::new(4), TextSize::new(16))),
         ));
 
-        let config = DisplayDiagnosticConfig::new("karva").context(0);
-        let rendered = render_diagnostic(&diagnostic, &cwd, &config).expect("render diagnostic");
+        let rendered = render_diagnostic(
+            &diagnostic,
+            &cwd,
+            &DisplayDiagnosticConfig::new(DiagnosticFormat::Full, false),
+        )
+        .expect("render diagnostic");
 
         assert_eq!(rendered.code(), "test-failure");
         assert_eq!(rendered.message(), "Test `test_example` failed");
@@ -134,16 +224,12 @@ mod tests {
         let temp_dir = tempfile::tempdir().expect("create temporary directory");
         let cwd =
             Utf8PathBuf::try_from(temp_dir.path().to_path_buf()).expect("temporary path is UTF-8");
-        let diagnostic = Diagnostic::new(
-            DiagnosticId::Lint(LintName::of("test-failure")),
-            Severity::Error,
-            "failed",
-        );
+        let diagnostic = Diagnostic::new("test-failure", Severity::Error, "failed");
 
         let rendered = render_diagnostic(
             &diagnostic,
             &cwd,
-            &DisplayDiagnosticConfig::new("karva").color(true),
+            &DisplayDiagnosticConfig::new(DiagnosticFormat::Full, true),
         )
         .expect("render diagnostic");
 

--- a/crates/karva_cache/src/diagnostics.rs
+++ b/crates/karva_cache/src/diagnostics.rs
@@ -114,36 +114,52 @@ fn render_message(
             files.push((source_file, vec![annotation]));
         }
     }
-    for (_, annotations) in &mut files {
-        annotations.sort_by_key(|annotation| annotation.span().range().start());
-    }
-
     let paths = files
         .iter()
         .map(|(source_file, _)| display_path(source_file, cwd).into_string())
         .collect::<Vec<_>>();
     let snippets = files
-        .iter()
+        .iter_mut()
         .zip(&paths)
-        .map(|((source_file, annotations), path)| {
-            Snippet::source(source_file.source_text())
-                .origin(path)
-                .fold(true)
-                .annotations(annotations.iter().map(|annotation| {
-                    let range = annotation.span().range();
-                    let level = if annotation.is_primary() {
-                        Level::Error
-                    } else {
-                        Level::Warning
-                    };
-                    let rendered_annotation =
-                        level.span(usize::from(range.start())..usize::from(range.end()));
-                    if let Some(message) = annotation.message_text() {
-                        rendered_annotation.label(message)
-                    } else {
-                        rendered_annotation
-                    }
-                }))
+        .flat_map(|((source_file, annotations), path)| {
+            let groups = if annotations.windows(2).all(|pair| {
+                source_file
+                    .to_source_code()
+                    .line_column(pair[0].span().range().start())
+                    .line
+                    == source_file
+                        .to_source_code()
+                        .line_column(pair[1].span().range().start())
+                        .line
+            }) {
+                annotations.sort_by_key(|annotation| annotation.span().range().start());
+                vec![annotations.clone()]
+            } else {
+                annotations
+                    .iter()
+                    .map(|annotation| vec![*annotation])
+                    .collect()
+            };
+            groups.into_iter().map(move |annotations| {
+                Snippet::source(source_file.source_text())
+                    .origin(path)
+                    .fold(true)
+                    .annotations(annotations.into_iter().map(|annotation| {
+                        let range = annotation.span().range();
+                        let level = if annotation.is_primary() {
+                            Level::Error
+                        } else {
+                            Level::Warning
+                        };
+                        let rendered_annotation =
+                            level.span(usize::from(range.start())..usize::from(range.end()));
+                        if let Some(message) = annotation.message_text() {
+                            rendered_annotation.label(message)
+                        } else {
+                            rendered_annotation
+                        }
+                    }))
+            })
         });
     let mut diagnostic = level(severity).title(message).snippets(snippets);
     if let Some(code) = code {

--- a/crates/karva_cache/src/lib.rs
+++ b/crates/karva_cache/src/lib.rs
@@ -2,7 +2,6 @@
 
 pub(crate) mod artifact;
 pub(crate) mod cache;
-pub(crate) mod diagnostics;
 pub(crate) mod hash;
 
 pub use cache::{
@@ -10,7 +9,6 @@ pub use cache::{
     read_last_failed, read_random_seed, read_recent_durations, write_last_failed,
     write_random_seed,
 };
-pub use diagnostics::{DiagnosticFormat, DisplayDiagnosticConfig};
 pub use hash::RunHash;
 pub use karva_diagnostic::{DisplayFlakyTests, FlakyTest};
 

--- a/crates/karva_cache/src/lib.rs
+++ b/crates/karva_cache/src/lib.rs
@@ -10,6 +10,7 @@ pub use cache::{
     read_last_failed, read_random_seed, read_recent_durations, write_last_failed,
     write_random_seed,
 };
+pub use diagnostics::{DiagnosticFormat, DisplayDiagnosticConfig};
 pub use hash::RunHash;
 pub use karva_diagnostic::{DisplayFlakyTests, FlakyTest};
 

--- a/crates/karva_cli/Cargo.toml
+++ b/crates/karva_cli/Cargo.toml
@@ -19,7 +19,6 @@ karva_version = { workspace = true }
 camino = { workspace = true }
 clap = { workspace = true, features = ["wrap_help", "string", "env"] }
 clap_complete_command = { workspace = true }
-ruff_db = { workspace = true }
 serde_json = { workspace = true }
 
 [lints]

--- a/crates/karva_cli/src/enums.rs
+++ b/crates/karva_cli/src/enums.rs
@@ -1,7 +1,6 @@
 use std::str::FromStr;
 
 use camino::Utf8PathBuf;
-use ruff_db::diagnostic::DiagnosticFormat;
 
 use karva_metadata::{
     FlakyResult as FlakyResultMode, JunitFlakyFailStatus as JunitFlakyFailStatusMode, NoTestsMode,
@@ -98,15 +97,6 @@ pub enum ResultFormat {
     /// Write newline-delimited JSON records.
     #[value(name = "jsonl")]
     Jsonl,
-}
-
-impl From<OutputFormat> for DiagnosticFormat {
-    fn from(value: OutputFormat) -> Self {
-        match value {
-            OutputFormat::Full => Self::Full,
-            OutputFormat::Concise => Self::Concise,
-        }
-    }
 }
 
 impl From<OutputFormat> for karva_metadata::OutputFormat {

--- a/crates/karva_diagnostic/Cargo.toml
+++ b/crates/karva_diagnostic/Cargo.toml
@@ -14,6 +14,7 @@ license.workspace = true
 traceback = ["pyo3"]
 
 [dependencies]
+annotate-snippets = { workspace = true }
 karva_logging = { workspace = true }
 karva_python_semantic = { workspace = true }
 

--- a/crates/karva_diagnostic/Cargo.toml
+++ b/crates/karva_diagnostic/Cargo.toml
@@ -21,7 +21,6 @@ camino = { workspace = true }
 colored = { workspace = true }
 fs-err = { workspace = true }
 pyo3 = { workspace = true, optional = true }
-ruff_db = { workspace = true }
 ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }
 serde = { workspace = true }

--- a/crates/karva_diagnostic/src/diagnostic.rs
+++ b/crates/karva_diagnostic/src/diagnostic.rs
@@ -28,11 +28,11 @@ impl Span {
         self
     }
 
-    pub(crate) fn source_file(&self) -> &SourceFile {
+    pub(super) fn source_file(&self) -> &SourceFile {
         &self.source_file
     }
 
-    pub(crate) fn range(&self) -> TextRange {
+    pub(super) fn range(&self) -> TextRange {
         self.range
     }
 }
@@ -83,15 +83,15 @@ impl Annotation {
         self
     }
 
-    pub(crate) fn is_primary(&self) -> bool {
+    pub(super) fn is_primary(&self) -> bool {
         self.kind == AnnotationKind::Primary
     }
 
-    pub(crate) fn span(&self) -> &Span {
+    pub(super) fn span(&self) -> &Span {
         &self.span
     }
 
-    pub(crate) fn message_text(&self) -> Option<&str> {
+    pub(super) fn message_text(&self) -> Option<&str> {
         self.message.as_deref()
     }
 }
@@ -117,15 +117,15 @@ impl SubDiagnostic {
         self.annotations.push(annotation);
     }
 
-    pub(crate) fn severity(&self) -> Severity {
+    pub(super) fn severity(&self) -> Severity {
         self.severity
     }
 
-    pub(crate) fn message(&self) -> &str {
+    pub(super) fn message(&self) -> &str {
         &self.message
     }
 
-    pub(crate) fn annotations(&self) -> &[Annotation] {
+    pub(super) fn annotations(&self) -> &[Annotation] {
         &self.annotations
     }
 }
@@ -169,33 +169,33 @@ impl Diagnostic {
         self.concise_message = Some(message.into());
     }
 
-    pub(crate) fn code(&self) -> &'static str {
+    pub(super) fn code(&self) -> &'static str {
         self.code
     }
 
-    pub(crate) fn severity(&self) -> Severity {
+    pub(super) fn severity(&self) -> Severity {
         self.severity
     }
 
-    pub(crate) fn primary_message(&self) -> &str {
+    pub(super) fn primary_message(&self) -> &str {
         &self.message
     }
 
-    pub(crate) fn concise_message(&self) -> &str {
+    pub(super) fn concise_message(&self) -> &str {
         self.concise_message.as_deref().unwrap_or(&self.message)
     }
 
-    pub(crate) fn primary_annotation(&self) -> Option<&Annotation> {
+    pub(super) fn primary_annotation(&self) -> Option<&Annotation> {
         self.annotations
             .iter()
             .find(|annotation| annotation.is_primary())
     }
 
-    pub(crate) fn annotations(&self) -> &[Annotation] {
+    pub(super) fn annotations(&self) -> &[Annotation] {
         &self.annotations
     }
 
-    pub(crate) fn sub_diagnostics(&self) -> &[SubDiagnostic] {
+    pub(super) fn sub_diagnostics(&self) -> &[SubDiagnostic] {
         &self.sub_diagnostics
     }
 }

--- a/crates/karva_diagnostic/src/diagnostic.rs
+++ b/crates/karva_diagnostic/src/diagnostic.rs
@@ -1,0 +1,201 @@
+//! Source-backed diagnostics produced while collecting and running tests.
+
+use ruff_source_file::SourceFile;
+use ruff_text_size::{TextRange, TextSize};
+use serde::{Deserialize, Serialize};
+
+/// Importance of a diagnostic and whether it makes the test run fail.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Info,
+    Warning,
+    Error,
+    Fatal,
+}
+
+/// Source location highlighted by a diagnostic.
+#[derive(Debug, Clone)]
+pub struct Span {
+    source_file: SourceFile,
+    range: TextRange,
+}
+
+impl Span {
+    #[must_use]
+    pub fn with_range(mut self, range: TextRange) -> Self {
+        self.range = range;
+        self
+    }
+
+    pub fn source_file(&self) -> &SourceFile {
+        &self.source_file
+    }
+
+    pub fn range(&self) -> TextRange {
+        self.range
+    }
+}
+
+impl From<SourceFile> for Span {
+    fn from(source_file: SourceFile) -> Self {
+        Self {
+            source_file,
+            range: TextRange::empty(TextSize::default()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AnnotationKind {
+    Primary,
+    Secondary,
+}
+
+/// Label attached to a source span.
+#[derive(Debug, Clone)]
+pub struct Annotation {
+    kind: AnnotationKind,
+    span: Span,
+    message: Option<String>,
+}
+
+impl Annotation {
+    pub fn primary(span: Span) -> Self {
+        Self {
+            kind: AnnotationKind::Primary,
+            span,
+            message: None,
+        }
+    }
+
+    pub fn secondary(span: Span) -> Self {
+        Self {
+            kind: AnnotationKind::Secondary,
+            span,
+            message: None,
+        }
+    }
+
+    #[must_use]
+    pub fn message(mut self, message: impl Into<String>) -> Self {
+        self.message = Some(message.into());
+        self
+    }
+
+    pub fn is_primary(&self) -> bool {
+        self.kind == AnnotationKind::Primary
+    }
+
+    pub fn span(&self) -> &Span {
+        &self.span
+    }
+
+    pub fn message_text(&self) -> Option<&str> {
+        self.message.as_deref()
+    }
+}
+
+/// Supporting diagnostic displayed after the primary diagnostic.
+#[derive(Debug, Clone)]
+pub struct SubDiagnostic {
+    severity: Severity,
+    message: String,
+    annotations: Vec<Annotation>,
+}
+
+impl SubDiagnostic {
+    pub fn new(severity: Severity, message: impl Into<String>) -> Self {
+        Self {
+            severity,
+            message: message.into(),
+            annotations: Vec::new(),
+        }
+    }
+
+    pub fn annotate(&mut self, annotation: Annotation) {
+        self.annotations.push(annotation);
+    }
+
+    pub fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    pub fn annotations(&self) -> &[Annotation] {
+        &self.annotations
+    }
+}
+
+/// Diagnostic value passed from test execution to the cache renderer.
+#[derive(Debug, Clone)]
+pub struct Diagnostic {
+    code: &'static str,
+    severity: Severity,
+    message: String,
+    concise_message: Option<String>,
+    annotations: Vec<Annotation>,
+    sub_diagnostics: Vec<SubDiagnostic>,
+}
+
+impl Diagnostic {
+    pub fn new(code: &'static str, severity: Severity, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            severity,
+            message: message.into(),
+            concise_message: None,
+            annotations: Vec::new(),
+            sub_diagnostics: Vec::new(),
+        }
+    }
+
+    pub fn annotate(&mut self, annotation: Annotation) {
+        self.annotations.push(annotation);
+    }
+
+    pub fn info(&mut self, message: impl Into<String>) {
+        self.sub(SubDiagnostic::new(Severity::Info, message));
+    }
+
+    pub fn sub(&mut self, diagnostic: SubDiagnostic) {
+        self.sub_diagnostics.push(diagnostic);
+    }
+
+    pub fn set_concise_message(&mut self, message: impl Into<String>) {
+        self.concise_message = Some(message.into());
+    }
+
+    pub fn code(&self) -> &'static str {
+        self.code
+    }
+
+    pub fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    pub fn primary_message(&self) -> &str {
+        &self.message
+    }
+
+    pub fn concise_message(&self) -> &str {
+        self.concise_message.as_deref().unwrap_or(&self.message)
+    }
+
+    pub fn primary_annotation(&self) -> Option<&Annotation> {
+        self.annotations
+            .iter()
+            .find(|annotation| annotation.is_primary())
+    }
+
+    pub fn annotations(&self) -> &[Annotation] {
+        &self.annotations
+    }
+
+    pub fn sub_diagnostics(&self) -> &[SubDiagnostic] {
+        &self.sub_diagnostics
+    }
+}

--- a/crates/karva_diagnostic/src/diagnostic.rs
+++ b/crates/karva_diagnostic/src/diagnostic.rs
@@ -28,11 +28,11 @@ impl Span {
         self
     }
 
-    pub fn source_file(&self) -> &SourceFile {
+    pub(crate) fn source_file(&self) -> &SourceFile {
         &self.source_file
     }
 
-    pub fn range(&self) -> TextRange {
+    pub(crate) fn range(&self) -> TextRange {
         self.range
     }
 }
@@ -83,15 +83,15 @@ impl Annotation {
         self
     }
 
-    pub fn is_primary(&self) -> bool {
+    pub(crate) fn is_primary(&self) -> bool {
         self.kind == AnnotationKind::Primary
     }
 
-    pub fn span(&self) -> &Span {
+    pub(crate) fn span(&self) -> &Span {
         &self.span
     }
 
-    pub fn message_text(&self) -> Option<&str> {
+    pub(crate) fn message_text(&self) -> Option<&str> {
         self.message.as_deref()
     }
 }
@@ -117,15 +117,15 @@ impl SubDiagnostic {
         self.annotations.push(annotation);
     }
 
-    pub fn severity(&self) -> Severity {
+    pub(crate) fn severity(&self) -> Severity {
         self.severity
     }
 
-    pub fn message(&self) -> &str {
+    pub(crate) fn message(&self) -> &str {
         &self.message
     }
 
-    pub fn annotations(&self) -> &[Annotation] {
+    pub(crate) fn annotations(&self) -> &[Annotation] {
         &self.annotations
     }
 }
@@ -169,33 +169,33 @@ impl Diagnostic {
         self.concise_message = Some(message.into());
     }
 
-    pub fn code(&self) -> &'static str {
+    pub(crate) fn code(&self) -> &'static str {
         self.code
     }
 
-    pub fn severity(&self) -> Severity {
+    pub(crate) fn severity(&self) -> Severity {
         self.severity
     }
 
-    pub fn primary_message(&self) -> &str {
+    pub(crate) fn primary_message(&self) -> &str {
         &self.message
     }
 
-    pub fn concise_message(&self) -> &str {
+    pub(crate) fn concise_message(&self) -> &str {
         self.concise_message.as_deref().unwrap_or(&self.message)
     }
 
-    pub fn primary_annotation(&self) -> Option<&Annotation> {
+    pub(crate) fn primary_annotation(&self) -> Option<&Annotation> {
         self.annotations
             .iter()
             .find(|annotation| annotation.is_primary())
     }
 
-    pub fn annotations(&self) -> &[Annotation] {
+    pub(crate) fn annotations(&self) -> &[Annotation] {
         &self.annotations
     }
 
-    pub fn sub_diagnostics(&self) -> &[SubDiagnostic] {
+    pub(crate) fn sub_diagnostics(&self) -> &[SubDiagnostic] {
         &self.sub_diagnostics
     }
 }

--- a/crates/karva_diagnostic/src/lib.rs
+++ b/crates/karva_diagnostic/src/lib.rs
@@ -1,12 +1,14 @@
 //! Test outcomes, diagnostics, tracebacks, and user-facing result reporting.
 
 mod diagnostic;
+mod render;
 mod reporter;
 mod result;
 #[cfg(feature = "traceback")]
 mod traceback;
 
 pub use diagnostic::{Annotation, Diagnostic, Severity, Span, SubDiagnostic};
+pub use render::{DiagnosticFormat, DisplayDiagnosticConfig, render_diagnostic};
 pub use reporter::{DummyReporter, Reporter, TestCaseReporter};
 pub use result::{
     CapturedTestOutput, DisplayFlakyTests, FixtureFailure, FixtureUsage, FlakyTest,

--- a/crates/karva_diagnostic/src/lib.rs
+++ b/crates/karva_diagnostic/src/lib.rs
@@ -1,10 +1,12 @@
 //! Test outcomes, diagnostics, tracebacks, and user-facing result reporting.
 
+mod diagnostic;
 mod reporter;
 mod result;
 #[cfg(feature = "traceback")]
 mod traceback;
 
+pub use diagnostic::{Annotation, Diagnostic, Severity, Span, SubDiagnostic};
 pub use reporter::{DummyReporter, Reporter, TestCaseReporter};
 pub use result::{
     CapturedTestOutput, DisplayFlakyTests, FixtureFailure, FixtureUsage, FlakyTest,

--- a/crates/karva_diagnostic/src/render.rs
+++ b/crates/karva_diagnostic/src/render.rs
@@ -1,6 +1,6 @@
+use crate::{Annotation, Diagnostic, RenderedDiagnostic, Severity};
 use annotate_snippets::{Level, Renderer, Snippet};
 use camino::{Utf8Path, Utf8PathBuf};
-use karva_diagnostic::{Annotation, Diagnostic, RenderedDiagnostic, Severity};
 use ruff_source_file::SourceFile;
 
 /// Shape used when rendering diagnostics for users.
@@ -192,61 +192,5 @@ fn severity_name(severity: Severity) -> &'static str {
         Severity::Warning => "warning",
         Severity::Error => "error",
         Severity::Fatal => "fatal",
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use karva_diagnostic::{Annotation, Diagnostic, Severity, Span};
-    use ruff_source_file::SourceFileBuilder;
-    use ruff_text_size::{TextRange, TextSize};
-
-    use super::*;
-
-    #[test]
-    fn renders_source_file_diagnostics() {
-        let temp_dir = tempfile::tempdir().expect("create temporary directory");
-        let cwd =
-            Utf8PathBuf::try_from(temp_dir.path().to_path_buf()).expect("temporary path is UTF-8");
-        let source = "def test_example():\n    assert False\n";
-        let source_file =
-            SourceFileBuilder::new(cwd.join("test_sample.py").as_str(), source).finish();
-        let mut diagnostic = Diagnostic::new(
-            "test-failure",
-            Severity::Error,
-            "Test `test_example` failed",
-        );
-        diagnostic.annotate(Annotation::primary(
-            Span::from(source_file).with_range(TextRange::new(TextSize::new(4), TextSize::new(16))),
-        ));
-
-        let rendered = render_diagnostic(
-            &diagnostic,
-            &cwd,
-            DisplayDiagnosticConfig::new(DiagnosticFormat::Full, false),
-        );
-
-        assert_eq!(rendered.code(), "test-failure");
-        assert_eq!(rendered.message(), "Test `test_example` failed");
-        assert!(rendered.rendered().contains("test_sample.py"));
-        assert!(rendered.rendered().contains("Test `test_example` failed"));
-        assert!(rendered.rendered().contains("def test_example():"));
-    }
-
-    #[test]
-    fn keeps_machine_rendering_plain_when_terminal_uses_color() {
-        let temp_dir = tempfile::tempdir().expect("create temporary directory");
-        let cwd =
-            Utf8PathBuf::try_from(temp_dir.path().to_path_buf()).expect("temporary path is UTF-8");
-        let diagnostic = Diagnostic::new("test-failure", Severity::Error, "failed");
-
-        let rendered = render_diagnostic(
-            &diagnostic,
-            &cwd,
-            DisplayDiagnosticConfig::new(DiagnosticFormat::Full, true),
-        );
-
-        assert!(!rendered.rendered().contains('\u{1b}'));
-        assert!(rendered.rendered_for_terminal().contains('\u{1b}'));
     }
 }

--- a/crates/karva_diagnostic/src/result/case.rs
+++ b/crates/karva_diagnostic/src/result/case.rs
@@ -1,8 +1,9 @@
 use std::time::Duration;
 
 use karva_python_semantic::QualifiedTestName;
-use ruff_db::diagnostic::Diagnostic;
 use serde::{Deserialize, Serialize};
+
+use crate::Diagnostic;
 
 use super::diagnostic::RenderedDiagnostic;
 use super::kind::IndividualTestResultKind;
@@ -476,11 +477,11 @@ pub enum FixtureUsage {
     AutoUse,
 }
 
-/// Worker-side test result retaining Ruff diagnostics.
+/// Worker-side test result retaining structured diagnostics.
 pub type TestExecutionResult = TestCaseResult<Diagnostic>;
-/// Worker-side test outcome retaining Ruff diagnostics.
+/// Worker-side test outcome retaining structured diagnostics.
 pub type TestExecutionOutcome = TestCaseOutcome<Diagnostic>;
-/// Worker-side retry attempt retaining Ruff diagnostics.
+/// Worker-side retry attempt retaining structured diagnostics.
 pub type TestExecutionAttempt = TestCaseAttempt<Diagnostic>;
 
 #[cfg(test)]

--- a/crates/karva_diagnostic/src/result/diagnostic.rs
+++ b/crates/karva_diagnostic/src/result/diagnostic.rs
@@ -1,11 +1,11 @@
-use ruff_db::diagnostic::Severity;
 use serde::{Deserialize, Serialize};
+
+use crate::Severity;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 /// Diagnostic serialized for controller-side display after worker execution.
 pub struct RenderedDiagnostic {
     code: String,
-    #[serde(with = "SerializableSeverity")]
     severity: Severity,
     message: String,
     rendered: String,
@@ -81,21 +81,12 @@ impl RenderedDiagnostic {
     }
 }
 
-#[derive(Serialize, Deserialize)]
-#[serde(remote = "Severity", rename_all = "lowercase")]
-enum SerializableSeverity {
-    Info,
-    Warning,
-    Error,
-    Fatal,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn serializes_ruff_severity() {
+    fn serializes_severity() {
         for (severity, name) in [
             (Severity::Info, "info"),
             (Severity::Warning, "warning"),

--- a/crates/karva_diagnostic/src/result/diagnostic.rs
+++ b/crates/karva_diagnostic/src/result/diagnostic.rs
@@ -80,27 +80,3 @@ impl RenderedDiagnostic {
         self.colored_rendered.as_deref().unwrap_or(&self.rendered)
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn serializes_severity() {
-        for (severity, name) in [
-            (Severity::Info, "info"),
-            (Severity::Warning, "warning"),
-            (Severity::Error, "error"),
-            (Severity::Fatal, "fatal"),
-        ] {
-            let diagnostic =
-                RenderedDiagnostic::new("test-failure", severity, "failed", "rendered");
-            let json = serde_json::to_string(&diagnostic).expect("serialize diagnostic");
-            let roundtrip: RenderedDiagnostic =
-                serde_json::from_str(&json).expect("deserialize diagnostic");
-
-            assert_eq!(roundtrip, diagnostic);
-            assert!(json.contains(&format!(r#""severity":"{name}""#)));
-        }
-    }
-}

--- a/crates/karva_diagnostic/src/result/diagnostic.rs
+++ b/crates/karva_diagnostic/src/result/diagnostic.rs
@@ -32,7 +32,7 @@ impl RenderedDiagnostic {
 
     /// Stores a colored rendering only when it differs from plain output.
     #[must_use]
-    pub fn with_colored_rendered(mut self, rendered: String) -> Self {
+    pub(crate) fn with_colored_rendered(mut self, rendered: String) -> Self {
         if rendered != self.rendered {
             self.colored_rendered = Some(rendered);
         }

--- a/crates/karva_diagnostic/src/result/mod.rs
+++ b/crates/karva_diagnostic/src/result/mod.rs
@@ -10,8 +10,7 @@ mod stats;
 use std::collections::{HashMap, HashSet};
 
 use karva_python_semantic::{QualifiedTestName, TestCacheKey};
-use ruff_db::diagnostic::Diagnostic;
-
+use crate::Diagnostic;
 use crate::reporter::Reporter;
 
 pub use case::{
@@ -65,21 +64,21 @@ pub struct TestRunResultParts {
 
 /// Orders diagnostics for display.
 ///
-/// `Diagnostic::ruff_start_ordering` panics when either diagnostic has no
-/// primary span pointing at a `SourceFile`, which is the case for karva
-/// diagnostics like `failed-to-import-module` that describe a whole module
-/// rather than a location within it. Diagnostics with a source file sort by
-/// that ordering first; span-less diagnostics sort after them, by id and
-/// then message, so they still appear rather than being dropped or causing
-/// the sort to panic.
+/// Diagnostics with a source file sort by source and span; span-less diagnostics
+/// sort after them by code and message.
 fn diagnostic_display_ordering(a: &Diagnostic, b: &Diagnostic) -> std::cmp::Ordering {
-    match (a.ruff_source_file(), b.ruff_source_file()) {
-        (Some(_), Some(_)) => a.ruff_start_ordering(b),
+    match (a.primary_annotation(), b.primary_annotation()) {
+        (Some(a), Some(b)) => a
+            .span()
+            .source_file()
+            .cmp(b.span().source_file())
+            .then_with(|| a.span().range().start().cmp(&b.span().range().start()))
+            .then_with(|| a.span().range().end().cmp(&b.span().range().end())),
         (Some(_), None) => std::cmp::Ordering::Less,
         (None, Some(_)) => std::cmp::Ordering::Greater,
         (None, None) => a
-            .id()
-            .cmp(&b.id())
+            .code()
+            .cmp(b.code())
             .then_with(|| a.primary_message().cmp(b.primary_message())),
     }
 }

--- a/crates/karva_diagnostic/src/result/mod.rs
+++ b/crates/karva_diagnostic/src/result/mod.rs
@@ -9,9 +9,9 @@ mod stats;
 
 use std::collections::{HashMap, HashSet};
 
-use karva_python_semantic::{QualifiedTestName, TestCacheKey};
 use crate::Diagnostic;
 use crate::reporter::Reporter;
+use karva_python_semantic::{QualifiedTestName, TestCacheKey};
 
 pub use case::{
     FixtureFailure, FixtureUsage, TestCaseAttempt, TestCaseOutcome, TestCaseResult, TestCaseRetry,

--- a/crates/karva_metadata/Cargo.toml
+++ b/crates/karva_metadata/Cargo.toml
@@ -26,7 +26,6 @@ camino = { workspace = true }
 fs-err = { workspace = true }
 globset = { workspace = true }
 regex = { workspace = true }
-ruff_db = { workspace = true }
 ruff_options_metadata = { workspace = true }
 ruff_python_ast = { workspace = true }
 ruff_python_stdlib = { workspace = true }

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -8,7 +8,6 @@ use std::collections::BTreeMap;
 use karva_combine::Combine;
 use karva_logging::{FinalStatusLevel, StatusLevel};
 use karva_macros::{Combine, OptionsMetadata};
-use ruff_db::diagnostic::DiagnosticFormat;
 use serde::{Deserialize, Serialize};
 
 pub use config::{Config, IncompatibleVersionError, KarvaTomlError, UnknownProfile};
@@ -1077,15 +1076,6 @@ impl OutputFormat {
         match self {
             Self::Full => "full",
             Self::Concise => "concise",
-        }
-    }
-}
-
-impl From<OutputFormat> for DiagnosticFormat {
-    fn from(value: OutputFormat) -> Self {
-        match value {
-            OutputFormat::Full => Self::Full,
-            OutputFormat::Concise => Self::Concise,
         }
     }
 }

--- a/crates/karva_test_semantic/Cargo.toml
+++ b/crates/karva_test_semantic/Cargo.toml
@@ -24,7 +24,6 @@ karva_python_semantic = { workspace = true }
 karva_snapshot = { workspace = true }
 karva_static = { workspace = true }
 pyo3 = { workspace = true }
-ruff_db = { workspace = true }
 ruff_macros = { workspace = true }
 ruff_python_ast = { workspace = true }
 ruff_python_parser = { workspace = true }

--- a/crates/karva_test_semantic/src/context.rs
+++ b/crates/karva_test_semantic/src/context.rs
@@ -1,12 +1,11 @@
 use camino::Utf8Path;
 use karva_collector::CollectionSettings;
 use karva_diagnostic::{
-    CapturedTestOutput, IndividualTestResultKind, Reporter, TestCaseRetry, TestExecutionAttempt,
-    TestExecutionOutcome, TestRunResult,
+    CapturedTestOutput, Diagnostic, IndividualTestResultKind, Reporter, TestCaseRetry,
+    TestExecutionAttempt, TestExecutionOutcome, TestRunResult,
 };
 use karva_metadata::ProjectSettings;
 use karva_python_semantic::{ModulePath, QualifiedFunctionName, QualifiedTestName};
-use ruff_db::diagnostic::Diagnostic;
 use ruff_python_ast::PythonVersion;
 
 /// Immutable configuration and reporting services shared by one test run.

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -1,16 +1,15 @@
-//! Converts collection and execution failures into source-backed `ruff_db` diagnostics.
+//! Converts collection and execution failures into source-backed diagnostics.
 //!
 //! Discovery and execution failures are rendered here without mutating run state.
 
 use camino::Utf8Path;
 use karva_collector::CollectionError;
-use karva_diagnostic::{Traceback, TracebackFrame};
+use karva_diagnostic::{
+    Annotation, Diagnostic, Severity, Span, SubDiagnostic, Traceback, TracebackFrame,
+};
 use karva_logging::time::format_duration;
 use karva_python_semantic::FunctionKind;
 use pyo3::{PyErr, Python};
-use ruff_db::diagnostic::{
-    Annotation, Diagnostic, Severity, Span, SubDiagnostic, SubDiagnosticSeverity,
-};
 use ruff_python_ast::StmtFunctionDef;
 use ruff_source_file::SourceFile;
 use ruff_text_size::TextRange;
@@ -278,7 +277,7 @@ fn annotate_first_definition(
     stmt_function_def: &StmtFunctionDef,
 ) {
     let mut sub = SubDiagnostic::new(
-        SubDiagnosticSeverity::Info,
+        Severity::Info,
         format!("First definition of `{name}` is here"),
     );
     let span = Span::from(source_file).with_range(stmt_function_def.name.range);
@@ -302,7 +301,7 @@ fn report_dependency_chain(
             .map_or(fixture_name, |next| next.name.as_str());
 
         let mut sub = SubDiagnostic::new(
-            SubDiagnosticSeverity::Info,
+            Severity::Info,
             format!("Fixture `{}` requires `{next_name}`", entry.name),
         );
 
@@ -470,7 +469,7 @@ fn fixture_cycle_diagnostic(cycle: &[FixtureResolutionEntry]) -> Diagnostic {
             continue;
         };
         let mut sub = SubDiagnostic::new(
-            SubDiagnosticSeverity::Info,
+            Severity::Info,
             format!("Fixture `{}` requires `{}`", fixture.name, dependency.name),
         );
         let span = Span::from(fixture.definition.source_file().clone())
@@ -511,7 +510,7 @@ fn fixture_scope_mismatch_diagnostic(
     for (index, path_fixture) in dependency_path.iter().enumerate() {
         let next_fixture = dependency_path.get(index + 1).unwrap_or(fixture);
         let mut sub = SubDiagnostic::new(
-            SubDiagnosticSeverity::Info,
+            Severity::Info,
             format!(
                 "Fixture `{}` depends on fixture `{}`",
                 path_fixture.name, next_fixture.name
@@ -524,7 +523,7 @@ fn fixture_scope_mismatch_diagnostic(
     }
 
     let mut dependency_sub = SubDiagnostic::new(
-        SubDiagnosticSeverity::Info,
+        Severity::Info,
         format!(
             "Fixture `{}` has `{}` scope",
             dependency.name,
@@ -552,7 +551,7 @@ fn fixture_missing_fixtures_diagnostic(
 
     for rejected_fixture in rejected_fixtures {
         let mut sub = SubDiagnostic::new(
-            SubDiagnosticSeverity::Info,
+            Severity::Info,
             format!(
                 "Fixture `{}` was rejected during discovery: {}",
                 rejected_fixture.name(),
@@ -759,7 +758,7 @@ fn handle_failed_function_call(
                 if let [caller, callee] = pair {
                     let message = format!("Called `{}` here", callee.function_name);
                     if let Some(source) = &caller.source {
-                        let mut sub = SubDiagnostic::new(SubDiagnosticSeverity::Info, message);
+                        let mut sub = SubDiagnostic::new(Severity::Info, message);
                         sub.annotate(Annotation::primary(
                             Span::from(source.source_file.clone()).with_range(source.location),
                         ));
@@ -787,7 +786,7 @@ fn handle_failed_function_call(
         if let Some(failure) = failure {
             let message = format!("{} failed here", function_kind.capitalised());
             if let Some(source) = &failure.source {
-                let mut sub = SubDiagnostic::new(SubDiagnosticSeverity::Info, message);
+                let mut sub = SubDiagnostic::new(Severity::Info, message);
                 sub.annotate(Annotation::primary(
                     Span::from(source.source_file.clone()).with_range(source.location),
                 ));

--- a/crates/karva_test_semantic/src/diagnostic/metadata.rs
+++ b/crates/karva_test_semantic/src/diagnostic/metadata.rs
@@ -1,4 +1,4 @@
-use ruff_db::diagnostic::{Diagnostic, DiagnosticId, LintName, Severity};
+use karva_diagnostic::{Diagnostic, Severity};
 
 /// Defines a type of diagnostic that can be reported during test execution.
 ///
@@ -7,7 +7,7 @@ use ruff_db::diagnostic::{Diagnostic, DiagnosticId, LintName, Severity};
 #[derive(Debug, Clone)]
 pub struct DiagnosticType {
     /// The unique identifier for this diagnostic type.
-    pub name: LintName,
+    pub name: &'static str,
 
     /// A one-sentence summary of what this diagnostic catches.
     #[expect(unused)]
@@ -28,7 +28,7 @@ macro_rules! declare_diagnostic_type {
     ) => {
         $( #[doc = $doc] )+
         $vis static $name: $crate::diagnostic::metadata::DiagnosticType = $crate::diagnostic::metadata::DiagnosticType {
-            name: ruff_db::diagnostic::LintName::of(ruff_macros::kebab_case!($name)),
+            name: ruff_macros::kebab_case!($name),
             summary: $summary,
             $( $key: $value, )*
         };
@@ -37,6 +37,6 @@ macro_rules! declare_diagnostic_type {
 
 impl DiagnosticType {
     pub(super) fn diagnostic(&self, message: impl std::fmt::Display) -> Diagnostic {
-        Diagnostic::new(DiagnosticId::Lint(self.name), self.severity, message)
+        Diagnostic::new(self.name, self.severity, message.to_string())
     }
 }

--- a/crates/karva_test_semantic/src/discovery/error.rs
+++ b/crates/karva_test_semantic/src/discovery/error.rs
@@ -2,8 +2,8 @@ use std::rc::Rc;
 
 use camino::Utf8PathBuf;
 use karva_collector::CollectionError;
+use karva_diagnostic::Diagnostic;
 use karva_python_semantic::ModulePath;
-use ruff_db::diagnostic::Diagnostic;
 use ruff_python_ast::StmtFunctionDef;
 use ruff_source_file::SourceFile;
 use ruff_text_size::TextRange;

--- a/crates/karva_test_semantic/src/extensions/fixtures/finalizer.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/finalizer.rs
@@ -1,11 +1,10 @@
 use std::rc::Rc;
 
 use camino::Utf8PathBuf;
+use karva_diagnostic::Diagnostic;
 use pyo3::prelude::*;
 use pyo3::types::PyIterator;
 use thiserror::Error;
-
-use ruff_db::diagnostic::Diagnostic;
 
 use crate::diagnostic::invalid_fixture_finalizer_diagnostic;
 use crate::extensions::fixtures::FixtureScope;

--- a/crates/karva_test_semantic/src/runner/finalizer_cache.rs
+++ b/crates/karva_test_semantic/src/runner/finalizer_cache.rs
@@ -1,7 +1,7 @@
 //! Scope-aware storage and execution for fixture teardown callbacks.
 
+use karva_diagnostic::Diagnostic;
 use pyo3::prelude::*;
-use ruff_db::diagnostic::Diagnostic;
 
 use crate::extensions::fixtures::{Finalizer, FixtureScope};
 use crate::runner::scoped_storage::{ScopeKey, ScopedStorage};

--- a/crates/karva_test_semantic/src/runner/package_runner/failure.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/failure.rs
@@ -1,7 +1,6 @@
 //! Test-owned execution errors shared across runner lifecycle boundaries.
 
-use karva_diagnostic::{FixtureFailure, TestExecutionOutcome};
-use ruff_db::diagnostic::Diagnostic;
+use karva_diagnostic::{Diagnostic, FixtureFailure, TestExecutionOutcome};
 
 /// Primary test error plus related diagnostics and fixture causality.
 ///

--- a/crates/karva_test_semantic/src/runner/package_runner/failure.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/failure.rs
@@ -9,7 +9,7 @@ use karva_diagnostic::{Diagnostic, FixtureFailure, TestExecutionOutcome};
 #[derive(Clone)]
 pub(super) struct TestError {
     /// Primary diagnostic displayed for every affected test.
-    diagnostic: Diagnostic,
+    diagnostic: Box<Diagnostic>,
 
     /// Diagnostics caused by the same failure after the primary error.
     related: Vec<Diagnostic>,
@@ -22,7 +22,7 @@ impl TestError {
     /// Creates an error with no related diagnostics or fixture causality.
     pub(super) fn new(diagnostic: Diagnostic) -> Self {
         Self {
-            diagnostic,
+            diagnostic: Box::new(diagnostic),
             related: Vec::new(),
             fixture_failures: Vec::new(),
         }
@@ -35,7 +35,7 @@ impl TestError {
         fixture_failures: Vec<FixtureFailure>,
     ) -> Self {
         Self {
-            diagnostic,
+            diagnostic: Box::new(diagnostic),
             related,
             fixture_failures,
         }
@@ -54,7 +54,7 @@ impl TestError {
     /// Converts this error into an owned test outcome.
     pub(super) fn into_outcome(self) -> TestExecutionOutcome {
         TestExecutionOutcome::error_with_fixture_failures(
-            self.diagnostic,
+            *self.diagnostic,
             self.related,
             self.fixture_failures,
         )

--- a/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
@@ -5,10 +5,9 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use camino::Utf8Path;
-use karva_diagnostic::{FixtureFailure, FixtureUsage};
+use karva_diagnostic::{Diagnostic, FixtureFailure, FixtureUsage};
 use pyo3::prelude::*;
 use pyo3::types::PyIterator;
-use ruff_db::diagnostic::Diagnostic;
 
 use crate::diagnostic::fixture_resolution_diagnostic;
 use crate::discovery::models::definition::FunctionDefinition;

--- a/crates/karva_test_semantic/src/runner/package_runner/outcome.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/outcome.rs
@@ -2,10 +2,9 @@
 
 use std::time::Duration;
 
-use karva_diagnostic::TestExecutionOutcome;
+use karva_diagnostic::{Diagnostic, TestExecutionOutcome};
 use karva_python_semantic::QualifiedFunctionName;
 use pyo3::prelude::*;
-use ruff_db::diagnostic::Diagnostic;
 use ruff_python_ast::StmtFunctionDef;
 use ruff_source_file::SourceFile;
 

--- a/crates/karva_worker/Cargo.toml
+++ b/crates/karva_worker/Cargo.toml
@@ -32,7 +32,6 @@ camino = { workspace = true }
 clap = { workspace = true, features = ["wrap_help", "string", "env"] }
 colored = { workspace = true }
 fs-err = { workspace = true }
-ruff_db = { workspace = true }
 wild = { workspace = true }
 
 [lints]

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -5,9 +5,11 @@ use camino::Utf8PathBuf;
 use clap::Parser;
 use colored::Colorize;
 use fs_err as fs;
-use karva_cache::{DiagnosticFormat, DisplayDiagnosticConfig, RunCache, RunHash};
+use karva_cache::{RunCache, RunHash};
 use karva_cli::{ExitStatus, SubTestCommand, Verbosity};
-use karva_diagnostic::{DummyReporter, Reporter, TestCaseReporter};
+use karva_diagnostic::{
+    DiagnosticFormat, DisplayDiagnosticConfig, DummyReporter, Reporter, TestCaseReporter,
+};
 use karva_logging::{Printer, StatusLevel, set_colored_override, setup_tracing};
 use karva_metadata::filter::FiltersetSet;
 use karva_metadata::{OutputFormat, RunIgnoredMode};

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -5,16 +5,15 @@ use camino::Utf8PathBuf;
 use clap::Parser;
 use colored::Colorize;
 use fs_err as fs;
-use karva_cache::{RunCache, RunHash};
+use karva_cache::{DiagnosticFormat, DisplayDiagnosticConfig, RunCache, RunHash};
 use karva_cli::{ExitStatus, SubTestCommand, Verbosity};
 use karva_diagnostic::{DummyReporter, Reporter, TestCaseReporter};
 use karva_logging::{Printer, StatusLevel, set_colored_override, setup_tracing};
-use karva_metadata::RunIgnoredMode;
 use karva_metadata::filter::FiltersetSet;
+use karva_metadata::{OutputFormat, RunIgnoredMode};
 use karva_project::path::{TestPath, TestPathError, absolute};
 use karva_python_semantic::current_python_version;
 use karva_static::EnvVars;
-use ruff_db::diagnostic::DisplayDiagnosticConfig;
 
 /// Command-line arguments for the `karva_worker` process.
 ///
@@ -172,12 +171,14 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
         !verbosity.is_default(),
     );
 
-    let diagnostic_format = settings.terminal().output_format.into();
-
-    let config = DisplayDiagnosticConfig::new("karva")
-        .format(diagnostic_format)
-        .color(colored::control::SHOULD_COLORIZE.should_colorize())
-        .context(0);
+    let diagnostic_format = match settings.terminal().output_format {
+        OutputFormat::Full => DiagnosticFormat::Full,
+        OutputFormat::Concise => DiagnosticFormat::Concise,
+    };
+    let config = DisplayDiagnosticConfig::new(
+        diagnostic_format,
+        colored::control::SHOULD_COLORIZE.should_colorize(),
+    );
 
     // Propagate the stop signal to sibling workers whenever this worker has
     // reached (or exceeded) its configured max-fail budget. The budget is


### PR DESCRIPTION
## Summary

Closes #1243.

This replaces Ruff's internal diagnostic API with a small Karva-owned diagnostic model rendered by annotate-snippets. It removes `ruff_db`, Salsa, and notebook dependencies from diagnostic reporting while preserving existing full and concise output. Version 0.11.5 preserves the current terminal format; newer renderer output can be evaluated separately.

## Test plan

`cargo insta test -p karva --test it`, workspace unit tests, generated references, and `uvx prek run -a`.