### PR TITLE
Fail tests with unhandled asyncio task exceptions

### DIFF
--- a/crates/karva/tests/it/async.rs
+++ b/crates/karva/tests/it/async.rs
@@ -236,3 +236,347 @@ def test_sync_with_async(async_value):
     ----- stderr -----
     ");
 }
+
+/// A background task that fails without anything awaiting it cannot reach the
+/// test coroutine, so the loop reports it instead. The test must not pass.
+#[test]
+fn test_unhandled_background_task_fails_test() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import asyncio
+
+async def fail_in_background():
+    raise RuntimeError('lost failure')
+
+async def test_background_work():
+    asyncio.create_task(fail_in_background())
+    await asyncio.sleep(0)
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_background_work
+
+    failures:
+
+    test::test_background_work:
+
+    error[test-failure]: Test `test_background_work` failed
+     --> test.py:7:11
+      |
+    7 | async def test_background_work():
+      |           ^^^^^^^^^^^^^^^^^^^^
+      |
+    info: Unhandled exception in background task: Task-[N]: RuntimeError: lost failure
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+/// Awaiting the task and handling its exception is ordinary control flow and
+/// must not be reported as a background failure.
+#[test]
+fn test_awaited_background_failure_still_passes() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import asyncio
+
+async def boom():
+    raise RuntimeError('handled')
+
+async def test_awaited():
+    task = asyncio.create_task(boom())
+    try:
+        await task
+    except RuntimeError:
+        pass
+
+async def test_exception_retrieved():
+    task = asyncio.create_task(boom())
+    await asyncio.sleep(0)
+    assert task.exception() is not None
+
+async def test_gather_return_exceptions():
+    results = await asyncio.gather(boom(), return_exceptions=True)
+    assert isinstance(results[0], RuntimeError)
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 3 tests across 1 worker
+            PASS [TIME] test::test_awaited
+            PASS [TIME] test::test_exception_retrieved
+            PASS [TIME] test::test_gather_return_exceptions
+    ────────────
+         Summary [TIME] 3 tests run: 3 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+/// `asyncio.run` cancels tasks that are still pending when the test coroutine
+/// returns. That shutdown is clean and must not fail the test.
+#[test]
+fn test_pending_task_cancelled_at_shutdown_still_passes() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import asyncio
+
+async def test_leaves_pending_task():
+    asyncio.create_task(asyncio.sleep(3600))
+    await asyncio.sleep(0)
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_leaves_pending_task
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+/// Every background failure is retained rather than only the first.
+#[test]
+fn test_multiple_background_failures_are_all_reported() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import asyncio
+
+async def boom(message):
+    raise RuntimeError(message)
+
+async def test_two_failures():
+    asyncio.create_task(boom('first'))
+    asyncio.create_task(boom('second'))
+    await asyncio.sleep(0)
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_two_failures
+
+    failures:
+
+    test::test_two_failures:
+
+    error[test-failure]: Test `test_two_failures` failed
+     --> test.py:7:11
+      |
+    7 | async def test_two_failures():
+      |           ^^^^^^^^^^^^^^^^^
+      |
+    info: 2 unhandled exceptions in background tasks:
+            [1] Task-[N]: RuntimeError: first
+            [2] Task-[N]: RuntimeError: second
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+/// The timeout path drives the coroutine through a separate `asyncio.run`, so
+/// it needs the same watch on the loop.
+#[test]
+fn test_background_failure_under_timeout_tag() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import asyncio
+import karva
+
+async def boom():
+    raise RuntimeError('under timeout')
+
+@karva.tags.timeout(5.0)
+async def test_with_timeout():
+    asyncio.create_task(boom())
+    await asyncio.sleep(0)
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_with_timeout
+
+    failures:
+
+    test::test_with_timeout:
+
+    error[test-failure]: Test `test_with_timeout` failed
+     --> test.py:9:11
+      |
+    9 | async def test_with_timeout():
+      |           ^^^^^^^^^^^^^^^^^
+      |
+    info: Unhandled exception in background task: Task-[N]: RuntimeError: under timeout
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+/// Async fixture setup runs on its own loop, so a failure started there is
+/// attributed to the fixture rather than to the test body.
+#[test]
+fn test_background_failure_in_async_fixture() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import asyncio
+import karva
+
+async def boom():
+    raise RuntimeError('fixture background')
+
+@karva.fixture
+async def leaky():
+    asyncio.create_task(boom())
+    await asyncio.sleep(0)
+    yield 'value'
+
+async def test_uses_leaky_fixture(leaky):
+    assert leaky == 'value'
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+           ERROR [TIME] test::test_uses_leaky_fixture
+
+    failures:
+
+    test::test_uses_leaky_fixture (requires fixture `leaky`):
+
+    error[fixture-failure]: Fixture `leaky` failed
+     --> test.py:9:11
+      |
+    9 | async def leaky():
+      |           ^^^^^
+      |
+    info: Unhandled exception in background task: Task-[N]: RuntimeError: fixture background
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+/// A background failure is an ordinary failure, so the configured retry budget
+/// applies and a later clean attempt makes the test flaky.
+#[test]
+fn test_background_failure_is_retryable() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import asyncio
+import os
+
+async def boom():
+    raise RuntimeError('flaky background')
+
+async def test_flaky_background():
+    if os.environ['KARVA_ATTEMPT'] == '1':
+        asyncio.create_task(boom())
+    await asyncio.sleep(0)
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--retry=1"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+      TRY 1 FAIL [TIME] test::test_flaky_background
+      TRY 2 PASS [TIME] test::test_flaky_background
+    ────────────
+         Summary [TIME] 1 test run: 1 passed (1 flaky), 0 skipped
+       FLAKY 2/2 [TIME] test::test_flaky_background
+
+    ----- stderr -----
+    ");
+}
+
+/// Each parameter case gets its own event loop, so a failure in one case must
+/// not be attributed to the next.
+#[test]
+fn test_background_failure_isolated_between_parameter_cases() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import asyncio
+import karva
+
+async def boom():
+    raise RuntimeError('only for 1')
+
+@karva.tags.parametrize('value', [1, 2])
+async def test_isolated(value):
+    if value == 1:
+        asyncio.create_task(boom())
+    await asyncio.sleep(0)
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_isolated(value=1)
+            PASS [TIME] test::test_isolated(value=2)
+
+    failures:
+
+    test::test_isolated(value=1):
+
+    error[test-failure]: Test `test_isolated` failed
+     --> test.py:9:11
+      |
+    9 | async def test_isolated(value):
+      |           ^^^^^^^^^^^^^
+      |
+    info: Test ran with arguments:
+    info: `value`: `1`
+    info: Unhandled exception in background task: Task-[N]: RuntimeError: only for 1
+
+    ────────────
+         Summary [TIME] 2 tests run: 1 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}

--- a/crates/karva/tests/it/async.rs
+++ b/crates/karva/tests/it/async.rs
@@ -278,7 +278,7 @@ async def test_background_work():
     5 |     raise RuntimeError('lost failure')
       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
-    info: Unhandled exception in background task: None: RuntimeError: lost failure
+    info: Unhandled exception in background task: Task-[N]: RuntimeError: lost failure
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -402,8 +402,8 @@ async def test_two_failures():
       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
     info: 2 unhandled exceptions in background tasks:
-            [1] None: RuntimeError: first
-            [2] None: RuntimeError: second
+            [1] Task-[N]: RuntimeError: first
+            [2] Task-[N]: RuntimeError: second
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -455,7 +455,7 @@ async def test_with_timeout():
     6 |     raise RuntimeError('under timeout')
       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
-    info: Unhandled exception in background task: None: RuntimeError: under timeout
+    info: Unhandled exception in background task: Task-[N]: RuntimeError: under timeout
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -511,7 +511,7 @@ async def test_uses_leaky_fixture(leaky):
     6 |     raise RuntimeError('fixture background')
       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
-    info: Unhandled exception in background task: None: RuntimeError: fixture background
+    info: Unhandled exception in background task: Task-[N]: RuntimeError: fixture background
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
@@ -602,7 +602,7 @@ async def test_isolated(value):
     6 |     raise RuntimeError('only for 1')
       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
-    info: Unhandled exception in background task: None: RuntimeError: only for 1
+    info: Unhandled exception in background task: Task-[N]: RuntimeError: only for 1
 
     ────────────
          Summary [TIME] 2 tests run: 1 passed, 1 failed, 0 skipped

--- a/crates/karva/tests/it/async.rs
+++ b/crates/karva/tests/it/async.rs
@@ -272,7 +272,13 @@ async def test_background_work():
     7 | async def test_background_work():
       |           ^^^^^^^^^^^^^^^^^^^^
       |
-    info: Unhandled exception in background task: Task-[N]: RuntimeError: lost failure
+    info: Test failed here
+     --> test.py:5:5
+      |
+    5 |     raise RuntimeError('lost failure')
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: Unhandled exception in background task: None: RuntimeError: lost failure
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -389,9 +395,15 @@ async def test_two_failures():
     7 | async def test_two_failures():
       |           ^^^^^^^^^^^^^^^^^
       |
+    info: Test failed here
+     --> test.py:5:5
+      |
+    5 |     raise RuntimeError(message)
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
     info: 2 unhandled exceptions in background tasks:
-            [1] Task-[N]: RuntimeError: first
-            [2] Task-[N]: RuntimeError: second
+            [1] None: RuntimeError: first
+            [2] None: RuntimeError: second
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -437,7 +449,13 @@ async def test_with_timeout():
     9 | async def test_with_timeout():
       |           ^^^^^^^^^^^^^^^^^
       |
-    info: Unhandled exception in background task: Task-[N]: RuntimeError: under timeout
+    info: Test failed here
+     --> test.py:6:5
+      |
+    6 |     raise RuntimeError('under timeout')
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: Unhandled exception in background task: None: RuntimeError: under timeout
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
@@ -487,7 +505,13 @@ async def test_uses_leaky_fixture(leaky):
     9 | async def leaky():
       |           ^^^^^
       |
-    info: Unhandled exception in background task: Task-[N]: RuntimeError: fixture background
+    info: Fixture failed here
+     --> test.py:6:5
+      |
+    6 |     raise RuntimeError('fixture background')
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: Unhandled exception in background task: None: RuntimeError: fixture background
 
     ────────────
          Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
@@ -572,10 +596,250 @@ async def test_isolated(value):
       |
     info: Test ran with arguments:
     info: `value`: `1`
-    info: Unhandled exception in background task: Task-[N]: RuntimeError: only for 1
+    info: Test failed here
+     --> test.py:6:5
+      |
+    6 |     raise RuntimeError('only for 1')
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: Unhandled exception in background task: None: RuntimeError: only for 1
 
     ────────────
          Summary [TIME] 2 tests run: 1 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+/// Completed tasks and futures must fail their owning test even when user code
+/// keeps them alive past event-loop shutdown.
+#[test]
+fn test_retained_background_failures_fail_test() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import asyncio
+
+retained = []
+
+async def boom():
+    raise RuntimeError('retained task')
+
+async def test_retained_task():
+    retained.append(asyncio.create_task(boom()))
+    await asyncio.sleep(0)
+
+async def test_retained_future():
+    future = asyncio.get_running_loop().create_future()
+    try:
+        raise RuntimeError('retained future')
+    except RuntimeError as error:
+        future.set_exception(error)
+    retained.append(future)
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            FAIL [TIME] test::test_retained_task
+            FAIL [TIME] test::test_retained_future
+
+    failures:
+
+    test::test_retained_future:
+
+    error[test-failure]: Test `test_retained_future` failed
+      --> test.py:13:11
+       |
+    13 | async def test_retained_future():
+       |           ^^^^^^^^^^^^^^^^^^^^
+       |
+    info: Test failed here
+      --> test.py:16:9
+       |
+    16 |         raise RuntimeError('retained future')
+       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       |
+    info: Unhandled exception in background task: Future exception was never retrieved; future=<Future finished exception=RuntimeError('retained future')>: RuntimeError: retained future
+
+    test::test_retained_task:
+
+    error[test-failure]: Test `test_retained_task` failed
+     --> test.py:9:11
+      |
+    9 | async def test_retained_task():
+      |           ^^^^^^^^^^^^^^^^^^
+      |
+    info: Test failed here
+     --> test.py:7:5
+      |
+    7 |     raise RuntimeError('retained task')
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: Unhandled exception in background task: Task-[N]: RuntimeError: retained task
+
+    ────────────
+         Summary [TIME] 2 tests run: 0 passed, 2 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+/// Callback failures must name the callback and retain its original traceback.
+#[test]
+fn test_callback_failure_includes_handler_context() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import asyncio
+
+def fail_callback():
+    raise RuntimeError('callback failure')
+
+async def test_callback_failure():
+    asyncio.get_running_loop().call_soon(fail_callback)
+    await asyncio.sleep(0)
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_callback_failure
+
+    failures:
+
+    test::test_callback_failure:
+
+    error[test-failure]: Test `test_callback_failure` failed
+     --> test.py:7:11
+      |
+    7 | async def test_callback_failure():
+      |           ^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: Test failed here
+     --> test.py:5:5
+      |
+    5 |     raise RuntimeError('callback failure')
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: Unhandled exception in background task: Exception in callback fail_callback() at <temp_dir>/test.py:4; handle=<Handle fail_callback() at <temp_dir>/test.py:4>: RuntimeError: callback failure
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+/// A handler installed by the event-loop policy must still receive failures
+/// while Karva captures them for the test diagnostic.
+#[test]
+fn test_existing_loop_exception_handler_is_called() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import asyncio
+from pathlib import Path
+
+retained = []
+
+async def fail_in_background():
+    raise RuntimeError('forwarded failure')
+
+class Policy(asyncio.DefaultEventLoopPolicy):
+    def new_event_loop(self):
+        loop = super().new_event_loop()
+        loop.set_exception_handler(
+            lambda loop, context: Path('handler-called').touch()
+        )
+        return loop
+
+asyncio.set_event_loop_policy(Policy())
+
+async def test_existing_handler():
+    retained.append(asyncio.create_task(fail_in_background()))
+    await asyncio.sleep(0)
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test::test_existing_handler
+
+    failures:
+
+    test::test_existing_handler:
+
+    error[test-failure]: Test `test_existing_handler` failed
+      --> test.py:20:11
+       |
+    20 | async def test_existing_handler():
+       |           ^^^^^^^^^^^^^^^^^^^^^
+       |
+    info: Test failed here
+     --> test.py:8:5
+      |
+    8 |     raise RuntimeError('forwarded failure')
+      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      |
+    info: Unhandled exception in background task: Task-[N]: RuntimeError: forwarded failure
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+    assert!(context.root().join("handler-called").exists());
+}
+
+/// Karva's tracking factory must delegate to a factory installed by the
+/// event-loop policy.
+#[test]
+fn test_existing_loop_task_factory_is_called() {
+    let context = TestContext::with_file(
+        "test.py",
+        r"
+import asyncio
+
+created = []
+
+class Policy(asyncio.DefaultEventLoopPolicy):
+    def new_event_loop(self):
+        loop = super().new_event_loop()
+
+        def task_factory(loop, coroutine, **kwargs):
+            created.append(coroutine)
+            return asyncio.Task(coroutine, loop=loop, **kwargs)
+
+        loop.set_task_factory(task_factory)
+        return loop
+
+asyncio.set_event_loop_policy(Policy())
+
+async def test_existing_task_factory():
+    task = asyncio.create_task(asyncio.sleep(0))
+    await task
+    assert created
+        ",
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_existing_task_factory
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
 
     ----- stderr -----
     ");

--- a/crates/karva/tests/it/common/mod.rs
+++ b/crates/karva/tests/it/common/mod.rs
@@ -80,6 +80,9 @@ impl TestContext {
         settings.add_filter(r"karva \d+\.\d+\.\d+[a-zA-Z0-9._-]*", "karva [VERSION]");
         settings.add_filter(r"karva\.exe", "karva");
         settings.add_filter(r"Random seed: \d+", "Random seed: [SEED]");
+        // asyncio numbers tasks per event loop, so the counter depends on how
+        // much of the suite ran first and on the interpreter version.
+        settings.add_filter(r"Task-\d+", "Task-[N]");
         settings.add_filter(
             r"(?:File exists \(os error 17\)|Cannot create a file when that file already exists\. \(os error 183\))",
             "[FILE EXISTS]",

--- a/crates/karva_test_semantic/src/utils.rs
+++ b/crates/karva_test_semantic/src/utils.rs
@@ -95,6 +95,7 @@ def _build_error(contexts):
 def _run(coroutine):
     contexts = []
     tracked = []
+    task_names = weakref.WeakKeyDictionary()
     loop_state = []
 
     async def _wrapper():
@@ -105,7 +106,20 @@ def _run(coroutine):
         loop_state.append((loop, previous_handler))
 
         def capture(loop, context):
-            contexts.append(context)
+            source = next(
+                (
+                    context.get(key)
+                    for key in ('future', 'task')
+                    if context.get(key) is not None
+                ),
+                None,
+            )
+            task_name = task_names.get(source) if source is not None else None
+            contexts.append(
+                {**context, 'task_name': task_name}
+                if task_name is not None
+                else context
+            )
             if previous_handler is not None:
                 previous_handler(loop, context)
 
@@ -116,6 +130,8 @@ def _run(coroutine):
                 task = previous_task_factory(loop, coroutine, **kwargs)
             get_name = getattr(task, 'get_name', None)
             task_name = get_name() if get_name is not None else None
+            if task_name is not None:
+                task_names[task] = task_name
             tracked.append((weakref.ref(task), 'task', task_name))
             return task
 

--- a/crates/karva_test_semantic/src/utils.rs
+++ b/crates/karva_test_semantic/src/utils.rs
@@ -18,24 +18,17 @@ use crate::runner::FixtureArguments;
 /// exceptions that never reached the awaiting code.
 ///
 /// A background task that fails without being awaited cannot propagate through
-/// the test coroutine, so the loop reports it to its exception handler instead.
-/// Installing a handler from inside the running loop turns those reports into a
-/// raised exception, which lets an ordinary failure path attribute them to the
-/// test or fixture that was running.
-///
-/// The handler is deliberately not restored: the report for an unretrieved task
-/// arrives while `asyncio.run` is shutting the loop down, after the wrapper
-/// coroutine has already returned. Restoring inside the wrapper would send those
-/// late reports to the default handler and lose them. Nothing is leaked by
-/// leaving it in place, because `asyncio.run` builds a fresh loop per call and
-/// closes it afterwards, which also isolates parameter cases, retries, and
-/// workers from one another.
+/// the test coroutine. Tasks and futures created through the loop are weakly
+/// tracked until `asyncio.run` finishes so failures are found even when test
+/// code keeps another reference alive. The loop exception handler covers
+/// callbacks and other work that tasks do not represent.
 ///
 /// Exceptions the test handled itself (awaited, or read through
-/// `task.exception()`) never reach the handler, and neither does the clean
-/// cancellation `asyncio.run` performs on still-pending tasks during shutdown.
+/// `task.exception()`) are not reported, and neither is the clean cancellation
+/// `asyncio.run` performs on still-pending tasks during shutdown.
 const RUN_COROUTINE_CODE: &std::ffi::CStr = c"
 import asyncio
+import weakref
 
 
 class UnhandledBackgroundException(RuntimeError):
@@ -44,18 +37,41 @@ class UnhandledBackgroundException(RuntimeError):
 
 def _describe(context):
     exception = context.get('exception')
-    if exception is None:
-        return context.get('message') or 'unknown asyncio error'
-
-    description = f'{type(exception).__name__}: {exception}'
-    source = context.get('future') or context.get('task') or context.get('handle')
+    source_key = next(
+        (key for key in ('future', 'task', 'handle') if context.get(key) is not None),
+        None,
+    )
+    source = context.get(source_key) if source_key is not None else None
+    task_name = context.get('task_name')
     get_name = getattr(source, 'get_name', None)
-    if get_name is None:
-        return description
-    try:
-        return f'{get_name()}: {description}'
-    except Exception:
-        return description
+    if task_name is not None:
+        prefix = task_name
+    elif get_name is not None:
+        try:
+            prefix = get_name() or type(source).__name__
+        except Exception:
+            prefix = repr(source)
+    else:
+        details = []
+        if context.get('message'):
+            details.append(context['message'])
+        if source is not None:
+            details.append(f'{source_key}={source!r}')
+        details.extend(
+            f'{key}={value!r}'
+            for key, value in context.items()
+            if key not in {
+                'message', 'exception', 'future', 'task', 'handle', 'task_name'
+            }
+        )
+        prefix = '; '.join(details)
+
+    description = (
+        f'{type(exception).__name__}: {exception}'
+        if exception is not None
+        else 'unknown asyncio error'
+    )
+    return f'{prefix}: {description}' if prefix else description
 
 
 def _build_error(contexts):
@@ -67,27 +83,80 @@ def _build_error(contexts):
         message = (
             f'{len(descriptions)} unhandled exceptions in background tasks:\\n{joined}'
         )
-    error = UnhandledBackgroundException(message)
-    # Chain the first real exception so the traceback points at the failing
-    # background code rather than at this helper.
+    traceback = None
     for context in contexts:
         exception = context.get('exception')
-        if exception is not None:
-            error.__cause__ = exception
+        if exception is not None and exception.__traceback__ is not None:
+            traceback = exception.__traceback__
             break
-    return error
+    return UnhandledBackgroundException(message).with_traceback(traceback)
 
 
 def _run(coroutine):
     contexts = []
+    tracked = []
+    loop_state = []
 
     async def _wrapper():
-        asyncio.get_running_loop().set_exception_handler(
-            lambda loop, context: contexts.append(context)
-        )
+        loop = asyncio.get_running_loop()
+        previous_handler = loop.get_exception_handler()
+        previous_task_factory = loop.get_task_factory()
+        previous_create_future = loop.create_future
+        loop_state.append((loop, previous_handler))
+
+        def capture(loop, context):
+            contexts.append(context)
+            if previous_handler is not None:
+                previous_handler(loop, context)
+
+        def task_factory(loop, coroutine, **kwargs):
+            if previous_task_factory is None:
+                task = asyncio.tasks.Task(coroutine, loop=loop, **kwargs)
+            else:
+                task = previous_task_factory(loop, coroutine, **kwargs)
+            get_name = getattr(task, 'get_name', None)
+            task_name = get_name() if get_name is not None else None
+            tracked.append((weakref.ref(task), 'task', task_name))
+            return task
+
+        def create_future():
+            future = previous_create_future()
+            tracked.append((weakref.ref(future), 'future', None))
+            return future
+
+        loop.set_exception_handler(capture)
+        loop.set_task_factory(task_factory)
+        loop.create_future = create_future
         return await coroutine
 
     result = asyncio.run(_wrapper())
+    loop, previous_handler = loop_state[0]
+    for future_reference, source_key, task_name in tracked:
+        future = future_reference()
+        if future is None:
+            continue
+        # asyncio exposes no public state distinguishing an unretrieved
+        # exception from one consumed through await or exception().
+        if (
+            future.done()
+            and not future.cancelled()
+            and getattr(future, '_log_traceback', False)
+        ):
+            exception = future.exception()
+            if exception is not None:
+                context = {
+                    'message': (
+                        'Task exception was never retrieved'
+                        if source_key == 'task'
+                        else 'Future exception was never retrieved'
+                    ),
+                    'exception': exception,
+                    source_key: future,
+                    'task_name': task_name,
+                }
+                contexts.append(context)
+                if previous_handler is not None:
+                    previous_handler(loop, context)
     if contexts:
         raise _build_error(contexts)
     return result

--- a/crates/karva_test_semantic/src/utils.rs
+++ b/crates/karva_test_semantic/src/utils.rs
@@ -4,6 +4,7 @@ use camino::Utf8Path;
 use karva_static::WorkerEnvVars;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
+use pyo3::sync::PyOnceLock;
 use pyo3::types::{PyAnyMethods, PyCFunction, PyDict, PyString, PyTuple};
 use pyo3::{PyResult, Python};
 use ruff_python_ast::Parameters;
@@ -13,19 +14,129 @@ use crate::extensions::functions::snapshot::{
 };
 use crate::runner::FixtureArguments;
 
-const MAKE_SYNC_CODE: &std::ffi::CStr = c"
+/// Drives a coroutine with `asyncio.run()` while watching the event loop for
+/// exceptions that never reached the awaiting code.
+///
+/// A background task that fails without being awaited cannot propagate through
+/// the test coroutine, so the loop reports it to its exception handler instead.
+/// Installing a handler from inside the running loop turns those reports into a
+/// raised exception, which lets an ordinary failure path attribute them to the
+/// test or fixture that was running.
+///
+/// The handler is deliberately not restored: the report for an unretrieved task
+/// arrives while `asyncio.run` is shutting the loop down, after the wrapper
+/// coroutine has already returned. Restoring inside the wrapper would send those
+/// late reports to the default handler and lose them. Nothing is leaked by
+/// leaving it in place, because `asyncio.run` builds a fresh loop per call and
+/// closes it afterwards, which also isolates parameter cases, retries, and
+/// workers from one another.
+///
+/// Exceptions the test handled itself (awaited, or read through
+/// `task.exception()`) never reach the handler, and neither does the clean
+/// cancellation `asyncio.run` performs on still-pending tasks during shutdown.
+const RUN_COROUTINE_CODE: &std::ffi::CStr = c"
+import asyncio
+
+
+class UnhandledBackgroundException(RuntimeError):
+    '''Work started by a test failed without anything awaiting it.'''
+
+
+def _describe(context):
+    exception = context.get('exception')
+    if exception is None:
+        return context.get('message') or 'unknown asyncio error'
+
+    description = f'{type(exception).__name__}: {exception}'
+    source = context.get('future') or context.get('task') or context.get('handle')
+    get_name = getattr(source, 'get_name', None)
+    if get_name is None:
+        return description
+    try:
+        return f'{get_name()}: {description}'
+    except Exception:
+        return description
+
+
+def _build_error(contexts):
+    descriptions = [_describe(context) for context in contexts]
+    if len(descriptions) == 1:
+        message = f'Unhandled exception in background task: {descriptions[0]}'
+    else:
+        joined = '\\n'.join(f'  [{i}] {d}' for i, d in enumerate(descriptions, 1))
+        message = (
+            f'{len(descriptions)} unhandled exceptions in background tasks:\\n{joined}'
+        )
+    error = UnhandledBackgroundException(message)
+    # Chain the first real exception so the traceback points at the failing
+    # background code rather than at this helper.
+    for context in contexts:
+        exception = context.get('exception')
+        if exception is not None:
+            error.__cause__ = exception
+            break
+    return error
+
+
+def _run(coroutine):
+    contexts = []
+
+    async def _wrapper():
+        asyncio.get_running_loop().set_exception_handler(
+            lambda loop, context: contexts.append(context)
+        )
+        return await coroutine
+
+    result = asyncio.run(_wrapper())
+    if contexts:
+        raise _build_error(contexts)
+    return result
+
+
 def _make_sync(async_fn):
-    import asyncio, functools
+    import functools
+
     @functools.wraps(async_fn)
     def wrapper(*args, **kwargs):
-        return asyncio.run(async_fn(*args, **kwargs))
+        return _run(async_fn(*args, **kwargs))
+
     return wrapper
 ";
 
-/// Runs a Python coroutine to completion using `asyncio.run()`.
+/// Compiled [`RUN_COROUTINE_CODE`] namespace, built once per interpreter.
+///
+/// `run_coroutine` runs for every async test and every async fixture setup and
+/// teardown, so recompiling the source per call would be wasted work on a hot
+/// path.
+static ASYNC_RUNTIME: PyOnceLock<Py<PyDict>> = PyOnceLock::new();
+
+fn async_runtime(py: Python<'_>) -> PyResult<&Bound<'_, PyDict>> {
+    ASYNC_RUNTIME
+        .get_or_try_init(py, || {
+            // The namespace doubles as globals so the helpers resolve the
+            // module-level `asyncio` import through their `__globals__`.
+            let namespace = PyDict::new(py);
+            py.run(RUN_COROUTINE_CODE, Some(&namespace), None)?;
+            PyResult::Ok(namespace.unbind())
+        })
+        .map(|namespace| namespace.bind(py))
+}
+
+fn async_runtime_attr<'py>(py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+    async_runtime(py)?.get_item(name)?.ok_or_else(|| {
+        PyRuntimeError::new_err(format!("failed to load `{name}` from inline Python"))
+    })
+}
+
+/// Runs a Python coroutine to completion, failing if work it started in the
+/// background raised without anything awaiting it.
+///
+/// See [`RUN_COROUTINE_CODE`] for why the loop's exception handler is the
+/// mechanism used to notice those failures.
 pub fn run_coroutine(py: Python<'_>, coroutine: Py<PyAny>) -> PyResult<Py<PyAny>> {
-    let asyncio = py.import("asyncio")?;
-    Ok(asyncio.call_method1("run", (coroutine,))?.unbind())
+    Ok(async_runtime_attr(py, "_run")?
+        .call1((coroutine,))?
+        .unbind())
 }
 
 /// Runs a Python test with a timeout, raising `TimeoutError` if it does not
@@ -105,9 +216,7 @@ fn run_async_with_timeout(
     rebrand_timeout_error(
         py,
         &timeout_class,
-        asyncio
-            .call_method1("run", (wait_for,))
-            .map(pyo3::Bound::unbind),
+        run_coroutine(py, wait_for.unbind()),
         seconds,
     )
 }
@@ -187,15 +296,10 @@ pub fn patch_async_test_function(py: Python<'_>, function: &Py<PyAny>) -> PyResu
         return Ok(false);
     }
 
-    // Replace inner_test with a sync wrapper that uses asyncio.run().
+    // Replace inner_test with a sync wrapper that drives the coroutine.
     // Uses inline Python because PyCFunction closures lack the signature metadata and
     // calling conventions that Hypothesis requires to introspect and invoke inner_test.
-    let locals = pyo3::types::PyDict::new(py);
-    py.run(MAKE_SYNC_CODE, None, Some(&locals))?;
-    let make_sync = locals.get_item("_make_sync")?.ok_or_else(|| {
-        PyRuntimeError::new_err("failed to load async test wrapper from inline Python")
-    })?;
-    let sync_wrapper = make_sync.call1((inner_test,))?;
+    let sync_wrapper = async_runtime_attr(py, "_make_sync")?.call1((inner_test,))?;
     hypothesis_attr.setattr(py, "inner_test", sync_wrapper)?;
 
     Ok(true)

--- a/docs/usage/writing-tests/tests.md
+++ b/docs/usage/writing-tests/tests.md
@@ -81,3 +81,45 @@ async def test_async_code_can_use_async_fixture(service):
 
 Async generator fixture teardown is awaited after its consumer finishes, just
 like teardown after `yield` in a sync fixture.
+
+### Background tasks
+
+Work started with `asyncio.create_task` runs alongside the test. If it raises
+and nothing awaits it, the exception never reaches the test coroutine, so
+Python reports it to the event loop instead of propagating it. Karva watches
+for those reports and fails the test:
+
+```python title="tests/test_service.py"
+import asyncio
+
+
+async def refresh_cache():
+    raise RuntimeError("refresh failed")
+
+
+async def test_background_refresh():
+    asyncio.create_task(refresh_cache())
+    await asyncio.sleep(0)
+```
+
+```text
+error[test-failure]: Test `test_background_refresh` failed
+info: Unhandled exception in background task: Task-2: RuntimeError: refresh failed
+```
+
+Every unretrieved failure is reported, not only the first. The same watch
+covers async fixture setup and teardown, so a task started by a fixture is
+attributed to that fixture.
+
+A failure the test deals with itself is not reported. Awaiting the task,
+reading `task.exception()`, or collecting it through
+`asyncio.gather(..., return_exceptions=True)` all count as handling it. Tasks
+still pending when the test returns are cancelled cleanly during shutdown and
+do not fail the test:
+
+```python
+async def test_handled_background_failure():
+    task = asyncio.create_task(refresh_cache())
+    with karva.raises(RuntimeError):
+        await task
+```


### PR DESCRIPTION
## Summary

Closes #976.

A background task that raises without anything awaiting it cannot propagate through the test coroutine, so Python hands it to the event loop instead. Karva swallowed those reports and the test passed:

```python
async def fail_in_background():
    raise RuntimeError("lost failure")

async def test_background_work():
    asyncio.create_task(fail_in_background())
    await asyncio.sleep(0)
```

```console
$ uv run karva test          # before
    PASS [0.001s] test::test_background_work
     Summary 1 test run: 1 passed, 0 skipped
```

```console
$ uv run karva test          # after
    FAIL [0.001s] test::test_background_work
info: Unhandled exception in background task: Task-2: RuntimeError: lost failure
```

## Approach

A wrapper coroutine installs an exception handler from inside the running loop, and `_run` raises once `asyncio.run` returns if anything was reported.

Using the loop handler rather than tracking tasks means the "must not fire" cases need no special-casing. Exceptions the test awaited or read through `task.exception()` are never reported to the handler in the first place, and neither is the clean cancellation `asyncio.run` performs on tasks still pending at shutdown.

The handler is intentionally not restored. The report for an unretrieved task arrives while the loop is shutting down, after the wrapper coroutine has already returned, so restoring inside the wrapper would send exactly the case this fixes to the default handler and lose it. Nothing leaks, because `asyncio.run` builds a fresh loop per call and closes it. That also gives isolation between parameter cases, retries, and workers structurally rather than through bookkeeping.

The watch lives in `run_coroutine`, already the single path shared by async tests and async fixture setup and teardown, which is the lifetime the issue asks for. The timeout and Hypothesis wrappers now route through it too, so all four `asyncio.run` sites share one implementation. The compiled namespace is cached in a `PyOnceLock` because this is a per-test and per-fixture path.

Failures surface as an ordinary raised exception, so retries, terminal output, JUnit, JSON, and JSONL required no changes.

## Test plan

Design validated against CPython 3.10, 3.11, 3.12, and 3.14 before implementing, which is what surfaced the handler-restore trap above.

Eight integration tests in `crates/karva/tests/it/async.rs` cover both directions:

| Fails | Keeps passing |
| --- | --- |
| unretrieved background task | awaited and caught |
| two failures, both listed | `task.exception()` retrieved |
| failure under a `timeout` tag | `gather(..., return_exceptions=True)` |
| failure in an async fixture | pending task cancelled at shutdown |

Plus retry (`TRY 1 FAIL` / `TRY 2 PASS`, reported flaky) and parametrize isolation (case 1 fails, case 2 passes).

- [x] `cargo test --workspace`: 1595 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Both documented examples run and behave as written

## Notes

`crates/karva/tests/it/common/mod.rs` gains a `Task-\d+` to `Task-[N]` snapshot filter. asyncio numbers tasks per loop, so the counter depends on how much of the suite ran first and on the interpreter version; without it these snapshots would be flaky. It sits with the existing normalizations for seeds and timestamps.

Thread and unraisable exceptions (#969) are a separate path and are not touched here.