### PR TITLE
Track open language-server documents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,7 +1178,12 @@ dependencies = [
  "gen-lsp-types",
  "karva_version",
  "lsp-server",
+ "rstest",
+ "ruff_source_file",
+ "ruff_text_size",
  "serde_json",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/karva_language_server/Cargo.toml
+++ b/crates/karva_language_server/Cargo.toml
@@ -23,7 +23,14 @@ anyhow = { workspace = true }
 karva_version = { workspace = true }
 lsp-server = { workspace = true }
 lsp-types = { workspace = true }
+ruff_source_file = { workspace = true }
+ruff_text_size = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/karva_language_server/src/capabilities.rs
+++ b/crates/karva_language_server/src/capabilities.rs
@@ -1,33 +1,57 @@
-use lsp_types::{ClientCapabilities, PositionEncodingKind, ServerCapabilities};
+#![expect(
+    clippy::redundant_pub_crate,
+    reason = "server uses these helpers across private sibling modules"
+)]
+
+use lsp_types::{
+    ClientCapabilities, ServerCapabilities, TextDocumentSyncKind, TextDocumentSyncOptions,
+    WorkspaceFoldersServerCapabilities,
+};
+
+use crate::PositionEncoding;
 
 /// Chooses the most efficient position encoding supported by the client.
-pub(crate) fn position_encoding(capabilities: &ClientCapabilities) -> PositionEncodingKind {
+pub(super) fn position_encoding(capabilities: &ClientCapabilities) -> PositionEncoding {
     capabilities
         .general
         .as_ref()
         .and_then(|general| general.position_encodings.as_ref())
         .and_then(|encodings| {
-            [
-                PositionEncodingKind::UTF8,
-                PositionEncodingKind::UTF32,
-                PositionEncodingKind::UTF16,
-            ]
-            .into_iter()
-            .find(|preferred| encodings.contains(preferred))
+            encodings
+                .iter()
+                .filter_map(|encoding| PositionEncoding::try_from(encoding).ok())
+                .max()
         })
-        .unwrap_or(PositionEncodingKind::UTF16)
+        .unwrap_or_default()
 }
 
-pub(crate) fn server_capabilities(position_encoding: PositionEncodingKind) -> ServerCapabilities {
+pub(super) fn server_capabilities(position_encoding: PositionEncoding) -> ServerCapabilities {
     ServerCapabilities {
-        position_encoding: Some(position_encoding),
+        position_encoding: Some(position_encoding.into()),
+        text_document_sync: Some(
+            TextDocumentSyncOptions {
+                open_close: Some(true),
+                change: Some(TextDocumentSyncKind::Incremental),
+                will_save: Some(false),
+                will_save_wait_until: Some(false),
+                save: None,
+            }
+            .into(),
+        ),
+        workspace: Some(lsp_types::WorkspaceOptions {
+            workspace_folders: Some(WorkspaceFoldersServerCapabilities {
+                supported: Some(true),
+                change_notifications: Some(true.into()),
+            }),
+            ..lsp_types::WorkspaceOptions::default()
+        }),
         ..ServerCapabilities::default()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use lsp_types::{ClientCapabilities, GeneralClientCapabilities};
+    use lsp_types::{ClientCapabilities, GeneralClientCapabilities, PositionEncodingKind};
 
     use super::*;
 
@@ -35,7 +59,7 @@ mod tests {
     fn defaults_to_utf16() {
         assert_eq!(
             position_encoding(&ClientCapabilities::default()),
-            PositionEncodingKind::UTF16
+            PositionEncoding::UTF16
         );
     }
 
@@ -52,6 +76,6 @@ mod tests {
             ..ClientCapabilities::default()
         };
 
-        assert_eq!(position_encoding(&capabilities), PositionEncodingKind::UTF8);
+        assert_eq!(position_encoding(&capabilities), PositionEncoding::UTF8);
     }
 }

--- a/crates/karva_language_server/src/document.rs
+++ b/crates/karva_language_server/src/document.rs
@@ -1,0 +1,63 @@
+//! Open text documents and LSP source-position conversion.
+
+mod range;
+mod text_document;
+
+use lsp_types::PositionEncodingKind;
+
+#[expect(
+    clippy::redundant_pub_crate,
+    reason = "session consumes this error across a private sibling module"
+)]
+pub(super) use text_document::DocumentChangeError;
+pub use text_document::TextDocument;
+
+/// A supported LSP source-position encoding, ordered by server preference.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PositionEncoding {
+    /// UTF-16 is the encoding every LSP client must support.
+    #[default]
+    UTF16,
+
+    /// UTF-32 counts Unicode scalar values.
+    UTF32,
+
+    /// UTF-8 positions are byte offsets and avoid conversion for Rust strings.
+    UTF8,
+}
+
+impl From<PositionEncoding> for ruff_source_file::PositionEncoding {
+    fn from(value: PositionEncoding) -> Self {
+        match value {
+            PositionEncoding::UTF8 => Self::Utf8,
+            PositionEncoding::UTF16 => Self::Utf16,
+            PositionEncoding::UTF32 => Self::Utf32,
+        }
+    }
+}
+
+impl From<PositionEncoding> for PositionEncodingKind {
+    fn from(value: PositionEncoding) -> Self {
+        match value {
+            PositionEncoding::UTF8 => Self::UTF8,
+            PositionEncoding::UTF16 => Self::UTF16,
+            PositionEncoding::UTF32 => Self::UTF32,
+        }
+    }
+}
+
+impl TryFrom<&PositionEncodingKind> for PositionEncoding {
+    type Error = ();
+
+    fn try_from(value: &PositionEncodingKind) -> Result<Self, Self::Error> {
+        if value == &PositionEncodingKind::UTF8 {
+            Ok(Self::UTF8)
+        } else if value == &PositionEncodingKind::UTF32 {
+            Ok(Self::UTF32)
+        } else if value == &PositionEncodingKind::UTF16 {
+            Ok(Self::UTF16)
+        } else {
+            Err(())
+        }
+    }
+}

--- a/crates/karva_language_server/src/document/range.rs
+++ b/crates/karva_language_server/src/document/range.rs
@@ -1,0 +1,33 @@
+use lsp_types::{Position, Range};
+use ruff_source_file::{LineIndex, OneIndexed, SourceLocation};
+use ruff_text_size::{TextRange, TextSize};
+
+use super::PositionEncoding;
+
+fn position_to_text_size(
+    position: Position,
+    text: &str,
+    index: &LineIndex,
+    encoding: PositionEncoding,
+) -> TextSize {
+    index.offset(
+        SourceLocation {
+            line: OneIndexed::from_zero_indexed(position.line as usize),
+            character_offset: OneIndexed::from_zero_indexed(position.character as usize),
+        },
+        text,
+        encoding.into(),
+    )
+}
+
+pub(super) fn range_to_text_range(
+    range: Range,
+    text: &str,
+    index: &LineIndex,
+    encoding: PositionEncoding,
+) -> TextRange {
+    TextRange::new(
+        position_to_text_size(range.start, text, index, encoding),
+        position_to_text_size(range.end, text, index, encoding),
+    )
+}

--- a/crates/karva_language_server/src/document/text_document.rs
+++ b/crates/karva_language_server/src/document/text_document.rs
@@ -1,0 +1,233 @@
+use lsp_types::{
+    LanguageKind, TextDocumentContentChangeEvent, TextDocumentContentChangePartial,
+    TextDocumentContentChangeWholeDocument, Uri,
+};
+use ruff_source_file::LineIndex;
+
+use super::PositionEncoding;
+use super::range::range_to_text_range;
+
+/// A document change that violates the client's version contract.
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+#[expect(
+    clippy::redundant_pub_crate,
+    reason = "document re-exports this error to a private sibling module"
+)]
+pub(crate) enum DocumentChangeError {
+    /// A client attempted to replace newer open-document state with an older version.
+    #[error("stale document version: current is {current}, requested {requested}")]
+    StaleVersion { current: i32, requested: i32 },
+}
+
+/// An open text document, including unsaved editor changes.
+#[derive(Debug, Clone)]
+pub struct TextDocument {
+    uri: Uri,
+    contents: String,
+    version: i32,
+}
+
+impl TextDocument {
+    /// Creates an open document from an LSP `didOpen` notification.
+    pub(crate) fn new(
+        uri: Uri,
+        contents: String,
+        version: i32,
+        _language_id: LanguageKind,
+    ) -> Self {
+        Self {
+            uri,
+            contents,
+            version,
+        }
+    }
+
+    /// Returns the URI supplied by the client.
+    pub(crate) fn uri(&self) -> &Uri {
+        &self.uri
+    }
+
+    /// Returns the latest editor contents, including unsaved changes.
+    #[cfg(test)]
+    fn contents(&self) -> &str {
+        &self.contents
+    }
+
+    /// Returns the client-managed document version.
+    #[cfg(test)]
+    fn version(&self) -> i32 {
+        self.version
+    }
+
+    /// Applies changes sequentially using positions from the negotiated encoding.
+    pub(crate) fn apply_changes(
+        &mut self,
+        changes: Vec<TextDocumentContentChangeEvent>,
+        new_version: i32,
+        encoding: PositionEncoding,
+    ) -> Result<(), DocumentChangeError> {
+        if new_version < self.version {
+            return Err(DocumentChangeError::StaleVersion {
+                current: self.version,
+                requested: new_version,
+            });
+        }
+
+        if let [
+            TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                TextDocumentContentChangeWholeDocument { text },
+            ),
+        ] = changes.as_slice()
+        {
+            self.contents.clone_from(text);
+            self.version = new_version;
+            return Ok(());
+        }
+
+        let mut new_contents = self.contents.clone();
+        let mut index = LineIndex::from_source_text(&new_contents);
+
+        for change in changes {
+            match change {
+                TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                    TextDocumentContentChangePartial { range, text, .. },
+                ) => {
+                    let range = range_to_text_range(range, &new_contents, &index, encoding);
+                    new_contents
+                        .replace_range(usize::from(range.start())..usize::from(range.end()), &text);
+                }
+                TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                    TextDocumentContentChangeWholeDocument { text },
+                ) => new_contents = text,
+            }
+            index = LineIndex::from_source_text(&new_contents);
+        }
+
+        self.contents = new_contents;
+        self.version = new_version;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use lsp_types::{
+        Position, Range, TextDocumentContentChangeEvent, TextDocumentContentChangePartial,
+        TextDocumentContentChangeWholeDocument, Uri,
+    };
+    use rstest::rstest;
+
+    use super::*;
+
+    fn document(contents: &str) -> TextDocument {
+        TextDocument::new(
+            Uri::parse("file:///test.py").expect("test URI should be valid"),
+            contents.to_owned(),
+            1,
+            LanguageKind::Python,
+        )
+    }
+
+    fn partial(line: u32, start: u32, end: u32, text: &str) -> TextDocumentContentChangeEvent {
+        TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+            TextDocumentContentChangePartial {
+                range: Range::new(Position::new(line, start), Position::new(line, end)),
+                text: text.to_owned(),
+                ..TextDocumentContentChangePartial::default()
+            },
+        )
+    }
+
+    #[test]
+    fn replaces_whole_document() {
+        let mut document = document("old");
+        document
+            .apply_changes(
+                vec![
+                    TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                        TextDocumentContentChangeWholeDocument {
+                            text: "new".to_owned(),
+                        },
+                    ),
+                ],
+                2,
+                PositionEncoding::UTF16,
+            )
+            .expect("whole-document change should apply");
+
+        assert_eq!(document.contents(), "new");
+        assert_eq!(document.version(), 2);
+    }
+
+    #[test]
+    fn applies_changes_sequentially() {
+        let mut document = document("def test():\n    pas\n");
+        document
+            .apply_changes(
+                vec![
+                    partial(1, 7, 7, "s"),
+                    partial(1, 7, 8, ""),
+                    partial(1, 7, 7, "s"),
+                ],
+                2,
+                PositionEncoding::UTF16,
+            )
+            .expect("sequential changes should apply");
+
+        assert_eq!(document.contents(), "def test():\n    pass\n");
+    }
+
+    #[rstest]
+    #[case(PositionEncoding::UTF8, 5)]
+    #[case(PositionEncoding::UTF16, 3)]
+    #[case(PositionEncoding::UTF32, 2)]
+    fn respects_position_encoding(#[case] encoding: PositionEncoding, #[case] end: u32) {
+        let mut document = document("a😀b\r\n");
+        document
+            .apply_changes(vec![partial(0, 1, end, "x")], 2, encoding)
+            .expect("encoded range should apply");
+
+        assert_eq!(document.contents(), "axb\r\n");
+    }
+
+    #[test]
+    fn applies_edits_after_crlf() {
+        let mut document = document("first\r\nsecond\r\n");
+        document
+            .apply_changes(
+                vec![partial(1, 0, 6, "changed")],
+                2,
+                PositionEncoding::UTF16,
+            )
+            .expect("second-line edit should apply");
+
+        assert_eq!(document.contents(), "first\r\nchanged\r\n");
+    }
+
+    #[test]
+    fn rejects_stale_version() {
+        let mut document = document("current");
+        let error = document
+            .apply_changes(
+                vec![
+                    TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                        TextDocumentContentChangeWholeDocument {
+                            text: "stale".to_owned(),
+                        },
+                    ),
+                ],
+                0,
+                PositionEncoding::UTF16,
+            )
+            .expect_err("stale change should fail");
+
+        assert_eq!(
+            error,
+            DocumentChangeError::StaleVersion {
+                current: 1,
+                requested: 0,
+            }
+        );
+        assert_eq!(document.contents(), "current");
+    }
+}

--- a/crates/karva_language_server/src/lib.rs
+++ b/crates/karva_language_server/src/lib.rs
@@ -5,8 +5,11 @@ use anyhow::Context;
 pub use server::{ConnectionInitializer, Server};
 
 mod capabilities;
+mod document;
 mod server;
 mod session;
+
+pub use document::{PositionEncoding, TextDocument};
 
 const SERVER_NAME: &str = "karva";
 

--- a/crates/karva_language_server/src/server.rs
+++ b/crates/karva_language_server/src/server.rs
@@ -1,7 +1,7 @@
 //! Scheduling, I/O, and API endpoints.
 
 use lsp_server::Connection;
-use lsp_types::InitializeParams;
+use lsp_types::{InitializeParams, WorkspaceFolders, WorkspaceFoldersInitializeParams};
 
 use crate::capabilities::{position_encoding, server_capabilities};
 use crate::session::Session;
@@ -22,8 +22,18 @@ impl Server {
     /// Completes the LSP initialization handshake.
     pub fn new(connection: ConnectionInitializer) -> anyhow::Result<Self> {
         let (id, init_params) = connection.initialize_start()?;
-        let InitializeParams { capabilities, .. } = init_params;
-        let capabilities = server_capabilities(position_encoding(&capabilities));
+        let InitializeParams {
+            capabilities,
+            workspace_folders_initialize_params:
+                WorkspaceFoldersInitializeParams { workspace_folders },
+            ..
+        } = init_params;
+        let position_encoding = position_encoding(&capabilities);
+        let capabilities = server_capabilities(position_encoding);
+        let workspace_folders = match workspace_folders {
+            Some(WorkspaceFolders::WorkspaceFolderList(folders)) => folders,
+            Some(WorkspaceFolders::Null) | None => Vec::new(),
+        };
         let connection = connection.initialize_finish(
             id,
             &capabilities,
@@ -33,7 +43,7 @@ impl Server {
 
         Ok(Self {
             connection,
-            session: Session::default(),
+            session: Session::new(position_encoding, workspace_folders),
         })
     }
 

--- a/crates/karva_language_server/src/server/api.rs
+++ b/crates/karva_language_server/src/server/api.rs
@@ -1,12 +1,17 @@
-use lsp_server::{ErrorCode, Request, Response};
-use lsp_types::{LspRequestMethod, Request as _, ShutdownRequest};
+use lsp_server::{ErrorCode, Notification, Request, Response};
+use lsp_types::{
+    DidChangeTextDocumentNotification, DidChangeWorkspaceFoldersNotification,
+    DidCloseTextDocumentNotification, DidOpenTextDocumentNotification, LspNotificationMethod,
+    LspRequestMethod, Notification as _, Request as _, ShutdownRequest,
+};
 
 use crate::session::Session;
 
+mod notifications;
 mod requests;
 mod traits;
 
-use self::traits::SyncRequestHandler;
+use self::traits::{SyncNotificationHandler, SyncRequestHandler};
 
 pub(super) fn request(request: Request, session: &mut Session) -> Response {
     match LspRequestMethod::from(request.method.as_str()) {
@@ -16,6 +21,31 @@ pub(super) fn request(request: Request, session: &mut Session) -> Response {
             ErrorCode::MethodNotFound as i32,
             format!("unknown request: {method}"),
         ),
+    }
+}
+
+pub(super) fn notification(notification: Notification, session: &mut Session) {
+    let result = match LspNotificationMethod::from(notification.method.as_str()) {
+        DidOpenTextDocumentNotification::METHOD => {
+            run_notification::<notifications::DidOpen>(notification, session)
+        }
+        DidChangeTextDocumentNotification::METHOD => {
+            run_notification::<notifications::DidChange>(notification, session)
+        }
+        DidCloseTextDocumentNotification::METHOD => {
+            run_notification::<notifications::DidClose>(notification, session)
+        }
+        DidChangeWorkspaceFoldersNotification::METHOD => {
+            run_notification::<notifications::DidChangeWorkspaceFolders>(notification, session)
+        }
+        method => {
+            tracing::debug!("ignoring unsupported notification {method}");
+            return;
+        }
+    };
+
+    if let Err(error) = result {
+        tracing::warn!("failed to handle notification: {error}");
     }
 }
 
@@ -38,4 +68,12 @@ where
         },
         Err(error) => Response::new_err(id, ErrorCode::InternalError as i32, error.to_string()),
     }
+}
+
+fn run_notification<H>(notification: Notification, session: &mut Session) -> anyhow::Result<()>
+where
+    H: SyncNotificationHandler,
+{
+    let params = serde_json::from_value(notification.params)?;
+    H::run(session, params)
 }

--- a/crates/karva_language_server/src/server/api/notifications.rs
+++ b/crates/karva_language_server/src/server/api/notifications.rs
@@ -1,0 +1,9 @@
+mod did_change;
+mod did_change_workspace_folders;
+mod did_close;
+mod did_open;
+
+pub(super) use did_change::DidChange;
+pub(super) use did_change_workspace_folders::DidChangeWorkspaceFolders;
+pub(super) use did_close::DidClose;
+pub(super) use did_open::DidOpen;

--- a/crates/karva_language_server/src/server/api/notifications/did_change.rs
+++ b/crates/karva_language_server/src/server/api/notifications/did_change.rs
@@ -1,0 +1,30 @@
+use lsp_types::{
+    DidChangeTextDocumentNotification, DidChangeTextDocumentParams, TextDocumentIdentifier,
+    VersionedTextDocumentIdentifier,
+};
+
+use super::super::traits::{NotificationHandler, SyncNotificationHandler};
+use crate::session::Session;
+
+pub(in crate::server::api) struct DidChange;
+
+impl NotificationHandler for DidChange {
+    type NotificationType = DidChangeTextDocumentNotification;
+}
+
+impl SyncNotificationHandler for DidChange {
+    fn run(
+        session: &mut Session,
+        DidChangeTextDocumentParams {
+            text_document:
+                VersionedTextDocumentIdentifier {
+                    text_document_identifier: TextDocumentIdentifier { uri },
+                    version,
+                },
+            content_changes,
+        }: DidChangeTextDocumentParams,
+    ) -> anyhow::Result<()> {
+        session.update_document(&uri, content_changes, version)?;
+        Ok(())
+    }
+}

--- a/crates/karva_language_server/src/server/api/notifications/did_change_workspace_folders.rs
+++ b/crates/karva_language_server/src/server/api/notifications/did_change_workspace_folders.rs
@@ -1,0 +1,30 @@
+use lsp_types::{
+    DidChangeWorkspaceFoldersNotification, DidChangeWorkspaceFoldersParams,
+    WorkspaceFoldersChangeEvent,
+};
+
+use super::super::traits::{NotificationHandler, SyncNotificationHandler};
+use crate::session::Session;
+
+pub(in crate::server::api) struct DidChangeWorkspaceFolders;
+
+impl NotificationHandler for DidChangeWorkspaceFolders {
+    type NotificationType = DidChangeWorkspaceFoldersNotification;
+}
+
+impl SyncNotificationHandler for DidChangeWorkspaceFolders {
+    fn run(
+        session: &mut Session,
+        DidChangeWorkspaceFoldersParams {
+            event: WorkspaceFoldersChangeEvent { added, removed },
+        }: DidChangeWorkspaceFoldersParams,
+    ) -> anyhow::Result<()> {
+        for folder in added {
+            session.open_workspace_folder(folder);
+        }
+        for folder in removed {
+            session.close_workspace_folder(&folder.uri)?;
+        }
+        Ok(())
+    }
+}

--- a/crates/karva_language_server/src/server/api/notifications/did_close.rs
+++ b/crates/karva_language_server/src/server/api/notifications/did_close.rs
@@ -1,0 +1,24 @@
+use lsp_types::{
+    DidCloseTextDocumentNotification, DidCloseTextDocumentParams, TextDocumentIdentifier,
+};
+
+use super::super::traits::{NotificationHandler, SyncNotificationHandler};
+use crate::session::Session;
+
+pub(in crate::server::api) struct DidClose;
+
+impl NotificationHandler for DidClose {
+    type NotificationType = DidCloseTextDocumentNotification;
+}
+
+impl SyncNotificationHandler for DidClose {
+    fn run(
+        session: &mut Session,
+        DidCloseTextDocumentParams {
+            text_document: TextDocumentIdentifier { uri },
+        }: DidCloseTextDocumentParams,
+    ) -> anyhow::Result<()> {
+        session.close_document(&uri)?;
+        Ok(())
+    }
+}

--- a/crates/karva_language_server/src/server/api/notifications/did_open.rs
+++ b/crates/karva_language_server/src/server/api/notifications/did_open.rs
@@ -1,0 +1,29 @@
+use lsp_types::{DidOpenTextDocumentNotification, DidOpenTextDocumentParams, TextDocumentItem};
+
+use super::super::traits::{NotificationHandler, SyncNotificationHandler};
+use crate::TextDocument;
+use crate::session::Session;
+
+pub(in crate::server::api) struct DidOpen;
+
+impl NotificationHandler for DidOpen {
+    type NotificationType = DidOpenTextDocumentNotification;
+}
+
+impl SyncNotificationHandler for DidOpen {
+    fn run(
+        session: &mut Session,
+        DidOpenTextDocumentParams {
+            text_document:
+                TextDocumentItem {
+                    uri,
+                    text,
+                    version,
+                    language_id,
+                },
+        }: DidOpenTextDocumentParams,
+    ) -> anyhow::Result<()> {
+        session.open_document(TextDocument::new(uri, text, version, language_id));
+        Ok(())
+    }
+}

--- a/crates/karva_language_server/src/server/api/traits.rs
+++ b/crates/karva_language_server/src/server/api/traits.rs
@@ -1,4 +1,4 @@
-use lsp_types::Request;
+use lsp_types::{Notification, Request};
 
 use crate::session::Session;
 
@@ -11,4 +11,15 @@ pub(super) trait SyncRequestHandler: RequestHandler {
         session: &mut Session,
         params: <<Self as RequestHandler>::RequestType as Request>::Params,
     ) -> anyhow::Result<<<Self as RequestHandler>::RequestType as Request>::Result>;
+}
+
+pub(super) trait NotificationHandler {
+    type NotificationType: Notification;
+}
+
+pub(super) trait SyncNotificationHandler: NotificationHandler {
+    fn run(
+        session: &mut Session,
+        params: <<Self as NotificationHandler>::NotificationType as Notification>::Params,
+    ) -> anyhow::Result<()>;
 }

--- a/crates/karva_language_server/src/server/main_loop.rs
+++ b/crates/karva_language_server/src/server/main_loop.rs
@@ -20,15 +20,16 @@ impl Server {
                     };
                     self.connection.sender.send(Message::Response(response))?;
                 }
-                Message::Notification(notification)
-                    if notification.method == ExitNotification::METHOD.as_str() =>
-                {
-                    if !self.session.is_shutdown_requested() {
-                        bail!("received exit notification before shutdown request");
+                Message::Notification(notification) => {
+                    if notification.method == ExitNotification::METHOD.as_str() {
+                        if !self.session.is_shutdown_requested() {
+                            bail!("received exit notification before shutdown request");
+                        }
+                        return Ok(());
                     }
-                    return Ok(());
+
+                    super::api::notification(notification, &mut self.session);
                 }
-                Message::Notification(_) => {}
                 Message::Response(response) => {
                     bail!("received unexpected response with ID {}", response.id);
                 }

--- a/crates/karva_language_server/src/session.rs
+++ b/crates/karva_language_server/src/session.rs
@@ -1,15 +1,80 @@
+//! Mutable language-server state.
+
+mod index;
+
+use lsp_types::{TextDocumentContentChangeEvent, Uri, WorkspaceFolder};
+
+use crate::{PositionEncoding, TextDocument};
+
+use self::index::Index;
+
+/// Failure to apply a document or workspace notification.
+#[derive(Debug, thiserror::Error)]
+pub enum SessionError {
+    /// The client referenced a document without opening it first.
+    #[error("document is not open: {0}")]
+    DocumentNotOpen(Uri),
+
+    /// The client referenced a workspace without opening it first.
+    #[error("workspace folder is not open: {0}")]
+    WorkspaceNotOpen(Uri),
+
+    /// The document change violated its version contract.
+    #[error(transparent)]
+    DocumentChange(#[from] crate::document::DocumentChangeError),
+}
+
 /// Mutable state owned by the language-server event loop.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Session {
+    index: Index,
+    position_encoding: PositionEncoding,
     shutdown_requested: bool,
 }
 
 impl Session {
+    pub(super) fn new(
+        position_encoding: PositionEncoding,
+        workspace_folders: impl IntoIterator<Item = WorkspaceFolder>,
+    ) -> Self {
+        Self {
+            index: Index::new(workspace_folders),
+            position_encoding,
+            shutdown_requested: false,
+        }
+    }
+
     pub(super) fn is_shutdown_requested(&self) -> bool {
         self.shutdown_requested
     }
 
     pub(super) fn request_shutdown(&mut self) {
         self.shutdown_requested = true;
+    }
+
+    pub(super) fn open_document(&mut self, document: TextDocument) {
+        self.index.open_document(document);
+    }
+
+    pub(super) fn update_document(
+        &mut self,
+        uri: &Uri,
+        changes: Vec<TextDocumentContentChangeEvent>,
+        version: i32,
+    ) -> Result<(), SessionError> {
+        self.index
+            .update_document(uri, changes, version, self.position_encoding)
+    }
+
+    pub(super) fn close_document(&mut self, uri: &Uri) -> Result<(), SessionError> {
+        self.index.close_document(uri)
+    }
+
+    pub(super) fn open_workspace_folder(&mut self, folder: WorkspaceFolder) {
+        self.index.open_workspace_folder(folder);
+    }
+
+    pub(super) fn close_workspace_folder(&mut self, uri: &Uri) -> Result<(), SessionError> {
+        self.index.close_workspace_folder(uri)
     }
 }

--- a/crates/karva_language_server/src/session/index.rs
+++ b/crates/karva_language_server/src/session/index.rs
@@ -1,0 +1,113 @@
+use std::collections::HashMap;
+
+use lsp_types::{TextDocumentContentChangeEvent, Uri, WorkspaceFolder};
+
+use crate::session::SessionError;
+use crate::{PositionEncoding, TextDocument};
+
+/// Open documents and workspace folders indexed by client URI.
+#[derive(Debug)]
+pub struct Index {
+    documents: HashMap<Uri, TextDocument>,
+    workspace_folders: HashMap<Uri, WorkspaceFolder>,
+}
+
+impl Index {
+    pub(super) fn new(workspace_folders: impl IntoIterator<Item = WorkspaceFolder>) -> Self {
+        Self {
+            documents: HashMap::new(),
+            workspace_folders: workspace_folders
+                .into_iter()
+                .map(|folder| (folder.uri.clone(), folder))
+                .collect(),
+        }
+    }
+
+    pub(super) fn open_document(&mut self, document: TextDocument) {
+        self.documents.insert(document.uri().clone(), document);
+    }
+
+    pub(super) fn update_document(
+        &mut self,
+        uri: &Uri,
+        changes: Vec<TextDocumentContentChangeEvent>,
+        version: i32,
+        encoding: PositionEncoding,
+    ) -> Result<(), SessionError> {
+        let document = self
+            .documents
+            .get_mut(uri)
+            .ok_or_else(|| SessionError::DocumentNotOpen(uri.clone()))?;
+        document.apply_changes(changes, version, encoding)?;
+        Ok(())
+    }
+
+    pub(super) fn close_document(&mut self, uri: &Uri) -> Result<(), SessionError> {
+        self.documents
+            .remove(uri)
+            .map(|_| ())
+            .ok_or_else(|| SessionError::DocumentNotOpen(uri.clone()))
+    }
+
+    pub(super) fn open_workspace_folder(&mut self, folder: WorkspaceFolder) {
+        self.workspace_folders.insert(folder.uri.clone(), folder);
+    }
+
+    pub(super) fn close_workspace_folder(&mut self, uri: &Uri) -> Result<(), SessionError> {
+        self.workspace_folders
+            .remove(uri)
+            .map(|_| ())
+            .ok_or_else(|| SessionError::WorkspaceNotOpen(uri.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use lsp_types::{LanguageKind, Uri, WorkspaceFolder};
+
+    use super::*;
+
+    fn uri(value: &str) -> Uri {
+        Uri::parse(value).expect("test URI should be valid")
+    }
+
+    #[test]
+    fn tracks_multiple_workspace_folders() {
+        let first = WorkspaceFolder {
+            uri: uri("file:///first"),
+            name: "first".to_owned(),
+        };
+        let second = WorkspaceFolder {
+            uri: uri("file:///second"),
+            name: "second".to_owned(),
+        };
+        let mut index = Index::new([first.clone(), second.clone()]);
+
+        index
+            .close_workspace_folder(&first.uri)
+            .expect("first workspace should close");
+        index
+            .close_workspace_folder(&second.uri)
+            .expect("second workspace should close");
+
+        assert!(index.workspace_folders.is_empty());
+    }
+
+    #[test]
+    fn closes_open_document() {
+        let document_uri = uri("file:///test.py");
+        let mut index = Index::new([]);
+        index.open_document(TextDocument::new(
+            document_uri.clone(),
+            "def test_example(): pass".to_owned(),
+            1,
+            LanguageKind::Python,
+        ));
+
+        index
+            .close_document(&document_uri)
+            .expect("open document should close");
+
+        assert!(index.documents.is_empty());
+    }
+}

--- a/crates/karva_language_server/tests/e2e/document_sync.rs
+++ b/crates/karva_language_server/tests/e2e/document_sync.rs
@@ -1,0 +1,41 @@
+use lsp_types::{
+    DidChangeTextDocumentNotification, DidChangeTextDocumentParams,
+    DidCloseTextDocumentNotification, DidCloseTextDocumentParams, DidOpenTextDocumentNotification,
+    DidOpenTextDocumentParams, LanguageKind, Position, Range, TextDocumentContentChangeEvent,
+    TextDocumentContentChangePartial, TextDocumentIdentifier, TextDocumentItem, Uri,
+    VersionedTextDocumentIdentifier,
+};
+
+use super::TestServer;
+
+#[test]
+fn accepts_incremental_unsaved_document_changes() {
+    let server = TestServer::new(lsp_types::ClientCapabilities::default());
+    let uri = Uri::parse("file:///workspace/test_example.py").expect("test URI should be valid");
+    server.notify::<DidOpenTextDocumentNotification>(DidOpenTextDocumentParams {
+        text_document: TextDocumentItem {
+            uri: uri.clone(),
+            language_id: LanguageKind::Python,
+            version: 1,
+            text: "def test_😀():\n    pas\n".to_owned(),
+        },
+    });
+    server.notify::<DidChangeTextDocumentNotification>(DidChangeTextDocumentParams {
+        text_document: VersionedTextDocumentIdentifier {
+            text_document_identifier: TextDocumentIdentifier { uri: uri.clone() },
+            version: 2,
+        },
+        content_changes: vec![
+            TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                TextDocumentContentChangePartial {
+                    range: Range::new(Position::new(1, 7), Position::new(1, 7)),
+                    text: "s".to_owned(),
+                    ..TextDocumentContentChangePartial::default()
+                },
+            ),
+        ],
+    });
+    server.notify::<DidCloseTextDocumentNotification>(DidCloseTextDocumentParams {
+        text_document: TextDocumentIdentifier { uri },
+    });
+}

--- a/crates/karva_language_server/tests/e2e/initialize.rs
+++ b/crates/karva_language_server/tests/e2e/initialize.rs
@@ -1,4 +1,7 @@
-use lsp_types::{ClientCapabilities, GeneralClientCapabilities, PositionEncodingKind};
+use lsp_types::{
+    ClientCapabilities, GeneralClientCapabilities, PositionEncodingKind, TextDocumentSync,
+    TextDocumentSyncKind,
+};
 
 use super::TestServer;
 
@@ -43,5 +46,25 @@ fn initialization_negotiates_utf8() {
             .capabilities
             .position_encoding,
         Some(PositionEncodingKind::UTF8)
+    );
+}
+
+#[test]
+fn initialization_advertises_document_and_workspace_sync() {
+    let server = TestServer::new(ClientCapabilities::default());
+    let capabilities = &server.initialization_result().capabilities;
+    let Some(TextDocumentSync::Options(sync)) = capabilities.text_document_sync else {
+        panic!("expected text document sync options");
+    };
+
+    assert_eq!(sync.open_close, Some(true));
+    assert_eq!(sync.change, Some(TextDocumentSyncKind::Incremental));
+    assert_eq!(
+        capabilities
+            .workspace
+            .as_ref()
+            .and_then(|workspace| workspace.workspace_folders.as_ref())
+            .and_then(|folders| folders.supported),
+        Some(true)
     );
 }

--- a/crates/karva_language_server/tests/e2e/main.rs
+++ b/crates/karva_language_server/tests/e2e/main.rs
@@ -1,5 +1,6 @@
 //! End-to-end language-server tests over an in-memory LSP connection.
 
+mod document_sync;
 mod initialize;
 
 use std::thread::JoinHandle;


### PR DESCRIPTION
## Summary

Tracks opened, changed, and closed document text so editor analysis can use unsaved sources. This is part of #1212.

## Test plan

ci