### PR TITLE
Send worker test selections over IPC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,9 +41,10 @@ under `crates/`.
 
 Karva runs tests through a main `karva` process and `karva-worker`
 subprocesses. The binaries do not link against each other. They communicate
-through CLI arguments and loopback IPC. Only coverage data uses run-scoped
-files, and only the worker embeds Python. Workers execute tests and emit typed
-events; a controller-side dispatcher linearizes those events into run state.
+through bounded CLI arguments and loopback IPC. Test selections and runtime
+events use IPC; only coverage data uses run-scoped files, and only the worker
+embeds Python. A controller-side dispatcher linearizes worker events into run
+state.
 
 ## Code Review Rules
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,6 +1000,7 @@ dependencies = [
  "crossbeam-channel",
  "karva_diagnostic",
  "karva_python_semantic",
+ "rstest",
  "serde",
  "serde_json",
 ]

--- a/crates/karva_benchmark/src/bin/karva_benchmark.rs
+++ b/crates/karva_benchmark/src/bin/karva_benchmark.rs
@@ -13,7 +13,7 @@ use std::process::{Command, Output};
 use std::sync::LazyLock;
 #[cfg(target_os = "linux")]
 use std::time::Instant;
-use std::{collections::HashSet, io};
+use std::{collections::HashMap, collections::HashSet, io};
 
 use anyhow::{Context as _, Result};
 use camino::{Utf8Path, Utf8PathBuf};
@@ -210,10 +210,18 @@ struct RunMeasurement {
     peak_rss_kib: f64,
 }
 
-/// Warmed cache directories retained to give every benchmark subject the same partition weights.
+/// Warmed cache state retained to give every benchmark subject the same partition weights.
 struct DurationCacheSeed {
     cache_dir: Utf8PathBuf,
     directories: HashSet<Utf8PathBuf>,
+    files: HashMap<Utf8PathBuf, Vec<u8>>,
+}
+
+#[derive(Default)]
+/// Root entries captured from a warmed benchmark cache.
+struct CacheContents {
+    directories: HashSet<Utf8PathBuf>,
+    files: HashMap<Utf8PathBuf, Vec<u8>>,
 }
 
 /// Invocation and cache state shared by every subject for one benchmark project.
@@ -570,43 +578,59 @@ fn prepare_benchmark(
 impl DurationCacheSeed {
     fn capture(project_root: &Utf8Path) -> Result<Self> {
         let cache_dir = project_root.join(CACHE_DIR);
-        let directories = cache_directories(&cache_dir)?;
+        let CacheContents { directories, files } = cache_contents(&cache_dir)?;
         anyhow::ensure!(
-            !directories.is_empty(),
-            "Warming benchmark cache created no run directories in `{cache_dir}`"
+            !directories.is_empty() || !files.is_empty(),
+            "Warming benchmark cache created no reusable state in `{cache_dir}`"
         );
         Ok(Self {
             cache_dir,
             directories,
+            files,
         })
     }
 
     fn restore(&self) -> Result<()> {
-        for directory in cache_directories(&self.cache_dir)? {
+        let CacheContents { directories, files } = cache_contents(&self.cache_dir)?;
+        for directory in directories {
             if !self.directories.contains(&directory) {
                 fs::remove_dir_all(&directory).with_context(|| {
                     format!("Failed to remove benchmark measurement cache `{directory}`")
                 })?;
             }
         }
+        for file in files.keys() {
+            if !self.files.contains_key(file) {
+                fs::remove_file(file).with_context(|| {
+                    format!("Failed to remove benchmark measurement cache `{file}`")
+                })?;
+            }
+        }
+        for (file, contents) in &self.files {
+            fs::write(file, contents)
+                .with_context(|| format!("Failed to restore benchmark cache `{file}`"))?;
+        }
         Ok(())
     }
 }
 
-fn cache_directories(cache_dir: &Utf8Path) -> Result<HashSet<Utf8PathBuf>> {
-    let mut directories = HashSet::new();
+fn cache_contents(cache_dir: &Utf8Path) -> Result<CacheContents> {
+    let mut contents = CacheContents::default();
     for entry in fs::read_dir(cache_dir)
         .with_context(|| format!("Failed to read benchmark cache `{cache_dir}`"))?
     {
         let entry = entry?;
-        if !entry.file_type()?.is_dir() {
-            continue;
-        }
-        let directory = Utf8PathBuf::try_from(entry.path())
+        let path = Utf8PathBuf::try_from(entry.path())
             .context("Benchmark cache directory path is not valid UTF-8")?;
-        directories.insert(directory);
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            contents.directories.insert(path);
+        } else if file_type.is_file() {
+            let file_contents = fs::read(&path)?;
+            contents.files.insert(path, file_contents);
+        }
     }
-    Ok(directories)
+    Ok(contents)
 }
 
 fn run_project_cli(
@@ -1444,21 +1468,31 @@ mod tests {
     };
 
     #[test]
-    fn duration_cache_seed_removes_measurement_runs() {
+    fn duration_cache_seed_restores_warmed_state() {
         let temp_dir = tempdir().expect("temporary directory should be created");
         let project_root = Utf8Path::from_path(temp_dir.path())
             .expect("temporary directory path should be valid UTF-8");
         let cache_dir = project_root.join(CACHE_DIR);
         let seed_run = cache_dir.join("run-seed");
         let measurement_run = cache_dir.join("run-measurement");
+        let duration_file = cache_dir.join("durations.json");
+        let measurement_file = cache_dir.join("last-failed.json");
         fs::create_dir_all(&seed_run).expect("seed cache should be created");
+        fs::write(&duration_file, b"seed").expect("duration cache should be created");
         let seed = DurationCacheSeed::capture(project_root).expect("seed should be captured");
         fs::create_dir_all(&measurement_run).expect("measurement cache should be created");
+        fs::write(&duration_file, b"measurement").expect("duration cache should be replaced");
+        fs::write(&measurement_file, b"measurement").expect("measurement cache should be created");
 
         seed.restore().expect("seed should be restored");
 
         assert!(seed_run.is_dir());
         assert!(!measurement_run.exists());
+        assert_eq!(
+            fs::read(duration_file).expect("read duration cache"),
+            b"seed"
+        );
+        assert!(!measurement_file.exists());
     }
 
     #[test]

--- a/crates/karva_ipc/Cargo.toml
+++ b/crates/karva_ipc/Cargo.toml
@@ -19,5 +19,8 @@ crossbeam-channel = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
+[dev-dependencies]
+rstest = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/karva_ipc/src/lib.rs
+++ b/crates/karva_ipc/src/lib.rs
@@ -1,10 +1,11 @@
 //! Private, typed communication between Karva's controller and workers.
 //!
 //! Workers connect over loopback TCP so transient coordination never touches
-//! the project filesystem. JSON values form a self-delimiting stream; keeping
-//! the wire format serde-based avoids platform-specific pipe implementations.
+//! the project filesystem. The controller sends each worker's test selection,
+//! then workers stream lifecycle and result events back. Keeping the wire
+//! format serde-based avoids platform-specific pipe implementations.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io::{BufReader, BufWriter, ErrorKind, Write};
 use std::net::{Ipv4Addr, Shutdown, SocketAddr, TcpListener, TcpStream};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -43,6 +44,7 @@ pub enum WorkerEvent {
 #[derive(Serialize, Deserialize)]
 enum WireMessage {
     Hello { run_id: String, worker_id: usize },
+    TestPaths(Vec<String>),
     Event(Box<WorkerEvent>),
 }
 
@@ -82,13 +84,20 @@ struct CurrentTestState {
 }
 
 impl WorkerClient {
-    /// Connects to the controller and identifies this worker before events.
-    pub fn connect(address: SocketAddr, run_id: &str, worker_id: usize) -> Result<Self> {
+    /// Connects to the controller and receives this worker's owned test selection.
+    pub fn connect(
+        address: SocketAddr,
+        run_id: &str,
+        worker_id: usize,
+    ) -> Result<(Self, Vec<String>)> {
         let stream = TcpStream::connect(address)
             .with_context(|| format!("failed to connect to Karva controller at {address}"))?;
         stream
             .set_nodelay(true)
             .context("failed to configure Karva controller connection")?;
+        let reader = stream
+            .try_clone()
+            .context("failed to read Karva controller connection")?;
         let writer = Arc::new(Mutex::new(BufWriter::new(stream)));
         let current_test = Arc::new(Mutex::new(CurrentTestState::default()));
         let stop = Arc::new(AtomicBool::new(false));
@@ -110,7 +119,8 @@ impl WorkerClient {
             },
             true,
         )?;
-        Ok(client)
+        let test_paths = read_test_paths(reader)?;
+        Ok((client, test_paths))
     }
 
     /// Queues one state change, flushing failures immediately for global fail-fast.
@@ -228,6 +238,20 @@ impl WorkerClient {
     }
 }
 
+fn read_test_paths(stream: TcpStream) -> Result<Vec<String>> {
+    let mut messages =
+        serde_json::Deserializer::from_reader(BufReader::new(stream)).into_iter::<WireMessage>();
+    let Some(message) = messages.next() else {
+        bail!("Karva controller connection closed before sending test paths");
+    };
+    match message.context("failed to read Karva worker test paths")? {
+        WireMessage::TestPaths(test_paths) => Ok(test_paths),
+        WireMessage::Hello { .. } | WireMessage::Event(_) => {
+            bail!("Karva controller sent an invalid worker startup message")
+        }
+    }
+}
+
 // Receipt: synchronous per-event flushing made the 16,807-case parametrized
 // benchmark 40.5% slower. The controller observes workers every 10 ms, so a
 // shorter flush interval cannot improve its response time.
@@ -308,6 +332,7 @@ pub struct ControllerServer {
     receiver: Receiver<Incoming>,
     readers: Vec<JoinHandle<()>>,
     workers: HashSet<usize>,
+    worker_paths: Arc<Mutex<HashMap<usize, Vec<String>>>>,
 }
 
 impl ControllerServer {
@@ -326,7 +351,28 @@ impl ControllerServer {
             receiver,
             readers: Vec::new(),
             workers: HashSet::new(),
+            worker_paths: Arc::new(Mutex::new(HashMap::new())),
         })
+    }
+
+    /// Registers one worker's owned test selection before spawning it.
+    ///
+    /// Ownership moves into the connection reader so large selections are not
+    /// cloned or collected into an encoded buffer on the controller.
+    pub fn register_worker_paths(
+        &mut self,
+        worker_id: usize,
+        test_paths: Vec<String>,
+    ) -> Result<()> {
+        let previous = self
+            .worker_paths
+            .lock()
+            .map_err(|_| anyhow::anyhow!("Karva worker path lock poisoned"))?
+            .insert(worker_id, test_paths);
+        if previous.is_some() {
+            bail!("Karva worker {worker_id} test paths registered more than once");
+        }
+        Ok(())
     }
 
     /// Returns address passed to newly spawned workers.
@@ -346,8 +392,9 @@ impl ControllerServer {
                         .context("failed to configure Karva worker connection")?;
                     let run_id = self.run_id.clone();
                     let sender = self.sender.clone();
+                    let worker_paths = Arc::clone(&self.worker_paths);
                     self.readers.push(thread::spawn(move || {
-                        if let Err(error) = read_worker(stream, &run_id, &sender) {
+                        if let Err(error) = read_worker(stream, &run_id, &worker_paths, &sender) {
                             sender.send(Incoming::Error(format!("{error:#}"))).ok();
                         }
                     }));
@@ -388,7 +435,15 @@ impl ControllerServer {
     }
 }
 
-fn read_worker(stream: TcpStream, expected_run_id: &str, sender: &Sender<Incoming>) -> Result<()> {
+fn read_worker(
+    stream: TcpStream,
+    expected_run_id: &str,
+    worker_paths: &Mutex<HashMap<usize, Vec<String>>>,
+    sender: &Sender<Incoming>,
+) -> Result<()> {
+    let response_stream = stream
+        .try_clone()
+        .context("failed to write Karva worker connection")?;
     let mut messages =
         serde_json::Deserializer::from_reader(BufReader::new(stream)).into_iter::<WireMessage>();
     let Some(first) = messages.next() else {
@@ -402,6 +457,20 @@ fn read_worker(stream: TcpStream, expected_run_id: &str, sender: &Sender<Incomin
     if run_id != expected_run_id {
         bail!("Karva worker connected with run id `{run_id}`, expected `{expected_run_id}`");
     }
+    let test_paths = worker_paths
+        .lock()
+        .map_err(|_| anyhow::anyhow!("Karva worker path lock poisoned"))?
+        .remove(&worker_id)
+        .with_context(|| format!("Karva worker {worker_id} connected without registered paths"))?;
+    let mut writer = BufWriter::new(response_stream);
+    serde_json::to_writer(&mut writer, &WireMessage::TestPaths(test_paths))
+        .context("failed to serialize Karva worker test paths")?;
+    writer
+        .write_all(b"\n")
+        .context("failed to frame Karva worker test paths")?;
+    writer
+        .flush()
+        .context("failed to send Karva worker test paths")?;
     if sender.send(Incoming::Connected { worker_id }).is_err() {
         return Ok(());
     }
@@ -415,6 +484,7 @@ fn read_worker(stream: TcpStream, expected_run_id: &str, sender: &Sender<Incomin
         let event = match message {
             WireMessage::Event(event) => event,
             WireMessage::Hello { .. } => bail!("Karva worker sent more than one handshake"),
+            WireMessage::TestPaths(_) => bail!("Karva worker sent test paths to its controller"),
         };
         if sender
             .send(Incoming::Event(ControllerEvent { worker_id, event }))
@@ -435,21 +505,38 @@ fn is_clean_disconnect(error: &serde_json::Error) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
+
+    fn accept_connections(server: &mut ControllerServer, count: usize) {
+        while server.readers.len() < count {
+            server.accept_pending().expect("accept worker");
+            thread::yield_now();
+        }
+    }
 
     #[test]
     fn streams_attributed_worker_events() {
         let mut server = ControllerServer::bind("run-id").expect("bind controller");
-        let client = WorkerClient::connect(server.address().expect("address"), "run-id", 7)
-            .expect("connect worker");
-        client
-            .send_event(WorkerEvent::TestStarted {
-                name: "mod::test".to_string(),
-            })
-            .expect("send event");
-        client.complete().expect("complete worker");
+        server
+            .register_worker_paths(7, vec!["mod::test".to_string()])
+            .expect("register worker paths");
+        let address = server.address().expect("address");
+        let worker = thread::spawn(move || {
+            let (client, test_paths) =
+                WorkerClient::connect(address, "run-id", 7).expect("connect worker");
+            assert_eq!(test_paths, ["mod::test"]);
+            client
+                .send_event(WorkerEvent::TestStarted {
+                    name: "mod::test".to_string(),
+                })
+                .expect("send event");
+            client.complete().expect("complete worker");
+        });
 
-        server.accept_pending().expect("accept worker");
+        accept_connections(&mut server, 1);
+        worker.join().expect("join worker");
         server.finish().expect("finish readers");
         let event = server
             .try_recv()
@@ -466,11 +553,16 @@ mod tests {
     #[test]
     fn rejects_wrong_run_id() {
         let mut server = ControllerServer::bind("expected").expect("bind controller");
-        let client = WorkerClient::connect(server.address().expect("address"), "wrong", 0)
-            .expect("connect worker");
-        drop(client);
+        let address = server.address().expect("address");
+        let worker = thread::spawn(move || {
+            let error = WorkerClient::connect(address, "wrong", 0)
+                .err()
+                .expect("wrong run id should close connection");
+            assert!(error.to_string().contains("before sending test paths"));
+        });
 
-        server.accept_pending().expect("accept worker");
+        accept_connections(&mut server, 1);
+        worker.join().expect("join worker");
         server.finish().expect("finish readers");
         let Err(error) = server.try_recv() else {
             panic!("wrong run id should be rejected");
@@ -493,11 +585,19 @@ mod tests {
     #[test]
     fn completion_closes_connection_after_terminal_event() {
         let mut server = ControllerServer::bind("run-id").expect("bind controller");
-        let client = WorkerClient::connect(server.address().expect("address"), "run-id", 7)
-            .expect("connect worker");
-        client.complete().expect("complete worker");
+        server
+            .register_worker_paths(7, Vec::new())
+            .expect("register worker paths");
+        let address = server.address().expect("address");
+        let worker = thread::spawn(move || {
+            let (client, test_paths) =
+                WorkerClient::connect(address, "run-id", 7).expect("connect worker");
+            assert!(test_paths.is_empty());
+            client.complete().expect("complete worker");
+        });
 
-        server.accept_pending().expect("accept worker");
+        accept_connections(&mut server, 1);
+        worker.join().expect("join worker");
         server.finish().expect("finish readers");
         let event = server
             .try_recv()
@@ -506,5 +606,39 @@ mod tests {
 
         assert_eq!(event.worker_id, 7);
         assert!(matches!(*event.event, WorkerEvent::WorkerFinished));
+    }
+
+    #[rstest]
+    fn transfers_large_worker_selection(#[values(50_000, 1_000_000)] path_count: usize) {
+        // Receipt: 50,000 is the reported workload; 1,000,000 is the requested stress case.
+        let mut test_paths = Vec::with_capacity(path_count);
+        for index in 0..path_count {
+            test_paths.push(format!("tests/test_{index}.py::test_case"));
+        }
+
+        let mut server = ControllerServer::bind("run-id").expect("bind controller");
+        server
+            .register_worker_paths(0, test_paths)
+            .expect("register worker paths");
+        let address = server.address().expect("address");
+        let worker = thread::spawn(move || {
+            let (client, test_paths) =
+                WorkerClient::connect(address, "run-id", 0).expect("connect worker");
+            assert_eq!(test_paths.len(), path_count);
+            assert_eq!(
+                test_paths.first().map(String::as_str),
+                Some("tests/test_0.py::test_case")
+            );
+            let last_path = format!("tests/test_{}.py::test_case", path_count - 1);
+            assert_eq!(
+                test_paths.last().map(String::as_str),
+                Some(last_path.as_str())
+            );
+            client.complete().expect("complete worker");
+        });
+
+        accept_connections(&mut server, 1);
+        worker.join().expect("join worker");
+        server.finish().expect("finish readers");
     }
 }

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -32,6 +32,10 @@ use crate::worker_args::{WorkerSpawn, worker_command};
 /// Width that result labels (`PASS`, `FAIL`, `SIGINT`) are right-padded to so
 /// columns align. Mirrors the constant in `karva_diagnostic::reporter`.
 const LABEL_COLUMN_WIDTH: usize = 12;
+// Receipt: worker writes and controller reads each advance every 10 ms. With
+// no window the cancellation integration test consistently missed the first
+// TestStarted; five intervals passed 20 consecutive repetitions.
+const CANCELLATION_EVENT_SETTLE: Duration = Duration::from_millis(50);
 
 /// How `wait_for_completion` exited.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -460,6 +464,8 @@ impl WorkerManager {
         }
 
         self.dispatcher.dispatch_pending(server)?;
+        std::thread::sleep(CANCELLATION_EVENT_SETTLE);
+        self.dispatcher.dispatch_pending(server)?;
         let mut worker_ids = Vec::with_capacity(self.workers.len());
         for worker in &self.workers {
             worker_ids.push(worker.id);
@@ -592,24 +598,27 @@ pub enum TestResultRetention {
 
 /// Spawn worker processes for each partition
 ///
-/// Creates a worker process for each non-empty partition, passing the appropriate
-/// subset of tests and command-line arguments to each worker.
+/// Creates a worker process for each non-empty partition, registering its
+/// owned test selection with the IPC controller before spawn.
 fn spawn_workers(
     spawn: &WorkerSpawn,
-    partitions: &[Partition],
+    partitions: Vec<Partition>,
+    controller: &mut ControllerServer,
     forward_stdout: bool,
     test_capacity: usize,
     result_retention: TestResultRetention,
 ) -> Result<WorkerManager> {
     let mut worker_manager = WorkerManager::with_test_capacity(test_capacity, result_retention);
 
-    for (worker_id, partition) in partitions.iter().enumerate() {
+    for (worker_id, partition) in partitions.into_iter().enumerate() {
         if partition.tests().is_empty() {
             tracing::debug!("Skipping worker {} with no tests", worker_id);
             continue;
         }
 
-        let mut command = worker_command(spawn, worker_id, partition);
+        let test_count = partition.tests().len();
+        controller.register_worker_paths(worker_id, partition.into_tests())?;
+        let mut command = worker_command(spawn, worker_id);
         command.stderr(Stdio::inherit());
         process_control::configure_worker_command(&mut command);
         if forward_stdout {
@@ -627,11 +636,7 @@ fn spawn_workers(
             None
         };
 
-        tracing::info!(
-            "Worker {} spawned with {} tests",
-            worker_id,
-            partition.tests().len()
-        );
+        tracing::info!("Worker {} spawned with {} tests", worker_id, test_count);
 
         worker_manager.spawn(worker_id, child, output);
     }
@@ -810,7 +815,8 @@ pub fn run_parallel_tests(
     let forward_stdout = printer.stream_for_test_result().is_enabled();
     let mut worker_manager = spawn_workers(
         &spawn,
-        &partitions,
+        partitions,
+        &mut controller,
         forward_stdout,
         scheduled_cases,
         config.result_retention,

--- a/crates/karva_runner/src/partition.rs
+++ b/crates/karva_runner/src/partition.rs
@@ -110,6 +110,10 @@ impl Partition {
         &self.tests
     }
 
+    pub(super) fn into_tests(self) -> Vec<String> {
+        self.tests
+    }
+
     pub(super) fn function_roots(&self) -> impl Iterator<Item = &str> {
         self.function_roots.iter().map(String::as_str)
     }

--- a/crates/karva_runner/src/worker_args.rs
+++ b/crates/karva_runner/src/worker_args.rs
@@ -10,8 +10,6 @@ use karva_metadata::{EnvironmentVariable, ProjectSettings};
 use karva_project::Project;
 use karva_static::{EnvVars, PythonEnvVars, WorkerEnvVars};
 
-use crate::partition::Partition;
-
 /// Inputs shared by every worker spawned in a single run.
 pub struct WorkerSpawn<'a> {
     /// Project whose tests the worker executes.
@@ -42,8 +40,8 @@ pub struct WorkerSpawn<'a> {
     pub coverage_enabled: bool,
 }
 
-/// Builds one worker command with its test selectors and resolved controller settings.
-pub fn worker_command(spawn: &WorkerSpawn, worker_id: usize, partition: &Partition) -> Command {
+/// Builds one worker command with its resolved controller settings.
+pub fn worker_command(spawn: &WorkerSpawn, worker_id: usize) -> Command {
     let mut cmd = Command::new(spawn.worker_binary);
     cmd.arg("--controller-address")
         .arg(spawn.controller_address.to_string())
@@ -92,10 +90,6 @@ pub fn worker_command(spawn: &WorkerSpawn, worker_id: usize, partition: &Partiti
                 cmd.env_remove(name.as_str());
             }
         }
-    }
-
-    for path in partition.tests() {
-        cmd.arg(path);
     }
 
     cmd.args(inner_cli_args(spawn.project.settings(), spawn.args));

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -112,16 +112,6 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
 
     let python_version = current_python_version();
 
-    let test_paths: Vec<Result<TestPath, TestPathError>> = args
-        .sub_command
-        .paths
-        .iter()
-        .map(|path| {
-            let path = absolute(path, &cwd);
-            TestPath::new(path.as_str())
-        })
-        .collect();
-
     let filter = FiltersetSet::new(&args.sub_command.filter_expressions)
         .context("invalid `--filter` expression")?;
 
@@ -151,7 +141,15 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
         diagnostic_format,
         colored::control::SHOULD_COLORIZE.should_colorize(),
     );
-    let client = WorkerClient::connect(args.controller_address, &args.run_id, args.worker_id)?;
+    let (client, test_paths) =
+        WorkerClient::connect(args.controller_address, &args.run_id, args.worker_id)?;
+    let test_paths: Vec<Result<TestPath, TestPathError>> = test_paths
+        .into_iter()
+        .map(|path| {
+            let path = absolute(&path, &cwd);
+            TestPath::new(path.as_str())
+        })
+        .collect();
     let reporter = WorkerReporter::new(
         TestCaseReporter::new(printer),
         client.clone(),

--- a/docs/usage/running-tests/cache.md
+++ b/docs/usage/running-tests/cache.md
@@ -1,6 +1,6 @@
 # Cache
 
-Karva keeps only reusable history on disk: per-test durations for parallel scheduling and the test names used by `--last-failed`. Live worker state and complete results travel over loopback IPC and remain in memory.
+Karva keeps only reusable history on disk: per-test durations for parallel scheduling and the test names used by `--last-failed`. Worker test selections, live state, and complete results travel over loopback IPC and remain in memory.
 
 The cache lives in `.karva_cache` under the project root. Coverage runs also write per-worker coverage artifacts there.
 


### PR DESCRIPTION
## Summary

Move worker test selections from per-path process arguments into the existing loopback IPC startup handshake. Partitions transfer ownership into the controller and serialize directly to the socket, avoiding command-length limits, controller-side clones, and an encoded staging buffer; workers consume received strings while resolving test paths. The 50,000-path case used 15.0 MB maximum RSS and completed in 0.05 seconds, while the 1,000,000-path stress case used 153.8 MB and completed in 1.02 seconds.

Benchmark cache seeding now restores root cache files as well as legacy run directories, allowing native stacked PR baselines to compare identical warmed state.

Stacked on #1251. Closes #1260.

## Test Plan

`just test`, targeted Clippy, Hawk, Shear, `uvx prek run -a`, and the 50,000/1,000,000-path IPC stress cases.