### PR TITLE
Keep language-server analysis Python-free

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,7 +1178,12 @@ dependencies = [
  "gen-lsp-types",
  "karva_version",
  "lsp-server",
+ "rstest",
+ "ruff_source_file",
+ "ruff_text_size",
  "serde_json",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,6 +1158,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "karva_ide"
+version = "0.0.0"
+dependencies = [
+ "camino",
+ "karva_collector",
+ "ruff_python_ast",
+ "ruff_text_size",
+]
+
+[[package]]
 name = "karva_ipc"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,13 +1175,20 @@ name = "karva_language_server"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "camino",
  "gen-lsp-types",
+ "karva_metadata",
+ "karva_project",
+ "karva_python_semantic",
  "karva_version",
  "lsp-server",
  "rstest",
+ "ruff_python_ast",
  "ruff_source_file",
  "ruff_text_size",
+ "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,6 +1176,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "camino",
+ "crossbeam-channel",
  "gen-lsp-types",
  "karva_metadata",
  "karva_project",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1190,7 +1190,6 @@ dependencies = [
  "gen-lsp-types",
  "karva_metadata",
  "karva_project",
- "karva_python_semantic",
  "karva_version",
  "lsp-server",
  "rstest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ karva_collector = { path = "crates/karva_collector" }
 karva_combine = { path = "crates/karva_combine" }
 karva_coverage = { path = "crates/karva_coverage" }
 karva_diagnostic = { path = "crates/karva_diagnostic" }
+karva_ide = { path = "crates/karva_ide" }
 karva_ipc = { path = "crates/karva_ipc" }
 karva_logging = { path = "crates/karva_logging" }
 karva_macros = { path = "crates/karva_macros" }

--- a/crates/karva/Cargo.toml
+++ b/crates/karva/Cargo.toml
@@ -24,7 +24,7 @@ karva_diagnostic = { workspace = true }
 karva_logging = { workspace = true }
 karva_metadata = { workspace = true }
 karva_project = { workspace = true }
-karva_python_semantic = { workspace = true }
+karva_python_semantic = { workspace = true, features = ["python-runtime"] }
 karva_runner = { workspace = true }
 karva_snapshot = { workspace = true }
 karva_static = { workspace = true }

--- a/crates/karva_collector/src/lib.rs
+++ b/crates/karva_collector/src/lib.rs
@@ -83,7 +83,7 @@ pub fn collect_file(
 /// This is the source-first collection boundary used for unsaved editor buffers.
 /// Ruff's error recovery preserves any functions it can parse from incomplete source.
 /// Returns `None` when `path` lies outside `cwd` or cannot produce a module syntax tree.
-fn collect_source(
+pub fn collect_source(
     path: &Utf8PathBuf,
     cwd: &Utf8Path,
     source_text: String,

--- a/crates/karva_ide/Cargo.toml
+++ b/crates/karva_ide/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "karva_ide"
+version = "0.0.0"
+
+edition = { workspace = true }
+rust-version = { workspace = true }
+description = "Source-only IDE analysis for Karva."
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+
+[lib]
+doctest = false
+
+[dependencies]
+camino = { workspace = true }
+karva_collector = { workspace = true }
+ruff_python_ast = { workspace = true }
+ruff_text_size = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/karva_ide/src/fixture.rs
+++ b/crates/karva_ide/src/fixture.rs
@@ -1,0 +1,1296 @@
+#![expect(
+    clippy::redundant_pub_crate,
+    reason = "the crate root re-exports fixture analysis across this private module"
+)]
+
+use std::collections::{HashMap, HashSet};
+
+use camino::Utf8PathBuf;
+use karva_collector::{CollectedModule, ModuleType};
+use ruff_python_ast::{Expr, Stmt, StmtFunctionDef};
+use ruff_text_size::{Ranged, TextRange};
+
+use crate::{DiagnosticCode, RelatedInformation, SourceDiagnostic, SourceLocation};
+
+/// Stable identity for a fixture provider.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct FixtureId {
+    /// File containing the fixture.
+    path: Utf8PathBuf,
+
+    /// Range of the fixture definition.
+    range: TextRange,
+}
+
+/// Runtime lifetime of a fixture value.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum FixtureScope {
+    /// Recreated for every test attempt.
+    #[default]
+    Function,
+
+    /// Shared by tests in one module.
+    Module,
+
+    /// Shared by modules in one package.
+    Package,
+
+    /// Shared by the complete worker session.
+    Session,
+}
+
+impl FixtureScope {
+    /// Returns whether this fixture may depend on `dependency`.
+    const fn can_use(self, dependency: Self) -> bool {
+        self as u8 <= dependency as u8
+    }
+
+    /// Returns the configuration spelling of the scope.
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Function => "function",
+            Self::Module => "module",
+            Self::Package => "package",
+            Self::Session => "session",
+        }
+    }
+}
+
+impl TryFrom<&str> for FixtureScope {
+    type Error = ();
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "function" => Ok(Self::Function),
+            "module" => Ok(Self::Module),
+            "package" => Ok(Self::Package),
+            "session" => Ok(Self::Session),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Result of resolving one fixture reference.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum FixtureResolution {
+    /// The reference resolves to a source fixture.
+    Resolved(FixtureId),
+
+    /// The reference resolves to a Karva-provided fixture.
+    Builtin,
+
+    /// Definitions with this name were rejected.
+    Rejected(Vec<FixtureId>),
+
+    /// No visible provider exists.
+    Missing,
+
+    /// Dynamic imports or decorator metadata prevent a definite answer.
+    Unknown,
+}
+
+/// One fixture reference from a function parameter.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct FixtureReference {
+    /// Requested fixture name.
+    name: String,
+
+    /// Range of the parameter name.
+    range: TextRange,
+
+    /// Static lookup result.
+    resolution: FixtureResolution,
+}
+
+/// A statically understood fixture declaration.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct FixtureDefinition {
+    /// Stable source identity.
+    id: FixtureId,
+
+    /// Public fixture name after literal decorator renaming.
+    name: String,
+
+    /// Python function name.
+    defining_name: String,
+
+    /// Function-name source range.
+    name_range: TextRange,
+
+    /// Statically known scope, or `None` for dynamic scope metadata.
+    scope: Option<FixtureScope>,
+
+    /// Statically known autouse value, or `None` for dynamic metadata.
+    auto_use: Option<bool>,
+
+    /// Fixture dependencies declared as non-variadic parameters.
+    dependencies: Vec<FixtureReference>,
+}
+
+#[derive(Clone, Debug)]
+struct ParsedFixture {
+    definition: FixtureDefinition,
+    public_name_known: bool,
+    invalid: Vec<InvalidMetadata>,
+}
+
+#[derive(Clone, Debug)]
+struct FixtureProvider {
+    definitions: Vec<FixtureDefinition>,
+    by_name: HashMap<String, FixtureId>,
+    rejected: HashMap<String, Vec<FixtureId>>,
+    unknown: bool,
+    diagnostics: Vec<SourceDiagnostic>,
+}
+
+#[derive(Clone, Debug)]
+struct InvalidMetadata {
+    range: TextRange,
+    message: String,
+}
+
+#[derive(Clone, Copy)]
+struct BuiltinFixture {
+    name: &'static str,
+    scope: FixtureScope,
+}
+
+const BUILTIN_FIXTURES: &[BuiltinFixture] = &[
+    BuiltinFixture {
+        name: "monkeypatch",
+        scope: FixtureScope::Function,
+    },
+    BuiltinFixture {
+        name: "capsys",
+        scope: FixtureScope::Function,
+    },
+    BuiltinFixture {
+        name: "capfd",
+        scope: FixtureScope::Function,
+    },
+    BuiltinFixture {
+        name: "capsysbinary",
+        scope: FixtureScope::Function,
+    },
+    BuiltinFixture {
+        name: "capfdbinary",
+        scope: FixtureScope::Function,
+    },
+    BuiltinFixture {
+        name: "caplog",
+        scope: FixtureScope::Function,
+    },
+    BuiltinFixture {
+        name: "tmp_path",
+        scope: FixtureScope::Function,
+    },
+    BuiltinFixture {
+        name: "temp_path",
+        scope: FixtureScope::Function,
+    },
+    BuiltinFixture {
+        name: "temp_dir",
+        scope: FixtureScope::Function,
+    },
+    BuiltinFixture {
+        name: "tmpdir",
+        scope: FixtureScope::Function,
+    },
+    BuiltinFixture {
+        name: "tmp_path_factory",
+        scope: FixtureScope::Session,
+    },
+    BuiltinFixture {
+        name: "tmpdir_factory",
+        scope: FixtureScope::Session,
+    },
+    BuiltinFixture {
+        name: "recwarn",
+        scope: FixtureScope::Function,
+    },
+];
+
+pub(super) fn analyze(
+    module: &CollectedModule,
+    try_import_fixtures: bool,
+) -> (Vec<FixtureDefinition>, Vec<SourceDiagnostic>) {
+    analyze_modules(module, &[], try_import_fixtures)
+}
+
+/// Analyzes a module against configuration providers ordered from the session
+/// root toward the nearest package.
+pub(super) fn analyze_modules(
+    current: &CollectedModule,
+    parents: &[&CollectedModule],
+    try_import_fixtures: bool,
+) -> (Vec<FixtureDefinition>, Vec<SourceDiagnostic>) {
+    let mut providers = parents
+        .iter()
+        .map(|module| parse_provider(module, try_import_fixtures))
+        .collect::<Vec<_>>();
+    let current_provider = parse_provider(current, try_import_fixtures);
+    providers.insert(0, current_provider);
+
+    let definition_order = providers
+        .iter()
+        .flat_map(|provider| provider.definitions.iter())
+        .map(|definition| definition.id.clone())
+        .collect::<Vec<_>>();
+    let mut definitions = providers
+        .iter()
+        .flat_map(|provider| provider.definitions.iter().cloned())
+        .map(|definition| (definition.id.clone(), definition))
+        .collect::<HashMap<_, _>>();
+
+    let resolutions = providers
+        .iter()
+        .flat_map(|provider| provider.definitions.iter())
+        .map(|definition| {
+            let resolved = definition
+                .dependencies
+                .iter()
+                .map(|reference| {
+                    (
+                        reference.name.clone(),
+                        resolve_reference(&providers, Some(definition), &reference.name),
+                    )
+                })
+                .collect::<Vec<_>>();
+            (definition.id.clone(), resolved)
+        })
+        .collect::<HashMap<_, _>>();
+
+    for definition in definitions.values_mut() {
+        if let Some(resolved) = resolutions.get(&definition.id) {
+            for reference in &mut definition.dependencies {
+                if let Some((_, resolution)) =
+                    resolved.iter().find(|(name, _)| name == &reference.name)
+                {
+                    reference.resolution = resolution.clone();
+                }
+            }
+        }
+    }
+
+    let mut diagnostics = providers
+        .iter()
+        .flat_map(|provider| provider.diagnostics.iter().cloned())
+        .collect::<Vec<_>>();
+    let all_definitions = definition_order
+        .iter()
+        .filter_map(|id| definitions.get(id))
+        .collect::<Vec<_>>();
+    diagnostics.extend(reference_diagnostics(&all_definitions));
+    diagnostics.extend(scope_diagnostics(&all_definitions));
+    diagnostics.extend(cycle_diagnostics(&all_definitions));
+    diagnostics.extend(test_diagnostics(current, &providers));
+
+    let current_definitions = providers[0]
+        .definitions
+        .iter()
+        .filter_map(|definition| definitions.get(&definition.id).cloned())
+        .collect::<Vec<_>>();
+    diagnostics.sort_by(|left, right| {
+        (
+            &left.location.path,
+            left.location.range.start(),
+            left.code.as_str(),
+        )
+            .cmp(&(
+                &right.location.path,
+                right.location.range.start(),
+                right.code.as_str(),
+            ))
+    });
+    (current_definitions, diagnostics)
+}
+
+impl FixtureProvider {
+    fn from_parsed(
+        parsed: &[ParsedFixture],
+        path: &Utf8PathBuf,
+        imported_fixtures_unknown: bool,
+    ) -> Self {
+        let mut diagnostics = Vec::new();
+        let rejected = duplicate_fixtures(parsed, path, &mut diagnostics);
+        let rejected = parsed
+            .iter()
+            .filter(|fixture| {
+                rejected.contains(&fixture.definition.id) || !fixture.invalid.is_empty()
+            })
+            .fold(
+                HashMap::<String, Vec<FixtureId>>::new(),
+                |mut by_name, fixture| {
+                    by_name
+                        .entry(fixture.definition.name.clone())
+                        .or_default()
+                        .push(fixture.definition.id.clone());
+                    by_name
+                },
+            );
+        diagnostics.extend(invalid_metadata_diagnostics(parsed, path));
+
+        let definitions = parsed
+            .iter()
+            .filter(|fixture| {
+                fixture.public_name_known
+                    && fixture.invalid.is_empty()
+                    && !rejected
+                        .values()
+                        .any(|ids| ids.contains(&fixture.definition.id))
+            })
+            .map(|fixture| fixture.definition.clone())
+            .collect::<Vec<_>>();
+        let by_name = definitions
+            .iter()
+            .map(|definition| (definition.name.clone(), definition.id.clone()))
+            .collect();
+
+        Self {
+            definitions,
+            by_name,
+            rejected,
+            unknown: imported_fixtures_unknown
+                || parsed.iter().any(|fixture| !fixture.public_name_known),
+            diagnostics,
+        }
+    }
+}
+
+fn parse_provider(module: &CollectedModule, try_import_fixtures: bool) -> FixtureProvider {
+    let path = module.path.path().clone();
+    let bindings = FixtureBindings::from_statements(&module.module_body);
+    let parsed = module
+        .fixture_function_defs
+        .iter()
+        .map(|function| parse_fixture(function, &path, bindings))
+        .collect::<Vec<_>>();
+    let imported_fixtures_unknown = (try_import_fixtures
+        || module.module_type == ModuleType::Configuration)
+        && has_external_imports(&module.module_body);
+    FixtureProvider::from_parsed(&parsed, &path, imported_fixtures_unknown)
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct FixtureBindings {
+    bare: bool,
+    karva: bool,
+    pytest: bool,
+}
+
+impl FixtureBindings {
+    fn from_statements(statements: &[Stmt]) -> Self {
+        let mut bindings = Self::default();
+        for statement in statements {
+            match statement {
+                Stmt::Import(import) => {
+                    for alias in &import.names {
+                        let binding = alias.asname.as_ref().map_or_else(
+                            || alias.name.as_str(),
+                            ruff_python_ast::Identifier::as_str,
+                        );
+                        match (alias.name.as_str(), binding) {
+                            ("karva", "karva") => bindings.karva = true,
+                            ("pytest", "pytest") => bindings.pytest = true,
+                            _ => {}
+                        }
+                    }
+                }
+                Stmt::ImportFrom(import)
+                    if import
+                        .module
+                        .as_ref()
+                        .is_some_and(|module| matches!(module.as_str(), "karva" | "pytest")) =>
+                {
+                    bindings.bare |= import.names.iter().any(|alias| {
+                        alias.name.as_str() == "fixture"
+                            && alias
+                                .asname
+                                .as_ref()
+                                .is_none_or(|name| name.as_str() == "fixture")
+                    });
+                }
+                _ => {}
+            }
+        }
+        bindings
+    }
+}
+
+fn parse_fixture(
+    function: &StmtFunctionDef,
+    path: &Utf8PathBuf,
+    bindings: FixtureBindings,
+) -> ParsedFixture {
+    let mut public_name = function.name.to_string();
+    let mut public_name_known = false;
+    let mut scope = None;
+    let mut auto_use = None;
+    let mut invalid = Vec::new();
+
+    if let Some(decorator) = function
+        .decorator_list
+        .iter()
+        .find(|decorator| is_fixture_decorator(&decorator.expression, bindings))
+    {
+        public_name_known = true;
+        scope = Some(FixtureScope::Function);
+        auto_use = Some(false);
+        let Some(call) = (match &decorator.expression {
+            Expr::Call(call) => Some(call),
+            _ => None,
+        }) else {
+            return ParsedFixture {
+                definition: fixture_definition(function, path, public_name, scope, auto_use),
+                public_name_known,
+                invalid,
+            };
+        };
+        if !call.arguments.args.is_empty() {
+            public_name_known = false;
+            scope = None;
+            auto_use = None;
+        }
+        for keyword in &call.arguments.keywords {
+            let Some(name) = keyword
+                .arg
+                .as_ref()
+                .map(ruff_python_ast::Identifier::as_str)
+            else {
+                public_name_known = false;
+                scope = None;
+                auto_use = None;
+                continue;
+            };
+            match name {
+                "name" => match &keyword.value {
+                    Expr::StringLiteral(value) => {
+                        value.value.to_str().clone_into(&mut public_name);
+                    }
+                    Expr::NoneLiteral(_) => {}
+                    Expr::NumberLiteral(_) | Expr::BooleanLiteral(_) => {
+                        invalid.push(InvalidMetadata {
+                            range: keyword.value.range(),
+                            message: "Fixture `name` must be a string or `None`".to_owned(),
+                        });
+                    }
+                    _ => public_name_known = false,
+                },
+                "scope" => match &keyword.value {
+                    Expr::StringLiteral(value) => {
+                        let value = value.value.to_str();
+                        match FixtureScope::try_from(value) {
+                            Ok(value) => scope = Some(value),
+                            Err(()) => invalid.push(InvalidMetadata {
+                                range: keyword.value.range(),
+                                message: format!("Invalid fixture scope `{value}`"),
+                            }),
+                        }
+                    }
+                    Expr::NumberLiteral(_) | Expr::BooleanLiteral(_) | Expr::NoneLiteral(_) => {
+                        invalid.push(InvalidMetadata {
+                            range: keyword.value.range(),
+                            message: "Fixture `scope` must be a string or callable".to_owned(),
+                        });
+                    }
+                    _ => scope = None,
+                },
+                "auto_use" | "autouse" => match &keyword.value {
+                    Expr::BooleanLiteral(value) => auto_use = Some(value.value),
+                    Expr::StringLiteral(_) | Expr::NumberLiteral(_) | Expr::NoneLiteral(_) => {
+                        invalid.push(InvalidMetadata {
+                            range: keyword.value.range(),
+                            message: "Fixture autouse value must be a boolean".to_owned(),
+                        });
+                    }
+                    _ => auto_use = None,
+                },
+                _ => invalid.push(InvalidMetadata {
+                    range: keyword.range,
+                    message: format!("Unsupported fixture argument `{name}`"),
+                }),
+            }
+        }
+    }
+
+    ParsedFixture {
+        definition: fixture_definition(function, path, public_name, scope, auto_use),
+        public_name_known,
+        invalid,
+    }
+}
+
+fn fixture_definition(
+    function: &StmtFunctionDef,
+    path: &Utf8PathBuf,
+    name: String,
+    scope: Option<FixtureScope>,
+    auto_use: Option<bool>,
+) -> FixtureDefinition {
+    FixtureDefinition {
+        id: FixtureId {
+            path: path.clone(),
+            range: function.range,
+        },
+        name,
+        defining_name: function.name.to_string(),
+        name_range: function.name.range,
+        scope,
+        auto_use,
+        dependencies: function
+            .parameters
+            .iter_non_variadic_params()
+            .map(|parameter| FixtureReference {
+                name: parameter.parameter.name.to_string(),
+                range: parameter.parameter.name.range,
+                resolution: FixtureResolution::Unknown,
+            })
+            .collect(),
+    }
+}
+
+fn is_fixture_decorator(expression: &Expr, bindings: FixtureBindings) -> bool {
+    match expression {
+        Expr::Call(call) => is_fixture_reference(call.func.as_ref(), bindings),
+        _ => is_fixture_reference(expression, bindings),
+    }
+}
+
+fn is_fixture_reference(expression: &Expr, bindings: FixtureBindings) -> bool {
+    match expression {
+        Expr::Name(name) => bindings.bare && name.id == "fixture",
+        Expr::Attribute(attribute) if attribute.attr.id == "fixture" => {
+            matches!(
+                attribute.value.as_ref(),
+                Expr::Name(name)
+                    if (bindings.karva && name.id == "karva")
+                        || (bindings.pytest && name.id == "pytest")
+            )
+        }
+        _ => false,
+    }
+}
+
+fn invalid_metadata_diagnostics(
+    fixtures: &[ParsedFixture],
+    path: &Utf8PathBuf,
+) -> Vec<SourceDiagnostic> {
+    fixtures
+        .iter()
+        .flat_map(|fixture| {
+            fixture.invalid.iter().map(|invalid| SourceDiagnostic {
+                code: DiagnosticCode::InvalidFixture,
+                message: invalid.message.clone(),
+                location: SourceLocation {
+                    path: path.clone(),
+                    range: invalid.range,
+                },
+                related: Vec::new(),
+            })
+        })
+        .collect()
+}
+
+fn duplicate_fixtures(
+    fixtures: &[ParsedFixture],
+    path: &Utf8PathBuf,
+    diagnostics: &mut Vec<SourceDiagnostic>,
+) -> HashSet<FixtureId> {
+    let mut first_by_name: HashMap<&str, &ParsedFixture> = HashMap::new();
+    let mut rejected = HashSet::new();
+    for fixture in fixtures
+        .iter()
+        .filter(|fixture| fixture.public_name_known && fixture.invalid.is_empty())
+    {
+        if let Some(first) = first_by_name.get(fixture.definition.name.as_str()) {
+            rejected.insert(first.definition.id.clone());
+            rejected.insert(fixture.definition.id.clone());
+            diagnostics.push(SourceDiagnostic {
+                code: DiagnosticCode::DuplicateFixture,
+                message: format!(
+                    "Fixture `{}` is defined more than once",
+                    fixture.definition.name
+                ),
+                location: SourceLocation {
+                    path: path.clone(),
+                    range: fixture.definition.name_range,
+                },
+                related: vec![RelatedInformation {
+                    message: "First definition is here".to_owned(),
+                    location: SourceLocation {
+                        path: path.clone(),
+                        range: first.definition.name_range,
+                    },
+                }],
+            });
+        } else {
+            first_by_name.insert(&fixture.definition.name, fixture);
+        }
+    }
+    rejected
+}
+
+fn resolve_reference(
+    providers: &[FixtureProvider],
+    active: Option<&FixtureDefinition>,
+    name: &str,
+) -> FixtureResolution {
+    for provider in providers {
+        if let Some(id) = provider.by_name.get(name) {
+            if active.is_none_or(|fixture| fixture.id != *id) {
+                return FixtureResolution::Resolved(id.clone());
+            }
+        }
+        if let Some(rejected) = provider.rejected.get(name) {
+            return FixtureResolution::Rejected(rejected.clone());
+        }
+        if provider.unknown {
+            return FixtureResolution::Unknown;
+        }
+    }
+
+    if let Some(active) = active
+        && active.name == name
+    {
+        return FixtureResolution::Resolved(active.id.clone());
+    }
+
+    if builtin(name).is_some() {
+        FixtureResolution::Builtin
+    } else {
+        FixtureResolution::Missing
+    }
+}
+
+fn reference_diagnostics(fixtures: &[&FixtureDefinition]) -> Vec<SourceDiagnostic> {
+    fixtures
+        .iter()
+        .flat_map(|fixture| {
+            fixture.dependencies.iter().filter_map(|reference| {
+                let related = match &reference.resolution {
+                    FixtureResolution::Rejected(definitions) => definitions
+                        .iter()
+                        .map(|definition| RelatedInformation {
+                            message: "Rejected fixture definition is here".to_owned(),
+                            location: SourceLocation {
+                                path: definition.path.clone(),
+                                range: definition.range,
+                            },
+                        })
+                        .collect(),
+                    FixtureResolution::Missing => Vec::new(),
+                    _ => return None,
+                };
+                Some(SourceDiagnostic {
+                    code: DiagnosticCode::MissingFixture,
+                    message: format!(
+                        "Fixture `{}` requires missing fixture `{}`",
+                        fixture.name, reference.name
+                    ),
+                    location: SourceLocation {
+                        path: fixture.id.path.clone(),
+                        range: reference.range,
+                    },
+                    related,
+                })
+            })
+        })
+        .collect()
+}
+
+fn scope_diagnostics(fixtures: &[&FixtureDefinition]) -> Vec<SourceDiagnostic> {
+    let by_id = fixtures
+        .iter()
+        .map(|fixture| (&fixture.id, *fixture))
+        .collect::<HashMap<_, _>>();
+    let mut diagnostics = Vec::new();
+    for fixture in fixtures {
+        let Some(scope) = fixture.scope else {
+            continue;
+        };
+        for reference in &fixture.dependencies {
+            let dependency = match &reference.resolution {
+                FixtureResolution::Resolved(id) => by_id.get(id).and_then(|fixture| {
+                    fixture
+                        .scope
+                        .map(|scope| (fixture.name.as_str(), scope, Some(*fixture)))
+                }),
+                FixtureResolution::Builtin => {
+                    builtin(&reference.name).map(|fixture| (fixture.name, fixture.scope, None))
+                }
+                _ => None,
+            };
+            let Some((dependency_name, dependency_scope, dependency)) = dependency else {
+                continue;
+            };
+            if !scope.can_use(dependency_scope) {
+                let mut related = vec![RelatedInformation {
+                    message: format!("Fixture `{}` has `{}` scope", fixture.name, scope.as_str()),
+                    location: SourceLocation {
+                        path: fixture.id.path.clone(),
+                        range: fixture.name_range,
+                    },
+                }];
+                if let Some(dependency) = dependency {
+                    related.push(RelatedInformation {
+                        message: format!(
+                            "Fixture `{dependency_name}` has `{}` scope",
+                            dependency_scope.as_str()
+                        ),
+                        location: SourceLocation {
+                            path: dependency.id.path.clone(),
+                            range: dependency.name_range,
+                        },
+                    });
+                }
+                diagnostics.push(SourceDiagnostic {
+                    code: DiagnosticCode::FixtureScopeMismatch,
+                    message: format!(
+                        "Fixture `{}` with `{}` scope cannot depend on fixture `{dependency_name}` with `{}` scope",
+                        fixture.name,
+                        scope.as_str(),
+                        dependency_scope.as_str(),
+                    ),
+                    location: SourceLocation {
+                        path: fixture.id.path.clone(),
+                        range: reference.range,
+                    },
+                    related,
+                });
+            }
+        }
+    }
+    diagnostics
+}
+
+fn cycle_diagnostics(fixtures: &[&FixtureDefinition]) -> Vec<SourceDiagnostic> {
+    let by_id = fixtures
+        .iter()
+        .map(|fixture| (fixture.id.clone(), *fixture))
+        .collect::<HashMap<_, _>>();
+    let mut visited = HashSet::new();
+    let mut active = Vec::new();
+    let mut reported = HashSet::new();
+    let mut diagnostics = Vec::new();
+
+    for fixture in fixtures {
+        visit_fixture(
+            fixture,
+            &by_id,
+            &mut visited,
+            &mut active,
+            &mut reported,
+            &mut diagnostics,
+        );
+    }
+    diagnostics
+}
+
+fn visit_fixture<'a>(
+    fixture: &'a FixtureDefinition,
+    by_id: &HashMap<FixtureId, &'a FixtureDefinition>,
+    visited: &mut HashSet<FixtureId>,
+    active: &mut Vec<&'a FixtureDefinition>,
+    reported: &mut HashSet<FixtureId>,
+    diagnostics: &mut Vec<SourceDiagnostic>,
+) {
+    if visited.contains(&fixture.id) {
+        return;
+    }
+    active.push(fixture);
+    for reference in &fixture.dependencies {
+        let FixtureResolution::Resolved(id) = &reference.resolution else {
+            continue;
+        };
+        let Some(dependency) = by_id.get(id).copied() else {
+            continue;
+        };
+        if let Some(start) = active.iter().position(|active| active.id == dependency.id) {
+            if reported.insert(dependency.id.clone()) {
+                let cycle = active[start..]
+                    .iter()
+                    .map(|fixture| fixture.name.as_str())
+                    .chain(std::iter::once(dependency.name.as_str()))
+                    .collect::<Vec<_>>();
+                diagnostics.push(SourceDiagnostic {
+                    code: DiagnosticCode::FixtureCycle,
+                    message: format!("Fixture dependency cycle: {}", cycle.join(" -> ")),
+                    location: SourceLocation {
+                        path: fixture.id.path.clone(),
+                        range: reference.range,
+                    },
+                    related: active[start..]
+                        .iter()
+                        .map(|fixture| RelatedInformation {
+                            message: format!(
+                                "Fixture `{}` participates in this cycle",
+                                fixture.name
+                            ),
+                            location: SourceLocation {
+                                path: fixture.id.path.clone(),
+                                range: fixture.name_range,
+                            },
+                        })
+                        .collect(),
+                });
+            }
+            continue;
+        }
+        visit_fixture(dependency, by_id, visited, active, reported, diagnostics);
+    }
+    let _ = active.pop();
+    visited.insert(fixture.id.clone());
+}
+
+fn test_diagnostics(
+    module: &CollectedModule,
+    providers: &[FixtureProvider],
+) -> Vec<SourceDiagnostic> {
+    let path = module.path.path();
+    let mut diagnostics = Vec::new();
+    for test in &module.test_function_defs {
+        let Some(parametrized) = parametrized_names(test) else {
+            continue;
+        };
+        diagnostics.extend(
+            test.parameters
+                .iter_non_variadic_params()
+                .filter(|parameter| !parametrized.contains(parameter.parameter.name.as_str()))
+                .map(|parameter| FixtureReference {
+                    name: parameter.parameter.name.to_string(),
+                    range: parameter.parameter.name.range,
+                    resolution: FixtureResolution::Unknown,
+                })
+                .filter_map(|reference| {
+                    let resolution = resolve_reference(providers, None, &reference.name);
+                    let related = match resolution {
+                        FixtureResolution::Rejected(definitions) => definitions
+                            .into_iter()
+                            .map(|definition| RelatedInformation {
+                                message: "Rejected fixture definition is here".to_owned(),
+                                location: SourceLocation {
+                                    path: definition.path,
+                                    range: definition.range,
+                                },
+                            })
+                            .collect(),
+                        FixtureResolution::Missing => Vec::new(),
+                        _ => return None,
+                    };
+                    Some(SourceDiagnostic {
+                        code: DiagnosticCode::MissingFixture,
+                        message: format!(
+                            "Test `{}` requires missing fixture `{}`",
+                            test.name, reference.name
+                        ),
+                        location: SourceLocation {
+                            path: path.clone(),
+                            range: reference.range,
+                        },
+                        related,
+                    })
+                }),
+        );
+    }
+    diagnostics
+}
+
+/// Returns `None` when a decorator may supply arguments dynamically.
+fn parametrized_names(function: &StmtFunctionDef) -> Option<HashSet<String>> {
+    let mut names = HashSet::new();
+    for decorator in &function.decorator_list {
+        let Expr::Call(call) = &decorator.expression else {
+            return None;
+        };
+        if !is_parametrize_reference(call.func.as_ref()) {
+            return None;
+        }
+        let argnames = call.arguments.args.first().or_else(|| {
+            call.arguments
+                .keywords
+                .iter()
+                .find(|keyword| keyword.arg.as_ref().is_some_and(|name| name == "argnames"))
+                .map(|keyword| &keyword.value)
+        })?;
+        names.extend(literal_names(argnames)?);
+    }
+    Some(names)
+}
+
+fn is_parametrize_reference(expression: &Expr) -> bool {
+    match expression {
+        Expr::Name(name) => name.id == "parametrize",
+        Expr::Attribute(attribute) if attribute.attr.id == "parametrize" => {
+            matches!(
+                attribute.value.as_ref(),
+                Expr::Attribute(namespace)
+                    if matches!(
+                        (namespace.value.as_ref(), namespace.attr.id.as_str()),
+                        (Expr::Name(name), "mark") if name.id == "pytest"
+                    ) || matches!(
+                        (namespace.value.as_ref(), namespace.attr.id.as_str()),
+                        (Expr::Name(name), "tags") if name.id == "karva"
+                    )
+            )
+        }
+        _ => false,
+    }
+}
+
+fn literal_names(expression: &Expr) -> Option<Vec<String>> {
+    match expression {
+        Expr::StringLiteral(value) => Some(
+            value
+                .value
+                .to_str()
+                .split(',')
+                .map(str::trim)
+                .filter(|name| !name.is_empty())
+                .map(str::to_owned)
+                .collect(),
+        ),
+        Expr::List(list) => list.elts.iter().map(literal_name).collect(),
+        Expr::Tuple(tuple) => tuple.elts.iter().map(literal_name).collect(),
+        _ => None,
+    }
+}
+
+fn literal_name(expression: &Expr) -> Option<String> {
+    let Expr::StringLiteral(value) = expression else {
+        return None;
+    };
+    Some(value.value.to_str().to_owned())
+}
+
+fn has_external_imports(statements: &[Stmt]) -> bool {
+    statements.iter().any(|statement| match statement {
+        Stmt::Import(import) => import.names.iter().any(|name| {
+            !matches!(
+                name.name.as_str(),
+                "karva" | "pytest" | "typing" | "collections"
+            )
+        }),
+        Stmt::ImportFrom(import) => import.module.as_ref().is_some_and(|module| {
+            !matches!(
+                module.as_str(),
+                "karva" | "pytest" | "typing" | "collections.abc"
+            )
+        }),
+        _ => false,
+    })
+}
+
+fn builtin(name: &str) -> Option<BuiltinFixture> {
+    BUILTIN_FIXTURES
+        .iter()
+        .find(|fixture| fixture.name == name)
+        .copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use camino::{Utf8Path, Utf8PathBuf};
+    use ruff_python_ast::PythonVersion;
+
+    use crate::{
+        DiagnosticCode, FixtureResolution, SourceAnalysisSettings, analyze_source, analyze_sources,
+    };
+
+    fn analyze(source: &str) -> crate::SourceAnalysis {
+        analyze_source(
+            &Utf8PathBuf::from("/project/test_example.py"),
+            Utf8Path::new("/project"),
+            source.to_owned(),
+            &SourceAnalysisSettings {
+                python_version: PythonVersion::PY312,
+                test_function_prefix: "test".to_owned(),
+                try_import_fixtures: false,
+            },
+        )
+        .expect("source should analyze")
+    }
+
+    fn diagnostic_codes(source: &str) -> Vec<DiagnosticCode> {
+        analyze(source)
+            .diagnostics
+            .into_iter()
+            .map(|diagnostic| diagnostic.code)
+            .collect()
+    }
+
+    fn module(path: &str, source: &str) -> karva_collector::CollectedModule {
+        analyze_source(
+            &Utf8PathBuf::from(path),
+            Utf8Path::new("/project"),
+            source.to_owned(),
+            &SourceAnalysisSettings {
+                python_version: PythonVersion::PY312,
+                test_function_prefix: "test".to_owned(),
+                try_import_fixtures: false,
+            },
+        )
+        .expect("source should analyze")
+        .module
+    }
+
+    #[test]
+    fn reports_missing_test_fixture() {
+        assert_eq!(
+            diagnostic_codes("def test_example(database): pass\n"),
+            [DiagnosticCode::MissingFixture]
+        );
+    }
+
+    #[test]
+    fn resolves_local_and_builtin_fixtures() {
+        assert!(
+            analyze(
+                "from karva import fixture\n\n@fixture\ndef database(): pass\n\ndef test_example(database, tmp_path): pass\n"
+            )
+            .diagnostics
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn reports_duplicate_fixture_names() {
+        let analysis = analyze(
+            "from karva import fixture\n\n@fixture\ndef first(): pass\n\n@fixture(name=\"first\")\ndef second(): pass\n",
+        );
+
+        assert_eq!(
+            analysis
+                .diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.code)
+                .collect::<Vec<_>>(),
+            [DiagnosticCode::DuplicateFixture]
+        );
+        assert_eq!(analysis.diagnostics[0].related.len(), 1);
+    }
+
+    #[test]
+    fn reports_invalid_literal_scope() {
+        let analysis = analyze(
+            "from karva import fixture\n\n@fixture(scope=\"forever\")\ndef database(): pass\n",
+        );
+
+        assert_eq!(analysis.diagnostics[0].code, DiagnosticCode::InvalidFixture);
+        assert_eq!(
+            analysis.diagnostics[0].message,
+            "Invalid fixture scope `forever`"
+        );
+    }
+
+    #[test]
+    fn dynamic_scope_remains_unknown() {
+        assert!(
+            analyze(
+                "from karva import fixture\n\n@fixture(scope=choose_scope)\ndef database(missing): pass\n"
+            )
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != DiagnosticCode::FixtureScopeMismatch)
+        );
+    }
+
+    #[test]
+    fn reports_dependency_cycle() {
+        assert!(diagnostic_codes(
+            "from karva import fixture\n\n@fixture\ndef first(second): pass\n\n@fixture\ndef second(first): pass\n"
+        )
+        .contains(&DiagnosticCode::FixtureCycle));
+    }
+
+    #[test]
+    fn reports_scope_mismatch() {
+        assert!(diagnostic_codes(
+            "from karva import fixture\n\n@fixture\ndef narrow(): pass\n\n@fixture(scope=\"session\")\ndef broad(narrow): pass\n"
+        )
+        .contains(&DiagnosticCode::FixtureScopeMismatch));
+    }
+
+    #[test]
+    fn parametrized_arguments_are_not_fixtures() {
+        assert!(
+            analyze(
+                "import pytest\n\n@pytest.mark.parametrize(\"value\", [1])\ndef test_example(value, tmp_path): pass\n"
+            )
+            .diagnostics
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn unresolved_imports_suppress_conftest_missing_error() {
+        let analysis = analyze_source(
+            &Utf8PathBuf::from("/project/conftest.py"),
+            Utf8Path::new("/project"),
+            "from support import external\nfrom karva import fixture\n\n@fixture\ndef local(external): pass\n".to_owned(),
+            &SourceAnalysisSettings {
+                python_version: PythonVersion::PY312,
+                test_function_prefix: "test".to_owned(),
+                try_import_fixtures: false,
+            },
+        )
+        .expect("source should analyze");
+
+        assert!(analysis.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn same_name_fixture_uses_nearest_parent_when_overridden() {
+        let parent = module(
+            "/project/conftest.py",
+            "from karva import fixture\n\n@fixture\ndef database(): pass\n",
+        );
+        let current = module(
+            "/project/test_example.py",
+            "from karva import fixture\n\n@fixture\ndef database(database): pass\n\ndef test_example(database): pass\n",
+        );
+        let analysis = analyze_sources(current, &[parent], &settings());
+
+        assert!(analysis.diagnostics.is_empty());
+        let dependency = &analysis.fixtures[0].dependencies[0].resolution;
+        assert!(
+            matches!(dependency, FixtureResolution::Resolved(id) if id.path == "/project/conftest.py")
+        );
+    }
+
+    #[test]
+    fn cross_file_scope_mismatch_has_related_parent_location() {
+        let parent = module(
+            "/project/conftest.py",
+            "from karva import fixture\n\n@fixture\ndef database(): pass\n",
+        );
+        let current = module(
+            "/project/test_example.py",
+            "from karva import fixture\n\n@fixture(scope=\"session\")\ndef shared(database): pass\n",
+        );
+        let analysis = analyze_sources(current, &[parent], &settings());
+
+        let diagnostic = analysis
+            .diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == DiagnosticCode::FixtureScopeMismatch)
+            .expect("scope mismatch");
+        assert!(
+            diagnostic
+                .related
+                .iter()
+                .any(|related| related.location.path == "/project/conftest.py")
+        );
+        assert_eq!(diagnostic.location.path, "/project/test_example.py");
+    }
+
+    #[test]
+    fn cross_file_cycle_reports_both_source_paths() {
+        let parent = module(
+            "/project/conftest.py",
+            "from karva import fixture\n\n@fixture\ndef parent(child): pass\n",
+        );
+        let current = module(
+            "/project/test_example.py",
+            "from karva import fixture\n\n@fixture\ndef child(parent): pass\n",
+        );
+        let analysis = analyze_sources(current, &[parent], &settings());
+
+        let diagnostic = analysis
+            .diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == DiagnosticCode::FixtureCycle)
+            .expect("fixture cycle");
+        assert!(matches!(
+            diagnostic.location.path.as_str(),
+            "/project/conftest.py" | "/project/test_example.py"
+        ));
+        assert!(
+            diagnostic
+                .related
+                .iter()
+                .any(|related| related.location.path == "/project/test_example.py")
+        );
+    }
+
+    #[test]
+    fn rejected_fixture_blocks_parent_fallback() {
+        let parent = module(
+            "/project/conftest.py",
+            "from karva import fixture\n\n@fixture\ndef database(): pass\n",
+        );
+        let current = module(
+            "/project/test_example.py",
+            "from karva import fixture\n\n@fixture(scope=\"invalid\")\ndef database(): pass\n\ndef test_example(database): pass\n",
+        );
+        let analysis = analyze_sources(current, &[parent], &settings());
+
+        let diagnostic = analysis
+            .diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == DiagnosticCode::MissingFixture)
+            .expect("rejected fixture diagnostic");
+        assert!(
+            diagnostic
+                .related
+                .iter()
+                .any(|related| related.location.path == "/project/test_example.py")
+        );
+    }
+
+    #[test]
+    fn unknown_fixture_decorator_suppresses_false_missing_error() {
+        let analysis = analyze(
+            "from custom import fixture\n\n@fixture\ndef database(): pass\n\ndef test_example(database): pass\n",
+        );
+
+        assert!(analysis.fixtures.is_empty());
+        assert!(analysis.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn known_fixture_import_produces_a_provider() {
+        let analysis = analyze(
+            "from karva import fixture\n\n@fixture\ndef database(): pass\n\ndef test_example(database): pass\n",
+        );
+
+        assert_eq!(analysis.fixtures[0].name, "database");
+        assert!(analysis.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_unsupported_fixture_argument() {
+        assert_eq!(
+            diagnostic_codes(
+                "from karva import fixture\n\n@fixture(reuse=True)\ndef database(): pass\n"
+            ),
+            [DiagnosticCode::InvalidFixture]
+        );
+    }
+
+    #[test]
+    fn karva_parametrized_arguments_are_not_fixtures() {
+        assert!(
+            analyze(
+                "import karva\n\n@karva.tags.parametrize(\"value\", [1])\ndef test_example(value, tmp_path): pass\n"
+            )
+            .diagnostics
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn unknown_parametrize_decorator_suppresses_false_missing_error() {
+        assert!(diagnostic_codes(
+            "import custom\n\n@custom.parametrize(\"value\", [1])\ndef test_example(value): pass\n"
+        )
+        .is_empty());
+    }
+
+    fn settings() -> SourceAnalysisSettings {
+        SourceAnalysisSettings {
+            python_version: PythonVersion::PY312,
+            test_function_prefix: "test".to_owned(),
+            try_import_fixtures: false,
+        }
+    }
+}

--- a/crates/karva_ide/src/lib.rs
+++ b/crates/karva_ide/src/lib.rs
@@ -1,0 +1,154 @@
+//! Source-only editor analysis for Karva projects.
+
+#![expect(
+    dead_code,
+    reason = "language-server consumers land in later stack layers"
+)]
+
+mod fixture;
+
+use camino::{Utf8Path, Utf8PathBuf};
+use karva_collector::{CollectedModule, CollectionSettings, collect_source};
+use ruff_python_ast::PythonVersion;
+use ruff_text_size::TextRange;
+
+use fixture::FixtureDefinition;
+
+#[cfg(test)]
+pub(crate) use fixture::FixtureResolution;
+
+/// Settings required to analyze one Python source document.
+#[derive(Clone, Debug)]
+pub(crate) struct SourceAnalysisSettings {
+    /// Python grammar version used by the project.
+    python_version: PythonVersion,
+
+    /// Prefix identifying test functions.
+    test_function_prefix: String,
+
+    /// Whether runtime discovery may import fixture providers from test modules.
+    try_import_fixtures: bool,
+}
+
+/// Stable identifier for a source diagnostic.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DiagnosticCode {
+    /// Two fixtures in one module resolve to the same public name.
+    DuplicateFixture,
+
+    /// A fixture decorator contains a statically invalid argument.
+    InvalidFixture,
+
+    /// A fixture or test requires a name with no visible provider.
+    MissingFixture,
+
+    /// Fixture dependencies contain a cycle.
+    FixtureCycle,
+
+    /// A broader fixture depends on a narrower fixture.
+    FixtureScopeMismatch,
+}
+
+impl DiagnosticCode {
+    /// Returns the stable protocol code.
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::DuplicateFixture => "duplicate-fixture",
+            Self::InvalidFixture => "invalid-fixture",
+            Self::MissingFixture => "missing-fixture",
+            Self::FixtureCycle => "fixture-cycle",
+            Self::FixtureScopeMismatch => "fixture-scope-mismatch",
+        }
+    }
+}
+
+/// A source location independent of editor protocol types.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SourceLocation {
+    /// File containing the location.
+    path: Utf8PathBuf,
+
+    /// UTF-8 byte range within the file.
+    range: TextRange,
+}
+
+/// Secondary location explaining a diagnostic.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RelatedInformation {
+    /// Human-readable relationship to the primary diagnostic.
+    message: String,
+
+    /// Relevant source location.
+    location: SourceLocation,
+}
+
+/// A definite source-only Karva diagnostic.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SourceDiagnostic {
+    /// Stable diagnostic identifier.
+    code: DiagnosticCode,
+
+    /// User-facing explanation.
+    message: String,
+
+    /// Primary source location.
+    location: SourceLocation,
+
+    /// Supporting source locations.
+    related: Vec<RelatedInformation>,
+}
+
+/// Parsed source plus Karva-specific semantic facts.
+#[derive(Debug)]
+pub(crate) struct SourceAnalysis {
+    /// Collector output retained for later editor features.
+    module: CollectedModule,
+
+    /// Statically understood fixture declarations.
+    fixtures: Vec<FixtureDefinition>,
+
+    /// Definite diagnostics. Unknown dynamic behavior remains silent.
+    diagnostics: Vec<SourceDiagnostic>,
+}
+
+/// Analyzes unsaved Python source without importing Python or launching workers.
+pub(crate) fn analyze_source(
+    path: &Utf8PathBuf,
+    project_root: &Utf8Path,
+    source_text: String,
+    settings: &SourceAnalysisSettings,
+) -> Option<SourceAnalysis> {
+    let collection_settings = CollectionSettings {
+        python_version: settings.python_version,
+        test_function_prefix: &settings.test_function_prefix,
+        respect_ignore_files: true,
+        collect_fixtures: true,
+        collect_doctests: false,
+    };
+    let module = collect_source(path, project_root, source_text, &collection_settings, &[])?;
+    let (fixtures, diagnostics) = fixture::analyze(&module, settings.try_import_fixtures);
+    Some(SourceAnalysis {
+        module,
+        fixtures,
+        diagnostics,
+    })
+}
+
+/// Analyzes a current document against already-collected configuration modules.
+///
+/// `parents` must be ordered from the project/session root toward the current
+/// package, matching runtime fixture lookup precedence.
+pub(crate) fn analyze_sources(
+    current: CollectedModule,
+    parents: &[CollectedModule],
+    settings: &SourceAnalysisSettings,
+) -> SourceAnalysis {
+    let parent_modules = parents.iter().collect::<Vec<_>>();
+    let (fixtures, diagnostics) =
+        fixture::analyze_modules(&current, &parent_modules, settings.try_import_fixtures);
+    SourceAnalysis {
+        module: current,
+        fixtures,
+        diagnostics,
+    }
+}

--- a/crates/karva_language_server/Cargo.toml
+++ b/crates/karva_language_server/Cargo.toml
@@ -20,17 +20,24 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+camino = { workspace = true }
+karva_metadata = { workspace = true }
+karva_project = { workspace = true }
+karva_python_semantic = { workspace = true }
 karva_version = { workspace = true }
 lsp-server = { workspace = true }
 lsp-types = { workspace = true }
+ruff_python_ast = { workspace = true }
 ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/karva_language_server/Cargo.toml
+++ b/crates/karva_language_server/Cargo.toml
@@ -24,7 +24,6 @@ camino = { workspace = true }
 crossbeam-channel = { workspace = true }
 karva_metadata = { workspace = true }
 karva_project = { workspace = true }
-karva_python_semantic = { workspace = true }
 karva_version = { workspace = true }
 lsp-server = { workspace = true }
 lsp-types = { workspace = true }

--- a/crates/karva_language_server/Cargo.toml
+++ b/crates/karva_language_server/Cargo.toml
@@ -23,7 +23,14 @@ anyhow = { workspace = true }
 karva_version = { workspace = true }
 lsp-server = { workspace = true }
 lsp-types = { workspace = true }
+ruff_source_file = { workspace = true }
+ruff_text_size = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/karva_language_server/Cargo.toml
+++ b/crates/karva_language_server/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 camino = { workspace = true }
+crossbeam-channel = { workspace = true }
 karva_metadata = { workspace = true }
 karva_project = { workspace = true }
 karva_python_semantic = { workspace = true }

--- a/crates/karva_language_server/src/capabilities.rs
+++ b/crates/karva_language_server/src/capabilities.rs
@@ -1,33 +1,57 @@
-use lsp_types::{ClientCapabilities, PositionEncodingKind, ServerCapabilities};
+#![expect(
+    clippy::redundant_pub_crate,
+    reason = "server uses these helpers across private sibling modules"
+)]
+
+use lsp_types::{
+    ClientCapabilities, ServerCapabilities, TextDocumentSyncKind, TextDocumentSyncOptions,
+    WorkspaceFoldersServerCapabilities,
+};
+
+use crate::PositionEncoding;
 
 /// Chooses the most efficient position encoding supported by the client.
-pub(crate) fn position_encoding(capabilities: &ClientCapabilities) -> PositionEncodingKind {
+pub(super) fn position_encoding(capabilities: &ClientCapabilities) -> PositionEncoding {
     capabilities
         .general
         .as_ref()
         .and_then(|general| general.position_encodings.as_ref())
         .and_then(|encodings| {
-            [
-                PositionEncodingKind::UTF8,
-                PositionEncodingKind::UTF32,
-                PositionEncodingKind::UTF16,
-            ]
-            .into_iter()
-            .find(|preferred| encodings.contains(preferred))
+            encodings
+                .iter()
+                .filter_map(|encoding| PositionEncoding::try_from(encoding).ok())
+                .max()
         })
-        .unwrap_or(PositionEncodingKind::UTF16)
+        .unwrap_or_default()
 }
 
-pub(crate) fn server_capabilities(position_encoding: PositionEncodingKind) -> ServerCapabilities {
+pub(super) fn server_capabilities(position_encoding: PositionEncoding) -> ServerCapabilities {
     ServerCapabilities {
-        position_encoding: Some(position_encoding),
+        position_encoding: Some(position_encoding.into()),
+        text_document_sync: Some(
+            TextDocumentSyncOptions {
+                open_close: Some(true),
+                change: Some(TextDocumentSyncKind::Incremental),
+                will_save: Some(false),
+                will_save_wait_until: Some(false),
+                save: None,
+            }
+            .into(),
+        ),
+        workspace: Some(lsp_types::WorkspaceOptions {
+            workspace_folders: Some(WorkspaceFoldersServerCapabilities {
+                supported: Some(true),
+                change_notifications: Some(true.into()),
+            }),
+            ..lsp_types::WorkspaceOptions::default()
+        }),
         ..ServerCapabilities::default()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use lsp_types::{ClientCapabilities, GeneralClientCapabilities};
+    use lsp_types::{ClientCapabilities, GeneralClientCapabilities, PositionEncodingKind};
 
     use super::*;
 
@@ -35,7 +59,7 @@ mod tests {
     fn defaults_to_utf16() {
         assert_eq!(
             position_encoding(&ClientCapabilities::default()),
-            PositionEncodingKind::UTF16
+            PositionEncoding::UTF16
         );
     }
 
@@ -52,6 +76,6 @@ mod tests {
             ..ClientCapabilities::default()
         };
 
-        assert_eq!(position_encoding(&capabilities), PositionEncodingKind::UTF8);
+        assert_eq!(position_encoding(&capabilities), PositionEncoding::UTF8);
     }
 }

--- a/crates/karva_language_server/src/document.rs
+++ b/crates/karva_language_server/src/document.rs
@@ -1,0 +1,63 @@
+//! Open text documents and LSP source-position conversion.
+
+mod range;
+mod text_document;
+
+use lsp_types::PositionEncodingKind;
+
+#[expect(
+    clippy::redundant_pub_crate,
+    reason = "session consumes this error across a private sibling module"
+)]
+pub(super) use text_document::DocumentChangeError;
+pub use text_document::TextDocument;
+
+/// A supported LSP source-position encoding, ordered by server preference.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PositionEncoding {
+    /// UTF-16 is the encoding every LSP client must support.
+    #[default]
+    UTF16,
+
+    /// UTF-32 counts Unicode scalar values.
+    UTF32,
+
+    /// UTF-8 positions are byte offsets and avoid conversion for Rust strings.
+    UTF8,
+}
+
+impl From<PositionEncoding> for ruff_source_file::PositionEncoding {
+    fn from(value: PositionEncoding) -> Self {
+        match value {
+            PositionEncoding::UTF8 => Self::Utf8,
+            PositionEncoding::UTF16 => Self::Utf16,
+            PositionEncoding::UTF32 => Self::Utf32,
+        }
+    }
+}
+
+impl From<PositionEncoding> for PositionEncodingKind {
+    fn from(value: PositionEncoding) -> Self {
+        match value {
+            PositionEncoding::UTF8 => Self::UTF8,
+            PositionEncoding::UTF16 => Self::UTF16,
+            PositionEncoding::UTF32 => Self::UTF32,
+        }
+    }
+}
+
+impl TryFrom<&PositionEncodingKind> for PositionEncoding {
+    type Error = ();
+
+    fn try_from(value: &PositionEncodingKind) -> Result<Self, Self::Error> {
+        if value == &PositionEncodingKind::UTF8 {
+            Ok(Self::UTF8)
+        } else if value == &PositionEncodingKind::UTF32 {
+            Ok(Self::UTF32)
+        } else if value == &PositionEncodingKind::UTF16 {
+            Ok(Self::UTF16)
+        } else {
+            Err(())
+        }
+    }
+}

--- a/crates/karva_language_server/src/document/range.rs
+++ b/crates/karva_language_server/src/document/range.rs
@@ -1,0 +1,33 @@
+use lsp_types::{Position, Range};
+use ruff_source_file::{LineIndex, OneIndexed, SourceLocation};
+use ruff_text_size::{TextRange, TextSize};
+
+use super::PositionEncoding;
+
+fn position_to_text_size(
+    position: Position,
+    text: &str,
+    index: &LineIndex,
+    encoding: PositionEncoding,
+) -> TextSize {
+    index.offset(
+        SourceLocation {
+            line: OneIndexed::from_zero_indexed(position.line as usize),
+            character_offset: OneIndexed::from_zero_indexed(position.character as usize),
+        },
+        text,
+        encoding.into(),
+    )
+}
+
+pub(super) fn range_to_text_range(
+    range: Range,
+    text: &str,
+    index: &LineIndex,
+    encoding: PositionEncoding,
+) -> TextRange {
+    TextRange::new(
+        position_to_text_size(range.start, text, index, encoding),
+        position_to_text_size(range.end, text, index, encoding),
+    )
+}

--- a/crates/karva_language_server/src/document/text_document.rs
+++ b/crates/karva_language_server/src/document/text_document.rs
@@ -1,0 +1,233 @@
+use lsp_types::{
+    LanguageKind, TextDocumentContentChangeEvent, TextDocumentContentChangePartial,
+    TextDocumentContentChangeWholeDocument, Uri,
+};
+use ruff_source_file::LineIndex;
+
+use super::PositionEncoding;
+use super::range::range_to_text_range;
+
+/// A document change that violates the client's version contract.
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+#[expect(
+    clippy::redundant_pub_crate,
+    reason = "document re-exports this error to a private sibling module"
+)]
+pub(crate) enum DocumentChangeError {
+    /// A client attempted to replace newer open-document state with an older version.
+    #[error("stale document version: current is {current}, requested {requested}")]
+    StaleVersion { current: i32, requested: i32 },
+}
+
+/// An open text document, including unsaved editor changes.
+#[derive(Debug, Clone)]
+pub struct TextDocument {
+    uri: Uri,
+    contents: String,
+    version: i32,
+}
+
+impl TextDocument {
+    /// Creates an open document from an LSP `didOpen` notification.
+    pub(crate) fn new(
+        uri: Uri,
+        contents: String,
+        version: i32,
+        _language_id: LanguageKind,
+    ) -> Self {
+        Self {
+            uri,
+            contents,
+            version,
+        }
+    }
+
+    /// Returns the URI supplied by the client.
+    pub(crate) fn uri(&self) -> &Uri {
+        &self.uri
+    }
+
+    /// Returns the latest editor contents, including unsaved changes.
+    #[cfg(test)]
+    fn contents(&self) -> &str {
+        &self.contents
+    }
+
+    /// Returns the client-managed document version.
+    #[cfg(test)]
+    fn version(&self) -> i32 {
+        self.version
+    }
+
+    /// Applies changes sequentially using positions from the negotiated encoding.
+    pub(crate) fn apply_changes(
+        &mut self,
+        changes: Vec<TextDocumentContentChangeEvent>,
+        new_version: i32,
+        encoding: PositionEncoding,
+    ) -> Result<(), DocumentChangeError> {
+        if new_version < self.version {
+            return Err(DocumentChangeError::StaleVersion {
+                current: self.version,
+                requested: new_version,
+            });
+        }
+
+        if let [
+            TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                TextDocumentContentChangeWholeDocument { text },
+            ),
+        ] = changes.as_slice()
+        {
+            self.contents.clone_from(text);
+            self.version = new_version;
+            return Ok(());
+        }
+
+        let mut new_contents = self.contents.clone();
+        let mut index = LineIndex::from_source_text(&new_contents);
+
+        for change in changes {
+            match change {
+                TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                    TextDocumentContentChangePartial { range, text, .. },
+                ) => {
+                    let range = range_to_text_range(range, &new_contents, &index, encoding);
+                    new_contents
+                        .replace_range(usize::from(range.start())..usize::from(range.end()), &text);
+                }
+                TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                    TextDocumentContentChangeWholeDocument { text },
+                ) => new_contents = text,
+            }
+            index = LineIndex::from_source_text(&new_contents);
+        }
+
+        self.contents = new_contents;
+        self.version = new_version;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use lsp_types::{
+        Position, Range, TextDocumentContentChangeEvent, TextDocumentContentChangePartial,
+        TextDocumentContentChangeWholeDocument, Uri,
+    };
+    use rstest::rstest;
+
+    use super::*;
+
+    fn document(contents: &str) -> TextDocument {
+        TextDocument::new(
+            Uri::parse("file:///test.py").expect("test URI should be valid"),
+            contents.to_owned(),
+            1,
+            LanguageKind::Python,
+        )
+    }
+
+    fn partial(line: u32, start: u32, end: u32, text: &str) -> TextDocumentContentChangeEvent {
+        TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+            TextDocumentContentChangePartial {
+                range: Range::new(Position::new(line, start), Position::new(line, end)),
+                text: text.to_owned(),
+                ..TextDocumentContentChangePartial::default()
+            },
+        )
+    }
+
+    #[test]
+    fn replaces_whole_document() {
+        let mut document = document("old");
+        document
+            .apply_changes(
+                vec![
+                    TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                        TextDocumentContentChangeWholeDocument {
+                            text: "new".to_owned(),
+                        },
+                    ),
+                ],
+                2,
+                PositionEncoding::UTF16,
+            )
+            .expect("whole-document change should apply");
+
+        assert_eq!(document.contents(), "new");
+        assert_eq!(document.version(), 2);
+    }
+
+    #[test]
+    fn applies_changes_sequentially() {
+        let mut document = document("def test():\n    pas\n");
+        document
+            .apply_changes(
+                vec![
+                    partial(1, 7, 7, "s"),
+                    partial(1, 7, 8, ""),
+                    partial(1, 7, 7, "s"),
+                ],
+                2,
+                PositionEncoding::UTF16,
+            )
+            .expect("sequential changes should apply");
+
+        assert_eq!(document.contents(), "def test():\n    pass\n");
+    }
+
+    #[rstest]
+    #[case(PositionEncoding::UTF8, 5)]
+    #[case(PositionEncoding::UTF16, 3)]
+    #[case(PositionEncoding::UTF32, 2)]
+    fn respects_position_encoding(#[case] encoding: PositionEncoding, #[case] end: u32) {
+        let mut document = document("a😀b\r\n");
+        document
+            .apply_changes(vec![partial(0, 1, end, "x")], 2, encoding)
+            .expect("encoded range should apply");
+
+        assert_eq!(document.contents(), "axb\r\n");
+    }
+
+    #[test]
+    fn applies_edits_after_crlf() {
+        let mut document = document("first\r\nsecond\r\n");
+        document
+            .apply_changes(
+                vec![partial(1, 0, 6, "changed")],
+                2,
+                PositionEncoding::UTF16,
+            )
+            .expect("second-line edit should apply");
+
+        assert_eq!(document.contents(), "first\r\nchanged\r\n");
+    }
+
+    #[test]
+    fn rejects_stale_version() {
+        let mut document = document("current");
+        let error = document
+            .apply_changes(
+                vec![
+                    TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                        TextDocumentContentChangeWholeDocument {
+                            text: "stale".to_owned(),
+                        },
+                    ),
+                ],
+                0,
+                PositionEncoding::UTF16,
+            )
+            .expect_err("stale change should fail");
+
+        assert_eq!(
+            error,
+            DocumentChangeError::StaleVersion {
+                current: 1,
+                requested: 0,
+            }
+        );
+        assert_eq!(document.contents(), "current");
+    }
+}

--- a/crates/karva_language_server/src/lib.rs
+++ b/crates/karva_language_server/src/lib.rs
@@ -8,6 +8,7 @@ mod capabilities;
 mod document;
 mod server;
 mod session;
+mod workspace;
 
 pub use document::{PositionEncoding, TextDocument};
 

--- a/crates/karva_language_server/src/lib.rs
+++ b/crates/karva_language_server/src/lib.rs
@@ -5,8 +5,11 @@ use anyhow::Context;
 pub use server::{ConnectionInitializer, Server};
 
 mod capabilities;
+mod document;
 mod server;
 mod session;
+
+pub use document::{PositionEncoding, TextDocument};
 
 const SERVER_NAME: &str = "karva";
 

--- a/crates/karva_language_server/src/server.rs
+++ b/crates/karva_language_server/src/server.rs
@@ -2,9 +2,11 @@
 
 use lsp_server::Connection;
 use lsp_types::{InitializeParams, WorkspaceFolders, WorkspaceFoldersInitializeParams};
+use serde::Deserialize;
 
 use crate::capabilities::{position_encoding, server_capabilities};
 use crate::session::Session;
+use crate::workspace::Workspaces;
 
 pub use self::connection::ConnectionInitializer;
 
@@ -18,12 +20,19 @@ pub struct Server {
     session: Session,
 }
 
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct InitializationOptions {
+    profile: Option<String>,
+}
+
 impl Server {
     /// Completes the LSP initialization handshake.
     pub fn new(connection: ConnectionInitializer) -> anyhow::Result<Self> {
         let (id, init_params) = connection.initialize_start()?;
         let InitializeParams {
             capabilities,
+            initialization_options,
             workspace_folders_initialize_params:
                 WorkspaceFoldersInitializeParams { workspace_folders },
             ..
@@ -34,6 +43,15 @@ impl Server {
             Some(WorkspaceFolders::WorkspaceFolderList(folders)) => folders,
             Some(WorkspaceFolders::Null) | None => Vec::new(),
         };
+        let options: InitializationOptions = initialization_options
+            .map(serde_json::from_value)
+            .transpose()?
+            .unwrap_or_default();
+        let workspaces = Workspaces::new(
+            workspace_folders,
+            karva_python_semantic::current_python_version(),
+            options.profile,
+        )?;
         let connection = connection.initialize_finish(
             id,
             &capabilities,
@@ -43,7 +61,7 @@ impl Server {
 
         Ok(Self {
             connection,
-            session: Session::new(position_encoding, workspace_folders),
+            session: Session::new(position_encoding, workspaces),
         })
     }
 

--- a/crates/karva_language_server/src/server.rs
+++ b/crates/karva_language_server/src/server.rs
@@ -1,7 +1,7 @@
 //! Scheduling, I/O, and API endpoints.
 
 use lsp_server::Connection;
-use lsp_types::InitializeParams;
+use lsp_types::{InitializeParams, WorkspaceFolders, WorkspaceFoldersInitializeParams};
 
 use crate::capabilities::{position_encoding, server_capabilities};
 use crate::session::Session;
@@ -22,8 +22,18 @@ impl Server {
     /// Completes the LSP initialization handshake.
     pub fn new(connection: ConnectionInitializer) -> anyhow::Result<Self> {
         let (id, init_params) = connection.initialize_start()?;
-        let InitializeParams { capabilities, .. } = init_params;
-        let capabilities = server_capabilities(position_encoding(&capabilities));
+        let InitializeParams {
+            capabilities,
+            workspace_folders_initialize_params:
+                WorkspaceFoldersInitializeParams { workspace_folders },
+            ..
+        } = init_params;
+        let position_encoding = position_encoding(&capabilities);
+        let capabilities = server_capabilities(position_encoding);
+        let workspace_folders = match workspace_folders {
+            Some(WorkspaceFolders::WorkspaceFolderList(folders)) => folders,
+            Some(WorkspaceFolders::Null) | None => Vec::new(),
+        };
         let connection = connection.initialize_finish(
             id,
             &capabilities,
@@ -33,7 +43,7 @@ impl Server {
 
         Ok(Self {
             connection,
-            session: Session::default(),
+            session: Session::new(position_encoding, workspace_folders),
         })
     }
 

--- a/crates/karva_language_server/src/server.rs
+++ b/crates/karva_language_server/src/server.rs
@@ -1,11 +1,17 @@
 //! Scheduling, I/O, and API endpoints.
 
 use lsp_server::Connection;
-use lsp_types::{InitializeParams, WorkspaceFolders, WorkspaceFoldersInitializeParams};
+use lsp_types::{
+    ClientCapabilities, DidChangeWatchedFilesNotification,
+    DidChangeWatchedFilesRegistrationOptions, FileSystemWatcher, GlobPattern, InitializeParams,
+    Notification as _, Registration, RegistrationParams, RegistrationRequest, WorkspaceFolders,
+    WorkspaceFoldersInitializeParams,
+};
 use serde::Deserialize;
 
 use crate::capabilities::{position_encoding, server_capabilities};
 use crate::session::Session;
+use crate::session::client::Client;
 use crate::workspace::Workspaces;
 
 pub use self::connection::ConnectionInitializer;
@@ -17,6 +23,7 @@ mod main_loop;
 /// An initialized Karva language server.
 pub struct Server {
     connection: Connection,
+    register_config_watchers: bool,
     session: Session,
 }
 
@@ -38,6 +45,7 @@ impl Server {
             ..
         } = init_params;
         let position_encoding = position_encoding(&capabilities);
+        let register_config_watchers = supports_dynamic_file_watching(&capabilities);
         let capabilities = server_capabilities(position_encoding);
         let workspace_folders = match workspace_folders {
             Some(WorkspaceFolders::WorkspaceFolderList(folders)) => folders,
@@ -61,12 +69,53 @@ impl Server {
 
         Ok(Self {
             connection,
+            register_config_watchers,
             session: Session::new(position_encoding, workspaces),
         })
     }
 
     /// Handles client messages until the LSP shutdown sequence completes.
     pub fn run(mut self) -> anyhow::Result<()> {
+        self.register_config_watchers()?;
         self.main_loop()
     }
+
+    fn register_config_watchers(&mut self) -> anyhow::Result<()> {
+        if !self.register_config_watchers {
+            return Ok(());
+        }
+
+        let id = lsp_server::RequestId::from("karva/register-config-watchers".to_owned());
+        self.session
+            .request_queue_mut()
+            .register_outgoing(id.clone());
+        let options = DidChangeWatchedFilesRegistrationOptions {
+            watchers: ["**/karva.toml", "**/pyproject.toml"]
+                .into_iter()
+                .map(|pattern| FileSystemWatcher {
+                    glob_pattern: GlobPattern::Pattern(pattern.to_owned()),
+                    kind: None,
+                })
+                .collect(),
+        };
+        let params = RegistrationParams {
+            registrations: vec![Registration {
+                id: "karva-config-watchers".to_owned(),
+                method: DidChangeWatchedFilesNotification::METHOD
+                    .as_str()
+                    .to_owned(),
+                register_options: Some(serde_json::to_value(options)?),
+            }],
+        };
+        Client::new(self.connection.sender.clone()).send_request::<RegistrationRequest>(id, params)
+    }
+}
+
+fn supports_dynamic_file_watching(capabilities: &ClientCapabilities) -> bool {
+    capabilities
+        .workspace
+        .as_ref()
+        .and_then(|workspace| workspace.did_change_watched_files)
+        .and_then(|watched_files| watched_files.dynamic_registration)
+        .unwrap_or(false)
 }

--- a/crates/karva_language_server/src/server.rs
+++ b/crates/karva_language_server/src/server.rs
@@ -7,6 +7,7 @@ use lsp_types::{
     Notification as _, Registration, RegistrationParams, RegistrationRequest, WorkspaceFolders,
     WorkspaceFoldersInitializeParams,
 };
+use ruff_python_ast::PythonVersion;
 use serde::Deserialize;
 
 use crate::capabilities::{position_encoding, server_capabilities};
@@ -31,6 +32,7 @@ pub struct Server {
 #[serde(default, rename_all = "camelCase")]
 struct InitializationOptions {
     profile: Option<String>,
+    python_version: Option<String>,
 }
 
 impl Server {
@@ -55,11 +57,13 @@ impl Server {
             .map(serde_json::from_value)
             .transpose()?
             .unwrap_or_default();
-        let workspaces = Workspaces::new(
-            workspace_folders,
-            karva_python_semantic::current_python_version(),
-            options.profile,
-        )?;
+        let python_version = options
+            .python_version
+            .as_deref()
+            .map(str::parse)
+            .transpose()?
+            .unwrap_or_else(PythonVersion::latest);
+        let workspaces = Workspaces::new(workspace_folders, python_version, options.profile)?;
         let connection = connection.initialize_finish(
             id,
             &capabilities,

--- a/crates/karva_language_server/src/server/api.rs
+++ b/crates/karva_language_server/src/server/api.rs
@@ -1,12 +1,17 @@
-use lsp_server::{ErrorCode, Request, Response};
-use lsp_types::{LspRequestMethod, Request as _, ShutdownRequest};
+use lsp_server::{ErrorCode, Notification, Request, Response};
+use lsp_types::{
+    DidChangeTextDocumentNotification, DidChangeWorkspaceFoldersNotification,
+    DidCloseTextDocumentNotification, DidOpenTextDocumentNotification, LspNotificationMethod,
+    LspRequestMethod, Notification as _, Request as _, ShutdownRequest,
+};
 
 use crate::session::Session;
 
+mod notifications;
 mod requests;
 mod traits;
 
-use self::traits::SyncRequestHandler;
+use self::traits::{SyncNotificationHandler, SyncRequestHandler};
 
 pub(super) fn request(request: Request, session: &mut Session) -> Response {
     match LspRequestMethod::from(request.method.as_str()) {
@@ -16,6 +21,31 @@ pub(super) fn request(request: Request, session: &mut Session) -> Response {
             ErrorCode::MethodNotFound as i32,
             format!("unknown request: {method}"),
         ),
+    }
+}
+
+pub(super) fn notification(notification: Notification, session: &mut Session) {
+    let result = match LspNotificationMethod::from(notification.method.as_str()) {
+        DidOpenTextDocumentNotification::METHOD => {
+            run_notification::<notifications::DidOpen>(notification, session)
+        }
+        DidChangeTextDocumentNotification::METHOD => {
+            run_notification::<notifications::DidChange>(notification, session)
+        }
+        DidCloseTextDocumentNotification::METHOD => {
+            run_notification::<notifications::DidClose>(notification, session)
+        }
+        DidChangeWorkspaceFoldersNotification::METHOD => {
+            run_notification::<notifications::DidChangeWorkspaceFolders>(notification, session)
+        }
+        method => {
+            tracing::debug!("ignoring unsupported notification {method}");
+            return;
+        }
+    };
+
+    if let Err(error) = result {
+        tracing::warn!("failed to handle notification: {error}");
     }
 }
 
@@ -38,4 +68,12 @@ where
         },
         Err(error) => Response::new_err(id, ErrorCode::InternalError as i32, error.to_string()),
     }
+}
+
+fn run_notification<H>(notification: Notification, session: &mut Session) -> anyhow::Result<()>
+where
+    H: SyncNotificationHandler,
+{
+    let params = serde_json::from_value(notification.params)?;
+    H::run(session, params)
 }

--- a/crates/karva_language_server/src/server/api.rs
+++ b/crates/karva_language_server/src/server/api.rs
@@ -1,8 +1,9 @@
 use lsp_server::{ErrorCode, Notification, Request, Response};
 use lsp_types::{
-    DidChangeTextDocumentNotification, DidChangeWorkspaceFoldersNotification,
-    DidCloseTextDocumentNotification, DidOpenTextDocumentNotification, LspNotificationMethod,
-    LspRequestMethod, Notification as _, Request as _, ShutdownRequest,
+    DidChangeTextDocumentNotification, DidChangeWatchedFilesNotification,
+    DidChangeWorkspaceFoldersNotification, DidCloseTextDocumentNotification,
+    DidOpenTextDocumentNotification, LspNotificationMethod, LspRequestMethod, Notification as _,
+    Request as _, ShutdownRequest,
 };
 
 use crate::session::Session;
@@ -37,6 +38,9 @@ pub(super) fn notification(notification: Notification, session: &mut Session) {
         }
         DidChangeWorkspaceFoldersNotification::METHOD => {
             run_notification::<notifications::DidChangeWorkspaceFolders>(notification, session)
+        }
+        DidChangeWatchedFilesNotification::METHOD => {
+            run_notification::<notifications::DidChangeWatchedFiles>(notification, session)
         }
         method => {
             tracing::debug!("ignoring unsupported notification {method}");

--- a/crates/karva_language_server/src/server/api/notifications.rs
+++ b/crates/karva_language_server/src/server/api/notifications.rs
@@ -1,9 +1,11 @@
 mod did_change;
+mod did_change_watched_files;
 mod did_change_workspace_folders;
 mod did_close;
 mod did_open;
 
 pub(super) use did_change::DidChange;
+pub(super) use did_change_watched_files::DidChangeWatchedFiles;
 pub(super) use did_change_workspace_folders::DidChangeWorkspaceFolders;
 pub(super) use did_close::DidClose;
 pub(super) use did_open::DidOpen;

--- a/crates/karva_language_server/src/server/api/notifications.rs
+++ b/crates/karva_language_server/src/server/api/notifications.rs
@@ -1,0 +1,9 @@
+mod did_change;
+mod did_change_workspace_folders;
+mod did_close;
+mod did_open;
+
+pub(super) use did_change::DidChange;
+pub(super) use did_change_workspace_folders::DidChangeWorkspaceFolders;
+pub(super) use did_close::DidClose;
+pub(super) use did_open::DidOpen;

--- a/crates/karva_language_server/src/server/api/notifications/did_change.rs
+++ b/crates/karva_language_server/src/server/api/notifications/did_change.rs
@@ -1,0 +1,30 @@
+use lsp_types::{
+    DidChangeTextDocumentNotification, DidChangeTextDocumentParams, TextDocumentIdentifier,
+    VersionedTextDocumentIdentifier,
+};
+
+use super::super::traits::{NotificationHandler, SyncNotificationHandler};
+use crate::session::Session;
+
+pub(in crate::server::api) struct DidChange;
+
+impl NotificationHandler for DidChange {
+    type NotificationType = DidChangeTextDocumentNotification;
+}
+
+impl SyncNotificationHandler for DidChange {
+    fn run(
+        session: &mut Session,
+        DidChangeTextDocumentParams {
+            text_document:
+                VersionedTextDocumentIdentifier {
+                    text_document_identifier: TextDocumentIdentifier { uri },
+                    version,
+                },
+            content_changes,
+        }: DidChangeTextDocumentParams,
+    ) -> anyhow::Result<()> {
+        session.update_document(&uri, content_changes, version)?;
+        Ok(())
+    }
+}

--- a/crates/karva_language_server/src/server/api/notifications/did_change_watched_files.rs
+++ b/crates/karva_language_server/src/server/api/notifications/did_change_watched_files.rs
@@ -1,0 +1,22 @@
+use lsp_types::{DidChangeWatchedFilesNotification, DidChangeWatchedFilesParams};
+
+use super::super::traits::{NotificationHandler, SyncNotificationHandler};
+use crate::session::Session;
+
+pub(in crate::server::api) struct DidChangeWatchedFiles;
+
+impl NotificationHandler for DidChangeWatchedFiles {
+    type NotificationType = DidChangeWatchedFilesNotification;
+}
+
+impl SyncNotificationHandler for DidChangeWatchedFiles {
+    fn run(
+        session: &mut Session,
+        DidChangeWatchedFilesParams { changes }: DidChangeWatchedFilesParams,
+    ) -> anyhow::Result<()> {
+        for change in changes {
+            session.configuration_changed(&change.uri)?;
+        }
+        Ok(())
+    }
+}

--- a/crates/karva_language_server/src/server/api/notifications/did_change_workspace_folders.rs
+++ b/crates/karva_language_server/src/server/api/notifications/did_change_workspace_folders.rs
@@ -1,0 +1,30 @@
+use lsp_types::{
+    DidChangeWorkspaceFoldersNotification, DidChangeWorkspaceFoldersParams,
+    WorkspaceFoldersChangeEvent,
+};
+
+use super::super::traits::{NotificationHandler, SyncNotificationHandler};
+use crate::session::Session;
+
+pub(in crate::server::api) struct DidChangeWorkspaceFolders;
+
+impl NotificationHandler for DidChangeWorkspaceFolders {
+    type NotificationType = DidChangeWorkspaceFoldersNotification;
+}
+
+impl SyncNotificationHandler for DidChangeWorkspaceFolders {
+    fn run(
+        session: &mut Session,
+        DidChangeWorkspaceFoldersParams {
+            event: WorkspaceFoldersChangeEvent { added, removed },
+        }: DidChangeWorkspaceFoldersParams,
+    ) -> anyhow::Result<()> {
+        for folder in added {
+            session.open_workspace_folder(folder);
+        }
+        for folder in removed {
+            session.close_workspace_folder(&folder.uri)?;
+        }
+        Ok(())
+    }
+}

--- a/crates/karva_language_server/src/server/api/notifications/did_change_workspace_folders.rs
+++ b/crates/karva_language_server/src/server/api/notifications/did_change_workspace_folders.rs
@@ -20,7 +20,7 @@ impl SyncNotificationHandler for DidChangeWorkspaceFolders {
         }: DidChangeWorkspaceFoldersParams,
     ) -> anyhow::Result<()> {
         for folder in added {
-            session.open_workspace_folder(folder);
+            session.open_workspace_folder(folder)?;
         }
         for folder in removed {
             session.close_workspace_folder(&folder.uri)?;

--- a/crates/karva_language_server/src/server/api/notifications/did_close.rs
+++ b/crates/karva_language_server/src/server/api/notifications/did_close.rs
@@ -1,0 +1,24 @@
+use lsp_types::{
+    DidCloseTextDocumentNotification, DidCloseTextDocumentParams, TextDocumentIdentifier,
+};
+
+use super::super::traits::{NotificationHandler, SyncNotificationHandler};
+use crate::session::Session;
+
+pub(in crate::server::api) struct DidClose;
+
+impl NotificationHandler for DidClose {
+    type NotificationType = DidCloseTextDocumentNotification;
+}
+
+impl SyncNotificationHandler for DidClose {
+    fn run(
+        session: &mut Session,
+        DidCloseTextDocumentParams {
+            text_document: TextDocumentIdentifier { uri },
+        }: DidCloseTextDocumentParams,
+    ) -> anyhow::Result<()> {
+        session.close_document(&uri)?;
+        Ok(())
+    }
+}

--- a/crates/karva_language_server/src/server/api/notifications/did_open.rs
+++ b/crates/karva_language_server/src/server/api/notifications/did_open.rs
@@ -1,0 +1,29 @@
+use lsp_types::{DidOpenTextDocumentNotification, DidOpenTextDocumentParams, TextDocumentItem};
+
+use super::super::traits::{NotificationHandler, SyncNotificationHandler};
+use crate::TextDocument;
+use crate::session::Session;
+
+pub(in crate::server::api) struct DidOpen;
+
+impl NotificationHandler for DidOpen {
+    type NotificationType = DidOpenTextDocumentNotification;
+}
+
+impl SyncNotificationHandler for DidOpen {
+    fn run(
+        session: &mut Session,
+        DidOpenTextDocumentParams {
+            text_document:
+                TextDocumentItem {
+                    uri,
+                    text,
+                    version,
+                    language_id,
+                },
+        }: DidOpenTextDocumentParams,
+    ) -> anyhow::Result<()> {
+        session.open_document(TextDocument::new(uri, text, version, language_id));
+        Ok(())
+    }
+}

--- a/crates/karva_language_server/src/server/api/notifications/did_open.rs
+++ b/crates/karva_language_server/src/server/api/notifications/did_open.rs
@@ -23,7 +23,11 @@ impl SyncNotificationHandler for DidOpen {
                 },
         }: DidOpenTextDocumentParams,
     ) -> anyhow::Result<()> {
-        session.open_document(TextDocument::new(uri, text, version, language_id));
+        let document = TextDocument::new(uri, text, version, language_id);
+        if let Err(error) = session.project_for_uri(document.uri()) {
+            tracing::warn!("failed to resolve Karva project: {error}");
+        }
+        session.open_document(document);
         Ok(())
     }
 }

--- a/crates/karva_language_server/src/server/api/traits.rs
+++ b/crates/karva_language_server/src/server/api/traits.rs
@@ -1,4 +1,4 @@
-use lsp_types::Request;
+use lsp_types::{Notification, Request};
 
 use crate::session::Session;
 
@@ -11,4 +11,15 @@ pub(super) trait SyncRequestHandler: RequestHandler {
         session: &mut Session,
         params: <<Self as RequestHandler>::RequestType as Request>::Params,
     ) -> anyhow::Result<<<Self as RequestHandler>::RequestType as Request>::Result>;
+}
+
+pub(super) trait NotificationHandler {
+    type NotificationType: Notification;
+}
+
+pub(super) trait SyncNotificationHandler: NotificationHandler {
+    fn run(
+        session: &mut Session,
+        params: <<Self as NotificationHandler>::NotificationType as Notification>::Params,
+    ) -> anyhow::Result<()>;
 }

--- a/crates/karva_language_server/src/server/main_loop.rs
+++ b/crates/karva_language_server/src/server/main_loop.rs
@@ -20,15 +20,16 @@ impl Server {
                     };
                     self.connection.sender.send(Message::Response(response))?;
                 }
-                Message::Notification(notification)
-                    if notification.method == ExitNotification::METHOD.as_str() =>
-                {
-                    if !self.session.is_shutdown_requested() {
-                        bail!("received exit notification before shutdown request");
+                Message::Notification(notification) => {
+                    if notification.method == ExitNotification::METHOD.as_str() {
+                        if !self.session.is_shutdown_requested() {
+                            bail!("received exit notification before shutdown request");
+                        }
+                        return Ok(());
                     }
-                    return Ok(());
+
+                    super::api::notification(notification, &mut self.session);
                 }
-                Message::Notification(_) => {}
                 Message::Response(response) => {
                     bail!("received unexpected response with ID {}", response.id);
                 }

--- a/crates/karva_language_server/src/server/main_loop.rs
+++ b/crates/karva_language_server/src/server/main_loop.rs
@@ -31,7 +31,13 @@ impl Server {
                     super::api::notification(notification, &mut self.session);
                 }
                 Message::Response(response) => {
-                    bail!("received unexpected response with ID {}", response.id);
+                    if !self
+                        .session
+                        .request_queue_mut()
+                        .complete_outgoing(&response.id)
+                    {
+                        tracing::warn!("received unexpected response with ID {}", response.id);
+                    }
                 }
             }
         }

--- a/crates/karva_language_server/src/session.rs
+++ b/crates/karva_language_server/src/session.rs
@@ -1,6 +1,8 @@
 //! Mutable language-server state.
 
+pub(super) mod client;
 mod index;
+mod request_queue;
 
 use std::sync::Arc;
 
@@ -11,6 +13,7 @@ use crate::workspace::{WorkspaceError, Workspaces};
 use crate::{PositionEncoding, TextDocument};
 
 use self::index::Index;
+use self::request_queue::RequestQueue;
 
 /// Failure to apply a document or workspace notification.
 #[derive(Debug, thiserror::Error)]
@@ -38,6 +41,7 @@ pub struct Session {
     index: Index,
     position_encoding: PositionEncoding,
     shutdown_requested: bool,
+    request_queue: RequestQueue,
     workspaces: Workspaces,
 }
 
@@ -46,6 +50,7 @@ impl Session {
         Self {
             index: Index::new(workspaces.folders().cloned()),
             position_encoding,
+            request_queue: RequestQueue::default(),
             shutdown_requested: false,
             workspaces,
         }
@@ -59,12 +64,21 @@ impl Session {
         self.shutdown_requested = true;
     }
 
+    pub(super) fn request_queue_mut(&mut self) -> &mut RequestQueue {
+        &mut self.request_queue
+    }
+
     pub(super) fn open_document(&mut self, document: TextDocument) {
         self.index.open_document(document);
     }
 
     pub(super) fn project_for_uri(&mut self, uri: &Uri) -> Result<Arc<Project>, SessionError> {
         Ok(self.workspaces.project_for_uri(uri)?)
+    }
+
+    pub(super) fn configuration_changed(&mut self, uri: &Uri) -> Result<(), SessionError> {
+        self.workspaces.configuration_changed(uri)?;
+        Ok(())
     }
 
     pub(super) fn update_document(

--- a/crates/karva_language_server/src/session.rs
+++ b/crates/karva_language_server/src/session.rs
@@ -1,15 +1,80 @@
+//! Mutable language-server state.
+
+mod index;
+
+use lsp_types::{TextDocumentContentChangeEvent, Uri, WorkspaceFolder};
+
+use crate::{PositionEncoding, TextDocument};
+
+use self::index::Index;
+
+/// Failure to apply a document or workspace notification.
+#[derive(Debug, thiserror::Error)]
+pub enum SessionError {
+    /// The client referenced a document without opening it first.
+    #[error("document is not open: {0}")]
+    DocumentNotOpen(Uri),
+
+    /// The client referenced a workspace without opening it first.
+    #[error("workspace folder is not open: {0}")]
+    WorkspaceNotOpen(Uri),
+
+    /// The document change violated its version contract.
+    #[error(transparent)]
+    DocumentChange(#[from] crate::document::DocumentChangeError),
+}
+
 /// Mutable state owned by the language-server event loop.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Session {
+    index: Index,
+    position_encoding: PositionEncoding,
     shutdown_requested: bool,
 }
 
 impl Session {
+    pub(super) fn new(
+        position_encoding: PositionEncoding,
+        workspace_folders: impl IntoIterator<Item = WorkspaceFolder>,
+    ) -> Self {
+        Self {
+            index: Index::new(workspace_folders),
+            position_encoding,
+            shutdown_requested: false,
+        }
+    }
+
     pub(super) fn is_shutdown_requested(&self) -> bool {
         self.shutdown_requested
     }
 
     pub(super) fn request_shutdown(&mut self) {
         self.shutdown_requested = true;
+    }
+
+    pub(super) fn open_document(&mut self, document: TextDocument) {
+        self.index.open_document(document);
+    }
+
+    pub(super) fn update_document(
+        &mut self,
+        uri: &Uri,
+        changes: Vec<TextDocumentContentChangeEvent>,
+        version: i32,
+    ) -> Result<(), SessionError> {
+        self.index
+            .update_document(uri, changes, version, self.position_encoding)
+    }
+
+    pub(super) fn close_document(&mut self, uri: &Uri) -> Result<(), SessionError> {
+        self.index.close_document(uri)
+    }
+
+    pub(super) fn open_workspace_folder(&mut self, folder: WorkspaceFolder) {
+        self.index.open_workspace_folder(folder);
+    }
+
+    pub(super) fn close_workspace_folder(&mut self, uri: &Uri) -> Result<(), SessionError> {
+        self.index.close_workspace_folder(uri)
     }
 }

--- a/crates/karva_language_server/src/session.rs
+++ b/crates/karva_language_server/src/session.rs
@@ -2,8 +2,12 @@
 
 mod index;
 
+use std::sync::Arc;
+
+use karva_project::Project;
 use lsp_types::{TextDocumentContentChangeEvent, Uri, WorkspaceFolder};
 
+use crate::workspace::{WorkspaceError, Workspaces};
 use crate::{PositionEncoding, TextDocument};
 
 use self::index::Index;
@@ -22,6 +26,10 @@ pub enum SessionError {
     /// The document change violated its version contract.
     #[error(transparent)]
     DocumentChange(#[from] crate::document::DocumentChangeError),
+
+    /// Project discovery or configuration resolution failed.
+    #[error(transparent)]
+    Workspace(#[from] WorkspaceError),
 }
 
 /// Mutable state owned by the language-server event loop.
@@ -30,17 +38,16 @@ pub struct Session {
     index: Index,
     position_encoding: PositionEncoding,
     shutdown_requested: bool,
+    workspaces: Workspaces,
 }
 
 impl Session {
-    pub(super) fn new(
-        position_encoding: PositionEncoding,
-        workspace_folders: impl IntoIterator<Item = WorkspaceFolder>,
-    ) -> Self {
+    pub(super) fn new(position_encoding: PositionEncoding, workspaces: Workspaces) -> Self {
         Self {
-            index: Index::new(workspace_folders),
+            index: Index::new(workspaces.folders().cloned()),
             position_encoding,
             shutdown_requested: false,
+            workspaces,
         }
     }
 
@@ -54,6 +61,10 @@ impl Session {
 
     pub(super) fn open_document(&mut self, document: TextDocument) {
         self.index.open_document(document);
+    }
+
+    pub(super) fn project_for_uri(&mut self, uri: &Uri) -> Result<Arc<Project>, SessionError> {
+        Ok(self.workspaces.project_for_uri(uri)?)
     }
 
     pub(super) fn update_document(
@@ -70,11 +81,17 @@ impl Session {
         self.index.close_document(uri)
     }
 
-    pub(super) fn open_workspace_folder(&mut self, folder: WorkspaceFolder) {
+    pub(super) fn open_workspace_folder(
+        &mut self,
+        folder: WorkspaceFolder,
+    ) -> Result<(), SessionError> {
+        self.workspaces.open_folder(folder.clone())?;
         self.index.open_workspace_folder(folder);
+        Ok(())
     }
 
     pub(super) fn close_workspace_folder(&mut self, uri: &Uri) -> Result<(), SessionError> {
+        self.workspaces.close_folder(uri)?;
         self.index.close_workspace_folder(uri)
     }
 }

--- a/crates/karva_language_server/src/session/client.rs
+++ b/crates/karva_language_server/src/session/client.rs
@@ -1,0 +1,34 @@
+#![expect(
+    clippy::redundant_pub_crate,
+    reason = "server consumes this client across a private sibling module"
+)]
+
+use crossbeam_channel::Sender;
+use lsp_server::{Message, RequestId};
+use lsp_types::Request;
+
+/// Typed access to messages sent from the server to the editor client.
+#[derive(Clone)]
+pub(crate) struct Client {
+    sender: Sender<Message>,
+}
+
+impl Client {
+    pub(crate) fn new(sender: Sender<Message>) -> Self {
+        Self { sender }
+    }
+
+    pub(crate) fn send_request<R: Request>(
+        &self,
+        id: RequestId,
+        params: R::Params,
+    ) -> anyhow::Result<()> {
+        let request = lsp_server::Request {
+            id,
+            method: R::METHOD.as_str().to_owned(),
+            params: serde_json::to_value(params)?,
+        };
+        self.sender.send(Message::Request(request))?;
+        Ok(())
+    }
+}

--- a/crates/karva_language_server/src/session/index.rs
+++ b/crates/karva_language_server/src/session/index.rs
@@ -1,0 +1,113 @@
+use std::collections::HashMap;
+
+use lsp_types::{TextDocumentContentChangeEvent, Uri, WorkspaceFolder};
+
+use crate::session::SessionError;
+use crate::{PositionEncoding, TextDocument};
+
+/// Open documents and workspace folders indexed by client URI.
+#[derive(Debug)]
+pub struct Index {
+    documents: HashMap<Uri, TextDocument>,
+    workspace_folders: HashMap<Uri, WorkspaceFolder>,
+}
+
+impl Index {
+    pub(super) fn new(workspace_folders: impl IntoIterator<Item = WorkspaceFolder>) -> Self {
+        Self {
+            documents: HashMap::new(),
+            workspace_folders: workspace_folders
+                .into_iter()
+                .map(|folder| (folder.uri.clone(), folder))
+                .collect(),
+        }
+    }
+
+    pub(super) fn open_document(&mut self, document: TextDocument) {
+        self.documents.insert(document.uri().clone(), document);
+    }
+
+    pub(super) fn update_document(
+        &mut self,
+        uri: &Uri,
+        changes: Vec<TextDocumentContentChangeEvent>,
+        version: i32,
+        encoding: PositionEncoding,
+    ) -> Result<(), SessionError> {
+        let document = self
+            .documents
+            .get_mut(uri)
+            .ok_or_else(|| SessionError::DocumentNotOpen(uri.clone()))?;
+        document.apply_changes(changes, version, encoding)?;
+        Ok(())
+    }
+
+    pub(super) fn close_document(&mut self, uri: &Uri) -> Result<(), SessionError> {
+        self.documents
+            .remove(uri)
+            .map(|_| ())
+            .ok_or_else(|| SessionError::DocumentNotOpen(uri.clone()))
+    }
+
+    pub(super) fn open_workspace_folder(&mut self, folder: WorkspaceFolder) {
+        self.workspace_folders.insert(folder.uri.clone(), folder);
+    }
+
+    pub(super) fn close_workspace_folder(&mut self, uri: &Uri) -> Result<(), SessionError> {
+        self.workspace_folders
+            .remove(uri)
+            .map(|_| ())
+            .ok_or_else(|| SessionError::WorkspaceNotOpen(uri.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use lsp_types::{LanguageKind, Uri, WorkspaceFolder};
+
+    use super::*;
+
+    fn uri(value: &str) -> Uri {
+        Uri::parse(value).expect("test URI should be valid")
+    }
+
+    #[test]
+    fn tracks_multiple_workspace_folders() {
+        let first = WorkspaceFolder {
+            uri: uri("file:///first"),
+            name: "first".to_owned(),
+        };
+        let second = WorkspaceFolder {
+            uri: uri("file:///second"),
+            name: "second".to_owned(),
+        };
+        let mut index = Index::new([first.clone(), second.clone()]);
+
+        index
+            .close_workspace_folder(&first.uri)
+            .expect("first workspace should close");
+        index
+            .close_workspace_folder(&second.uri)
+            .expect("second workspace should close");
+
+        assert!(index.workspace_folders.is_empty());
+    }
+
+    #[test]
+    fn closes_open_document() {
+        let document_uri = uri("file:///test.py");
+        let mut index = Index::new([]);
+        index.open_document(TextDocument::new(
+            document_uri.clone(),
+            "def test_example(): pass".to_owned(),
+            1,
+            LanguageKind::Python,
+        ));
+
+        index
+            .close_document(&document_uri)
+            .expect("open document should close");
+
+        assert!(index.documents.is_empty());
+    }
+}

--- a/crates/karva_language_server/src/session/request_queue.rs
+++ b/crates/karva_language_server/src/session/request_queue.rs
@@ -1,0 +1,19 @@
+use std::collections::HashSet;
+
+use lsp_server::RequestId;
+
+/// Tracks server requests awaiting a client response.
+#[derive(Debug, Default)]
+pub struct RequestQueue {
+    outgoing: HashSet<RequestId>,
+}
+
+impl RequestQueue {
+    pub(crate) fn register_outgoing(&mut self, id: RequestId) {
+        self.outgoing.insert(id);
+    }
+
+    pub(crate) fn complete_outgoing(&mut self, id: &RequestId) -> bool {
+        self.outgoing.remove(id)
+    }
+}

--- a/crates/karva_language_server/src/workspace.rs
+++ b/crates/karva_language_server/src/workspace.rs
@@ -155,6 +155,20 @@ impl Workspaces {
         self.roots.retain(|workspace| workspace.root != root);
         Ok(())
     }
+
+    pub(super) fn configuration_changed(&mut self, uri: &Uri) -> Result<(), WorkspaceError> {
+        let path = uri_to_path(uri)?;
+        if !matches!(path.file_name(), Some("karva.toml" | "pyproject.toml")) {
+            return Ok(());
+        }
+
+        for workspace in &mut self.roots {
+            if path.starts_with(&workspace.root) {
+                workspace.projects.clear();
+            }
+        }
+        Ok(())
+    }
 }
 
 fn uri_to_path(uri: &Uri) -> Result<Utf8PathBuf, WorkspaceError> {
@@ -360,5 +374,40 @@ mod tests {
         assert_eq!(prefix(&first_project), "first_");
         assert_eq!(prefix(&second_project), "second_");
         assert!(!Arc::ptr_eq(&first_project, &second_project));
+    }
+
+    #[test]
+    fn configuration_change_invalidates_cached_project() {
+        let temp_dir = tempfile::tempdir().expect("create temp directory");
+        let root = root(&temp_dir);
+        let config = root.join("karva.toml");
+        fs::write(
+            &config,
+            "[profile.default.test]\ntest-function-prefix = \"before_\"\n",
+        )
+        .expect("write initial configuration");
+        let mut workspaces =
+            Workspaces::new(vec![folder(&root, "root")], PythonVersion::PY311, None)
+                .expect("create workspaces");
+        let document = file_uri(&root.join("test_example.py"));
+        let before = workspaces
+            .project_for_uri(&document)
+            .expect("discover initial project");
+        fs::write(
+            &config,
+            "[profile.default.test]\ntest-function-prefix = \"after_\"\n",
+        )
+        .expect("write updated configuration");
+
+        workspaces
+            .configuration_changed(&file_uri(&config))
+            .expect("invalidate project");
+        let after = workspaces
+            .project_for_uri(&document)
+            .expect("rediscover project");
+
+        assert_eq!(prefix(&before), "before_");
+        assert_eq!(prefix(&after), "after_");
+        assert!(!Arc::ptr_eq(&before, &after));
     }
 }

--- a/crates/karva_language_server/src/workspace.rs
+++ b/crates/karva_language_server/src/workspace.rs
@@ -1,0 +1,364 @@
+//! Karva project discovery isolated by LSP workspace folder.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use camino::{Utf8Path, Utf8PathBuf};
+use karva_metadata::{
+    Options, ProjectMetadata, ProjectMetadataError, ProjectOptionsOverrides, UnknownProfile,
+};
+use karva_project::Project;
+use lsp_types::{Uri, WorkspaceFolder};
+use ruff_python_ast::PythonVersion;
+
+/// Failure to map an editor document to resolved Karva configuration.
+#[derive(Debug, thiserror::Error)]
+pub enum WorkspaceError {
+    /// The client sent a file URI whose path is not UTF-8.
+    #[error("URI does not contain a UTF-8 file path: {0}")]
+    NonUtf8FileUri(Uri),
+
+    /// The client sent a URI that does not identify a local file.
+    #[error("URI does not identify a local file: {0}")]
+    NotAFileUri(Uri),
+
+    /// The file URI has no containing directory.
+    #[error("document has no containing directory: {0}")]
+    MissingParent(Utf8PathBuf),
+
+    /// Karva configuration discovery failed.
+    #[error(transparent)]
+    Metadata(#[from] ProjectMetadataError),
+
+    /// The configured profile does not exist.
+    #[error(transparent)]
+    UnknownProfile(#[from] UnknownProfile),
+}
+
+#[derive(Debug)]
+struct Workspace {
+    root: Utf8PathBuf,
+    projects: HashMap<Utf8PathBuf, Arc<Project>>,
+}
+
+impl Workspace {
+    fn new(root: Utf8PathBuf) -> Self {
+        Self {
+            root,
+            projects: HashMap::new(),
+        }
+    }
+
+    fn project_for_path(
+        &mut self,
+        path: &Utf8Path,
+        python_version: PythonVersion,
+        profile: Option<&str>,
+    ) -> Result<Arc<Project>, WorkspaceError> {
+        let directory = path
+            .parent()
+            .ok_or_else(|| WorkspaceError::MissingParent(path.to_path_buf()))?;
+        let mut metadata = ProjectMetadata::discover(directory, python_version)?;
+        if metadata.root() == directory
+            && !directory.join("karva.toml").exists()
+            && !directory.join("pyproject.toml").exists()
+        {
+            let fallback_root = directory
+                .ancestors()
+                .take_while(|ancestor| ancestor.starts_with(&self.root))
+                .find(|ancestor| ancestor.join(".git").exists())
+                .unwrap_or(&self.root);
+            metadata = ProjectMetadata::discover(fallback_root, python_version)?;
+        }
+        let root = metadata.root().clone();
+        if let Some(project) = self.projects.get(&root) {
+            return Ok(Arc::clone(project));
+        }
+
+        metadata.apply_overrides(
+            &ProjectOptionsOverrides::new(None, Options::default())
+                .with_profile(profile.map(str::to_owned)),
+        )?;
+        let project = Arc::new(Project::from_metadata(metadata));
+        self.projects.insert(root, Arc::clone(&project));
+        Ok(project)
+    }
+}
+
+/// Independent project caches for every editor workspace folder.
+#[derive(Debug)]
+pub struct Workspaces {
+    folders: Vec<WorkspaceFolder>,
+    profile: Option<String>,
+    python_version: PythonVersion,
+    roots: Vec<Workspace>,
+}
+
+impl Workspaces {
+    pub(super) fn new(
+        folders: Vec<WorkspaceFolder>,
+        python_version: PythonVersion,
+        profile: Option<String>,
+    ) -> Result<Self, WorkspaceError> {
+        let roots = folders
+            .iter()
+            .map(|folder| uri_to_path(&folder.uri).map(Workspace::new))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            folders,
+            profile,
+            python_version,
+            roots,
+        })
+    }
+
+    pub(super) fn folders(&self) -> impl Iterator<Item = &WorkspaceFolder> {
+        self.folders.iter()
+    }
+
+    pub(super) fn project_for_uri(&mut self, uri: &Uri) -> Result<Arc<Project>, WorkspaceError> {
+        let path = uri_to_path(uri)?;
+        let workspace = self
+            .roots
+            .iter_mut()
+            .filter(|workspace| path.starts_with(&workspace.root))
+            .max_by_key(|workspace| workspace.root.components().count());
+
+        if let Some(workspace) = workspace {
+            return workspace.project_for_path(&path, self.python_version, self.profile.as_deref());
+        }
+
+        let root = path
+            .parent()
+            .ok_or_else(|| WorkspaceError::MissingParent(path.clone()))?
+            .to_path_buf();
+        let mut workspace = Workspace::new(root);
+        let project =
+            workspace.project_for_path(&path, self.python_version, self.profile.as_deref())?;
+        self.roots.push(workspace);
+        Ok(project)
+    }
+
+    pub(super) fn open_folder(&mut self, folder: WorkspaceFolder) -> Result<(), WorkspaceError> {
+        if self.folders.iter().any(|open| open.uri == folder.uri) {
+            return Ok(());
+        }
+        let root = uri_to_path(&folder.uri)?;
+        self.folders.push(folder);
+        self.roots.push(Workspace::new(root));
+        Ok(())
+    }
+
+    pub(super) fn close_folder(&mut self, uri: &Uri) -> Result<(), WorkspaceError> {
+        let root = uri_to_path(uri)?;
+        self.folders.retain(|folder| &folder.uri != uri);
+        self.roots.retain(|workspace| workspace.root != root);
+        Ok(())
+    }
+}
+
+fn uri_to_path(uri: &Uri) -> Result<Utf8PathBuf, WorkspaceError> {
+    let path = uri
+        .to_file_path()
+        .map_err(|()| WorkspaceError::NotAFileUri(uri.clone()))?;
+    Utf8PathBuf::from_path_buf(path).map_err(|_| WorkspaceError::NonUtf8FileUri(uri.clone()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use ruff_python_ast::PythonVersion;
+
+    use super::*;
+
+    fn root(temp_dir: &tempfile::TempDir) -> Utf8PathBuf {
+        let root = Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf())
+            .expect("temp directory should be UTF-8");
+        fs::create_dir(root.join(".git")).expect("create project boundary");
+        root
+    }
+
+    fn file_uri(path: &Utf8Path) -> Uri {
+        Uri::from_file_path(path).expect("test path should produce a file URI")
+    }
+
+    fn folder(root: &Utf8Path, name: &str) -> WorkspaceFolder {
+        WorkspaceFolder {
+            uri: file_uri(root),
+            name: name.to_owned(),
+        }
+    }
+
+    fn prefix(project: &Project) -> &str {
+        &project.settings().test().test_function_prefix
+    }
+
+    #[test]
+    fn discovers_karva_toml_for_nested_document() {
+        let temp_dir = tempfile::tempdir().expect("create temp directory");
+        let root = root(&temp_dir);
+        let nested = root.join("src/package");
+        fs::create_dir_all(&nested).expect("create nested source directory");
+        fs::write(
+            root.join("karva.toml"),
+            "[profile.default.test]\ntest-function-prefix = \"spec_\"\n",
+        )
+        .expect("write Karva configuration");
+        let mut workspaces =
+            Workspaces::new(vec![folder(&root, "root")], PythonVersion::PY311, None)
+                .expect("create workspaces");
+
+        let project = workspaces
+            .project_for_uri(&file_uri(&nested.join("test_example.py")))
+            .expect("discover project");
+
+        assert_eq!(project.cwd(), &root);
+        assert_eq!(prefix(&project), "spec_");
+    }
+
+    #[test]
+    fn discovers_pyproject_configuration() {
+        let temp_dir = tempfile::tempdir().expect("create temp directory");
+        let root = root(&temp_dir);
+        fs::write(
+            root.join("pyproject.toml"),
+            "[tool.karva.profile.default.test]\ntest-function-prefix = \"check_\"\n",
+        )
+        .expect("write Python project configuration");
+        let mut workspaces =
+            Workspaces::new(vec![folder(&root, "root")], PythonVersion::PY311, None)
+                .expect("create workspaces");
+
+        let project = workspaces
+            .project_for_uri(&file_uri(&root.join("test_example.py")))
+            .expect("discover project");
+
+        assert_eq!(prefix(&project), "check_");
+    }
+
+    #[test]
+    fn selects_initialization_profile() {
+        let temp_dir = tempfile::tempdir().expect("create temp directory");
+        let root = root(&temp_dir);
+        fs::write(
+            root.join("karva.toml"),
+            "[profile.default.test]\ntest-function-prefix = \"test_\"\n\n[profile.ci.test]\ntest-function-prefix = \"ci_\"\n",
+        )
+        .expect("write profiled configuration");
+        let mut workspaces = Workspaces::new(
+            vec![folder(&root, "root")],
+            PythonVersion::PY311,
+            Some("ci".to_owned()),
+        )
+        .expect("create workspaces");
+
+        let project = workspaces
+            .project_for_uri(&file_uri(&root.join("test_example.py")))
+            .expect("discover project");
+
+        assert_eq!(prefix(&project), "ci_");
+    }
+
+    #[test]
+    fn closest_nested_configuration_wins() {
+        let temp_dir = tempfile::tempdir().expect("create temp directory");
+        let root = root(&temp_dir);
+        let nested = root.join("packages/child");
+        fs::create_dir_all(&nested).expect("create nested project");
+        fs::write(
+            root.join("karva.toml"),
+            "[profile.default.test]\ntest-function-prefix = \"root_\"\n",
+        )
+        .expect("write root configuration");
+        fs::write(
+            nested.join("karva.toml"),
+            "[profile.default.test]\ntest-function-prefix = \"child_\"\n",
+        )
+        .expect("write nested configuration");
+        let mut workspaces =
+            Workspaces::new(vec![folder(&root, "root")], PythonVersion::PY311, None)
+                .expect("create workspaces");
+
+        let project = workspaces
+            .project_for_uri(&file_uri(&nested.join("test_example.py")))
+            .expect("discover nested project");
+
+        assert_eq!(project.cwd(), &nested);
+        assert_eq!(prefix(&project), "child_");
+    }
+
+    #[test]
+    fn missing_configuration_uses_defaults() {
+        let temp_dir = tempfile::tempdir().expect("create temp directory");
+        let root = root(&temp_dir);
+        let mut workspaces =
+            Workspaces::new(vec![folder(&root, "root")], PythonVersion::PY311, None)
+                .expect("create workspaces");
+
+        let nested = root.join("src/package");
+        fs::create_dir_all(&nested).expect("create nested source directory");
+        let project = workspaces
+            .project_for_uri(&file_uri(&nested.join("test_example.py")))
+            .expect("create default project");
+
+        assert_eq!(project.cwd(), &root);
+        assert_eq!(prefix(&project), "test");
+    }
+
+    #[test]
+    fn resolves_configured_test_overrides() {
+        let temp_dir = tempfile::tempdir().expect("create temp directory");
+        let root = root(&temp_dir);
+        fs::write(
+            root.join("karva.toml"),
+            "[[profile.default.overrides]]\nfilter = \"tag(network)\"\nretries = 1\n",
+        )
+        .expect("write override configuration");
+        let mut workspaces =
+            Workspaces::new(vec![folder(&root, "root")], PythonVersion::PY311, None)
+                .expect("create workspaces");
+
+        let project = workspaces
+            .project_for_uri(&file_uri(&root.join("test_example.py")))
+            .expect("discover project");
+
+        assert_eq!(project.settings().overrides().len(), 1);
+        assert_eq!(project.settings().overrides()[0].retries, Some(1));
+    }
+
+    #[test]
+    fn workspace_folders_keep_projects_independent() {
+        let first_dir = tempfile::tempdir().expect("create first temp directory");
+        let second_dir = tempfile::tempdir().expect("create second temp directory");
+        let first = root(&first_dir);
+        let second = root(&second_dir);
+        fs::write(
+            first.join("karva.toml"),
+            "[profile.default.test]\ntest-function-prefix = \"first_\"\n",
+        )
+        .expect("write first configuration");
+        fs::write(
+            second.join("karva.toml"),
+            "[profile.default.test]\ntest-function-prefix = \"second_\"\n",
+        )
+        .expect("write second configuration");
+        let mut workspaces = Workspaces::new(
+            vec![folder(&first, "first"), folder(&second, "second")],
+            PythonVersion::PY311,
+            None,
+        )
+        .expect("create workspaces");
+
+        let first_project = workspaces
+            .project_for_uri(&file_uri(&first.join("test_example.py")))
+            .expect("discover first project");
+        let second_project = workspaces
+            .project_for_uri(&file_uri(&second.join("test_example.py")))
+            .expect("discover second project");
+
+        assert_eq!(prefix(&first_project), "first_");
+        assert_eq!(prefix(&second_project), "second_");
+        assert!(!Arc::ptr_eq(&first_project, &second_project));
+    }
+}

--- a/crates/karva_language_server/tests/e2e/config_reload.rs
+++ b/crates/karva_language_server/tests/e2e/config_reload.rs
@@ -1,0 +1,35 @@
+use lsp_types::{
+    ClientCapabilities, DidChangeWatchedFilesClientCapabilities, DidChangeWatchedFilesNotification,
+    DidChangeWatchedFilesParams, FileChangeType, FileEvent, RegistrationRequest, Uri,
+    WorkspaceClientCapabilities,
+};
+
+use super::TestServer;
+
+#[test]
+fn registers_and_accepts_configuration_file_changes() {
+    let server = TestServer::new(ClientCapabilities {
+        workspace: Some(WorkspaceClientCapabilities {
+            did_change_watched_files: Some(DidChangeWatchedFilesClientCapabilities {
+                dynamic_registration: Some(true),
+                relative_pattern_support: Some(false),
+            }),
+            ..WorkspaceClientCapabilities::default()
+        }),
+        ..ClientCapabilities::default()
+    });
+    let (id, params) = server.receive_request::<RegistrationRequest>();
+    let registration = params
+        .registrations
+        .first()
+        .expect("configuration watcher should be registered");
+    assert_eq!(registration.method, "workspace/didChangeWatchedFiles");
+    server.respond::<RegistrationRequest>(id, ());
+
+    server.notify::<DidChangeWatchedFilesNotification>(DidChangeWatchedFilesParams {
+        changes: vec![FileEvent {
+            uri: Uri::parse("file:///workspace/karva.toml").expect("test URI should be valid"),
+            kind: FileChangeType::Changed,
+        }],
+    });
+}

--- a/crates/karva_language_server/tests/e2e/document_sync.rs
+++ b/crates/karva_language_server/tests/e2e/document_sync.rs
@@ -1,0 +1,41 @@
+use lsp_types::{
+    DidChangeTextDocumentNotification, DidChangeTextDocumentParams,
+    DidCloseTextDocumentNotification, DidCloseTextDocumentParams, DidOpenTextDocumentNotification,
+    DidOpenTextDocumentParams, LanguageKind, Position, Range, TextDocumentContentChangeEvent,
+    TextDocumentContentChangePartial, TextDocumentIdentifier, TextDocumentItem, Uri,
+    VersionedTextDocumentIdentifier,
+};
+
+use super::TestServer;
+
+#[test]
+fn accepts_incremental_unsaved_document_changes() {
+    let server = TestServer::new(lsp_types::ClientCapabilities::default());
+    let uri = Uri::parse("file:///workspace/test_example.py").expect("test URI should be valid");
+    server.notify::<DidOpenTextDocumentNotification>(DidOpenTextDocumentParams {
+        text_document: TextDocumentItem {
+            uri: uri.clone(),
+            language_id: LanguageKind::Python,
+            version: 1,
+            text: "def test_😀():\n    pas\n".to_owned(),
+        },
+    });
+    server.notify::<DidChangeTextDocumentNotification>(DidChangeTextDocumentParams {
+        text_document: VersionedTextDocumentIdentifier {
+            text_document_identifier: TextDocumentIdentifier { uri: uri.clone() },
+            version: 2,
+        },
+        content_changes: vec![
+            TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                TextDocumentContentChangePartial {
+                    range: Range::new(Position::new(1, 7), Position::new(1, 7)),
+                    text: "s".to_owned(),
+                    ..TextDocumentContentChangePartial::default()
+                },
+            ),
+        ],
+    });
+    server.notify::<DidCloseTextDocumentNotification>(DidCloseTextDocumentParams {
+        text_document: TextDocumentIdentifier { uri },
+    });
+}

--- a/crates/karva_language_server/tests/e2e/initialize.rs
+++ b/crates/karva_language_server/tests/e2e/initialize.rs
@@ -1,4 +1,7 @@
-use lsp_types::{ClientCapabilities, GeneralClientCapabilities, PositionEncodingKind};
+use lsp_types::{
+    ClientCapabilities, GeneralClientCapabilities, PositionEncodingKind, TextDocumentSync,
+    TextDocumentSyncKind,
+};
 
 use super::TestServer;
 
@@ -43,5 +46,25 @@ fn initialization_negotiates_utf8() {
             .capabilities
             .position_encoding,
         Some(PositionEncodingKind::UTF8)
+    );
+}
+
+#[test]
+fn initialization_advertises_document_and_workspace_sync() {
+    let server = TestServer::new(ClientCapabilities::default());
+    let capabilities = &server.initialization_result().capabilities;
+    let Some(TextDocumentSync::Options(sync)) = capabilities.text_document_sync else {
+        panic!("expected text document sync options");
+    };
+
+    assert_eq!(sync.open_close, Some(true));
+    assert_eq!(sync.change, Some(TextDocumentSyncKind::Incremental));
+    assert_eq!(
+        capabilities
+            .workspace
+            .as_ref()
+            .and_then(|workspace| workspace.workspace_folders.as_ref())
+            .and_then(|folders| folders.supported),
+        Some(true)
     );
 }

--- a/crates/karva_language_server/tests/e2e/main.rs
+++ b/crates/karva_language_server/tests/e2e/main.rs
@@ -1,5 +1,6 @@
 //! End-to-end language-server tests over an in-memory LSP connection.
 
+mod document_sync;
 mod initialize;
 
 use std::thread::JoinHandle;

--- a/crates/karva_language_server/tests/e2e/main.rs
+++ b/crates/karva_language_server/tests/e2e/main.rs
@@ -1,5 +1,6 @@
 //! End-to-end language-server tests over an in-memory LSP connection.
 
+mod config_reload;
 mod document_sync;
 mod initialize;
 
@@ -88,6 +89,27 @@ impl TestServer {
         };
         assert_eq!(&response.id, expected_id);
         response
+    }
+
+    fn receive_request<R: Request>(&self) -> (RequestId, R::Params) {
+        let message = self
+            .connection
+            .as_ref()
+            .expect("test client should be connected")
+            .receiver
+            .recv()
+            .expect("language server should send a request");
+        let Message::Request(request) = message else {
+            panic!("expected request, received {message:?}");
+        };
+        assert_eq!(request.method, R::METHOD.as_str());
+        let params = serde_json::from_value(request.params)
+            .expect("request parameters should match their protocol type");
+        (request.id, params)
+    }
+
+    fn respond<R: Request>(&self, id: RequestId, result: R::Result) {
+        self.send(Message::Response(Response::new_ok(id, result)));
     }
 }
 

--- a/crates/karva_python_semantic/Cargo.toml
+++ b/crates/karva_python_semantic/Cargo.toml
@@ -10,9 +10,13 @@ repository.workspace = true
 authors.workspace = true
 license.workspace = true
 
+[features]
+default = []
+python-runtime = ["dep:pyo3"]
+
 [dependencies]
 camino = { workspace = true }
-pyo3 = { workspace = true }
+pyo3 = { workspace = true, optional = true }
 ruff_python_ast = { workspace = true }
 serde = { workspace = true }
 

--- a/crates/karva_python_semantic/src/lib.rs
+++ b/crates/karva_python_semantic/src/lib.rs
@@ -7,8 +7,11 @@ mod name;
 
 pub use function_kind::FunctionKind;
 pub use name::{ModulePath, QualifiedFunctionName, QualifiedTestName, TestCacheKey};
+#[cfg(feature = "python-runtime")]
 use pyo3::Python;
-use ruff_python_ast::{Expr, PythonVersion, StmtFunctionDef};
+#[cfg(feature = "python-runtime")]
+use ruff_python_ast::PythonVersion;
+use ruff_python_ast::{Expr, StmtFunctionDef};
 
 /// Check whether a file path has a `.py` extension.
 pub fn is_python_file(path: &Utf8Path) -> bool {
@@ -63,6 +66,7 @@ pub(crate) fn module_name(cwd: &Utf8Path, path: &Utf8Path) -> Option<String> {
 /// This function queries the embedded Python interpreter to determine
 /// the major and minor version numbers, which are used for AST parsing
 /// compatibility and feature detection.
+#[cfg(feature = "python-runtime")]
 pub fn current_python_version() -> PythonVersion {
     Python::initialize();
     PythonVersion::from(Python::attach(|py| {

--- a/crates/karva_worker/Cargo.toml
+++ b/crates/karva_worker/Cargo.toml
@@ -22,7 +22,7 @@ karva_ipc = { workspace = true }
 karva_logging = { workspace = true }
 karva_metadata = { workspace = true }
 karva_project = { workspace = true }
-karva_python_semantic = { workspace = true }
+karva_python_semantic = { workspace = true, features = ["python-runtime"] }
 karva_static = { workspace = true }
 karva_test_semantic = { workspace = true }
 


### PR DESCRIPTION
## Summary

Keeps editor analysis independent of Python initialization and user-module imports. This is part of #1212.

## Test plan

ci