### PR TITLE
Add opt-in Python doctest support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 
 ### Test Running
 
+- Support opt-in module docstring doctests ([#1273](https://github.com/MatthewMckee4/karva/issues/1273))
 - Reuse the last generated random seed ([#1215](https://github.com/MatthewMckee4/karva/pull/1215))
 - Add seeded randomized test ordering ([#1194](https://github.com/MatthewMckee4/karva/pull/1194))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@
 
 ### Test Running
 
-- Support opt-in module docstring doctests ([#1273](https://github.com/MatthewMckee4/karva/issues/1273))
+- Support opt-in Python docstring doctests ([#1275](https://github.com/MatthewMckee4/karva/pull/1275))
 - Reuse the last generated random seed ([#1215](https://github.com/MatthewMckee4/karva/pull/1215))
 - Add seeded randomized test ordering ([#1194](https://github.com/MatthewMckee4/karva/pull/1194))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,6 +919,7 @@ dependencies = [
  "karva_python_semantic",
  "ruff_python_ast",
  "ruff_python_parser",
+ "ruff_text_size",
  "tempfile",
  "thiserror",
 ]

--- a/crates/karva/tests/it/doctest.rs
+++ b/crates/karva/tests/it/doctest.rs
@@ -1,4 +1,6 @@
+use insta::assert_snapshot;
 use insta_cmd::assert_cmd_snapshot;
+use regex::Regex;
 use serde_json::Value;
 
 use crate::common::TestContext;
@@ -64,12 +66,9 @@ fn doctest_modules_is_opt_in() {
     11 |     >>> 2 + 2
        |     ^^^
        |
-    info: Doctest failed at test_examples.py:11
-          Example:
-            2 + 2
-          Expected:
+    info: Expected output:
             5
-          Got:
+          Actual output:
             4
 
     test_examples::doctest:raises_unexpectedly:
@@ -80,10 +79,7 @@ fn doctest_modules_is_opt_in() {
     18 |     >>> 1 / 0
        |     ^^^
        |
-    info: Doctest raised at test_examples.py:18
-          Example:
-            1 / 0
-          Exception:
+    info: Unexpected exception:
             ZeroDivisionError: division by zero
 
     ────────────
@@ -126,12 +122,9 @@ doctest-modules = true
     11 |     >>> 2 + 2
        |     ^^^
        |
-    info: Doctest failed at test_examples.py:11
-          Example:
-            2 + 2
-          Expected:
+    info: Expected output:
             5
-          Got:
+          Actual output:
             4
 
     test_examples::doctest:raises_unexpectedly:
@@ -142,10 +135,7 @@ doctest-modules = true
     18 |     >>> 1 / 0
        |     ^^^
        |
-    info: Doctest raised at test_examples.py:18
-          Example:
-            1 / 0
-          Exception:
+    info: Unexpected exception:
             ZeroDivisionError: division by zero
 
     ────────────
@@ -273,12 +263,9 @@ def documented():
     7 |     >>> 2 + 2
       |     ^^^
       |
-    info: Doctest failed at test_location.py:7
-          Example:
-            2 + 2
-          Expected:
+    info: Expected output:
             5
-          Got:
+          Actual output:
             4
 
     ────────────
@@ -464,12 +451,9 @@ def broken():
     21 |     >>> 3 * 3
        |     ^^^
        |
-    info: Doctest failed at test_reports.py:21
-          Example:
-            3 * 3
-          Expected:
+    info: Expected output:
             10
-          Got:
+          Actual output:
             9
 
     ────────────
@@ -481,34 +465,61 @@ def broken():
 
     let report: Value = serde_json::from_str(&context.read_file("reports/results.json"))
         .expect("JSON report should parse");
-    let doctest = report["tests"]
-        .as_array()
-        .expect("JSON tests should be an array")
-        .iter()
-        .find(|test| test["name"] == "doctest:@module")
-        .expect("JSON report should include module doctest");
-    assert_eq!(doctest["module"], "test_reports");
-    assert_eq!(doctest["full_name"], "test_reports::doctest:@module");
-    assert!(
-        report["tests"]
-            .as_array()
-            .expect("JSON tests should be an array")
-            .iter()
-            .any(|test| test["full_name"] == "test_reports::doctest:module"),
-        "JSON report should distinguish an object named module"
+    assert_snapshot!(
+        serde_json::to_string_pretty(&report).expect("JSON report should serialize"),
+        @r#"
+    {
+      "elapsed_seconds": "[TIME]",
+      "schema_version": 2,
+      "stats": {
+        "errors": 0,
+        "failed": 1,
+        "flaky": 0,
+        "passed": 3,
+        "skipped": 0,
+        "slow": 0,
+        "total": 4
+      },
+      "status": "failed",
+      "tests": [
+        {
+          "duration_seconds": "[TIME]",
+          "full_name": "test_reports::doctest:@module",
+          "module": "test_reports",
+          "name": "doctest:@module",
+          "status": "passed"
+        },
+        {
+          "diagnostic": {
+            "code": "test-failure",
+            "message": "Test `doctest:broken` failed",
+            "rendered": "error[test-failure]: Test `doctest:broken` failed\n  --> test_reports.py:21:5\n   |/n21 |     >>> 3 * 3\n   |     ^^^\n   |/ninfo: Expected output:\n        10\n      Actual output:\n        9\n\n",
+            "severity": "error"
+          },
+          "duration_seconds": "[TIME]",
+          "full_name": "test_reports::doctest:broken",
+          "module": "test_reports",
+          "name": "doctest:broken",
+          "status": "failed"
+        },
+        {
+          "duration_seconds": "[TIME]",
+          "full_name": "test_reports::doctest:module",
+          "module": "test_reports",
+          "name": "doctest:module",
+          "status": "passed"
+        },
+        {
+          "duration_seconds": "[TIME]",
+          "full_name": "test_reports::test_regular",
+          "module": "test_reports",
+          "name": "test_regular",
+          "status": "passed"
+        }
+      ]
+    }
+    "#
     );
-    let failed = report["tests"]
-        .as_array()
-        .expect("JSON tests should be an array")
-        .iter()
-        .find(|test| test["name"] == "doctest:broken")
-        .expect("JSON report should include failing doctest");
-    assert_eq!(failed["status"], "failed");
-    let diagnostic = failed["diagnostic"]["rendered"]
-        .as_str()
-        .expect("failing JSON doctest should include a diagnostic");
-    assert!(diagnostic.contains("Expected:\n        10"));
-    assert!(diagnostic.contains("Got:\n        9"));
 
     assert_cmd_snapshot!(
         context.command_no_parallel().args([
@@ -532,12 +543,9 @@ def broken():
     21 |     >>> 3 * 3
        |     ^^^
        |
-    info: Doctest failed at test_reports.py:21
-          Example:
-            3 * 3
-          Expected:
+    info: Expected output:
             10
-          Got:
+          Actual output:
             9
 
     ────────────
@@ -547,50 +555,105 @@ def broken():
     "
     );
 
-    let doctest = context
+    let records = context
         .read_file("reports/results.jsonl")
         .lines()
         .map(|line| serde_json::from_str::<Value>(line).expect("JSONL record should parse"))
-        .find(|record| record["type"] == "test" && record["name"] == "doctest:@module")
-        .expect("JSONL report should include module doctest");
-    assert_eq!(doctest["module"], "test_reports");
-    assert_eq!(doctest["full_name"], "test_reports::doctest:@module");
-
-    assert!(
-        context
-            .read_file("reports/results.jsonl")
-            .lines()
-            .map(|line| serde_json::from_str::<Value>(line).expect("JSONL record should parse"))
-            .any(|record| record["full_name"] == "test_reports::doctest:module"),
-        "JSONL report should distinguish an object named module"
+        .collect::<Vec<_>>();
+    assert_snapshot!(
+        serde_json::to_string_pretty(&records).expect("JSONL records should serialize"),
+        @r#"
+    [
+      {
+        "duration_seconds": "[TIME]",
+        "full_name": "test_reports::doctest:@module",
+        "module": "test_reports",
+        "name": "doctest:@module",
+        "schema_version": 2,
+        "status": "passed",
+        "type": "test"
+      },
+      {
+        "diagnostic": {
+          "code": "test-failure",
+          "message": "Test `doctest:broken` failed",
+          "rendered": "error[test-failure]: Test `doctest:broken` failed\n  --> test_reports.py:21:5\n   |/n21 |     >>> 3 * 3\n   |     ^^^\n   |/ninfo: Expected output:\n        10\n      Actual output:\n        9\n\n",
+          "severity": "error"
+        },
+        "duration_seconds": "[TIME]",
+        "full_name": "test_reports::doctest:broken",
+        "module": "test_reports",
+        "name": "doctest:broken",
+        "schema_version": 2,
+        "status": "failed",
+        "type": "test"
+      },
+      {
+        "duration_seconds": "[TIME]",
+        "full_name": "test_reports::doctest:module",
+        "module": "test_reports",
+        "name": "doctest:module",
+        "schema_version": 2,
+        "status": "passed",
+        "type": "test"
+      },
+      {
+        "duration_seconds": "[TIME]",
+        "full_name": "test_reports::test_regular",
+        "module": "test_reports",
+        "name": "test_regular",
+        "schema_version": 2,
+        "status": "passed",
+        "type": "test"
+      },
+      {
+        "elapsed_seconds": "[TIME]",
+        "schema_version": 2,
+        "stats": {
+          "errors": 0,
+          "failed": 1,
+          "flaky": 0,
+          "passed": 3,
+          "skipped": 0,
+          "slow": 0,
+          "total": 4
+        },
+        "status": "failed",
+        "type": "run_finished"
+      }
+    ]
+    "#
     );
 
-    let failed = context
-        .read_file("reports/results.jsonl")
-        .lines()
-        .map(|line| serde_json::from_str::<Value>(line).expect("JSONL record should parse"))
-        .find(|record| record["name"] == "doctest:broken")
-        .expect("JSONL report should include failing doctest");
-    assert_eq!(failed["status"], "failed");
-    let diagnostic = failed["diagnostic"]["rendered"]
-        .as_str()
-        .expect("failing JSONL doctest should include a diagnostic");
-    assert!(diagnostic.contains("Expected:\n        10"));
-    assert!(diagnostic.contains("Got:\n        9"));
+    let junit = Regex::new(r#"time="[0-9.]+""#)
+        .expect("valid time regex")
+        .replace_all(
+            &context.read_file("reports/results.xml"),
+            r#"time="[TIME]""#,
+        )
+        .to_string();
+    assert_snapshot!(junit, @r#"
+    <?xml version="1.0" encoding="UTF-8"?>
+    <testsuites name="karva-tests" tests="4" failures="1" skipped="0" errors="0" time="[TIME]">
+      <testsuite name="test_reports" tests="4" failures="1" skipped="0" errors="0" time="[TIME]">
+        <testcase classname="test_reports" name="doctest:@module" time="[TIME]"/>
+        <testcase classname="test_reports" name="doctest:broken" time="[TIME]">
+          <failure message="Test `doctest:broken` failed" type="test-failure">error[test-failure]: Test `doctest:broken` failed
+      --&gt; test_reports.py:21:5
+       |
+    21 |     &gt;&gt;&gt; 3 * 3
+       |     ^^^
+       |
+    info: Expected output:
+            10
+          Actual output:
+            9
 
-    let junit = context.read_file("reports/results.xml");
-    assert!(
-        junit.contains(r#"<testcase classname="test_reports" name="doctest:@module""#),
-        "JUnit report should include module doctest ID"
-    );
-    assert!(
-        junit.contains(r#"<testcase classname="test_reports" name="doctest:module""#),
-        "JUnit report should distinguish an object named module"
-    );
-    assert!(
-        junit.contains(r#"<testcase classname="test_reports" name="doctest:broken""#)
-            && junit.contains("Expected:")
-            && junit.contains("Got:"),
-        "JUnit report should include the failing doctest diagnostic"
-    );
+    </failure>
+        </testcase>
+        <testcase classname="test_reports" name="doctest:module" time="[TIME]"/>
+        <testcase classname="test_reports" name="test_regular" time="[TIME]"/>
+      </testsuite>
+    </testsuites>
+    "#);
 }

--- a/crates/karva/tests/it/doctest.rs
+++ b/crates/karva/tests/it/doctest.rs
@@ -241,6 +241,54 @@ class Calculator:
 }
 
 #[test]
+fn doctest_failure_points_to_the_failing_example() {
+    let context = TestContext::with_file(
+        "test_location.py",
+        r#"
+def documented():
+    """Two examples.
+
+    >>> 1 + 1
+    2
+    >>> 2 + 2
+    5
+    """
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--doctest-modules"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            FAIL [TIME] test_location::doctest:documented
+
+    failures:
+
+    test_location::doctest:documented:
+
+    error[test-failure]: Test `doctest:documented` failed
+     --> test_location.py:7:5
+      |
+    7 |     >>> 2 + 2
+      |     ^^^
+      |
+    info: Doctest failed at test_location.py:7
+          Example:
+            2 + 2
+          Expected:
+            5
+          Got:
+            4
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn doctests_validate_strict_module_tags() {
     let context = TestContext::with_files([
         (
@@ -322,6 +370,14 @@ fn doctests_require_a_runtime_visible_docstring() {
     let context = TestContext::with_file(
         "test_decorated.py",
         r#"
+from pathlib import Path
+
+import pytest
+
+@pytest.fixture(autouse=True)
+def automatic():
+    Path("fixture-ran").touch()
+
 def hide_docstring(function):
     return object()
 
@@ -331,9 +387,6 @@ def documented():
     >>> 1 + 1
     2
     """
-
-def test_regular():
-    pass
 "#,
     );
 
@@ -341,13 +394,14 @@ def test_regular():
     success: true
     exit_code: 0
     ----- stdout -----
-        Starting 2 tests across 1 worker
-            PASS [TIME] test_decorated::test_regular
+        Starting 1 test across 1 worker
     ────────────
-         Summary [TIME] 2 tests run: 1 passed, 1 skipped
+         Summary [TIME] 1 test run: 0 passed, 1 skipped
 
     ----- stderr -----
     ");
+
+    assert!(!context.root().join("fixture-ran").exists());
 }
 
 #[test]

--- a/crates/karva/tests/it/doctest.rs
+++ b/crates/karva/tests/it/doctest.rs
@@ -1,0 +1,513 @@
+use insta_cmd::assert_cmd_snapshot;
+use serde_json::Value;
+
+use crate::common::TestContext;
+
+const DOCTEST_FIXTURE: &str = r#"
+"""Module examples.
+
+>>> 1 + 1
+2
+"""
+
+def documented():
+    """Function examples.
+
+    >>> 2 + 2
+    5
+    """
+
+def raises_unexpectedly():
+    """An unexpected exception includes its type and message.
+
+    >>> 1 / 0
+    0
+    """
+
+def test_regular():
+    pass
+"#;
+
+#[test]
+fn doctest_modules_is_opt_in() {
+    let context = TestContext::with_file("test_examples.py", DOCTEST_FIXTURE);
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test_examples::test_regular
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--doctest-modules"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 4 tests across 1 worker
+            PASS [TIME] test_examples::doctest:@module
+            FAIL [TIME] test_examples::doctest:documented
+            FAIL [TIME] test_examples::doctest:raises_unexpectedly
+            PASS [TIME] test_examples::test_regular
+
+    failures:
+
+    test_examples::doctest:documented:
+
+    error[test-failure]: Test `doctest:documented` failed
+      --> test_examples.py:11:5
+       |
+    11 |     >>> 2 + 2
+       |     ^^^
+       |
+    info: Doctest failed at test_examples.py:11
+          Example:
+            2 + 2
+          Expected:
+            5
+          Got:
+            4
+
+    test_examples::doctest:raises_unexpectedly:
+
+    error[test-failure]: Test `doctest:raises_unexpectedly` failed
+      --> test_examples.py:18:5
+       |
+    18 |     >>> 1 / 0
+       |     ^^^
+       |
+    info: Doctest raised at test_examples.py:18
+          Example:
+            1 / 0
+          Exception:
+            ZeroDivisionError: division by zero
+
+    ────────────
+         Summary [TIME] 4 tests run: 2 passed, 2 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn doctest_modules_can_be_enabled_in_configuration() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.default.test]
+doctest-modules = true
+"#,
+        ),
+        ("test_examples.py", DOCTEST_FIXTURE),
+    ]);
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 4 tests across 1 worker
+            PASS [TIME] test_examples::doctest:@module
+            FAIL [TIME] test_examples::doctest:documented
+            FAIL [TIME] test_examples::doctest:raises_unexpectedly
+            PASS [TIME] test_examples::test_regular
+
+    failures:
+
+    test_examples::doctest:documented:
+
+    error[test-failure]: Test `doctest:documented` failed
+      --> test_examples.py:11:5
+       |
+    11 |     >>> 2 + 2
+       |     ^^^
+       |
+    info: Doctest failed at test_examples.py:11
+          Example:
+            2 + 2
+          Expected:
+            5
+          Got:
+            4
+
+    test_examples::doctest:raises_unexpectedly:
+
+    error[test-failure]: Test `doctest:raises_unexpectedly` failed
+      --> test_examples.py:18:5
+       |
+    18 |     >>> 1 / 0
+       |     ^^^
+       |
+    info: Doctest raised at test_examples.py:18
+          Example:
+            1 / 0
+          Exception:
+            ZeroDivisionError: division by zero
+
+    ────────────
+         Summary [TIME] 4 tests run: 2 passed, 2 failed, 0 skipped
+
+    ----- stderr -----
+    ");
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--doctest-modules=false"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test_examples::test_regular
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn doctest_selector_runs_one_document() {
+    let context = TestContext::with_file("test_examples.py", DOCTEST_FIXTURE);
+
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .args(["--doctest-modules", "test_examples.py::doctest:@module"]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test_examples::doctest:@module
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
+fn doctest_objects_share_state_and_honor_directives() {
+    let context = TestContext::with_file(
+        "test_objects.py",
+        r#"
+def stateful():
+    """Examples share their namespace.
+
+    >>> values = []
+    >>> values.append(1)
+    >>> values
+    [1]
+    >>> "alphabet"  # doctest: +ELLIPSIS
+    'alpha...'
+    >>> print("left    right")  # doctest: +NORMALIZE_WHITESPACE
+    left right
+    >>> missing_name  # doctest: +SKIP
+    """
+
+class Calculator:
+    """A documented class.
+
+    >>> Calculator().multiply(2, 3)
+    6
+    """
+
+    def multiply(self, left, right):
+        """Multiply two values.
+
+        >>> Calculator().multiply(3, 4)
+        12
+        """
+        return left * right
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--doctest-modules"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 3 tests across 1 worker
+            PASS [TIME] test_objects::doctest:stateful
+            PASS [TIME] test_objects::doctest:Calculator
+            PASS [TIME] test_objects::doctest:Calculator.multiply
+    ────────────
+         Summary [TIME] 3 tests run: 3 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn doctests_validate_strict_module_tags() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.default.test]
+doctest-modules = true
+strict-tags = true
+"#,
+        ),
+        (
+            "test_tagged.py",
+            r#"
+"""
+>>> 1 + 1
+2
+"""
+
+import pytest
+
+pytestmark = pytest.mark.typo
+"#,
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+    diagnostics:
+
+    error[unknown-tag]: Tag `typo` is not registered
+     --> test_tagged.py:9:26
+      |
+    9 | pytestmark = pytest.mark.typo
+      |                          ^^^^ unregistered tag
+      |
+    info: Register `typo` in the project-wide `[tags]` table.
+
+    ────────────
+         Summary [TIME] 0 tests run: 0 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn doctests_require_a_runtime_visible_docstring() {
+    let context = TestContext::with_file(
+        "test_decorated.py",
+        r#"
+def hide_docstring(function):
+    return object()
+
+@hide_docstring
+def documented():
+    """
+    >>> 1 + 1
+    2
+    """
+
+def test_regular():
+    pass
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--doctest-modules"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            PASS [TIME] test_decorated::test_regular
+    ────────────
+         Summary [TIME] 2 tests run: 1 passed, 1 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn doctest_ids_are_stable_in_reports() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.default.junit]
+path = "reports/results.xml"
+"#,
+        ),
+        (
+            "test_reports.py",
+            r#"
+"""Module examples.
+
+>>> 1 + 1
+2
+"""
+
+def test_regular():
+    pass
+
+def module():
+    """An object whose name cannot collide with the module case.
+
+    >>> 2 + 2
+    4
+    """
+
+def broken():
+    """A failing example is preserved in machine-readable reports.
+
+    >>> 3 * 3
+    10
+    """
+"#,
+        ),
+    ]);
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
+            "--doctest-modules",
+            "--status-level=none",
+            "--result-output=reports/results.json",
+        ]),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    failures:
+
+    test_reports::doctest:broken:
+
+    error[test-failure]: Test `doctest:broken` failed
+      --> test_reports.py:21:5
+       |
+    21 |     >>> 3 * 3
+       |     ^^^
+       |
+    info: Doctest failed at test_reports.py:21
+          Example:
+            3 * 3
+          Expected:
+            10
+          Got:
+            9
+
+    ────────────
+         Summary [TIME] 4 tests run: 3 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+
+    let report: Value = serde_json::from_str(&context.read_file("reports/results.json"))
+        .expect("JSON report should parse");
+    let doctest = report["tests"]
+        .as_array()
+        .expect("JSON tests should be an array")
+        .iter()
+        .find(|test| test["name"] == "doctest:@module")
+        .expect("JSON report should include module doctest");
+    assert_eq!(doctest["module"], "test_reports");
+    assert_eq!(doctest["full_name"], "test_reports::doctest:@module");
+    assert!(
+        report["tests"]
+            .as_array()
+            .expect("JSON tests should be an array")
+            .iter()
+            .any(|test| test["full_name"] == "test_reports::doctest:module"),
+        "JSON report should distinguish an object named module"
+    );
+    let failed = report["tests"]
+        .as_array()
+        .expect("JSON tests should be an array")
+        .iter()
+        .find(|test| test["name"] == "doctest:broken")
+        .expect("JSON report should include failing doctest");
+    assert_eq!(failed["status"], "failed");
+    let diagnostic = failed["diagnostic"]["rendered"]
+        .as_str()
+        .expect("failing JSON doctest should include a diagnostic");
+    assert!(diagnostic.contains("Expected:\n        10"));
+    assert!(diagnostic.contains("Got:\n        9"));
+
+    assert_cmd_snapshot!(
+        context.command_no_parallel().args([
+            "--doctest-modules",
+            "--status-level=none",
+            "--result-output=reports/results.jsonl",
+            "--result-format=jsonl",
+        ]),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    failures:
+
+    test_reports::doctest:broken:
+
+    error[test-failure]: Test `doctest:broken` failed
+      --> test_reports.py:21:5
+       |
+    21 |     >>> 3 * 3
+       |     ^^^
+       |
+    info: Doctest failed at test_reports.py:21
+          Example:
+            3 * 3
+          Expected:
+            10
+          Got:
+            9
+
+    ────────────
+         Summary [TIME] 4 tests run: 3 passed, 1 failed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+
+    let doctest = context
+        .read_file("reports/results.jsonl")
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).expect("JSONL record should parse"))
+        .find(|record| record["type"] == "test" && record["name"] == "doctest:@module")
+        .expect("JSONL report should include module doctest");
+    assert_eq!(doctest["module"], "test_reports");
+    assert_eq!(doctest["full_name"], "test_reports::doctest:@module");
+
+    assert!(
+        context
+            .read_file("reports/results.jsonl")
+            .lines()
+            .map(|line| serde_json::from_str::<Value>(line).expect("JSONL record should parse"))
+            .any(|record| record["full_name"] == "test_reports::doctest:module"),
+        "JSONL report should distinguish an object named module"
+    );
+
+    let failed = context
+        .read_file("reports/results.jsonl")
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).expect("JSONL record should parse"))
+        .find(|record| record["name"] == "doctest:broken")
+        .expect("JSONL report should include failing doctest");
+    assert_eq!(failed["status"], "failed");
+    let diagnostic = failed["diagnostic"]["rendered"]
+        .as_str()
+        .expect("failing JSONL doctest should include a diagnostic");
+    assert!(diagnostic.contains("Expected:\n        10"));
+    assert!(diagnostic.contains("Got:\n        9"));
+
+    let junit = context.read_file("reports/results.xml");
+    assert!(
+        junit.contains(r#"<testcase classname="test_reports" name="doctest:@module""#),
+        "JUnit report should include module doctest ID"
+    );
+    assert!(
+        junit.contains(r#"<testcase classname="test_reports" name="doctest:module""#),
+        "JUnit report should distinguish an object named module"
+    );
+    assert!(
+        junit.contains(r#"<testcase classname="test_reports" name="doctest:broken""#)
+            && junit.contains("Expected:")
+            && junit.contains("Got:"),
+        "JUnit report should include the failing doctest diagnostic"
+    );
+}

--- a/crates/karva/tests/it/doctest.rs
+++ b/crates/karva/tests/it/doctest.rs
@@ -353,6 +353,41 @@ pytestmark = pytest.mark.parametrize("unused", [1, 2])
 }
 
 #[test]
+fn doctests_honor_module_usefixtures() {
+    let context = TestContext::with_file(
+        "test_fixtures.py",
+        r#"
+"""
+>>> Path("fixture-ran").exists()
+True
+"""
+
+from pathlib import Path
+
+import pytest
+
+@pytest.fixture
+def prepared():
+    Path("fixture-ran").touch()
+
+pytestmark = pytest.mark.usefixtures("prepared")
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--doctest-modules"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test_fixtures::doctest:@module
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn doctests_require_a_runtime_visible_docstring() {
     let context = TestContext::with_file(
         "test_decorated.py",

--- a/crates/karva/tests/it/doctest.rs
+++ b/crates/karva/tests/it/doctest.rs
@@ -98,10 +98,10 @@ fn doctest_modules_can_be_enabled_in_configuration() {
     let context = TestContext::with_files([
         (
             "karva.toml",
-            r#"
+            r"
 [profile.default.test]
 doctest-modules = true
-"#,
+",
         ),
         ("test_examples.py", DOCTEST_FIXTURE),
     ]);
@@ -245,11 +245,11 @@ fn doctests_validate_strict_module_tags() {
     let context = TestContext::with_files([
         (
             "karva.toml",
-            r#"
+            r"
 [profile.default.test]
 doctest-modules = true
 strict-tags = true
-"#,
+",
         ),
         (
             "test_tagged.py",
@@ -283,6 +283,35 @@ pytestmark = pytest.mark.typo
 
     ────────────
          Summary [TIME] 0 tests run: 0 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn doctests_ignore_module_parametrization() {
+    let context = TestContext::with_file(
+        "test_parametrized.py",
+        r#"
+"""
+>>> 1 + 1
+2
+"""
+
+import pytest
+
+pytestmark = pytest.mark.parametrize("unused", [1, 2])
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel().arg("--doctest-modules"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test_parametrized::doctest:@module
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
 
     ----- stderr -----
     ");

--- a/crates/karva/tests/it/extensions/fixtures/invalid.rs
+++ b/crates/karva/tests/it/extensions/fixtures/invalid.rs
@@ -301,6 +301,48 @@ fn test_fixture_missing_fixtures() {
 }
 
 #[test]
+fn test_aliased_fixture_missing_fixtures_uses_source_name() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import pytest
+
+@pytest.fixture(name="aliased_fixture")
+def source_fixture(missing_fixture):
+    return 1
+
+def test_fixture(aliased_fixture):
+    pass
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+           ERROR [TIME] test::test_fixture
+
+    failures:
+
+    test::test_fixture:
+
+    error[missing-fixtures]: Fixture `source_fixture` has missing fixtures
+     --> test.py:5:5
+      |
+    5 | def source_fixture(missing_fixture):
+      |     ^^^^^^^^^^^^^^
+      |
+    info: Missing fixtures: `missing_fixture`
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn missing_arguments_in_nested_function() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva/tests/it/main.rs
+++ b/crates/karva/tests/it/main.rs
@@ -8,6 +8,7 @@ mod configuration;
 mod coverage;
 mod coverage_command;
 mod discovery;
+mod doctest;
 mod durations;
 mod extensions;
 mod filterset;

--- a/crates/karva/tests/it/show_config.rs
+++ b/crates/karva/tests/it/show_config.rs
@@ -24,6 +24,7 @@ fn show_config_default_profile() {
     test-function-prefix = "test"
     strict-tags = false
     try-import-fixtures = false
+    doctest-modules = false
     retry = 0
     shuffle = false
     flaky-result = "pass"

--- a/crates/karva_cli/src/test.rs
+++ b/crates/karva_cli/src/test.rs
@@ -57,6 +57,10 @@ pub struct SubTestCommand {
     #[clap(long, default_missing_value = "true", require_equals = true, num_args=0..=1, help_heading = "Filter options")]
     pub try_import_fixtures: Option<bool>,
 
+    /// Collect examples from module, class, function, and method docstrings.
+    #[clap(long, default_missing_value = "true", require_equals = true, num_args=0..=1, help_heading = "Filter options")]
+    pub doctest_modules: Option<bool>,
+
     /// Filter tests using a filterset expression.
     ///
     /// Predicates: `test(<matcher>)` matches the fully qualified test name;
@@ -535,6 +539,7 @@ impl SubTestCommand {
                 fail_fast,
                 max_fail,
                 try_import_fixtures: self.try_import_fixtures,
+                doctest_modules: self.doctest_modules,
                 retry: self.retry,
                 shuffle: None,
                 random_seed: None,
@@ -691,6 +696,7 @@ mod tests {
             "karva-test",
             "--no-ignore=false",
             "--try-import-fixtures=false",
+            "--doctest-modules=false",
             "--fail-fast=false",
             "--snapshot-update=false",
             "--show-output=false",
@@ -701,6 +707,7 @@ mod tests {
 
         assert_eq!(command.sub_command.no_ignore, Some(false));
         assert_eq!(command.sub_command.try_import_fixtures, Some(false));
+        assert_eq!(command.sub_command.doctest_modules, Some(false));
         assert_eq!(command.sub_command.fail_fast, Some(false));
         assert_eq!(command.sub_command.snapshot_update, Some(false));
         assert_eq!(command.sub_command.show_output, Some(false));
@@ -715,6 +722,7 @@ mod tests {
             "karva-test",
             "--no-ignore",
             "--try-import-fixtures",
+            "--doctest-modules",
             "--fail-fast",
             "--snapshot-update",
             "--show-output",
@@ -725,6 +733,7 @@ mod tests {
 
         assert_eq!(command.sub_command.no_ignore, Some(true));
         assert_eq!(command.sub_command.try_import_fixtures, Some(true));
+        assert_eq!(command.sub_command.doctest_modules, Some(true));
         assert_eq!(command.sub_command.fail_fast, Some(true));
         assert_eq!(command.sub_command.snapshot_update, Some(true));
         assert_eq!(command.sub_command.show_output, Some(true));

--- a/crates/karva_collector/Cargo.toml
+++ b/crates/karva_collector/Cargo.toml
@@ -17,6 +17,7 @@ camino = { workspace = true }
 fs-err = { workspace = true }
 ruff_python_ast = { workspace = true }
 ruff_python_parser = { workspace = true }
+ruff_text_size = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/karva_collector/src/lib.rs
+++ b/crates/karva_collector/src/lib.rs
@@ -2,8 +2,11 @@
 
 use camino::{Utf8Path, Utf8PathBuf};
 use fs_err as fs;
-use ruff_python_ast::{PythonVersion, Stmt};
+use ruff_python_ast::{
+    AtomicNodeIndex, Expr, Identifier, Parameters, PythonVersion, Stmt, StmtFunctionDef,
+};
 use ruff_python_parser::{Mode, ParseOptions, parse_unchecked};
+use ruff_text_size::{Ranged, TextRange, TextSize};
 use thiserror::Error;
 
 use karva_python_semantic::ModulePath;
@@ -12,7 +15,7 @@ use karva_python_semantic::is_fixture_function;
 mod models;
 mod parametrize;
 
-pub use models::{CollectedModule, CollectedPackage, ModuleType};
+pub use models::{CollectedDoctest, CollectedModule, CollectedPackage, DoctestTarget, ModuleType};
 pub use parametrize::count_parametrize_cases;
 
 #[derive(Debug, Error)]
@@ -43,6 +46,9 @@ pub struct CollectionSettings<'a> {
 
     /// Whether to collect fixture function definitions in addition to test functions.
     pub collect_fixtures: bool,
+
+    /// Whether to collect docstrings containing doctest examples.
+    pub collect_doctests: bool,
 }
 
 /// Collects test functions and fixtures from a Python file.
@@ -89,6 +95,20 @@ pub fn collect_file(
         source_text,
     );
 
+    if settings.collect_doctests && module_type == ModuleType::Test {
+        for doctest in
+            collect_doctests(&collected_module.module_body, &collected_module.source_text)
+        {
+            if function_names.is_empty()
+                || function_names
+                    .iter()
+                    .any(|name| name == doctest.function_def.name.as_str())
+            {
+                collected_module.add_doctest(doctest);
+            }
+        }
+    }
+
     for function_def in function_defs {
         if settings.collect_fixtures && is_fixture_function(&function_def) {
             collected_module.add_fixture_function_def(function_def);
@@ -105,6 +125,128 @@ pub fn collect_file(
     }
 
     Ok(Some(collected_module))
+}
+
+fn collect_doctests(module_body: &[Stmt], source_text: &str) -> Vec<CollectedDoctest> {
+    let mut doctests = Vec::new();
+    collect_body_doctest(
+        module_body,
+        DoctestTarget::Module,
+        source_text,
+        &mut doctests,
+    );
+
+    for statement in module_body {
+        collect_object_doctests(statement, "", source_text, &mut doctests);
+    }
+
+    doctests
+}
+
+fn collect_object_doctests(
+    statement: &Stmt,
+    parent: &str,
+    source_text: &str,
+    doctests: &mut Vec<CollectedDoctest>,
+) {
+    let (name, body, recurse) = match statement {
+        Stmt::FunctionDef(function) => (function.name.as_str(), function.body.as_slice(), false),
+        Stmt::ClassDef(class) => (class.name.as_str(), class.body.as_slice(), true),
+        _ => return,
+    };
+    let object_name = if parent.is_empty() {
+        name.to_string()
+    } else {
+        format!("{parent}.{name}")
+    };
+    remove_redefined_doctests(doctests, &object_name);
+    collect_body_doctest(
+        body,
+        DoctestTarget::Object(object_name.clone()),
+        source_text,
+        doctests,
+    );
+
+    if recurse {
+        for statement in body {
+            collect_object_doctests(statement, &object_name, source_text, doctests);
+        }
+    }
+}
+
+fn remove_redefined_doctests(doctests: &mut Vec<CollectedDoctest>, object_name: &str) {
+    doctests.retain(|doctest| match &doctest.target {
+        DoctestTarget::Module => true,
+        DoctestTarget::Object(existing) => {
+            existing != object_name
+                && !existing
+                    .strip_prefix(object_name)
+                    .is_some_and(|suffix| suffix.starts_with('.'))
+        }
+    });
+}
+
+fn collect_body_doctest(
+    body: &[Stmt],
+    target: DoctestTarget,
+    source_text: &str,
+    doctests: &mut Vec<CollectedDoctest>,
+) {
+    let Some(Stmt::Expr(docstring)) = body.first() else {
+        return;
+    };
+    let Expr::StringLiteral(value) = docstring.value.as_ref() else {
+        return;
+    };
+    if !value.value.to_str().lines().any(is_doctest_prompt) {
+        return;
+    }
+
+    let range = prompt_range(source_text, value.range()).unwrap_or_else(|| value.range());
+    let name = match &target {
+        DoctestTarget::Module => "doctest:@module".to_string(),
+        DoctestTarget::Object(object_name) => format!("doctest:{object_name}"),
+    };
+    doctests.push(CollectedDoctest {
+        target,
+        function_def: StmtFunctionDef {
+            node_index: AtomicNodeIndex::NONE,
+            range,
+            is_async: false,
+            decorator_list: Vec::new(),
+            name: Identifier::new(name, range),
+            type_params: None,
+            parameters: Box::<Parameters>::default(),
+            returns: None,
+            body: Vec::new(),
+        },
+    });
+}
+
+fn is_doctest_prompt(line: &str) -> bool {
+    let Some(rest) = line.trim_start().strip_prefix(">>>") else {
+        return false;
+    };
+    let source = rest.trim_start();
+    rest.starts_with(char::is_whitespace) && !source.is_empty() && !source.starts_with('#')
+}
+
+fn prompt_range(source_text: &str, range: TextRange) -> Option<TextRange> {
+    let source = source_text.get(usize::from(range.start())..usize::from(range.end()))?;
+    let mut line_offset = 0;
+    let mut prompt_offset = None;
+    for line in source.split_inclusive('\n') {
+        if is_doctest_prompt(line)
+            && let Some(prompt) = line.find(">>>")
+        {
+            prompt_offset = Some(line_offset + prompt);
+            break;
+        }
+        line_offset += line.len();
+    }
+    let offset = prompt_offset?;
+    let offset = TextSize::try_from(offset).ok()?;
+    Some(TextRange::at(range.start() + offset, TextSize::new(3)))
 }
 
 /// Returns `true` if a function should be collected as a test.
@@ -133,6 +275,7 @@ mod tests {
             test_function_prefix: "test_",
             respect_ignore_files: true,
             collect_fixtures: false,
+            collect_doctests: false,
         }
     }
 
@@ -207,6 +350,183 @@ mod tests {
 
         assert_eq!(function_names(&module.fixture_function_defs), ["db"]);
         assert_eq!(function_names(&module.test_function_defs), ["test_uses_db"]);
+    }
+
+    #[test]
+    fn collect_file_collects_module_function_class_and_method_doctests() {
+        let (_temp_dir, root, path) = python_file(
+            "sample.py",
+            r#"
+"""Module docs.
+
+>>> 1 + 1
+2
+"""
+def function():
+    """Function docs.
+
+    >>> 2 + 2
+    4
+    """
+class Thing:
+    """Class docs.
+
+    >>> 3 + 3
+    6
+    """
+    def method(self):
+        """Method docs.
+
+        >>> 4 + 4
+        8
+        """
+def ordinary():
+    """Documentation without an example."""
+"#,
+        );
+        let settings = CollectionSettings {
+            collect_doctests: true,
+            ..settings()
+        };
+
+        let module = collect_file(&path, &root, &settings, &[])
+            .expect("collect file")
+            .expect("module should collect");
+
+        let names: Vec<_> = module
+            .doctests
+            .iter()
+            .map(|doctest| doctest.function_def.name.as_str())
+            .collect();
+        assert_eq!(
+            names,
+            [
+                "doctest:@module",
+                "doctest:function",
+                "doctest:Thing",
+                "doctest:Thing.method"
+            ]
+        );
+    }
+
+    #[test]
+    fn collect_file_ignores_doctests_when_disabled() {
+        let (_temp_dir, root, path) = python_file(
+            "sample.py",
+            r#"
+"""
+>>> 1 + 1
+2
+"""
+"#,
+        );
+
+        let module = collect_file(&path, &root, &settings(), &[])
+            .expect("collect file")
+            .expect("module should collect");
+
+        assert!(module.doctests.is_empty());
+    }
+
+    #[test]
+    fn collect_file_filters_doctests_by_synthetic_selector() {
+        let (_temp_dir, root, path) = python_file(
+            "sample.py",
+            r#"
+"""
+>>> 1 + 1
+2
+"""
+class Thing:
+    """
+    >>> 2 + 2
+    4
+    """
+"#,
+        );
+        let settings = CollectionSettings {
+            collect_doctests: true,
+            ..settings()
+        };
+
+        let module = collect_file(&path, &root, &settings, &["doctest:Thing".to_string()])
+            .expect("collect file")
+            .expect("module should collect");
+
+        assert_eq!(module.doctests.len(), 1);
+        assert_eq!(
+            module.doctests[0].target,
+            DoctestTarget::Object("Thing".to_string())
+        );
+    }
+
+    #[test]
+    fn doctest_prompt_requires_executable_source() {
+        assert!(is_doctest_prompt(">>> value"));
+        assert!(is_doctest_prompt("    >>>\tvalue"));
+        assert!(!is_doctest_prompt(">>>"));
+        assert!(!is_doctest_prompt(">>>   "));
+        assert!(!is_doctest_prompt(">>> # comment"));
+        assert!(!is_doctest_prompt(">>>value"));
+
+        let source = "\"\"\"Mention >>> inline.\n>>> value\n\"\"\"";
+        let range = TextRange::new(
+            TextSize::default(),
+            TextSize::try_from(source.len()).expect("source length should fit"),
+        );
+        let prompt = prompt_range(source, range).expect("find executable prompt");
+        assert_eq!(
+            usize::from(prompt.start()),
+            source.find("\n>>>").expect("find prompt line") + 1
+        );
+    }
+
+    #[test]
+    fn collect_file_uses_the_final_object_binding() {
+        let (_temp_dir, root, path) = python_file(
+            "sample.py",
+            r#"
+def documented():
+    """
+    >>> 1
+    1
+    """
+
+def documented():
+    """
+    >>> 2
+    2
+    """
+
+class Thing:
+    def stale(self):
+        """
+        >>> 3
+        3
+        """
+
+class Thing:
+    """
+    >>> 4
+    4
+    """
+"#,
+        );
+        let settings = CollectionSettings {
+            collect_doctests: true,
+            ..settings()
+        };
+
+        let module = collect_file(&path, &root, &settings, &[])
+            .expect("collect file")
+            .expect("module should collect");
+
+        let names: Vec<_> = module
+            .doctests
+            .iter()
+            .map(|doctest| doctest.function_def.name.as_str())
+            .collect();
+        assert_eq!(names, ["doctest:documented", "doctest:Thing"]);
     }
 
     #[test]

--- a/crates/karva_collector/src/lib.rs
+++ b/crates/karva_collector/src/lib.rs
@@ -2,9 +2,7 @@
 
 use camino::{Utf8Path, Utf8PathBuf};
 use fs_err as fs;
-use ruff_python_ast::{
-    AtomicNodeIndex, Expr, Identifier, Parameters, PythonVersion, Stmt, StmtFunctionDef,
-};
+use ruff_python_ast::{Expr, PythonVersion, Stmt};
 use ruff_python_parser::{Mode, ParseOptions, parse_unchecked};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use thiserror::Error;
@@ -51,10 +49,10 @@ pub struct CollectionSettings<'a> {
     pub collect_doctests: bool,
 }
 
-/// Collects test functions and fixtures from a Python file.
+/// Collects tests and fixtures from a Python file.
 ///
-/// If `function_names` is empty, all test functions matching the configured prefix are collected.
-/// If `function_names` is non-empty, only test functions with names in the list are collected.
+/// If `function_names` is empty, all matching tests are collected. Otherwise, only tests whose
+/// function name or doctest selector appears in the list are collected.
 /// Fixtures are always collected regardless of the filter.
 pub fn collect_file(
     path: &Utf8PathBuf,
@@ -99,10 +97,7 @@ pub fn collect_file(
         for doctest in
             collect_doctests(&collected_module.module_body, &collected_module.source_text)
         {
-            if function_names.is_empty()
-                || function_names
-                    .iter()
-                    .any(|name| name == doctest.function_def.name.as_str())
+            if function_names.is_empty() || function_names.iter().any(|name| name == &doctest.name)
             {
                 collected_module.add_doctest(doctest);
             }
@@ -209,17 +204,8 @@ fn collect_body_doctest(
     };
     doctests.push(CollectedDoctest {
         target,
-        function_def: StmtFunctionDef {
-            node_index: AtomicNodeIndex::NONE,
-            range,
-            is_async: false,
-            decorator_list: Vec::new(),
-            name: Identifier::new(name, range),
-            type_params: None,
-            parameters: Box::<Parameters>::default(),
-            returns: None,
-            body: Vec::new(),
-        },
+        name,
+        range,
     });
 }
 
@@ -396,7 +382,7 @@ def ordinary():
         let names: Vec<_> = module
             .doctests
             .iter()
-            .map(|doctest| doctest.function_def.name.as_str())
+            .map(|doctest| doctest.name.as_str())
             .collect();
         assert_eq!(
             names,
@@ -429,7 +415,7 @@ def ordinary():
     }
 
     #[test]
-    fn collect_file_filters_doctests_by_synthetic_selector() {
+    fn collect_file_filters_doctests_by_selector() {
         let (_temp_dir, root, path) = python_file(
             "sample.py",
             r#"
@@ -524,7 +510,7 @@ class Thing:
         let names: Vec<_> = module
             .doctests
             .iter()
-            .map(|doctest| doctest.function_def.name.as_str())
+            .map(|doctest| doctest.name.as_str())
             .collect();
         assert_eq!(names, ["doctest:documented", "doctest:Thing"]);
     }

--- a/crates/karva_collector/src/models.rs
+++ b/crates/karva_collector/src/models.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use camino::Utf8PathBuf;
 use karva_python_semantic::ModulePath;
 use ruff_python_ast::{Stmt, StmtFunctionDef};
+use ruff_text_size::TextRange;
 
 /// The Python object whose docstring defines a doctest case.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -20,11 +21,14 @@ pub struct CollectedDoctest {
     /// Python object that owns the docstring.
     pub target: DoctestTarget,
 
-    /// Synthetic zero-argument function definition used by shared test semantics.
-    pub function_def: StmtFunctionDef,
+    /// Stable test selector.
+    pub name: String,
+
+    /// First executable prompt, or the docstring when no prompt range is available.
+    pub range: TextRange,
 }
 
-/// A collected module containing raw AST function definitions.
+/// A collected module containing raw AST definitions and doctest metadata.
 /// This is populated during the parallel collection phase.
 #[derive(Debug, Clone)]
 pub struct CollectedModule {

--- a/crates/karva_collector/src/models.rs
+++ b/crates/karva_collector/src/models.rs
@@ -4,6 +4,26 @@ use camino::Utf8PathBuf;
 use karva_python_semantic::ModulePath;
 use ruff_python_ast::{Stmt, StmtFunctionDef};
 
+/// The Python object whose docstring defines a doctest case.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DoctestTarget {
+    /// The containing Python module.
+    Module,
+
+    /// A module member, named relative to the containing module.
+    Object(String),
+}
+
+/// One docstring containing examples scheduled as a single doctest case.
+#[derive(Debug, Clone)]
+pub struct CollectedDoctest {
+    /// Python object that owns the docstring.
+    pub target: DoctestTarget,
+
+    /// Synthetic zero-argument function definition used by shared test semantics.
+    pub function_def: StmtFunctionDef,
+}
+
 /// A collected module containing raw AST function definitions.
 /// This is populated during the parallel collection phase.
 #[derive(Debug, Clone)]
@@ -23,6 +43,9 @@ pub struct CollectedModule {
     /// Test function definitions (functions starting with test prefix)
     pub test_function_defs: Vec<StmtFunctionDef>,
 
+    /// Docstrings containing doctest examples.
+    pub doctests: Vec<CollectedDoctest>,
+
     /// Fixture function definitions (functions with fixture decorators)
     pub fixture_function_defs: Vec<StmtFunctionDef>,
 }
@@ -40,12 +63,17 @@ impl CollectedModule {
             source_text,
             module_body,
             test_function_defs: Vec::new(),
+            doctests: Vec::new(),
             fixture_function_defs: Vec::new(),
         }
     }
 
     pub(super) fn add_test_function_def(&mut self, function_def: StmtFunctionDef) {
         self.test_function_defs.push(function_def);
+    }
+
+    pub(super) fn add_doctest(&mut self, doctest: CollectedDoctest) {
+        self.doctests.push(doctest);
     }
 
     pub(super) fn add_fixture_function_def(&mut self, function_def: StmtFunctionDef) {
@@ -62,7 +90,9 @@ impl CollectedModule {
     }
 
     fn is_empty(&self) -> bool {
-        self.test_function_defs.is_empty() && self.fixture_function_defs.is_empty()
+        self.test_function_defs.is_empty()
+            && self.doctests.is_empty()
+            && self.fixture_function_defs.is_empty()
     }
 }
 
@@ -215,7 +245,7 @@ impl CollectedPackage {
         let module_tests: usize = self
             .modules
             .values()
-            .map(|m| m.test_function_defs.len())
+            .map(|m| m.test_function_defs.len() + m.doctests.len())
             .sum();
         let package_tests: usize = self.packages.values().map(Self::test_count).sum();
         module_tests + package_tests
@@ -242,6 +272,15 @@ impl CollectedModule {
     fn update(&mut self, module: Self) {
         if self.path == module.path {
             add_new_definitions(&mut self.test_function_defs, module.test_function_defs);
+            for doctest in module.doctests {
+                if !self
+                    .doctests
+                    .iter()
+                    .any(|existing| existing.target == doctest.target)
+                {
+                    self.doctests.push(doctest);
+                }
+            }
             add_new_definitions(
                 &mut self.fixture_function_defs,
                 module.fixture_function_defs,

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -454,6 +454,19 @@ pub struct TestOptions {
     )]
     pub try_import_fixtures: Option<bool>,
 
+    /// Collect examples from module, class, function, and method docstrings.
+    ///
+    /// Defaults to `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option(
+        default = r#"false"#,
+        value_type = "true | false",
+        example = r#"
+            doctest-modules = true
+        "#
+    )]
+    pub doctest_modules: Option<bool>,
+
     /// When set, we will retry failed tests up to this number of times.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[option(
@@ -635,6 +648,7 @@ impl TestOptions {
             strict_tags: self.strict_tags.unwrap_or_default(),
             max_fail,
             try_import_fixtures: self.try_import_fixtures.unwrap_or_default(),
+            doctest_modules: self.doctest_modules.unwrap_or_default(),
             retry: self.retry.unwrap_or_default(),
             shuffle: self.shuffle.unwrap_or_default(),
             random_seed: self.random_seed,
@@ -1142,6 +1156,27 @@ mod tests {
             ),
         )
         ");
+    }
+
+    #[test]
+    fn to_settings_doctest_modules_defaults_to_disabled() {
+        assert!(!TestOptions::default().to_settings().doctest_modules);
+    }
+
+    #[test]
+    fn parse_profile_doctest_modules() {
+        let config = Config::from_toml_str("[profile.default.test]\ndoctest-modules = true\n")
+            .expect("parse");
+
+        assert_eq!(
+            config
+                .resolve_profile(None)
+                .expect("resolve")
+                .test
+                .expect("test options")
+                .doctest_modules,
+            Some(true)
+        );
     }
 
     #[test]

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -783,6 +783,10 @@ fn is_false(value: &bool) -> bool {
 
 #[derive(Default, Debug, Clone, Serialize)]
 #[serde(rename_all = "kebab-case")]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "resolved settings mirror independent boolean configuration switches"
+)]
 /// Resolved test selection, retry, timeout, and failure settings.
 pub struct TestSettings {
     /// Prefix identifying Python test functions during syntax collection.
@@ -798,6 +802,9 @@ pub struct TestSettings {
 
     /// Whether collection imports modules to discover fixtures dynamically.
     pub try_import_fixtures: bool,
+
+    /// Whether module, class, function, and method docstrings are collected as tests.
+    pub doctest_modules: bool,
 
     /// Additional attempts permitted after first failure.
     pub retry: u32,

--- a/crates/karva_runner/src/collection.rs
+++ b/crates/karva_runner/src/collection.rs
@@ -212,6 +212,7 @@ mod tests {
             test_function_prefix: "test_",
             respect_ignore_files: true,
             collect_fixtures: false,
+            collect_doctests: false,
         }
     }
 

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -659,6 +659,7 @@ pub fn collect_tests(project: &Project) -> Result<CollectedPackage> {
         test_function_prefix: &project.settings().test().test_function_prefix,
         respect_ignore_files: project.settings().src().respect_ignore_files,
         collect_fixtures: false,
+        collect_doctests: project.settings().test().doctest_modules,
     };
 
     let collector = ParallelCollector::new(project.cwd(), collection_settings);

--- a/crates/karva_runner/src/partition.rs
+++ b/crates/karva_runner/src/partition.rs
@@ -407,6 +407,20 @@ fn collect_test_paths_recursive(
                 });
             }
         }
+
+        for doctest in &module.doctests {
+            let module_name = module.path.module_name();
+            let module_path = module.path.path();
+            let function_name = doctest.function_def.name.as_str();
+            let qualified_name = format!("{module_name}::{function_name}");
+            test_infos.push(TestInfo {
+                module_name: module_name.to_string(),
+                duration: previous_durations.get(qualified_name.as_str()).copied(),
+                path: format!("{module_path}::{function_name}"),
+                function_root: qualified_name.clone(),
+                qualified_name,
+            });
+        }
     }
 
     for subpackage in package.packages.values() {
@@ -419,11 +433,16 @@ pub fn scheduled_test_count(package: &karva_collector::CollectedPackage) -> usiz
     let direct = package
         .modules
         .values()
-        .flat_map(|module| &module.test_function_defs)
-        .map(|test| {
-            karva_collector::count_parametrize_cases(test)
-                .unwrap_or(1)
-                .max(1)
+        .map(|module| {
+            module
+                .test_function_defs
+                .iter()
+                .map(|test| {
+                    karva_collector::count_parametrize_cases(test)
+                        .unwrap_or(1)
+                        .max(1)
+                })
+                .fold(module.doctests.len(), usize::saturating_add)
         })
         .fold(0usize, usize::saturating_add);
     package
@@ -772,6 +791,7 @@ mod tests {
             test_function_prefix: "test_",
             respect_ignore_files: true,
             collect_fixtures: false,
+            collect_doctests: false,
         };
         let mut package = CollectedPackage::new(root);
         let mut test_paths = HashMap::new();

--- a/crates/karva_runner/src/partition.rs
+++ b/crates/karva_runner/src/partition.rs
@@ -411,7 +411,7 @@ fn collect_test_paths_recursive(
         for doctest in &module.doctests {
             let module_name = module.path.module_name();
             let module_path = module.path.path();
-            let function_name = doctest.function_def.name.as_str();
+            let function_name = doctest.name.as_str();
             let qualified_name = format!("{module_name}::{function_name}");
             test_infos.push(TestInfo {
                 module_name: module_name.to_string(),

--- a/crates/karva_runner/src/worker_args.rs
+++ b/crates/karva_runner/src/worker_args.rs
@@ -151,6 +151,10 @@ fn inner_cli_args(settings: &ProjectSettings, args: &SubTestCommand) -> Vec<Stri
         cli_args.push("--try-import-fixtures".to_string());
     }
 
+    if settings.test().doctest_modules {
+        cli_args.push("--doctest-modules".to_string());
+    }
+
     if settings.test().strict_tags {
         cli_args.push("--strict-tags=true".to_string());
         for name in settings.tags().keys() {

--- a/crates/karva_test_semantic/src/context.rs
+++ b/crates/karva_test_semantic/src/context.rs
@@ -67,6 +67,7 @@ impl<'a> Context<'a> {
             test_function_prefix: &self.settings.test().test_function_prefix,
             respect_ignore_files: self.settings.src().respect_ignore_files,
             collect_fixtures: true,
+            collect_doctests: self.settings.test().doctest_modules,
         }
     }
 

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -10,13 +10,14 @@ use karva_diagnostic::{
 use karva_logging::time::format_duration;
 use karva_python_semantic::FunctionKind;
 use pyo3::{PyErr, Python};
-use ruff_python_ast::StmtFunctionDef;
+use ruff_python_ast::{Parameters, StmtFunctionDef};
 use ruff_source_file::{OneIndexed, SourceFile};
 use ruff_text_size::{TextRange, TextSize};
 
 mod metadata;
 
 use crate::declare_diagnostic_type;
+use crate::discovery::models::definition::TestDefinition;
 use crate::extensions::fixtures::RejectedFixture;
 use crate::extensions::tags::parametrize::InvalidParametrizeError;
 use crate::runner::{
@@ -30,6 +31,31 @@ struct FailedFunctionCallOptions {
     function_kind: FunctionKind,
     verbose: bool,
     primary_range: Option<TextRange>,
+}
+
+#[derive(Clone, Copy)]
+struct FailedFunctionDefinition<'a> {
+    source_file: &'a SourceFile,
+    range: TextRange,
+    parameters: Option<&'a Parameters>,
+}
+
+impl<'a> FailedFunctionDefinition<'a> {
+    fn function(source_file: &'a SourceFile, statement: &'a StmtFunctionDef) -> Self {
+        Self {
+            source_file,
+            range: statement.name.range,
+            parameters: Some(statement.parameters.as_ref()),
+        }
+    }
+
+    fn test(definition: &'a TestDefinition) -> Self {
+        Self {
+            source_file: definition.source_file(),
+            range: definition.diagnostic_range(),
+            parameters: definition.parameters(),
+        }
+    }
 }
 
 declare_diagnostic_type! {
@@ -271,6 +297,12 @@ fn annotate_function_name(
     diagnostic.annotate(Annotation::primary(span));
 }
 
+fn annotate_test(diagnostic: &mut Diagnostic, definition: &TestDefinition) {
+    let span =
+        Span::from(definition.source_file().clone()).with_range(definition.diagnostic_range());
+    diagnostic.annotate(Annotation::primary(span));
+}
+
 fn annotate_first_definition(
     diagnostic: &mut Diagnostic,
     source_file: SourceFile,
@@ -417,8 +449,7 @@ pub fn fixture_failure_diagnostic(
     handle_failed_function_call(
         &mut diagnostic,
         py,
-        definition.source_file(),
-        definition.statement(),
+        FailedFunctionDefinition::function(definition.source_file(), definition.statement()),
         &arguments,
         FailedFunctionCallOptions {
             function_kind: FunctionKind::Fixture,
@@ -448,7 +479,8 @@ pub fn fixture_resolution_diagnostic(error: FixtureResolutionError) -> Diagnosti
             missing_fixtures,
         } => missing_fixtures_diagnostic(
             definition.source_file().clone(),
-            definition.statement(),
+            definition.name().function_name(),
+            definition.diagnostic_range(),
             &missing_fixtures,
             FunctionKind::Test,
         ),
@@ -546,7 +578,8 @@ fn fixture_missing_fixtures_diagnostic(
 ) -> Diagnostic {
     let mut diagnostic = missing_fixtures_diagnostic(
         fixture.definition.source_file().clone(),
-        fixture.definition.statement(),
+        fixture.name.as_str(),
+        fixture.definition.statement().name.range,
         missing_fixtures,
         FunctionKind::Fixture,
     );
@@ -571,17 +604,19 @@ fn fixture_missing_fixtures_diagnostic(
 
 pub fn missing_fixtures_diagnostic(
     source_file: SourceFile,
-    stmt_function_def: &StmtFunctionDef,
+    name: &str,
+    range: TextRange,
     missing_fixtures: &[String],
     function_kind: FunctionKind,
 ) -> Diagnostic {
     let mut diagnostic = MISSING_FIXTURES.diagnostic(format!(
-        "{} `{}` has missing fixtures",
+        "{} `{name}` has missing fixtures",
         function_kind.capitalised(),
-        stmt_function_def.name
     ));
 
-    annotate_function_name(&mut diagnostic, source_file, stmt_function_def);
+    diagnostic.annotate(Annotation::primary(
+        Span::from(source_file).with_range(range),
+    ));
 
     let missing_fixtures_string = missing_fixtures
         .iter()
@@ -592,25 +627,23 @@ pub fn missing_fixtures_diagnostic(
     diagnostic.info(format!("Missing fixtures: {missing_fixtures_string}"));
 
     diagnostic.set_concise_message(format!(
-        "{} `{}` has missing fixtures: {missing_fixtures_string}",
+        "{} `{name}` has missing fixtures: {missing_fixtures_string}",
         function_kind.capitalised(),
-        stmt_function_def.name,
     ));
 
     diagnostic
 }
 
 pub fn test_pass_on_expect_failure_diagnostic(
-    source_file: SourceFile,
-    stmt_function_def: &StmtFunctionDef,
+    definition: &TestDefinition,
     reason: Option<String>,
 ) -> Diagnostic {
     let mut diagnostic = TEST_PASS_ON_EXPECT_FAILURE.diagnostic(format!(
         "Test `{}` passes when expected to fail",
-        stmt_function_def.name
+        definition.name().function_name()
     ));
 
-    annotate_function_name(&mut diagnostic, source_file, stmt_function_def);
+    annotate_test(&mut diagnostic, definition);
 
     if let Some(reason) = reason {
         diagnostic.info(format!("Reason: {reason}"));
@@ -620,25 +653,25 @@ pub fn test_pass_on_expect_failure_diagnostic(
 
 pub fn test_failure_diagnostic(
     py: Python,
-    source_file: &SourceFile,
-    stmt_function_def: &StmtFunctionDef,
+    definition: &TestDefinition,
     arguments: &FixtureArguments,
     error: &PyErr,
     verbose: bool,
 ) -> Diagnostic {
-    let mut diagnostic =
-        TEST_FAILURE.diagnostic(format!("Test `{}` failed", stmt_function_def.name));
+    let mut diagnostic = TEST_FAILURE.diagnostic(format!(
+        "Test `{}` failed",
+        definition.name().function_name()
+    ));
 
     handle_failed_function_call(
         &mut diagnostic,
         py,
-        source_file,
-        stmt_function_def,
+        FailedFunctionDefinition::test(definition),
         arguments,
         FailedFunctionCallOptions {
             function_kind: FunctionKind::Test,
             verbose,
-            primary_range: doctest_failure_range(py, error, source_file),
+            primary_range: doctest_failure_range(py, error, definition.source_file()),
         },
         error,
     );
@@ -684,16 +717,15 @@ pub fn invalid_parametrize_diagnostic(
 }
 
 pub fn test_returned_value_diagnostic(
-    source_file: SourceFile,
-    stmt_function_def: &StmtFunctionDef,
+    definition: &TestDefinition,
     returned_value: &str,
 ) -> Diagnostic {
     let mut diagnostic = TEST_RETURNED_VALUE.diagnostic(format!(
         "Test `{}` returned `{returned_value}`",
-        stmt_function_def.name
+        definition.name().function_name()
     ));
 
-    annotate_function_name(&mut diagnostic, source_file, stmt_function_def);
+    annotate_test(&mut diagnostic, definition);
     diagnostic.info("Test functions must return None. Did you mean to use `assert`?");
     diagnostic
 }
@@ -704,18 +736,17 @@ pub fn test_returned_value_diagnostic(
 /// `actual` and `slowest_phase` describe the measured setup, call, and
 /// teardown phases for one attempt.
 pub fn fail_slow_exceeded_diagnostic(
-    source_file: SourceFile,
-    stmt_function_def: &StmtFunctionDef,
+    definition: &TestDefinition,
     budget: std::time::Duration,
     actual: std::time::Duration,
     slowest_phase: &str,
 ) -> Diagnostic {
     let mut diagnostic = FAIL_SLOW_EXCEEDED.diagnostic(format!(
         "Test `{}` exceeded its fail-slow budget",
-        stmt_function_def.name
+        definition.name().function_name()
     ));
 
-    annotate_function_name(&mut diagnostic, source_file, stmt_function_def);
+    annotate_test(&mut diagnostic, definition);
 
     diagnostic.info(format!(
         "Configured budget: {}, actual duration: {} (slowest phase: {slowest_phase})",
@@ -729,8 +760,7 @@ pub fn fail_slow_exceeded_diagnostic(
 fn handle_failed_function_call(
     diagnostic: &mut Diagnostic,
     py: Python,
-    source_file: &SourceFile,
-    stmt_function_def: &StmtFunctionDef,
+    definition: FailedFunctionDefinition<'_>,
     arguments: &FixtureArguments,
     options: FailedFunctionCallOptions,
     error: &PyErr,
@@ -740,13 +770,14 @@ fn handle_failed_function_call(
         verbose,
         primary_range,
     } = options;
-    if let Some(range) = primary_range {
-        diagnostic.annotate(Annotation::primary(
-            Span::from(source_file.clone()).with_range(range),
-        ));
-    } else {
-        annotate_function_name(diagnostic, source_file.clone(), stmt_function_def);
-    }
+    let FailedFunctionDefinition {
+        source_file,
+        range,
+        parameters,
+    } = definition;
+    diagnostic.annotate(Annotation::primary(
+        Span::from(source_file.clone()).with_range(primary_range.unwrap_or(range)),
+    ));
 
     if !arguments.is_empty() {
         diagnostic.info(format!(
@@ -755,7 +786,7 @@ fn handle_failed_function_call(
         ));
     }
 
-    for (name, value) in arguments.iter_in_signature_order(&stmt_function_def.parameters) {
+    for (name, value) in arguments.iter_in_signature_order(parameters) {
         let value_str = value.bind(py).to_string();
         let truncated_value = truncate_string(&value_str);
         let truncated_name = truncate_string(name);

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -11,8 +11,8 @@ use karva_logging::time::format_duration;
 use karva_python_semantic::FunctionKind;
 use pyo3::{PyErr, Python};
 use ruff_python_ast::StmtFunctionDef;
-use ruff_source_file::SourceFile;
-use ruff_text_size::TextRange;
+use ruff_source_file::{OneIndexed, SourceFile};
+use ruff_text_size::{TextRange, TextSize};
 
 mod metadata;
 
@@ -29,6 +29,7 @@ use crate::utils::truncate_string;
 struct FailedFunctionCallOptions {
     function_kind: FunctionKind,
     verbose: bool,
+    primary_range: Option<TextRange>,
 }
 
 declare_diagnostic_type! {
@@ -422,6 +423,7 @@ pub fn fixture_failure_diagnostic(
         FailedFunctionCallOptions {
             function_kind: FunctionKind::Fixture,
             verbose,
+            primary_range: None,
         },
         &error,
     );
@@ -636,6 +638,7 @@ pub fn test_failure_diagnostic(
         FailedFunctionCallOptions {
             function_kind: FunctionKind::Test,
             verbose,
+            primary_range: doctest_failure_range(py, error, source_file),
         },
         error,
     );
@@ -735,8 +738,15 @@ fn handle_failed_function_call(
     let FailedFunctionCallOptions {
         function_kind,
         verbose,
+        primary_range,
     } = options;
-    annotate_function_name(diagnostic, source_file.clone(), stmt_function_def);
+    if let Some(range) = primary_range {
+        diagnostic.annotate(Annotation::primary(
+            Span::from(source_file.clone()).with_range(range),
+        ));
+    } else {
+        annotate_function_name(diagnostic, source_file.clone(), stmt_function_def);
+    }
 
     if !arguments.is_empty() {
         diagnostic.info(format!(
@@ -805,6 +815,19 @@ fn handle_failed_function_call(
     if !error_string.is_empty() {
         diagnostic.info(indent_continuation_lines(&error_string));
     }
+}
+
+fn doctest_failure_range(py: Python, error: &PyErr, source_file: &SourceFile) -> Option<TextRange> {
+    let line = crate::doctest::failure_line(py, error)?;
+    let line = OneIndexed::new(line)?;
+    let source = source_file.to_source_code();
+    if line.get() > source.line_count() {
+        return None;
+    }
+    let line_range = source.line_range(line);
+    let prompt = source.slice(line_range).find(">>>")?;
+    let prompt = TextSize::try_from(prompt).ok()?;
+    Some(TextRange::at(line_range.start() + prompt, TextSize::new(3)))
 }
 
 fn is_installed_package_frame(frame: &TracebackFrame) -> bool {

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -578,7 +578,7 @@ fn fixture_missing_fixtures_diagnostic(
 ) -> Diagnostic {
     let mut diagnostic = missing_fixtures_diagnostic(
         fixture.definition.source_file().clone(),
-        fixture.name.as_str(),
+        fixture.definition.statement().name.as_str(),
         fixture.definition.statement().name.range,
         missing_fixtures,
         FunctionKind::Fixture,

--- a/crates/karva_test_semantic/src/discovery/discoverer.rs
+++ b/crates/karva_test_semantic/src/discovery/discoverer.rs
@@ -161,6 +161,7 @@ impl<'ctx, 'a> StandardDiscoverer<'ctx, 'a> {
             source_text,
             module_body,
             test_function_defs,
+            doctests,
             fixture_function_defs,
         } = collected_module;
 
@@ -208,6 +209,7 @@ impl<'ctx, 'a> StandardDiscoverer<'ctx, 'a> {
             &mut module,
             module_body,
             test_function_defs,
+            doctests,
             fixture_function_defs,
         ));
 

--- a/crates/karva_test_semantic/src/discovery/models/definition.rs
+++ b/crates/karva_test_semantic/src/discovery/models/definition.rs
@@ -1,10 +1,11 @@
 use std::rc::Rc;
 
 use karva_python_semantic::QualifiedFunctionName;
-use ruff_python_ast::StmtFunctionDef;
+use ruff_python_ast::{Parameters, StmtFunctionDef};
 use ruff_source_file::SourceFile;
+use ruff_text_size::TextRange;
 
-/// Immutable source identity shared by discovered tests, fixtures, and diagnostics.
+/// Immutable source identity shared by fixtures and fixture diagnostics.
 #[derive(Debug)]
 pub struct FunctionDefinition {
     name: QualifiedFunctionName,
@@ -39,5 +40,101 @@ impl FunctionDefinition {
 
     pub(crate) fn source_file(&self) -> &SourceFile {
         &self.source_file
+    }
+}
+
+/// Immutable source identity for an executable test.
+///
+/// Python functions retain their source AST. Doctests retain only real source metadata because
+/// they have no corresponding function definition.
+#[derive(Debug)]
+pub struct TestDefinition {
+    name: QualifiedFunctionName,
+    source_file: SourceFile,
+    kind: TestDefinitionKind,
+}
+
+#[derive(Debug)]
+enum TestDefinitionKind {
+    /// A Python test function backed by its parsed source definition.
+    Function(Rc<StmtFunctionDef>),
+
+    /// A doctest located at its first executable prompt.
+    Doctest { range: TextRange },
+}
+
+impl TestDefinition {
+    pub(crate) fn function(
+        name: QualifiedFunctionName,
+        statement: Rc<StmtFunctionDef>,
+        source_file: SourceFile,
+    ) -> Self {
+        Self {
+            name,
+            source_file,
+            kind: TestDefinitionKind::Function(statement),
+        }
+    }
+
+    pub(crate) fn doctest(
+        name: QualifiedFunctionName,
+        range: TextRange,
+        source_file: SourceFile,
+    ) -> Self {
+        Self {
+            name,
+            source_file,
+            kind: TestDefinitionKind::Doctest { range },
+        }
+    }
+
+    pub(crate) fn name(&self) -> &QualifiedFunctionName {
+        &self.name
+    }
+
+    pub(crate) fn source_file(&self) -> &SourceFile {
+        &self.source_file
+    }
+
+    pub(crate) fn source_range(&self) -> TextRange {
+        match &self.kind {
+            TestDefinitionKind::Function(statement) => statement.range,
+            TestDefinitionKind::Doctest { range } => *range,
+        }
+    }
+
+    /// Returns the source range to underline in diagnostics.
+    pub(crate) fn diagnostic_range(&self) -> TextRange {
+        match &self.kind {
+            TestDefinitionKind::Function(statement) => statement.name.range,
+            TestDefinitionKind::Doctest { range } => *range,
+        }
+    }
+
+    /// Returns syntax available only for regular Python test functions.
+    pub(crate) fn function_statement(&self) -> Option<&StmtFunctionDef> {
+        match &self.kind {
+            TestDefinitionKind::Function(statement) => Some(statement),
+            TestDefinitionKind::Doctest { .. } => None,
+        }
+    }
+
+    pub(crate) fn parameters(&self) -> Option<&Parameters> {
+        self.function_statement()
+            .map(|statement| statement.parameters.as_ref())
+    }
+
+    pub(crate) fn is_async(&self) -> bool {
+        self.function_statement()
+            .is_some_and(|statement| statement.is_async)
+    }
+
+    pub(crate) fn required_fixtures(&self) -> Vec<String> {
+        self.parameters().map_or_else(Vec::new, |parameters| {
+            parameters
+                .iter_non_variadic_params()
+                .map(|parameter| parameter.parameter.name.to_string())
+                .collect()
+        })
     }
 }

--- a/crates/karva_test_semantic/src/discovery/models/definition.rs
+++ b/crates/karva_test_semantic/src/discovery/models/definition.rs
@@ -64,7 +64,7 @@ enum TestDefinitionKind {
 }
 
 impl TestDefinition {
-    pub(crate) fn function(
+    pub(super) fn function(
         name: QualifiedFunctionName,
         statement: Rc<StmtFunctionDef>,
         source_file: SourceFile,
@@ -76,7 +76,7 @@ impl TestDefinition {
         }
     }
 
-    pub(crate) fn doctest(
+    pub(super) fn doctest(
         name: QualifiedFunctionName,
         range: TextRange,
         source_file: SourceFile,
@@ -96,7 +96,7 @@ impl TestDefinition {
         &self.source_file
     }
 
-    pub(crate) fn source_range(&self) -> TextRange {
+    pub(super) fn source_range(&self) -> TextRange {
         match &self.kind {
             TestDefinitionKind::Function(statement) => statement.range,
             TestDefinitionKind::Doctest { range } => *range,
@@ -112,7 +112,7 @@ impl TestDefinition {
     }
 
     /// Returns syntax available only for regular Python test functions.
-    pub(crate) fn function_statement(&self) -> Option<&StmtFunctionDef> {
+    pub(super) fn function_statement(&self) -> Option<&StmtFunctionDef> {
         match &self.kind {
             TestDefinitionKind::Function(statement) => Some(statement),
             TestDefinitionKind::Doctest { .. } => None,
@@ -124,12 +124,12 @@ impl TestDefinition {
             .map(|statement| statement.parameters.as_ref())
     }
 
-    pub(crate) fn is_async(&self) -> bool {
+    pub(super) fn is_async(&self) -> bool {
         self.function_statement()
             .is_some_and(|statement| statement.is_async)
     }
 
-    pub(crate) fn required_fixtures(&self) -> Vec<String> {
+    pub(super) fn required_fixtures(&self) -> Vec<String> {
         self.parameters().map_or_else(Vec::new, |parameters| {
             parameters
                 .iter_non_variadic_params()

--- a/crates/karva_test_semantic/src/discovery/models/function.rs
+++ b/crates/karva_test_semantic/src/discovery/models/function.rs
@@ -98,7 +98,7 @@ impl DiscoveredTestFunction {
         self.definition.name()
     }
 
-    pub(crate) fn source_range(&self) -> TextRange {
+    pub(super) fn source_range(&self) -> TextRange {
         self.definition.source_range()
     }
 

--- a/crates/karva_test_semantic/src/discovery/models/function.rs
+++ b/crates/karva_test_semantic/src/discovery/models/function.rs
@@ -3,22 +3,22 @@ use std::rc::Rc;
 use karva_python_semantic::QualifiedFunctionName;
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
-use ruff_python_ast::StmtFunctionDef;
+use ruff_python_ast::{Parameters, StmtFunctionDef};
 use ruff_source_file::SourceFile;
+use ruff_text_size::TextRange;
 
 use crate::discovery::DiscoveredModule;
-use crate::discovery::models::definition::FunctionDefinition;
+use crate::discovery::models::definition::TestDefinition;
 use crate::extensions::tags::Tags;
 
-/// Represents a single test function discovered from Python source code.
+/// Represents a single executable test discovered from Python source code.
 ///
 /// Contains all the information needed to execute a test, including the
-/// function's qualified name, AST representation, Python callable, and
-/// any associated decorator tags.
+/// test's qualified name, source definition, Python callable, and tags.
 #[derive(Debug)]
 pub struct DiscoveredTestFunction {
-    /// Immutable source identity and syntax.
-    definition: Rc<FunctionDefinition>,
+    /// Immutable source identity and test-kind-specific syntax.
+    definition: Rc<TestDefinition>,
 
     /// Reference to the actual Python callable object.
     pub(crate) py_function: Py<PyAny>,
@@ -33,7 +33,7 @@ pub struct DiscoveredTestFunction {
 }
 
 impl DiscoveredTestFunction {
-    pub(crate) fn new(
+    pub(crate) fn new_function(
         py: Python<'_>,
         module: &DiscoveredModule,
         py_module: &Bound<'_, PyModule>,
@@ -48,14 +48,14 @@ impl DiscoveredTestFunction {
 
         let mut tags = Tags::from_py_any(py, &py_function, Some(&stmt_function_def))?;
         if let Ok(marks) = py_module.getattr("pytestmark") {
-            let module_tags =
-                Tags::from_pytest_marks(py, &marks.unbind(), Some(&py_module.dict()))?
-                    .unwrap_or_default();
-            tags.extend(&module_tags);
+            tags.extend(
+                &Tags::from_pytest_marks(py, &marks.unbind(), Some(&py_module.dict()))?
+                    .unwrap_or_default(),
+            );
         }
 
         Ok(Self {
-            definition: Rc::new(FunctionDefinition::new(
+            definition: Rc::new(TestDefinition::function(
                 name,
                 stmt_function_def,
                 module.source_file(),
@@ -66,7 +66,31 @@ impl DiscoveredTestFunction {
         })
     }
 
-    pub(crate) fn definition(&self) -> &Rc<FunctionDefinition> {
+    pub(crate) fn new_doctest(
+        py: Python<'_>,
+        module: &DiscoveredModule,
+        py_module: &Bound<'_, PyModule>,
+        name: String,
+        range: TextRange,
+        py_function: Py<PyAny>,
+    ) -> PyResult<Self> {
+        let name = QualifiedFunctionName::new(name, module.module_path().clone());
+        let tags = if let Ok(marks) = py_module.getattr("pytestmark") {
+            Tags::from_pytest_marks(py, &marks.unbind(), Some(&py_module.dict()))?
+                .unwrap_or_default()
+        } else {
+            Tags::default()
+        };
+
+        Ok(Self {
+            definition: Rc::new(TestDefinition::doctest(name, range, module.source_file())),
+            py_function,
+            tags,
+            case_filter: None,
+        })
+    }
+
+    pub(crate) fn definition(&self) -> &Rc<TestDefinition> {
         &self.definition
     }
 
@@ -74,8 +98,28 @@ impl DiscoveredTestFunction {
         self.definition.name()
     }
 
-    pub(crate) fn statement(&self) -> &StmtFunctionDef {
-        self.definition.statement()
+    pub(crate) fn source_range(&self) -> TextRange {
+        self.definition.source_range()
+    }
+
+    pub(crate) fn diagnostic_range(&self) -> TextRange {
+        self.definition.diagnostic_range()
+    }
+
+    pub(crate) fn function_statement(&self) -> Option<&StmtFunctionDef> {
+        self.definition.function_statement()
+    }
+
+    pub(crate) fn parameters(&self) -> Option<&Parameters> {
+        self.definition.parameters()
+    }
+
+    pub(crate) fn is_async(&self) -> bool {
+        self.definition.is_async()
+    }
+
+    pub(crate) fn required_fixtures(&self) -> Vec<String> {
+        self.definition.required_fixtures()
     }
 
     pub(crate) fn source_file(&self) -> &SourceFile {

--- a/crates/karva_test_semantic/src/discovery/models/module.rs
+++ b/crates/karva_test_semantic/src/discovery/models/module.rs
@@ -89,6 +89,6 @@ impl DiscoveredModule {
 
     pub(super) fn shrink(&mut self) {
         self.test_functions
-            .sort_by_key(|function| function.statement().range.start());
+            .sort_by_key(|function| function.source_range().start());
     }
 }

--- a/crates/karva_test_semantic/src/discovery/visitor.rs
+++ b/crates/karva_test_semantic/src/discovery/visitor.rs
@@ -224,19 +224,23 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
                     format!("{}.{}", self.module.name(), object_name)
                 }
             };
-            let function = match functions.get_item(&object_name) {
-                Ok(Some(function)) => function,
-                Ok(None) => match crate::doctest::missing_doctest_function(self.py, &object_name) {
-                    Ok(function) => function,
-                    Err(error) => {
-                        self.issues
-                            .push(DiscoveryIssue::Error(DiscoveryError::Import {
-                                module_name: self.module.name().to_string(),
-                                reason: error.value(self.py).to_string(),
-                            }));
-                        continue;
+            let (function, missing_reason) = match functions.get_item(&object_name) {
+                Ok(Some(function)) => (function, None),
+                Ok(None) => {
+                    let reason =
+                        format!("Doctest `{object_name}` is not available after module import");
+                    match crate::doctest::missing_doctest_function(self.py, &reason) {
+                        Ok(function) => (function, Some(reason)),
+                        Err(error) => {
+                            self.issues
+                                .push(DiscoveryIssue::Error(DiscoveryError::Import {
+                                    module_name: self.module.name().to_string(),
+                                    reason: error.value(self.py).to_string(),
+                                }));
+                            continue;
+                        }
                     }
-                },
+                }
                 Err(error) => {
                     self.issues
                         .push(DiscoveryIssue::Error(DiscoveryError::Import {
@@ -257,6 +261,9 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
             ) {
                 Ok(mut test_function) => {
                     test_function.tags.remove_parametrize();
+                    if let Some(reason) = missing_reason {
+                        test_function.tags.add_skip(reason);
+                    }
                     if self.context.settings().test().strict_tags {
                         let unknown = unknown_runtime_tags(
                             test_function.statement(),

--- a/crates/karva_test_semantic/src/discovery/visitor.rs
+++ b/crates/karva_test_semantic/src/discovery/visitor.rs
@@ -21,10 +21,9 @@ use crate::extensions::fixtures::{DiscoveredFixture, RejectedFixture};
 use crate::extensions::tags::skip::{extract_skip_reason, is_skip_exception};
 use crate::extensions::tags::validation::unknown_runtime_tags;
 
-/// Visitor for discovering test functions and fixture definitions in a given module.
+/// Visitor for discovering executable tests and fixture definitions in a given module.
 ///
-/// Processes function definitions found during AST traversal and converts them
-/// into test functions or fixtures by importing the corresponding Python module.
+/// Resolves collected source definitions and doctest metadata against the imported Python module.
 struct FunctionDefinitionVisitor<'ctx, 'py, 'a, 'b> {
     /// Reference to the test execution context.
     context: &'ctx Context<'a>,
@@ -153,7 +152,7 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
         };
 
         if let Ok(py_function) = py_module.getattr(stmt_function_def.name.to_string()) {
-            match DiscoveredTestFunction::new(
+            match DiscoveredTestFunction::new_function(
                 self.py,
                 self.module,
                 py_module,
@@ -164,7 +163,8 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
                 Ok(test_function) => {
                     if self.context.settings().test().strict_tags {
                         let unknown = unknown_runtime_tags(
-                            test_function.statement(),
+                            test_function.function_statement(),
+                            test_function.diagnostic_range(),
                             &self.module_body,
                             &test_function.tags,
                             self.context.settings().tags(),
@@ -250,14 +250,13 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
                     continue;
                 }
             };
-            let statement = Rc::new(doctest.function_def);
-            match DiscoveredTestFunction::new(
+            match DiscoveredTestFunction::new_doctest(
                 self.py,
                 self.module,
                 &py_module,
-                statement,
+                doctest.name,
+                doctest.range,
                 function.unbind(),
-                None,
             ) {
                 Ok(mut test_function) => {
                     test_function.tags.remove_parametrize();
@@ -266,7 +265,8 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
                     }
                     if self.context.settings().test().strict_tags {
                         let unknown = unknown_runtime_tags(
-                            test_function.statement(),
+                            test_function.function_statement(),
+                            test_function.diagnostic_range(),
                             &self.module_body,
                             &test_function.tags,
                             self.context.settings().tags(),

--- a/crates/karva_test_semantic/src/discovery/visitor.rs
+++ b/crates/karva_test_semantic/src/discovery/visitor.rs
@@ -255,7 +255,8 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
                 function.unbind(),
                 None,
             ) {
-                Ok(test_function) => {
+                Ok(mut test_function) => {
+                    test_function.tags.remove_parametrize();
                     if self.context.settings().test().strict_tags {
                         let unknown = unknown_runtime_tags(
                             test_function.statement(),

--- a/crates/karva_test_semantic/src/discovery/visitor.rs
+++ b/crates/karva_test_semantic/src/discovery/visitor.rs
@@ -4,6 +4,7 @@ use std::rc::Rc;
 
 use camino::Utf8Path;
 use fs_err as fs;
+use karva_collector::{CollectedDoctest, DoctestTarget};
 use karva_python_semantic::ModulePath;
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
@@ -195,6 +196,100 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
         }
     }
 
+    fn process_doctests(&mut self, doctests: Vec<CollectedDoctest>) {
+        if doctests.is_empty() {
+            return;
+        }
+
+        self.try_import_module();
+        let Some(py_module) = self.py_module.clone() else {
+            return;
+        };
+        let functions = match crate::doctest::find_doctest_functions(self.py, &py_module) {
+            Ok(functions) => functions,
+            Err(error) => {
+                self.issues
+                    .push(DiscoveryIssue::Error(DiscoveryError::Import {
+                        module_name: self.module.name().to_string(),
+                        reason: error.value(self.py).to_string(),
+                    }));
+                return;
+            }
+        };
+
+        for doctest in doctests {
+            let object_name = match &doctest.target {
+                DoctestTarget::Module => self.module.name().to_string(),
+                DoctestTarget::Object(object_name) => {
+                    format!("{}.{}", self.module.name(), object_name)
+                }
+            };
+            let function = match functions.get_item(&object_name) {
+                Ok(Some(function)) => function,
+                Ok(None) => match crate::doctest::missing_doctest_function(self.py, &object_name) {
+                    Ok(function) => function,
+                    Err(error) => {
+                        self.issues
+                            .push(DiscoveryIssue::Error(DiscoveryError::Import {
+                                module_name: self.module.name().to_string(),
+                                reason: error.value(self.py).to_string(),
+                            }));
+                        continue;
+                    }
+                },
+                Err(error) => {
+                    self.issues
+                        .push(DiscoveryIssue::Error(DiscoveryError::Import {
+                            module_name: self.module.name().to_string(),
+                            reason: error.value(self.py).to_string(),
+                        }));
+                    continue;
+                }
+            };
+            let statement = Rc::new(doctest.function_def);
+            match DiscoveredTestFunction::new(
+                self.py,
+                self.module,
+                &py_module,
+                statement,
+                function.unbind(),
+                None,
+            ) {
+                Ok(test_function) => {
+                    if self.context.settings().test().strict_tags {
+                        let unknown = unknown_runtime_tags(
+                            test_function.statement(),
+                            &self.module_body,
+                            &test_function.tags,
+                            self.context.settings().tags(),
+                        );
+                        if !unknown.is_empty() {
+                            for unknown in unknown {
+                                self.issues.push(DiscoveryIssue::Error(
+                                    DiscoveryError::UnknownTag {
+                                        source_file: self.module.source_file(),
+                                        name: unknown.name,
+                                        range: unknown.range,
+                                        suggestion: unknown.suggestion,
+                                    },
+                                ));
+                            }
+                            continue;
+                        }
+                    }
+                    self.module.add_test_function(test_function);
+                }
+                Err(error) => {
+                    self.issues
+                        .push(DiscoveryIssue::Error(DiscoveryError::Import {
+                            module_name: self.module.name().to_string(),
+                            reason: error.value(self.py).to_string(),
+                        }));
+                }
+            }
+        }
+    }
+
     fn find_extra_fixtures(&mut self) {
         self.try_import_module();
 
@@ -338,6 +433,7 @@ pub fn discover(
     module: &mut DiscoveredModule,
     module_body: Box<[Stmt]>,
     test_function_defs: Vec<(StmtFunctionDef, Option<Vec<usize>>)>,
+    doctests: Vec<CollectedDoctest>,
     fixture_function_defs: Vec<StmtFunctionDef>,
 ) -> Vec<DiscoveryIssue> {
     let is_conftest = module
@@ -380,6 +476,8 @@ pub fn discover(
 
         visitor.process_test_function(test_function_def, case_filter);
     }
+
+    visitor.process_doctests(doctests);
 
     let mut fixtures = Vec::with_capacity(fixture_function_defs.len());
     for fixture_function_def in fixture_function_defs {

--- a/crates/karva_test_semantic/src/doctest.rs
+++ b/crates/karva_test_semantic/src/doctest.rs
@@ -1,0 +1,114 @@
+//! Runtime binding and execution for statically collected Python doctests.
+
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+use pyo3::sync::PyOnceLock;
+use pyo3::types::{PyDict, PyModule};
+
+const DOCTEST_RUNTIME_CODE: &std::ffi::CStr = c"
+import doctest
+import os
+import textwrap
+import traceback
+
+
+def _block(label, value):
+    value = value.rstrip('\\n') or '<nothing>'
+    indented = textwrap.indent(value, '  ')
+    return f'{label}:\\n{indented}'
+
+
+def _location(test, example):
+    if test.filename is not None and test.lineno is not None:
+        filename = os.path.relpath(test.filename)
+        return f'{filename}:{test.lineno + example.lineno + 1}'
+    return test.name
+
+
+def _function(test):
+    def run():
+        fresh = doctest.DocTest(
+            test.examples,
+            test.globs,
+            test.name,
+            test.filename,
+            test.lineno,
+            test.docstring,
+        )
+        try:
+            doctest.DebugRunner().run(fresh)
+        except doctest.DocTestFailure as error:
+            message = '\\n'.join(
+                (
+                    f'Doctest failed at {_location(error.test, error.example)}',
+                    _block('Example', error.example.source),
+                    _block('Expected', error.example.want),
+                    _block('Got', error.got),
+                )
+            )
+            raise AssertionError(message) from None
+        except doctest.UnexpectedException as error:
+            exception = ''.join(
+                traceback.format_exception_only(*error.exc_info[:2])
+            )
+            message = '\\n'.join(
+                (
+                    f'Doctest raised at {_location(error.test, error.example)}',
+                    _block('Example', error.example.source),
+                    _block('Exception', exception),
+                )
+            )
+            raise AssertionError(message) from None
+
+    return run
+
+
+def _missing(name):
+    def run():
+        import karva
+
+        karva.skip(f'Doctest `{name}` is not available after module import')
+
+    return run
+
+
+def _find(module):
+    return {
+        test.name: _function(test)
+        for test in doctest.DocTestFinder().find(module)
+        if test.examples
+    }
+";
+
+static DOCTEST_RUNTIME: PyOnceLock<Py<PyDict>> = PyOnceLock::new();
+
+fn runtime(py: Python<'_>) -> PyResult<&Bound<'_, PyDict>> {
+    DOCTEST_RUNTIME
+        .get_or_try_init(py, || {
+            let namespace = PyDict::new(py);
+            py.run(DOCTEST_RUNTIME_CODE, Some(&namespace), None)?;
+            PyResult::Ok(namespace.unbind())
+        })
+        .map(|namespace| namespace.bind(py))
+}
+
+/// Returns zero-argument callables keyed by their stdlib doctest object name.
+pub fn find_doctest_functions<'py>(
+    py: Python<'py>,
+    module: &Bound<'py, PyModule>,
+) -> PyResult<Bound<'py, PyDict>> {
+    runtime(py)?
+        .get_item("_find")?
+        .ok_or_else(|| PyRuntimeError::new_err("failed to load inline doctest finder"))?
+        .call1((module,))?
+        .cast_into::<PyDict>()
+        .map_err(Into::into)
+}
+
+/// Returns a skipped placeholder for a source doctest unavailable after import.
+pub fn missing_doctest_function<'py>(py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+    runtime(py)?
+        .get_item("_missing")?
+        .ok_or_else(|| PyRuntimeError::new_err("failed to load inline missing-doctest handler"))?
+        .call1((name,))
+}

--- a/crates/karva_test_semantic/src/doctest.rs
+++ b/crates/karva_test_semantic/src/doctest.rs
@@ -7,7 +7,6 @@ use pyo3::types::{PyDict, PyModule};
 
 const DOCTEST_RUNTIME_CODE: &std::ffi::CStr = c"
 import doctest
-import os
 import textwrap
 import traceback
 
@@ -22,13 +21,6 @@ def _block(label, value):
     value = value.rstrip('\\n') or '<nothing>'
     indented = textwrap.indent(value, '  ')
     return f'{label}:\\n{indented}'
-
-
-def _location(test, example):
-    if test.filename is not None and test.lineno is not None:
-        filename = os.path.relpath(test.filename)
-        return f'{filename}:{test.lineno + example.lineno + 1}'
-    return test.name
 
 
 def _function(test):
@@ -47,10 +39,8 @@ def _function(test):
             line = error.test.lineno + error.example.lineno + 1
             message = '\\n'.join(
                 (
-                    f'Doctest failed at {_location(error.test, error.example)}',
-                    _block('Example', error.example.source),
-                    _block('Expected', error.example.want),
-                    _block('Got', error.got),
+                    _block('Expected output', error.example.want),
+                    _block('Actual output', error.got),
                 )
             )
             raise _Failure(message, line) from None
@@ -59,13 +49,7 @@ def _function(test):
             exception = ''.join(
                 traceback.format_exception_only(*error.exc_info[:2])
             )
-            message = '\\n'.join(
-                (
-                    f'Doctest raised at {_location(error.test, error.example)}',
-                    _block('Example', error.example.source),
-                    _block('Exception', exception),
-                )
-            )
+            message = _block('Unexpected exception', exception)
             raise _Failure(message, line) from None
 
     return run

--- a/crates/karva_test_semantic/src/doctest.rs
+++ b/crates/karva_test_semantic/src/doctest.rs
@@ -12,6 +12,12 @@ import textwrap
 import traceback
 
 
+class _Failure(AssertionError):
+    def __init__(self, message, line):
+        super().__init__(message)
+        self.line = line
+
+
 def _block(label, value):
     value = value.rstrip('\\n') or '<nothing>'
     indented = textwrap.indent(value, '  ')
@@ -38,6 +44,7 @@ def _function(test):
         try:
             doctest.DebugRunner().run(fresh)
         except doctest.DocTestFailure as error:
+            line = error.test.lineno + error.example.lineno + 1
             message = '\\n'.join(
                 (
                     f'Doctest failed at {_location(error.test, error.example)}',
@@ -46,8 +53,9 @@ def _function(test):
                     _block('Got', error.got),
                 )
             )
-            raise AssertionError(message) from None
+            raise _Failure(message, line) from None
         except doctest.UnexpectedException as error:
+            line = error.test.lineno + error.example.lineno + 1
             exception = ''.join(
                 traceback.format_exception_only(*error.exc_info[:2])
             )
@@ -58,16 +66,16 @@ def _function(test):
                     _block('Exception', exception),
                 )
             )
-            raise AssertionError(message) from None
+            raise _Failure(message, line) from None
 
     return run
 
 
-def _missing(name):
+def _missing(reason):
     def run():
         import karva
 
-        karva.skip(f'Doctest `{name}` is not available after module import')
+        karva.skip(reason)
 
     return run
 
@@ -106,9 +114,18 @@ pub fn find_doctest_functions<'py>(
 }
 
 /// Returns a skipped placeholder for a source doctest unavailable after import.
-pub fn missing_doctest_function<'py>(py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+pub fn missing_doctest_function<'py>(py: Python<'py>, reason: &str) -> PyResult<Bound<'py, PyAny>> {
     runtime(py)?
         .get_item("_missing")?
         .ok_or_else(|| PyRuntimeError::new_err("failed to load inline missing-doctest handler"))?
-        .call1((name,))
+        .call1((reason,))
+}
+
+/// Returns the source line carried by a doctest execution failure.
+pub fn failure_line(py: Python<'_>, error: &PyErr) -> Option<usize> {
+    let failure = runtime(py).ok()?.get_item("_Failure").ok()??;
+    if !error.matches(py, &failure).ok()? {
+        return None;
+    }
+    error.value(py).getattr("line").ok()?.extract().ok()
 }

--- a/crates/karva_test_semantic/src/extensions/tags/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/mod.rs
@@ -426,6 +426,12 @@ impl Tags {
         self.inner.retain(|tag| !matches!(tag, Tag::Parametrize(_)));
     }
 
+    /// Adds an unconditional skip determined during semantic discovery.
+    pub(crate) fn add_skip(&mut self, reason: String) {
+        self.inner
+            .push(Tag::Skip(SkipTag::new(Vec::new(), Some(reason))));
+    }
+
     /// Returns unregistered custom names, including parameter-specific tags.
     fn unknown_custom_names<'a>(&'a self, registered: &BTreeMap<String, String>) -> Vec<&'a str> {
         let mut unknown = Vec::new();

--- a/crates/karva_test_semantic/src/extensions/tags/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/mod.rs
@@ -421,6 +421,11 @@ impl Tags {
         self.inner.extend(other.inner.iter().cloned());
     }
 
+    /// Removes parametrization from test kinds that pytest does not parametrize.
+    pub(crate) fn remove_parametrize(&mut self) {
+        self.inner.retain(|tag| !matches!(tag, Tag::Parametrize(_)));
+    }
+
     /// Returns unregistered custom names, including parameter-specific tags.
     fn unknown_custom_names<'a>(&'a self, registered: &BTreeMap<String, String>) -> Vec<&'a str> {
         let mut unknown = Vec::new();

--- a/crates/karva_test_semantic/src/extensions/tags/validation.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/validation.rs
@@ -32,7 +32,8 @@ pub fn unknown_tags(
 
 /// Validates tags discovered from Python objects, covering aliases and module marks.
 pub fn unknown_runtime_tags(
-    function: &StmtFunctionDef,
+    function: Option<&StmtFunctionDef>,
+    fallback_range: TextRange,
     module_body: &[Stmt],
     tags: &Tags,
     registered: &BTreeMap<String, String>,
@@ -41,20 +42,21 @@ pub fn unknown_runtime_tags(
         .into_iter()
         .map(|name| UnknownTag {
             name: name.to_string(),
-            range: tag_range(function, module_body, name).unwrap_or(function.name.range),
+            range: function
+                .and_then(|function| tag_range(function, name))
+                .or_else(|| module_tag_range(module_body, name))
+                .unwrap_or(fallback_range),
             suggestion: unique_suggestion(name, registered.keys()),
         })
         .collect()
 }
 
-fn tag_range(function: &StmtFunctionDef, module_body: &[Stmt], name: &str) -> Option<TextRange> {
+fn tag_range(function: &StmtFunctionDef, name: &str) -> Option<TextRange> {
     let mut visitor = TagRangeVisitor { name, range: None };
     for decorator in &function.decorator_list {
         visitor.visit_expr(&decorator.expression);
     }
-    visitor
-        .range
-        .or_else(|| module_tag_range(module_body, name))
+    visitor.range
 }
 
 fn module_tag_range(module_body: &[Stmt], name: &str) -> Option<TextRange> {

--- a/crates/karva_test_semantic/src/lib.rs
+++ b/crates/karva_test_semantic/src/lib.rs
@@ -4,6 +4,7 @@ pub(crate) mod collection;
 mod context;
 pub(crate) mod diagnostic;
 pub(crate) mod discovery;
+mod doctest;
 pub(crate) mod extensions;
 mod output_capture;
 mod py_attach;

--- a/crates/karva_test_semantic/src/runner/fixture_arguments.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_arguments.rs
@@ -30,14 +30,20 @@ impl FixtureArguments {
     }
 
     /// Iterates arguments by Python signature position, then name.
+    ///
+    /// Without a function signature, arguments are ordered by name.
     pub fn iter_in_signature_order<'a>(
         &'a self,
-        parameters: &Parameters,
+        parameters: Option<&Parameters>,
     ) -> impl Iterator<Item = (&'a String, &'a Py<PyAny>)> {
         let mut arguments = self.iter().collect::<Vec<_>>();
         arguments.sort_by(|(left, _), (right, _)| {
-            let left_position = parameters.index(left).unwrap_or(usize::MAX);
-            let right_position = parameters.index(right).unwrap_or(usize::MAX);
+            let left_position = parameters
+                .and_then(|parameters| parameters.index(left))
+                .unwrap_or(usize::MAX);
+            let right_position = parameters
+                .and_then(|parameters| parameters.index(right))
+                .unwrap_or(usize::MAX);
             left_position
                 .cmp(&right_position)
                 .then_with(|| left.cmp(right))

--- a/crates/karva_test_semantic/src/runner/fixture_resolver.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_resolver.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 use camino::Utf8Path;
 use pyo3::prelude::*;
 
-use crate::discovery::models::definition::FunctionDefinition;
+use crate::discovery::models::definition::{FunctionDefinition, TestDefinition};
 use crate::discovery::{DiscoveredPackage, DiscoveredTestFunction};
 use crate::extensions::fixtures::{
     DiscoveredFixture, FixtureId, FixturePlan, FixtureScope, HasFixtures, NormalizedFixture,
@@ -72,8 +72,8 @@ pub enum FixtureResolutionError {
     },
     /// Test requires names that cannot be resolved.
     MissingTestFixtures {
-        /// Immutable test identity, syntax, and source.
-        definition: Rc<FunctionDefinition>,
+        /// Immutable test identity and source.
+        definition: Rc<TestDefinition>,
         /// Unresolved fixture names.
         missing_fixtures: Vec<String>,
     },
@@ -255,7 +255,7 @@ impl<'a> FixturePlanCompiler<'a> {
         test: &DiscoveredTestFunction,
         parametrize_param_names: &HashSet<&str>,
     ) -> FixtureResolutionResult<Vec<FixtureId>> {
-        let fixture_names = test.statement().required_fixtures(py);
+        let fixture_names = test.required_fixtures();
         let regular_fixture_names: Vec<String> = fixture_names
             .iter()
             .filter(|name| !parametrize_param_names.contains(name.as_str()))

--- a/crates/karva_test_semantic/src/runner/package_runner/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/mod.rs
@@ -125,10 +125,13 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
 
         for module in package.modules().values() {
             for test in module.test_functions() {
-                if let Err(error) = test.tags.validate_parametrize(test.statement()) {
+                let Some(statement) = test.function_statement() else {
+                    continue;
+                };
+                if let Err(error) = test.tags.validate_parametrize(statement) {
                     let diagnostic = invalid_parametrize_diagnostic(
                         test.source_file().clone(),
-                        test.statement(),
+                        statement,
                         &error,
                     );
                     self.register_error_test(test, TestError::new(diagnostic));

--- a/crates/karva_test_semantic/src/runner/package_runner/outcome.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/outcome.rs
@@ -3,15 +3,13 @@
 use std::time::Duration;
 
 use karva_diagnostic::{Diagnostic, TestExecutionOutcome};
-use karva_python_semantic::QualifiedFunctionName;
 use pyo3::prelude::*;
-use ruff_python_ast::StmtFunctionDef;
-use ruff_source_file::SourceFile;
 
 use crate::diagnostic::{
     fail_slow_exceeded_diagnostic, missing_fixtures_diagnostic, test_failure_diagnostic,
     test_pass_on_expect_failure_diagnostic, test_returned_value_diagnostic,
 };
+use crate::discovery::models::definition::TestDefinition;
 use crate::extensions::fixtures::missing_arguments_from_error;
 use crate::extensions::tags::expect_fail::ExpectFailTag;
 use crate::extensions::tags::skip::{extract_skip_reason, is_skip_exception};
@@ -28,12 +26,8 @@ pub(super) enum TestCallOutcome {
 
 /// Immutable inputs needed to turn one Python call result into a Karva outcome.
 pub(super) struct OutcomeContext<'a> {
-    /// Qualified function name used for missing-argument detection.
-    pub(super) name: &'a QualifiedFunctionName,
-    /// Source containing the test definition.
-    pub(super) source_file: &'a SourceFile,
-    /// Test definition used to locate diagnostics.
-    pub(super) stmt_function_def: &'a StmtFunctionDef,
+    /// Test identity and source location used for diagnostics.
+    pub(super) definition: &'a TestDefinition,
     /// Fixture and parameter values supplied to the test.
     pub(super) function_arguments: &'a FixtureArguments,
     /// Active expected-failure policy, when configured.
@@ -105,20 +99,12 @@ pub(super) fn classify_test_result(
             return ClassifiedTestResult::new(TestExecutionOutcome::Passed, false);
         }
         Ok(TestCallOutcome::ReturnedValue(value)) => {
-            let diagnostic = test_returned_value_diagnostic(
-                context.source_file.clone(),
-                context.stmt_function_def,
-                &value,
-            );
+            let diagnostic = test_returned_value_diagnostic(context.definition, &value);
             return ClassifiedTestResult::new(TestExecutionOutcome::failed(diagnostic), true);
         }
         Ok(TestCallOutcome::ReturnedNone) if expect_fail => {
             let reason = context.expect_fail_tag.and_then(ExpectFailTag::reason);
-            let diagnostic = test_pass_on_expect_failure_diagnostic(
-                context.source_file.clone(),
-                context.stmt_function_def,
-                reason,
-            );
+            let diagnostic = test_pass_on_expect_failure_diagnostic(context.definition, reason);
             return ClassifiedTestResult::new(TestExecutionOutcome::failed(diagnostic), false);
         }
         Ok(TestCallOutcome::ReturnedNone) => {
@@ -140,13 +126,14 @@ pub(super) fn classify_test_result(
         return ClassifiedTestResult::new(TestExecutionOutcome::Passed, false);
     }
 
-    let missing_arguments =
-        missing_arguments_from_error(context.name.function_name(), &error.to_string());
+    let missing_arguments = missing_arguments_from_error(
+        context.definition.name().function_name(),
+        &error.to_string(),
+    );
     if missing_arguments.is_empty() {
         let diagnostic = test_failure_diagnostic(
             py,
-            context.source_file,
-            context.stmt_function_def,
+            context.definition,
             context.function_arguments,
             &error,
             context.verbose,
@@ -154,8 +141,9 @@ pub(super) fn classify_test_result(
         ClassifiedTestResult::new(TestExecutionOutcome::failed(diagnostic), true)
     } else {
         let diagnostic = missing_fixtures_diagnostic(
-            context.source_file.clone(),
-            context.stmt_function_def,
+            context.definition.source_file().clone(),
+            context.definition.name().function_name(),
+            context.definition.diagnostic_range(),
             &missing_arguments,
             karva_python_semantic::FunctionKind::Test,
         );
@@ -216,8 +204,7 @@ pub(super) fn apply_fail_slow_budget(
     lifecycle_duration: Duration,
     phases: PhaseDurations,
     budget: Option<Duration>,
-    source_file: &SourceFile,
-    stmt_function_def: &StmtFunctionDef,
+    definition: &TestDefinition,
 ) -> TestExecutionOutcome {
     let Some(budget) = budget else {
         return outcome;
@@ -226,13 +213,8 @@ pub(super) fn apply_fail_slow_budget(
         return outcome;
     }
 
-    let diagnostic = fail_slow_exceeded_diagnostic(
-        source_file.clone(),
-        stmt_function_def,
-        budget,
-        lifecycle_duration,
-        phases.slowest(),
-    );
+    let diagnostic =
+        fail_slow_exceeded_diagnostic(definition, budget, lifecycle_duration, phases.slowest());
 
     match outcome {
         TestExecutionOutcome::Passed => TestExecutionOutcome::failed(diagnostic),

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/attempt.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/attempt.rs
@@ -78,8 +78,7 @@ impl VariantRunner<'_, '_, '_, '_, '_> {
             duration,
             phases,
             settings.fail_slow_budget,
-            self.test.source_file(),
-            self.test.statement(),
+            self.test.definition(),
         );
         let retryable = body.retryable || teardown_failed || (budget_exceeded && !skipped);
 
@@ -154,9 +153,7 @@ impl VariantRunner<'_, '_, '_, '_, '_> {
             self.py,
             test_result,
             &OutcomeContext {
-                name: self.test.name(),
-                source_file: self.test.source_file(),
-                stmt_function_def: self.test.statement(),
+                definition: self.test.definition(),
                 function_arguments,
                 expect_fail_tag: settings.expect_fail_tag.as_ref(),
                 verbose: self.package_runner.context.is_verbose(),

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
@@ -224,7 +224,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             test_parameters(
                 self.py,
                 function_arguments,
-                &self.test.statement().parameters,
+                self.test.parameters(),
                 &framework_fixture_names,
             )
         };
@@ -284,17 +284,17 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             .settings()
             .junit_flaky_fail_status_for(&evaluation_context);
         let expect_fail_tag = self.tags.expect_fail_tag();
-        let async_patch_result = if self.test.statement().is_async {
+        let async_patch_result = if self.test.is_async() {
             crate::utils::patch_async_test_function(self.py, &self.test.py_function)
         } else {
             Ok(false)
         };
-        let is_async = self.test.statement().is_async && matches!(&async_patch_result, Ok(false));
+        let is_async = self.test.is_async() && matches!(&async_patch_result, Ok(false));
         let mut snapshot_test_name = name.function_name().to_string();
         if let Some(parameters) = test_parameters(
             self.py,
             function_arguments,
-            &self.test.statement().parameters,
+            self.test.parameters(),
             &fixture_names,
         ) {
             snapshot_test_name.push('(');

--- a/crates/karva_test_semantic/src/utils.rs
+++ b/crates/karva_test_semantic/src/utils.rs
@@ -458,7 +458,7 @@ pub fn add_to_sys_path(py: Python<'_>, path: &Utf8Path, index: isize) -> PyResul
 pub fn test_parameters(
     py: Python,
     kwargs: &FixtureArguments,
-    parameters: &Parameters,
+    parameters: Option<&Parameters>,
     name_only_arguments: &[&str],
 ) -> Option<String> {
     if kwargs.is_empty() {

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -868,6 +868,34 @@ Defaults to `pass`.
 
 Controls test selection, retries, timeouts, and failure policies.
 
+#### `doctest-modules`
+
+Collect examples from module, class, function, and method docstrings.
+
+Defaults to `false`.
+
+**Default value**: `false`
+
+**Type**: `true | false`
+
+**Example usage**:
+
+=== "karva.toml"
+
+    ```toml
+    [profile.default.test]
+    doctest-modules = true
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.karva.profile.default.test]
+    doctest-modules = true
+    ```
+
+---
+
 #### `fail-fast`
 
 Whether to stop at the first test failure.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -69,7 +69,12 @@ karva test [OPTIONS] [PATH]...
 <p>May be passed multiple times.</p>
 </dd><dt id="karva-test--cov-report"><a href="#karva-test--cov-report"><code>--cov-report</code></a> <i>type</i></dt><dd><p>Coverage report type.</p>
 <p><code>term</code> (default) prints a compact terminal table. <code>term-missing</code> extends it with a <code>Missing</code> column listing the uncovered line numbers per file. <code>xml&#91;:PATH&#93;</code>, <code>json&#91;:PATH&#93;</code>, <code>html&#91;:DIR&#93;</code>, and <code>lcov&#91;:PATH&#93;</code> write reports to disk. May be passed multiple times to render several reports from one analysis. Pass an empty value (<code>--cov-report=</code>) to persist native data only.</p>
-</dd><dt id="karva-test--durations"><a href="#karva-test--durations"><code>--durations</code></a> <i>n</i></dt><dd><p>Show the N slowest tests after the run completes</p>
+</dd><dt id="karva-test--doctest-modules"><a href="#karva-test--doctest-modules"><code>--doctest-modules</code></a> <i>doctest-modules</i></dt><dd><p>Collect examples from module, class, function, and method docstrings</p>
+<p>Possible values:</p>
+<ul>
+<li><code>true</code></li>
+<li><code>false</code></li>
+</ul></dd><dt id="karva-test--durations"><a href="#karva-test--durations"><code>--durations</code></a> <i>n</i></dt><dd><p>Show the N slowest tests after the run completes</p>
 </dd><dt id="karva-test--fail-fast"><a href="#karva-test--fail-fast"><code>--fail-fast</code></a> <i>fail-fast</i></dt><dd><p>Stop scheduling new tests after the first failure.</p>
 <p>Equivalent to <code>--max-fail=1</code>. Use <code>--no-fail-fast</code> to keep running after failures.</p>
 <p>Possible values:</p>

--- a/docs/usage/writing-tests/doctests.md
+++ b/docs/usage/writing-tests/doctests.md
@@ -1,0 +1,52 @@
+# Doctests
+
+Karva can run Python's standard-library doctest examples from module, function,
+class, and method docstrings. Doctest collection is opt-in:
+
+```bash
+uv run karva test --doctest-modules
+```
+
+Enable it for a profile in `karva.toml`:
+
+```toml
+[profile.default.test]
+doctest-modules = true
+```
+
+Each docstring containing examples becomes one Karva test case. Examples in one
+docstring share their doctest namespace, so they can build on values created by
+earlier examples. Karva gives each case a stable `doctest:` ID, such as
+`doctest:@module`, `doctest:add`, or `doctest:Calculator.multiply`; use that ID
+when filtering a run:
+
+```bash
+uv run karva test tests/calculator.py::doctest:add
+```
+
+Karva uses Python's standard-library doctest parser and runner, including
+standard directives such as `# doctest: +SKIP`, `ELLIPSIS`, and
+`NORMALIZE_WHITESPACE`:
+
+```python
+def add(left, right):
+    """Add two numbers.
+
+    >>> add(1, 2)
+    3
+    >>> add(1, 2)  # doctest: +SKIP
+    999
+    """
+    return left + right
+```
+
+This MVP collects source-defined module docstrings, functions and classes
+declared directly at module scope, and members declared directly on those
+classes. The documented object must remain visible under its source name after
+the module is imported; otherwise, Karva reports that case as skipped. Dynamic
+docstrings, definitions inside control flow, and `__test__` entries are not
+collected.
+
+Karva does not collect `.txt` doctest files or provide pytest's other doctest
+collection and option flags. Use standard-library directives inside examples
+instead.

--- a/docs/usage/writing-tests/doctests.md
+++ b/docs/usage/writing-tests/doctests.md
@@ -42,10 +42,10 @@ def add(left, right):
 
 This MVP collects source-defined module docstrings, functions and classes
 declared directly at module scope, and members declared directly on those
-classes. The documented object must remain visible under its source name after
-the module is imported; otherwise, Karva reports that case as skipped. Dynamic
-docstrings, definitions inside control flow, and `__test__` entries are not
-collected.
+classes, including nested classes. The documented object must remain visible
+under its source name after the module is imported; otherwise, Karva reports
+that case as skipped. Dynamic docstrings, definitions inside control flow, and
+`__test__` entries are not collected.
 
 Karva does not collect `.txt` doctest files or provide pytest's other doctest
 collection and option flags. Use standard-library directives inside examples

--- a/karva.schema.json
+++ b/karva.schema.json
@@ -742,6 +742,13 @@
       "description": "Controls test selection, retries, timeouts, and failure policies.",
       "type": "object",
       "properties": {
+        "doctest-modules": {
+          "description": "Collect examples from module, class, function, and method docstrings.\n\nDefaults to `false`.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "fail-fast": {
           "description": "Whether to stop at the first test failure.\n\nThis is a legacy alias for [`max_fail`](#max-fail): `true`\ncorresponds to `max-fail = 1` and `false` leaves the limit unset.\nWhen both are set, `max-fail` takes precedence.\n\nDefaults to `false`.",
           "type": [

--- a/seal.toml
+++ b/seal.toml
@@ -23,7 +23,7 @@ draft = false
 
 [changelog.section-labels]
 "Bug Fixes" = ["bug"]
-"Test Running" = ["test-running", "retries"]
+"Test Running" = ["test-running", "retries", "doctest"]
 "Discovery" = ["discovery"]
 "Fixtures" = ["extensions/fixtures"]
 "Functions" = ["extensions/functions"]

--- a/zensical.toml
+++ b/zensical.toml
@@ -39,6 +39,7 @@ nav = [
         ]},
         { "Writing Tests" = [
             { "Basics" = "usage/writing-tests/tests.md"},
+            { "Doctests" = "usage/writing-tests/doctests.md"},
             { "Snapshots" = "usage/writing-tests/snapshots.md"},
             { "Coverage" = "usage/writing-tests/coverage.md"},
             { "Other Functions" = "usage/writing-tests/functions.md"},


### PR DESCRIPTION
## Summary

Closes #1273.

Adds opt-in source doctest collection through --doctest-modules and doctest-modules = true. Karva schedules one case per docstring, runs examples with Python’s standard-library doctest semantics, and reports stable IDs and expected/actual diagnostics across terminal, JUnit, JSON, and JSONL output. Collection stores doctest target, selector, and source range directly; it does not fabricate Python AST nodes.

This MVP supports source-defined module, function, class, and method docstrings. Text doctest files, dynamic docstrings, control-flow definitions, __test__ entries, and pytest’s additional doctest flags remain out of scope.

## Test Plan

Focused Rust tests, integration tests on Python 3.10, 3.13, and 3.14, focused Clippy, generated-reference validation, docs build, and repository hooks.