### PR TITLE
Schedule requests and complete fixtures

### DIFF
--- a/crates/karva_ide/src/completion.rs
+++ b/crates/karva_ide/src/completion.rs
@@ -1,0 +1,417 @@
+use std::convert::TryFrom;
+
+use ruff_python_ast::Expr;
+use ruff_text_size::{Ranged, TextRange, TextSize};
+
+use crate::{FixtureId, FixtureScope, SourceAnalysis};
+
+/// A fixture completion independent of an editor protocol.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FixtureCompletion {
+    /// Text inserted by the editor.
+    pub label: String,
+
+    /// Human-readable provider, scope, and autouse information.
+    pub detail: String,
+
+    /// Range replaced by `label`.
+    pub replacement_range: TextRange,
+}
+
+/// Computes fixture completions at a UTF-8 byte offset.
+///
+/// Dynamic expressions and positions outside test/fixture parameters or known
+/// `use_fixtures` decorators return `None`.
+pub fn complete_fixtures(
+    analysis: &SourceAnalysis,
+    offset: TextSize,
+) -> Option<Vec<FixtureCompletion>> {
+    let source = &analysis.module.source_text;
+    let replacement =
+        parameter_context(analysis, offset).or_else(|| use_fixtures_context(analysis, offset))?;
+    let prefix = source.get(replacement.start().to_usize()..replacement.end().to_usize())?;
+
+    let mut completions = Vec::new();
+    let mut names = analysis.fixture_completion_blocked_names.clone();
+    for fixture in &analysis.visible_fixtures {
+        if names.insert(fixture.name.clone()) && fixture.name.starts_with(prefix) {
+            completions.push(completion(
+                fixture.name.clone(),
+                replacement,
+                Some(&fixture.id),
+                fixture.scope,
+                fixture.auto_use,
+            ));
+        }
+    }
+    if analysis.fixture_completion_builtins_visible {
+        for (name, scope) in crate::fixture::builtin_fixtures() {
+            if names.insert(name.to_owned()) && name.starts_with(prefix) {
+                completions.push(completion(
+                    name.to_owned(),
+                    replacement,
+                    None,
+                    Some(scope),
+                    Some(false),
+                ));
+            }
+        }
+    }
+    completions.sort_by(|left, right| left.label.cmp(&right.label));
+    Some(completions)
+}
+
+fn completion(
+    label: String,
+    replacement_range: TextRange,
+    provider: Option<&FixtureId>,
+    scope: Option<FixtureScope>,
+    auto_use: Option<bool>,
+) -> FixtureCompletion {
+    let origin = provider.map_or_else(|| "Karva built-in".to_owned(), |id| id.path.to_string());
+    let scope_detail =
+        scope.map_or_else(|| "dynamic".to_owned(), |scope| scope.as_str().to_owned());
+    let auto_use_detail =
+        auto_use.map_or_else(|| "dynamic".to_owned(), |auto_use| auto_use.to_string());
+    FixtureCompletion {
+        label,
+        detail: format!("fixture · {origin} · scope={scope_detail} · autouse={auto_use_detail}"),
+        replacement_range,
+    }
+}
+
+fn parameter_context(analysis: &SourceAnalysis, offset: TextSize) -> Option<TextRange> {
+    let source = &analysis.module.source_text;
+    let functions = analysis
+        .module
+        .test_function_defs
+        .iter()
+        .chain(&analysis.module.fixture_function_defs);
+    for function in functions {
+        let parameters = function.parameters.range;
+        if !parameters.contains_inclusive(offset) {
+            continue;
+        }
+        if let Some(parameter) = function
+            .parameters
+            .iter_non_variadic_params()
+            .find(|parameter| parameter.parameter.name.range.contains_inclusive(offset))
+        {
+            return Some(parameter.parameter.name.range);
+        }
+        let token = identifier_range(source, offset, parameters);
+        if let Some(token) = token {
+            if parameter_slot(source, parameters, token.start()) {
+                return Some(token);
+            }
+        } else if parameter_slot(source, parameters, offset) {
+            return Some(TextRange::at(offset, TextSize::ZERO));
+        }
+    }
+    None
+}
+
+fn parameter_slot(source: &str, parameters: TextRange, offset: TextSize) -> bool {
+    let start = parameters.start().to_usize();
+    let end = offset.to_usize();
+    let Some(prefix) = source.get(start..end) else {
+        return false;
+    };
+    let segment = prefix
+        .rsplit_once(',')
+        .map_or(prefix, |(_, segment)| segment);
+    let segment = segment.trim();
+    !segment.is_empty()
+        && segment
+            .chars()
+            .all(|character| character == '_' || character.is_ascii_alphanumeric())
+        || segment.is_empty()
+}
+
+fn use_fixtures_context(analysis: &SourceAnalysis, offset: TextSize) -> Option<TextRange> {
+    let source = &analysis.module.source_text;
+    for function in &analysis.module.test_function_defs {
+        for decorator in &function.decorator_list {
+            if !decorator.range().contains_inclusive(offset) {
+                continue;
+            }
+            let Expr::Call(call) = &decorator.expression else {
+                continue;
+            };
+            if !is_use_fixtures_reference(&call.func) {
+                continue;
+            }
+            for argument in &call.arguments.args {
+                let Expr::StringLiteral(literal) = argument else {
+                    return None;
+                };
+                let interior = string_interior(source, literal.range)?;
+                if interior.contains_inclusive(offset) {
+                    return Some(
+                        identifier_range(source, offset, interior)
+                            .unwrap_or_else(|| TextRange::at(offset, TextSize::ZERO)),
+                    );
+                }
+            }
+        }
+    }
+    None
+}
+
+fn is_use_fixtures_reference(expression: &Expr) -> bool {
+    let Expr::Attribute(attribute) = expression else {
+        return false;
+    };
+    match attribute.attr.as_str() {
+        "use_fixtures" => matches!(
+            attribute.value.as_ref(),
+            Expr::Attribute(namespace)
+                if namespace.attr.as_str() == "tags"
+                    && matches!(namespace.value.as_ref(), Expr::Name(name) if name.id == "karva")
+        ),
+        "usefixtures" => matches!(
+            attribute.value.as_ref(),
+            Expr::Attribute(namespace)
+                if namespace.attr.as_str() == "mark"
+                    && matches!(namespace.value.as_ref(), Expr::Name(name) if name.id == "pytest")
+        ),
+        _ => false,
+    }
+}
+
+fn string_interior(source: &str, range: TextRange) -> Option<TextRange> {
+    let text = source.get(range.start().to_usize()..range.end().to_usize())?;
+    let quote = text
+        .bytes()
+        .position(|byte| byte == b'\'' || byte == b'"')?;
+    let end_quote = text
+        .bytes()
+        .rposition(|byte| byte == b'\'' || byte == b'"')?;
+    if quote >= end_quote {
+        return None;
+    }
+    Some(TextRange::new(
+        range.start() + size(quote + 1)?,
+        range.start() + size(end_quote)?,
+    ))
+}
+
+fn identifier_range(source: &str, offset: TextSize, boundary: TextRange) -> Option<TextRange> {
+    let offset = offset.to_usize();
+    let start = boundary.start().to_usize();
+    let end = boundary.end().to_usize().min(source.len());
+    if offset < start || offset > end {
+        return None;
+    }
+    if !source.is_char_boundary(offset) {
+        return None;
+    }
+    let mut token_start = offset;
+    for (index, character) in source.get(start..offset)?.char_indices().rev() {
+        if !is_identifier_character(character) {
+            break;
+        }
+        token_start = start + index;
+    }
+    let mut token_end = offset;
+    for (index, character) in source.get(offset..end)?.char_indices() {
+        if !is_identifier_character(character) {
+            break;
+        }
+        token_end = offset + index + character.len_utf8();
+    }
+    if token_start >= token_end {
+        return None;
+    }
+    Some(TextRange::new(size(token_start)?, size(token_end)?))
+}
+
+fn is_identifier_character(character: char) -> bool {
+    character == '_' || character.is_alphanumeric()
+}
+
+fn size(value: usize) -> Option<TextSize> {
+    u32::try_from(value).ok().map(TextSize::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use camino::{Utf8Path, Utf8PathBuf};
+    use ruff_python_ast::PythonVersion;
+    use ruff_text_size::TextSize;
+
+    use super::*;
+    use crate::{
+        SourceAnalysisSettings, SourceDocument, analyze_source, analyze_source_with_parents,
+    };
+
+    fn settings() -> SourceAnalysisSettings {
+        SourceAnalysisSettings {
+            python_version: PythonVersion::PY312,
+            test_function_prefix: "test".to_owned(),
+            try_import_fixtures: false,
+        }
+    }
+
+    fn analysis(source: &str) -> SourceAnalysis {
+        analyze_source(
+            &Utf8PathBuf::from("/project/test_example.py"),
+            Utf8Path::new("/project"),
+            source.to_owned(),
+            &settings(),
+        )
+        .expect("source should analyze")
+    }
+
+    fn at(source: &str, marker: &str) -> TextSize {
+        size(source.find(marker).expect("marker")).expect("source fits in TextSize")
+    }
+
+    #[test]
+    fn completes_local_and_builtin_fixtures_in_test_parameters() {
+        let source = "from karva import fixture\n\n@fixture\ndef database(): pass\n\ndef test_example(dat): pass\n";
+        let analysis = analysis(source);
+        let marker = source.rfind("dat").expect("test parameter");
+        let completions = complete_fixtures(
+            &analysis,
+            size(marker).expect("source fits") + TextSize::from(2),
+        )
+        .expect("parameter completion");
+        assert_eq!(completions[0].label, "database");
+        assert!(
+            completions
+                .iter()
+                .any(|completion| completion.label == "database")
+        );
+        assert_eq!(
+            completions[0].replacement_range,
+            TextRange::new(
+                size(marker).expect("source fits"),
+                size(marker).expect("source fits") + TextSize::from(3),
+            )
+        );
+    }
+
+    #[test]
+    fn parent_override_and_rejected_fixtures_follow_runtime_visibility() {
+        let parent = SourceDocument::new(
+            Utf8PathBuf::from("/project/conftest.py"),
+            "from karva import fixture\n\n@fixture\ndef database(): pass\n@fixture\ndef parent_only(): pass\n".to_owned(),
+        );
+        let source = "from karva import fixture\n\n@fixture(scope=\"invalid\")\ndef database(): pass\n\ndef test_example(pa): pass\n";
+        let current = SourceDocument::new(
+            Utf8PathBuf::from("/project/test_example.py"),
+            source.to_owned(),
+        );
+        let analysis =
+            analyze_source_with_parents(current, [parent], Utf8Path::new("/project"), &settings())
+                .expect("source should analyze");
+        let marker = source.find("pa):").expect("test parameter");
+        let completions = complete_fixtures(
+            &analysis,
+            size(marker).expect("source fits") + TextSize::from(2),
+        )
+        .expect("completion");
+        assert!(
+            completions
+                .iter()
+                .all(|completion| completion.label != "database")
+        );
+        assert!(
+            completions
+                .iter()
+                .any(|completion| completion.label == "parent_only")
+        );
+    }
+
+    #[test]
+    fn rejected_fixture_name_blocks_builtin_completion() {
+        let source = "from karva import fixture\n\n@fixture(scope=\"invalid\")\ndef tmp_path(): pass\n\ndef test_example(tmp): pass\n";
+        let analysis = analysis(source);
+        let marker = source.rfind("tmp").expect("test parameter");
+        let completions = complete_fixtures(
+            &analysis,
+            size(marker).expect("source fits") + TextSize::from(3),
+        )
+        .expect("parameter completion");
+
+        assert!(
+            completions
+                .iter()
+                .all(|completion| completion.label != "tmp_path")
+        );
+    }
+
+    #[test]
+    fn replaces_unicode_parameter_prefix() {
+        let source = "from karva import fixture\n\n@fixture\ndef δεδομενα(): pass\n\ndef test_example(δε): pass\n";
+        let analysis = analysis(source);
+        let marker = source.rfind("δε").expect("test parameter");
+        let completions =
+            complete_fixtures(&analysis, size(marker + "δε".len()).expect("source fits"))
+                .expect("parameter completion");
+
+        assert_eq!(completions[0].label, "δεδομενα");
+        assert_eq!(
+            completions[0].replacement_range,
+            TextRange::new(
+                size(marker).expect("source fits"),
+                size(marker + "δε".len()).expect("source fits"),
+            )
+        );
+    }
+
+    #[test]
+    fn completes_fixture_parameters_and_use_fixtures_strings() {
+        let source = "from karva import fixture\nimport karva\n\n@fixture\ndef database(): pass\n\n@karva.tags.use_fixtures(\"dat\")\ndef test_example(): pass\n\n@fixture\ndef wrapper(dat): pass\n";
+        let analysis = analysis(source);
+        let first = source.find("\"dat\"").expect("use_fixtures argument") + 1;
+        assert!(
+            complete_fixtures(
+                &analysis,
+                size(first).expect("source fits") + TextSize::from(2)
+            )
+            .is_some()
+        );
+        let second = source.rfind("dat").expect("fixture parameter");
+        assert!(
+            complete_fixtures(
+                &analysis,
+                size(second).expect("source fits") + TextSize::from(2)
+            )
+            .is_some()
+        );
+    }
+
+    #[test]
+    fn custom_test_prefix_is_collected() {
+        let source = "def spec_example(dat): pass\n";
+        let settings = SourceAnalysisSettings {
+            test_function_prefix: "spec".to_owned(),
+            ..settings()
+        };
+        let analysis = analyze_source(
+            &Utf8PathBuf::from("/project/test_example.py"),
+            Utf8Path::new("/project"),
+            source.to_owned(),
+            &settings,
+        )
+        .expect("source should analyze");
+        let marker = source.find("dat").expect("fixture parameter");
+        assert!(
+            complete_fixtures(
+                &analysis,
+                size(marker).expect("source fits") + TextSize::from(2)
+            )
+            .is_some()
+        );
+    }
+
+    #[test]
+    fn dynamic_context_is_not_completed() {
+        let source = "def helper(dat): pass\n";
+        assert!(
+            complete_fixtures(&analysis(source), at(source, "dat") + TextSize::from(2)).is_none()
+        );
+    }
+}

--- a/crates/karva_ide/src/fixture.rs
+++ b/crates/karva_ide/src/fixture.rs
@@ -14,9 +14,9 @@ use crate::{DiagnosticCode, RelatedInformation, SourceDiagnostic, SourceLocation
 
 /// Stable identity for a fixture provider.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub(crate) struct FixtureId {
+pub(super) struct FixtureId {
     /// File containing the fixture.
-    path: Utf8PathBuf,
+    pub(super) path: Utf8PathBuf,
 
     /// Range of the fixture definition.
     range: TextRange,
@@ -24,7 +24,7 @@ pub(crate) struct FixtureId {
 
 /// Runtime lifetime of a fixture value.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) enum FixtureScope {
+pub(super) enum FixtureScope {
     /// Recreated for every test attempt.
     #[default]
     Function,
@@ -46,7 +46,7 @@ impl FixtureScope {
     }
 
     /// Returns the configuration spelling of the scope.
-    const fn as_str(self) -> &'static str {
+    pub(super) const fn as_str(self) -> &'static str {
         match self {
             Self::Function => "function",
             Self::Module => "module",
@@ -72,7 +72,7 @@ impl TryFrom<&str> for FixtureScope {
 
 /// Result of resolving one fixture reference.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum FixtureResolution {
+enum FixtureResolution {
     /// The reference resolves to a source fixture.
     Resolved(FixtureId),
 
@@ -91,7 +91,7 @@ pub(crate) enum FixtureResolution {
 
 /// One fixture reference from a function parameter.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct FixtureReference {
+struct FixtureReference {
     /// Requested fixture name.
     name: String,
 
@@ -104,12 +104,12 @@ pub(crate) struct FixtureReference {
 
 /// A statically understood fixture declaration.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct FixtureDefinition {
+pub(super) struct FixtureDefinition {
     /// Stable source identity.
-    id: FixtureId,
+    pub(super) id: FixtureId,
 
     /// Public fixture name after literal decorator renaming.
-    name: String,
+    pub(super) name: String,
 
     /// Python function name.
     defining_name: String,
@@ -118,10 +118,10 @@ pub(crate) struct FixtureDefinition {
     name_range: TextRange,
 
     /// Statically known scope, or `None` for dynamic scope metadata.
-    scope: Option<FixtureScope>,
+    pub(super) scope: Option<FixtureScope>,
 
     /// Statically known autouse value, or `None` for dynamic metadata.
-    auto_use: Option<bool>,
+    pub(super) auto_use: Option<bool>,
 
     /// Fixture dependencies declared as non-variadic parameters.
     dependencies: Vec<FixtureReference>,
@@ -310,6 +310,67 @@ pub(super) fn analyze_modules(
             ))
     });
     (current_definitions, diagnostics)
+}
+
+/// Visible fixture providers plus conservative completion barriers.
+pub(super) struct VisibleFixtures {
+    /// Definitions selected before any dynamic provider barrier.
+    pub(super) definitions: Vec<FixtureDefinition>,
+
+    /// Rejected names that prevent fallback to later providers.
+    pub(super) blocked_names: HashSet<String>,
+
+    /// Whether every provider was statically known, allowing built-in fallback.
+    pub(super) builtins_visible: bool,
+}
+
+/// Returns fixture definitions that can be selected from the current module.
+///
+/// Providers follow runtime lookup order. A rejected definition blocks the same
+/// name from every later provider, including Karva's built-ins.
+pub(super) fn visible_fixtures(
+    current: &CollectedModule,
+    parents: &[&CollectedModule],
+    try_import_fixtures: bool,
+) -> VisibleFixtures {
+    let mut providers = parents
+        .iter()
+        .map(|module| parse_provider(module, try_import_fixtures))
+        .collect::<Vec<_>>();
+    providers.insert(0, parse_provider(current, try_import_fixtures));
+
+    let mut visible = Vec::new();
+    let mut names = HashSet::new();
+    let mut blocked_names = HashSet::new();
+    let mut builtins_visible = true;
+    for provider in providers {
+        for rejected in provider.rejected.keys() {
+            if names.insert(rejected.clone()) {
+                blocked_names.insert(rejected.clone());
+            }
+        }
+        for definition in provider.definitions {
+            if names.insert(definition.name.clone()) {
+                visible.push(definition);
+            }
+        }
+        if provider.unknown {
+            builtins_visible = false;
+            break;
+        }
+    }
+    VisibleFixtures {
+        definitions: visible,
+        blocked_names,
+        builtins_visible,
+    }
+}
+
+/// Returns the built-in fixtures exposed by Karva's runtime.
+pub(super) fn builtin_fixtures() -> impl Iterator<Item = (&'static str, FixtureScope)> {
+    BUILTIN_FIXTURES
+        .iter()
+        .map(|fixture| (fixture.name, fixture.scope))
 }
 
 impl FixtureProvider {
@@ -999,9 +1060,8 @@ mod tests {
     use camino::{Utf8Path, Utf8PathBuf};
     use ruff_python_ast::PythonVersion;
 
-    use crate::{
-        DiagnosticCode, FixtureResolution, SourceAnalysisSettings, analyze_source, analyze_sources,
-    };
+    use super::FixtureResolution;
+    use crate::{DiagnosticCode, SourceAnalysisSettings, analyze_source, analyze_sources};
 
     fn analyze(source: &str) -> crate::SourceAnalysis {
         analyze_source(

--- a/crates/karva_ide/src/lib.rs
+++ b/crates/karva_ide/src/lib.rs
@@ -1,5 +1,6 @@
 //! Source-only editor analysis for Karva projects.
 
+mod completion;
 mod fixture;
 
 use camino::{Utf8Path, Utf8PathBuf};
@@ -7,10 +8,9 @@ use karva_collector::{CollectedModule, CollectionSettings, collect_source};
 use ruff_python_ast::PythonVersion;
 use ruff_text_size::TextRange;
 
-use fixture::FixtureDefinition;
+pub use completion::{FixtureCompletion, complete_fixtures};
 
-#[cfg(test)]
-pub(crate) use fixture::FixtureResolution;
+use fixture::{FixtureDefinition, FixtureId, FixtureScope};
 
 /// Owned Python source used as an input to source-only analysis.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -23,6 +23,16 @@ impl SourceDocument {
     /// Creates a source document with its stable filesystem path.
     pub fn new(path: Utf8PathBuf, source_text: String) -> Self {
         Self { path, source_text }
+    }
+
+    /// Returns the document's filesystem path.
+    pub fn path(&self) -> &Utf8Path {
+        &self.path
+    }
+
+    /// Returns the complete source text owned by this document.
+    pub fn source_text(&self) -> &str {
+        &self.source_text
     }
 
     /// Consumes the document and returns its path and source text.
@@ -128,6 +138,13 @@ pub struct SourceAnalysis {
     /// Statically understood fixture declarations.
     fixtures: Vec<FixtureDefinition>,
 
+    /// Fixture declarations visible to the current module, including parents.
+    visible_fixtures: Vec<FixtureDefinition>,
+
+    fixture_completion_blocked_names: std::collections::HashSet<String>,
+
+    fixture_completion_builtins_visible: bool,
+
     /// Definite diagnostics. Unknown dynamic behavior remains silent.
     pub diagnostics: Vec<SourceDiagnostic>,
 }
@@ -155,9 +172,13 @@ pub(crate) fn analyze_source(
     };
     let module = collect_source(path, project_root, source_text, &collection_settings, &[])?;
     let (fixtures, diagnostics) = fixture::analyze(&module, settings.try_import_fixtures);
+    let visible_fixtures = fixture::visible_fixtures(&module, &[], settings.try_import_fixtures);
     Some(SourceAnalysis {
         module,
         fixtures,
+        visible_fixtures: visible_fixtures.definitions,
+        fixture_completion_blocked_names: visible_fixtures.blocked_names,
+        fixture_completion_builtins_visible: visible_fixtures.builtins_visible,
         diagnostics,
     })
 }
@@ -200,9 +221,14 @@ pub fn analyze_source_with_parents(
     let parent_modules = parent_modules.iter().collect::<Vec<_>>();
     let (fixtures, diagnostics) =
         fixture::analyze_modules(&current, &parent_modules, settings.try_import_fixtures);
+    let visible_fixtures =
+        fixture::visible_fixtures(&current, &parent_modules, settings.try_import_fixtures);
     Some(SourceAnalysis {
         module: current,
         fixtures,
+        visible_fixtures: visible_fixtures.definitions,
+        fixture_completion_blocked_names: visible_fixtures.blocked_names,
+        fixture_completion_builtins_visible: visible_fixtures.builtins_visible,
         diagnostics,
     })
 }
@@ -226,9 +252,14 @@ pub(crate) fn analyze_sources(
     let parent_modules = parents.iter().collect::<Vec<_>>();
     let (fixtures, diagnostics) =
         fixture::analyze_modules(&current, &parent_modules, settings.try_import_fixtures);
+    let visible_fixtures =
+        fixture::visible_fixtures(&current, &parent_modules, settings.try_import_fixtures);
     SourceAnalysis {
         module: current,
         fixtures,
+        visible_fixtures: visible_fixtures.definitions,
+        fixture_completion_blocked_names: visible_fixtures.blocked_names,
+        fixture_completion_builtins_visible: visible_fixtures.builtins_visible,
         diagnostics,
     }
 }

--- a/crates/karva_language_server/src/capabilities.rs
+++ b/crates/karva_language_server/src/capabilities.rs
@@ -4,8 +4,8 @@
 )]
 
 use lsp_types::{
-    ClientCapabilities, ServerCapabilities, TextDocumentSyncKind, TextDocumentSyncOptions,
-    WorkspaceFoldersServerCapabilities,
+    ClientCapabilities, CompletionOptions, ServerCapabilities, TextDocumentSyncKind,
+    TextDocumentSyncOptions, WorkspaceFoldersServerCapabilities,
 };
 
 use crate::PositionEncoding;
@@ -52,6 +52,7 @@ pub(super) fn server_capabilities(position_encoding: PositionEncoding) -> Server
             }
             .into(),
         ),
+        completion_provider: Some(CompletionOptions::default()),
         workspace: Some(lsp_types::WorkspaceOptions {
             workspace_folders: Some(WorkspaceFoldersServerCapabilities {
                 supported: Some(true),

--- a/crates/karva_language_server/src/document.rs
+++ b/crates/karva_language_server/src/document.rs
@@ -7,6 +7,11 @@ use lsp_types::PositionEncodingKind;
 
 #[expect(
     clippy::redundant_pub_crate,
+    reason = "server endpoints map positions across a private sibling module"
+)]
+pub(super) use range::position_to_text_size;
+#[expect(
+    clippy::redundant_pub_crate,
     reason = "server endpoints map source ranges across a private sibling module"
 )]
 pub(super) use range::text_range_to_range;

--- a/crates/karva_language_server/src/document/range.rs
+++ b/crates/karva_language_server/src/document/range.rs
@@ -4,7 +4,11 @@ use ruff_text_size::{TextRange, TextSize};
 
 use super::PositionEncoding;
 
-fn position_to_text_size(
+#[expect(
+    clippy::redundant_pub_crate,
+    reason = "server endpoints consume position conversion through the document boundary"
+)]
+pub(crate) fn position_to_text_size(
     position: Position,
     text: &str,
     index: &LineIndex,

--- a/crates/karva_language_server/src/server.rs
+++ b/crates/karva_language_server/src/server.rs
@@ -22,10 +22,15 @@ pub use self::connection::ConnectionInitializer;
 mod api;
 mod connection;
 mod main_loop;
+mod schedule;
+
+pub use main_loop::{Action, Event, MainLoopReceiver, MainLoopSender};
 
 /// An initialized Karva language server.
 pub struct Server {
     connection: Connection,
+    main_loop_receiver: MainLoopReceiver,
+    main_loop_sender: MainLoopSender,
     register_config_watchers: bool,
     session: Session,
 }
@@ -74,9 +79,12 @@ impl Server {
             crate::SERVER_NAME,
             karva_version::version(),
         )?;
+        let (main_loop_sender, main_loop_receiver) = crossbeam_channel::unbounded();
 
         Ok(Self {
             connection,
+            main_loop_receiver,
+            main_loop_sender,
             register_config_watchers,
             session: Session::new(
                 position_encoding,
@@ -119,7 +127,11 @@ impl Server {
                 register_options: Some(serde_json::to_value(options)?),
             }],
         };
-        Client::new(self.connection.sender.clone()).send_request::<RegistrationRequest>(id, params)
+        Client::new(
+            self.main_loop_sender.clone(),
+            self.connection.sender.clone(),
+        )
+        .send_request::<RegistrationRequest>(id, params)
     }
 }
 

--- a/crates/karva_language_server/src/server/api.rs
+++ b/crates/karva_language_server/src/server/api.rs
@@ -1,61 +1,61 @@
+//! Typed protocol routing into scheduled language-server tasks.
+
 use lsp_server::{ErrorCode, Notification, Request, Response};
 use lsp_types::{
-    DidChangeTextDocumentNotification, DidChangeWatchedFilesNotification,
+    CancelNotification, DidChangeTextDocumentNotification, DidChangeWatchedFilesNotification,
     DidChangeWorkspaceFoldersNotification, DidCloseTextDocumentNotification,
     DidOpenTextDocumentNotification, LspNotificationMethod, LspRequestMethod, Notification as _,
     Request as _, ShutdownRequest,
 };
 
-use crate::session::Session;
+use crate::server::schedule::{BackgroundSchedule, Task};
 use crate::session::client::Client;
+use crate::session::{RequestCancellationToken, Session};
 
 mod diagnostics;
 mod notifications;
 mod requests;
 mod traits;
 
-use self::traits::{SyncNotificationHandler, SyncRequestHandler};
+use self::traits::{BackgroundRequestHandler, SyncNotificationHandler, SyncRequestHandler};
 
-pub(super) fn request(request: Request, session: &mut Session) -> Response {
+pub(super) fn request(request: Request) -> Task {
     match LspRequestMethod::from(request.method.as_str()) {
-        ShutdownRequest::METHOD => run::<requests::Shutdown>(request, session),
-        method => Response::new_err(
+        ShutdownRequest::METHOD => sync_request_task::<requests::Shutdown>(request),
+        method => Task::immediate(Response::new_err(
             request.id,
             ErrorCode::MethodNotFound as i32,
             format!("unknown request: {method}"),
-        ),
+        )),
     }
 }
 
-pub(super) fn notification(notification: Notification, session: &mut Session, client: &Client) {
-    let result = match LspNotificationMethod::from(notification.method.as_str()) {
+pub(super) fn notification(notification: Notification) -> Task {
+    match LspNotificationMethod::from(notification.method.as_str()) {
+        CancelNotification::METHOD => sync_notification_task::<notifications::Cancel>(notification),
         DidOpenTextDocumentNotification::METHOD => {
-            run_notification::<notifications::DidOpen>(notification, session, client)
+            sync_notification_task::<notifications::DidOpen>(notification)
         }
         DidChangeTextDocumentNotification::METHOD => {
-            run_notification::<notifications::DidChange>(notification, session, client)
+            sync_notification_task::<notifications::DidChange>(notification)
         }
         DidCloseTextDocumentNotification::METHOD => {
-            run_notification::<notifications::DidClose>(notification, session, client)
+            sync_notification_task::<notifications::DidClose>(notification)
         }
-        DidChangeWorkspaceFoldersNotification::METHOD => run_notification::<
-            notifications::DidChangeWorkspaceFolders,
-        >(notification, session, client),
+        DidChangeWorkspaceFoldersNotification::METHOD => {
+            sync_notification_task::<notifications::DidChangeWorkspaceFolders>(notification)
+        }
         DidChangeWatchedFilesNotification::METHOD => {
-            run_notification::<notifications::DidChangeWatchedFiles>(notification, session, client)
+            sync_notification_task::<notifications::DidChangeWatchedFiles>(notification)
         }
         method => {
-            tracing::debug!("ignoring unsupported notification {method}");
-            return;
+            tracing::debug!(%method, "ignoring unsupported notification");
+            Task::nothing()
         }
-    };
-
-    if let Err(error) = result {
-        tracing::warn!("failed to handle notification: {error}");
     }
 }
 
-fn run<H>(request: Request, session: &mut Session) -> Response
+fn sync_request_task<H>(request: Request) -> Task
 where
     H: SyncRequestHandler,
 {
@@ -63,27 +63,123 @@ where
     let params = match serde_json::from_value(request.params) {
         Ok(params) => params,
         Err(error) => {
-            return Response::new_err(id, ErrorCode::InvalidParams as i32, error.to_string());
+            return Task::immediate(Response::new_err(
+                id,
+                ErrorCode::InvalidParams as i32,
+                error.to_string(),
+            ));
         }
     };
 
-    match H::run(session, params) {
+    Task::sync(move |session, client| {
+        let response = result_response(id, H::run(session, client, params));
+        if let Err(error) = client.respond(response) {
+            tracing::error!(%error, "failed to queue request response");
+        }
+    })
+}
+
+#[expect(
+    dead_code,
+    reason = "the first background feature handler lands in the next stacked layer"
+)]
+fn background_request_task<H>(request: Request) -> Task
+where
+    H: BackgroundRequestHandler,
+    <<H as traits::RequestHandler>::RequestType as lsp_types::Request>::Params: Send + 'static,
+{
+    let id = request.id;
+    let params = match serde_json::from_value(request.params) {
+        Ok(params) => params,
+        Err(error) => {
+            return Task::immediate(Response::new_err(
+                id,
+                ErrorCode::InvalidParams as i32,
+                error.to_string(),
+            ));
+        }
+    };
+    let task_id = id.clone();
+
+    Task::background(BackgroundSchedule::Worker, move |session| {
+        let cancellation = session
+            .request_queue()
+            .incoming()
+            .cancellation_token(&task_id);
+        let snapshot = if cancellation.is_some() {
+            match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                H::prepare(session, &params)
+            })) {
+                Ok(snapshot) => snapshot,
+                Err(_) => Err(anyhow::anyhow!(
+                    "background request snapshot preparation panicked"
+                )),
+            }
+        } else {
+            Err(anyhow::anyhow!(
+                "background request was not registered before scheduling"
+            ))
+        };
+
+        Box::new(move |client| {
+            if cancellation
+                .as_ref()
+                .is_some_and(RequestCancellationToken::is_cancelled)
+            {
+                return;
+            }
+            let response = if let Ok(response) =
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    let result = snapshot.and_then(|snapshot| H::run(snapshot, client, params));
+                    result_response(id.clone(), result)
+                })) {
+                response
+            } else {
+                tracing::error!(%id, "background request handler panicked");
+                Response::new_err(
+                    id,
+                    ErrorCode::InternalError as i32,
+                    "background request handler panicked".to_owned(),
+                )
+            };
+            if let Err(error) = client.respond(response) {
+                tracing::error!(%error, "failed to queue background request response");
+            }
+        })
+    })
+}
+
+fn result_response<R: serde::Serialize>(
+    id: lsp_server::RequestId,
+    result: anyhow::Result<R>,
+) -> Response {
+    match result {
         Ok(result) => match serde_json::to_value(result) {
-            Ok(result) => Response::new_ok(id, result),
+            Ok(result) => Response {
+                id,
+                response_result: Ok(result),
+            },
             Err(error) => Response::new_err(id, ErrorCode::InternalError as i32, error.to_string()),
         },
         Err(error) => Response::new_err(id, ErrorCode::InternalError as i32, error.to_string()),
     }
 }
 
-fn run_notification<H>(
-    notification: Notification,
-    session: &mut Session,
-    client: &Client,
-) -> anyhow::Result<()>
+fn sync_notification_task<H>(notification: Notification) -> Task
 where
     H: SyncNotificationHandler,
 {
-    let params = serde_json::from_value(notification.params)?;
-    H::run(session, client, params)
+    let params = match serde_json::from_value(notification.params) {
+        Ok(params) => params,
+        Err(error) => {
+            tracing::warn!(%error, "invalid notification parameters");
+            return Task::nothing();
+        }
+    };
+
+    Task::sync(move |session: &mut Session, client: &Client| {
+        if let Err(error) = H::run(session, client, params) {
+            tracing::warn!(%error, "failed to handle notification");
+        }
+    })
 }

--- a/crates/karva_language_server/src/server/api.rs
+++ b/crates/karva_language_server/src/server/api.rs
@@ -2,10 +2,10 @@
 
 use lsp_server::{ErrorCode, Notification, Request, Response};
 use lsp_types::{
-    CancelNotification, DidChangeTextDocumentNotification, DidChangeWatchedFilesNotification,
-    DidChangeWorkspaceFoldersNotification, DidCloseTextDocumentNotification,
-    DidOpenTextDocumentNotification, LspNotificationMethod, LspRequestMethod, Notification as _,
-    Request as _, ShutdownRequest,
+    CancelNotification, CompletionRequest, DidChangeTextDocumentNotification,
+    DidChangeWatchedFilesNotification, DidChangeWorkspaceFoldersNotification,
+    DidCloseTextDocumentNotification, DidOpenTextDocumentNotification, LspNotificationMethod,
+    LspRequestMethod, Notification as _, Request as _, ShutdownRequest,
 };
 
 use crate::server::schedule::{BackgroundSchedule, Task};
@@ -22,6 +22,7 @@ use self::traits::{BackgroundRequestHandler, SyncNotificationHandler, SyncReques
 pub(super) fn request(request: Request) -> Task {
     match LspRequestMethod::from(request.method.as_str()) {
         ShutdownRequest::METHOD => sync_request_task::<requests::Shutdown>(request),
+        CompletionRequest::METHOD => background_request_task::<requests::Completion>(request),
         method => Task::immediate(Response::new_err(
             request.id,
             ErrorCode::MethodNotFound as i32,
@@ -79,10 +80,6 @@ where
     })
 }
 
-#[expect(
-    dead_code,
-    reason = "the first background feature handler lands in the next stacked layer"
-)]
 fn background_request_task<H>(request: Request) -> Task
 where
     H: BackgroundRequestHandler,
@@ -120,6 +117,7 @@ where
                 "background request was not registered before scheduling"
             ))
         };
+        let document_version = snapshot.as_ref().ok().and_then(H::document_version);
 
         Box::new(move |client| {
             if cancellation
@@ -142,7 +140,12 @@ where
                     "background request handler panicked".to_owned(),
                 )
             };
-            if let Err(error) = client.respond(response) {
+            let send_result = if let Some((uri, version)) = document_version {
+                client.respond_versioned(response, uri, version)
+            } else {
+                client.respond(response)
+            };
+            if let Err(error) = send_result {
                 tracing::error!(%error, "failed to queue background request response");
             }
         })

--- a/crates/karva_language_server/src/server/api/notifications.rs
+++ b/crates/karva_language_server/src/server/api/notifications.rs
@@ -1,9 +1,11 @@
+mod cancel;
 mod did_change;
 mod did_change_watched_files;
 mod did_change_workspace_folders;
 mod did_close;
 mod did_open;
 
+pub(super) use cancel::Cancel;
 pub(super) use did_change::DidChange;
 pub(super) use did_change_watched_files::DidChangeWatchedFiles;
 pub(super) use did_change_workspace_folders::DidChangeWorkspaceFolders;

--- a/crates/karva_language_server/src/server/api/notifications/cancel.rs
+++ b/crates/karva_language_server/src/server/api/notifications/cancel.rs
@@ -1,0 +1,26 @@
+use lsp_server::RequestId;
+use lsp_types::{CancelNotification, CancelParams, Id};
+
+use super::super::traits::{NotificationHandler, SyncNotificationHandler};
+use crate::session::Session;
+use crate::session::client::Client;
+
+pub(in crate::server::api) struct Cancel;
+
+impl NotificationHandler for Cancel {
+    type NotificationType = CancelNotification;
+}
+
+impl SyncNotificationHandler for Cancel {
+    fn run(
+        session: &mut Session,
+        client: &Client,
+        CancelParams { id }: CancelParams,
+    ) -> anyhow::Result<()> {
+        let id = match id {
+            Id::Int(id) => RequestId::from(id),
+            Id::String(id) => RequestId::from(id),
+        };
+        client.cancel(session, id)
+    }
+}

--- a/crates/karva_language_server/src/server/api/requests.rs
+++ b/crates/karva_language_server/src/server/api/requests.rs
@@ -4,6 +4,10 @@ use super::traits::{RequestHandler, SyncRequestHandler};
 use crate::session::Session;
 use crate::session::client::Client;
 
+mod completion;
+
+pub(super) use completion::Completion;
+
 pub(super) struct Shutdown;
 
 impl RequestHandler for Shutdown {

--- a/crates/karva_language_server/src/server/api/requests.rs
+++ b/crates/karva_language_server/src/server/api/requests.rs
@@ -2,6 +2,7 @@ use lsp_types::ShutdownRequest;
 
 use super::traits::{RequestHandler, SyncRequestHandler};
 use crate::session::Session;
+use crate::session::client::Client;
 
 pub(super) struct Shutdown;
 
@@ -10,7 +11,7 @@ impl RequestHandler for Shutdown {
 }
 
 impl SyncRequestHandler for Shutdown {
-    fn run(session: &mut Session, (): ()) -> anyhow::Result<()> {
+    fn run(session: &mut Session, _client: &Client, (): ()) -> anyhow::Result<()> {
         session.request_shutdown();
         Ok(())
     }

--- a/crates/karva_language_server/src/server/api/requests/completion.rs
+++ b/crates/karva_language_server/src/server/api/requests/completion.rs
@@ -1,0 +1,99 @@
+//! Fixture-name completion from source-only Karva analysis.
+
+use karva_ide::complete_fixtures;
+use lsp_types::{
+    CompletionItem, CompletionItemKind, CompletionList, CompletionParams, CompletionRequest,
+    CompletionResponse, TextEdit,
+};
+use ruff_source_file::LineIndex;
+
+use super::super::traits::{BackgroundRequestHandler, RequestHandler};
+use crate::PositionEncoding;
+use crate::document::{position_to_text_size, text_range_to_range};
+use crate::session::client::Client;
+use crate::session::{PreparedSourceAnalysis, Session};
+
+pub(in crate::server::api) struct Completion;
+
+pub(in crate::server::api) struct CompletionSnapshot {
+    analysis: Option<PreparedSourceAnalysis>,
+    position_encoding: PositionEncoding,
+}
+
+impl RequestHandler for Completion {
+    type RequestType = CompletionRequest;
+}
+
+impl BackgroundRequestHandler for Completion {
+    type Snapshot = CompletionSnapshot;
+
+    fn prepare(session: &mut Session, params: &CompletionParams) -> anyhow::Result<Self::Snapshot> {
+        let uri = &params.text_document_position_params.text_document.uri;
+        Ok(CompletionSnapshot {
+            analysis: session.prepare_source_analysis(uri)?,
+            position_encoding: session.position_encoding(),
+        })
+    }
+
+    fn run(
+        snapshot: Self::Snapshot,
+        _client: &Client,
+        params: CompletionParams,
+    ) -> anyhow::Result<Option<CompletionResponse>> {
+        let Some(prepared) = snapshot.analysis else {
+            return Ok(None);
+        };
+        let source_text = prepared.source_text().to_owned();
+        let index = LineIndex::from_source_text(&source_text);
+        let offset = position_to_text_size(
+            params.text_document_position_params.position,
+            &source_text,
+            &index,
+            snapshot.position_encoding,
+        );
+        let Some(analysis) = prepared.analyze()? else {
+            return Ok(None);
+        };
+        let Some(completions) = complete_fixtures(&analysis.analysis, offset) else {
+            return Ok(None);
+        };
+
+        let items = completions
+            .into_iter()
+            .filter_map(|completion| {
+                Some(CompletionItem {
+                    label: completion.label.clone(),
+                    kind: Some(CompletionItemKind::Variable),
+                    detail: Some(completion.detail),
+                    text_edit: Some(
+                        TextEdit::new(
+                            text_range_to_range(
+                                completion.replacement_range,
+                                &source_text,
+                                &index,
+                                snapshot.position_encoding,
+                            )?,
+                            completion.label,
+                        )
+                        .into(),
+                    ),
+                    ..CompletionItem::default()
+                })
+            })
+            .collect();
+
+        Ok(Some(CompletionResponse::CompletionList(CompletionList {
+            is_incomplete: false,
+            items,
+            item_defaults: None,
+            apply_kind: None,
+        })))
+    }
+
+    fn document_version(snapshot: &Self::Snapshot) -> Option<(lsp_types::Uri, i32)> {
+        snapshot
+            .analysis
+            .as_ref()
+            .map(|analysis| (analysis.document_uri().clone(), analysis.document_version()))
+    }
+}

--- a/crates/karva_language_server/src/server/api/traits.rs
+++ b/crates/karva_language_server/src/server/api/traits.rs
@@ -10,6 +10,27 @@ pub(super) trait RequestHandler {
 pub(super) trait SyncRequestHandler: RequestHandler {
     fn run(
         session: &mut Session,
+        client: &Client,
+        params: <<Self as RequestHandler>::RequestType as Request>::Params,
+    ) -> anyhow::Result<<<Self as RequestHandler>::RequestType as Request>::Result>;
+}
+
+/// A request whose owned snapshot can run without blocking the event loop.
+#[expect(
+    dead_code,
+    reason = "the first background feature handler lands in the next stacked layer"
+)]
+pub(super) trait BackgroundRequestHandler: RequestHandler {
+    type Snapshot: Send + 'static;
+
+    fn prepare(
+        session: &mut Session,
+        params: &<<Self as RequestHandler>::RequestType as Request>::Params,
+    ) -> anyhow::Result<Self::Snapshot>;
+
+    fn run(
+        snapshot: Self::Snapshot,
+        client: &Client,
         params: <<Self as RequestHandler>::RequestType as Request>::Params,
     ) -> anyhow::Result<<<Self as RequestHandler>::RequestType as Request>::Result>;
 }

--- a/crates/karva_language_server/src/server/api/traits.rs
+++ b/crates/karva_language_server/src/server/api/traits.rs
@@ -16,10 +16,6 @@ pub(super) trait SyncRequestHandler: RequestHandler {
 }
 
 /// A request whose owned snapshot can run without blocking the event loop.
-#[expect(
-    dead_code,
-    reason = "the first background feature handler lands in the next stacked layer"
-)]
 pub(super) trait BackgroundRequestHandler: RequestHandler {
     type Snapshot: Send + 'static;
 
@@ -33,6 +29,10 @@ pub(super) trait BackgroundRequestHandler: RequestHandler {
         client: &Client,
         params: <<Self as RequestHandler>::RequestType as Request>::Params,
     ) -> anyhow::Result<<<Self as RequestHandler>::RequestType as Request>::Result>;
+
+    fn document_version(_snapshot: &Self::Snapshot) -> Option<(lsp_types::Uri, i32)> {
+        None
+    }
 }
 
 pub(super) trait NotificationHandler {

--- a/crates/karva_language_server/src/server/main_loop.rs
+++ b/crates/karva_language_server/src/server/main_loop.rs
@@ -1,28 +1,64 @@
+//! Main-loop message ordering and cancellation-aware response delivery.
+
 use anyhow::bail;
+use crossbeam_channel::{Receiver, RecvError, Sender, select};
 use lsp_server::{ErrorCode, Message, Response};
 use lsp_types::{ExitNotification, Notification as _};
 
 use crate::Server;
+use crate::server::schedule::Scheduler;
 use crate::session::client::Client;
+
+pub type MainLoopSender = Sender<Event>;
+pub type MainLoopReceiver = Receiver<Event>;
+
+#[derive(Debug)]
+pub enum Event {
+    Action(Action),
+}
+
+#[derive(Debug)]
+pub enum Action {
+    SendResponse(Response),
+}
+
+enum NextEvent {
+    Message(Message),
+    Action(Action),
+}
 
 impl Server {
     pub(super) fn main_loop(&mut self) -> anyhow::Result<()> {
-        let client = Client::new(self.connection.sender.clone());
-        for message in &self.connection.receiver {
-            match message {
-                Message::Request(request) => {
-                    let response = if self.session.is_shutdown_requested() {
-                        Response::new_err(
+        let mut scheduler = Scheduler::new(std::thread::available_parallelism()?);
+
+        loop {
+            let Some(event) = self.next_event()? else {
+                bail!("client exited without completing the shutdown sequence");
+            };
+            let client = Client::new(
+                self.main_loop_sender.clone(),
+                self.connection.sender.clone(),
+            );
+
+            match event {
+                NextEvent::Message(Message::Request(request)) => {
+                    self.session
+                        .request_queue_mut()
+                        .incoming_mut()
+                        .register(request.id.clone(), request.method.clone());
+
+                    let task = if self.session.is_shutdown_requested() {
+                        crate::server::schedule::Task::immediate(Response::new_err(
                             request.id,
                             ErrorCode::InvalidRequest as i32,
                             "shutdown already requested".to_owned(),
-                        )
+                        ))
                     } else {
-                        super::api::request(request, &mut self.session)
+                        super::api::request(request)
                     };
-                    self.connection.sender.send(Message::Response(response))?;
+                    scheduler.dispatch(task, &mut self.session, client);
                 }
-                Message::Notification(notification) => {
+                NextEvent::Message(Message::Notification(notification)) => {
                     if notification.method == ExitNotification::METHOD.as_str() {
                         if !self.session.is_shutdown_requested() {
                             bail!("received exit notification before shutdown request");
@@ -30,20 +66,50 @@ impl Server {
                         return Ok(());
                     }
 
-                    super::api::notification(notification, &mut self.session, &client);
+                    let task = super::api::notification(notification);
+                    scheduler.dispatch(task, &mut self.session, client);
                 }
-                Message::Response(response) => {
+                NextEvent::Message(Message::Response(response)) => {
                     if !self
                         .session
                         .request_queue_mut()
                         .complete_outgoing(&response.id)
                     {
-                        tracing::warn!("received unexpected response with ID {}", response.id);
+                        tracing::warn!(id = %response.id, "received unexpected response");
+                    }
+                }
+                NextEvent::Action(Action::SendResponse(response)) => {
+                    if let Some((started, method)) = self
+                        .session
+                        .request_queue_mut()
+                        .incoming_mut()
+                        .complete(&response.id)
+                    {
+                        tracing::debug!(
+                            id = %response.id,
+                            %method,
+                            elapsed = ?started.elapsed(),
+                            "completed request"
+                        );
+                        self.connection.sender.send(Message::Response(response))?;
+                    } else {
+                        tracing::debug!(id = %response.id, "discarding cancelled response");
                     }
                 }
             }
         }
+    }
 
-        bail!("client exited without completing the shutdown sequence")
+    fn next_event(&self) -> Result<Option<NextEvent>, RecvError> {
+        select! {
+            recv(self.connection.receiver) -> message => {
+                Ok(message.ok().map(NextEvent::Message))
+            },
+            recv(self.main_loop_receiver) -> event => {
+                event.map(|event| Some(match event {
+                    Event::Action(action) => NextEvent::Action(action),
+                }))
+            },
+        }
     }
 }

--- a/crates/karva_language_server/src/server/main_loop.rs
+++ b/crates/karva_language_server/src/server/main_loop.rs
@@ -1,7 +1,7 @@
 //! Main-loop message ordering and cancellation-aware response delivery.
 
 use anyhow::bail;
-use crossbeam_channel::{Receiver, RecvError, Sender, select};
+use crossbeam_channel::{Receiver, RecvError, Sender, select_biased};
 use lsp_server::{ErrorCode, Message, Response};
 use lsp_types::{ExitNotification, Notification as _};
 
@@ -20,6 +20,12 @@ pub enum Event {
 #[derive(Debug)]
 pub enum Action {
     SendResponse(Response),
+
+    SendVersionedResponse {
+        response: Response,
+        uri: lsp_types::Uri,
+        version: i32,
+    },
 }
 
 enum NextEvent {
@@ -79,29 +85,36 @@ impl Server {
                     }
                 }
                 NextEvent::Action(Action::SendResponse(response)) => {
-                    if let Some((started, method)) = self
+                    self.send_response_if_pending(response)?;
+                }
+                NextEvent::Action(Action::SendVersionedResponse {
+                    response,
+                    uri,
+                    version,
+                }) => {
+                    let response = if self
                         .session
-                        .request_queue_mut()
-                        .incoming_mut()
-                        .complete(&response.id)
+                        .document(&uri)
+                        .is_some_and(|document| document.version() == version)
                     {
-                        tracing::debug!(
-                            id = %response.id,
-                            %method,
-                            elapsed = ?started.elapsed(),
-                            "completed request"
-                        );
-                        self.connection.sender.send(Message::Response(response))?;
+                        response
                     } else {
-                        tracing::debug!(id = %response.id, "discarding cancelled response");
-                    }
+                        Response::new_err(
+                            response.id,
+                            ErrorCode::ContentModified as i32,
+                            "document changed before request completed".to_owned(),
+                        )
+                    };
+                    self.send_response_if_pending(response)?;
                 }
             }
         }
     }
 
     fn next_event(&self) -> Result<Option<NextEvent>, RecvError> {
-        select! {
+        // Document mutations and cancellations already queued by the client
+        // take precedence over results computed from older session state.
+        select_biased! {
             recv(self.connection.receiver) -> message => {
                 Ok(message.ok().map(NextEvent::Message))
             },
@@ -111,5 +124,25 @@ impl Server {
                 }))
             },
         }
+    }
+
+    fn send_response_if_pending(&mut self, response: Response) -> anyhow::Result<()> {
+        if let Some((started, method)) = self
+            .session
+            .request_queue_mut()
+            .incoming_mut()
+            .complete(&response.id)
+        {
+            tracing::debug!(
+                id = %response.id,
+                %method,
+                elapsed = ?started.elapsed(),
+                "completed request"
+            );
+            self.connection.sender.send(Message::Response(response))?;
+        } else {
+            tracing::debug!(id = %response.id, "discarding cancelled response");
+        }
+        Ok(())
     }
 }

--- a/crates/karva_language_server/src/server/schedule.rs
+++ b/crates/karva_language_server/src/server/schedule.rs
@@ -1,0 +1,58 @@
+//! Scheduling for work that must not block the language-server event loop.
+
+use std::io;
+use std::num::NonZeroUsize;
+
+use crate::session::Session;
+use crate::session::client::Client;
+
+mod task;
+mod thread;
+
+pub(super) use task::{BackgroundSchedule, Task};
+
+/// Runs synchronous tasks on the event-loop thread and background tasks on a
+/// joined worker pool.
+pub(super) struct Scheduler {
+    worker_threads: NonZeroUsize,
+    background_pool: Option<thread::Pool>,
+}
+
+impl Scheduler {
+    /// Creates scheduler using explicit worker count.
+    pub(super) fn new(worker_threads: NonZeroUsize) -> Self {
+        Self {
+            worker_threads,
+            background_pool: None,
+        }
+    }
+
+    /// Dispatches task while retaining mutable session access only for sync work.
+    pub(super) fn dispatch(&mut self, task: Task, session: &mut Session, client: Client) {
+        match task {
+            Task::Sync(task::SyncTask { func }) => func(session, &client),
+            Task::Background(task::BackgroundTaskBuilder { schedule, builder }) => {
+                let function = builder(session);
+                let job = move || function(&client);
+                match schedule {
+                    BackgroundSchedule::Worker => match self.background_pool() {
+                        Ok(pool) => pool.spawn(job),
+                        Err(error) => {
+                            tracing::error!(%error, "failed to initialize worker pool; running task on event loop");
+                            job();
+                        }
+                    },
+                }
+            }
+        }
+    }
+
+    fn background_pool(&mut self) -> io::Result<&thread::Pool> {
+        if self.background_pool.is_none() {
+            self.background_pool = Some(thread::Pool::new(self.worker_threads)?);
+        }
+        self.background_pool
+            .as_ref()
+            .ok_or_else(|| io::Error::other("language-server worker pool did not initialize"))
+    }
+}

--- a/crates/karva_language_server/src/server/schedule/task.rs
+++ b/crates/karva_language_server/src/server/schedule/task.rs
@@ -1,0 +1,73 @@
+use crate::session::Session;
+use crate::session::client::Client;
+
+type LocalFunction = Box<dyn FnOnce(&mut Session, &Client)>;
+type BackgroundFunction = Box<dyn FnOnce(&Client) + Send + 'static>;
+type BackgroundFunctionBuilder = Box<dyn FnOnce(&mut Session) -> BackgroundFunction>;
+
+/// Selects worker priority for background work.
+#[derive(Clone, Copy, Debug, Default)]
+pub(in crate::server) enum BackgroundSchedule {
+    /// Run on regular-priority workers.
+    #[default]
+    Worker,
+}
+
+/// Work waiting for dispatch by [`super::Scheduler`].
+#[must_use]
+pub(in crate::server) enum Task {
+    /// Work requiring mutable event-loop state.
+    Sync(SyncTask),
+
+    /// Work built from an owned session snapshot.
+    Background(BackgroundTaskBuilder),
+}
+
+/// Builder for work that captures owned state before queueing.
+pub(in crate::server) struct BackgroundTaskBuilder {
+    pub(super) schedule: BackgroundSchedule,
+    pub(super) builder: BackgroundFunctionBuilder,
+}
+
+/// Work executed synchronously by the event loop.
+pub(in crate::server) struct SyncTask {
+    pub(super) func: LocalFunction,
+}
+
+impl Task {
+    /// Creates background work. Builder runs synchronously to create a `'static`
+    /// closure before worker dispatch.
+    pub(in crate::server) fn background<F>(schedule: BackgroundSchedule, function: F) -> Self
+    where
+        F: FnOnce(&mut Session) -> BackgroundFunction + 'static,
+    {
+        Self::Background(BackgroundTaskBuilder {
+            schedule,
+            builder: Box::new(function),
+        })
+    }
+
+    /// Creates work that runs on event-loop thread.
+    pub(in crate::server) fn sync<F>(function: F) -> Self
+    where
+        F: FnOnce(&mut Session, &Client) + 'static,
+    {
+        Self::Sync(SyncTask {
+            func: Box::new(function),
+        })
+    }
+
+    /// Creates work that immediately queues a protocol response.
+    pub(in crate::server) fn immediate(response: lsp_server::Response) -> Self {
+        Self::sync(move |_, client| {
+            if let Err(error) = client.respond(response) {
+                tracing::error!(%error, "failed to queue immediate response");
+            }
+        })
+    }
+
+    /// Creates no-op event-loop work.
+    pub(in crate::server) fn nothing() -> Self {
+        Self::sync(|_, _| {})
+    }
+}

--- a/crates/karva_language_server/src/server/schedule/thread.rs
+++ b/crates/karva_language_server/src/server/schedule/thread.rs
@@ -1,0 +1,3 @@
+mod pool;
+
+pub(super) use pool::Pool;

--- a/crates/karva_language_server/src/server/schedule/thread/pool.rs
+++ b/crates/karva_language_server/src/server/schedule/thread/pool.rs
@@ -1,0 +1,111 @@
+use std::io;
+use std::num::NonZeroUsize;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::thread::{self, JoinHandle};
+
+use crossbeam_channel::{Receiver, Sender, unbounded};
+
+struct Job(Box<dyn FnOnce() + Send + 'static>);
+
+impl Job {
+    fn run(self) {
+        (self.0)();
+    }
+}
+
+/// Small worker pool whose threads finish all queued work during drop.
+pub(in crate::server::schedule) struct Pool {
+    sender: Option<Sender<Job>>,
+    handles: Vec<JoinHandle<()>>,
+}
+
+impl Pool {
+    pub(in crate::server::schedule) fn new(worker_threads: NonZeroUsize) -> io::Result<Self> {
+        let (sender, receiver) = unbounded();
+        let mut handles = Vec::with_capacity(worker_threads.get());
+
+        for index in 0..worker_threads.get() {
+            let worker_receiver = receiver.clone();
+            let result = thread::Builder::new()
+                .name(format!("karva-language-server-worker-{index}"))
+                .spawn(move || worker_loop(&worker_receiver));
+            match result {
+                Ok(handle) => handles.push(handle),
+                Err(error) => {
+                    drop(receiver);
+                    drop(sender);
+                    join_handles(handles);
+                    return Err(error);
+                }
+            }
+        }
+
+        Ok(Self {
+            sender: Some(sender),
+            handles,
+        })
+    }
+
+    pub(in crate::server::schedule) fn spawn<F>(&self, function: F)
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        let Some(sender) = self.sender.as_ref() else {
+            tracing::error!("language-server worker pool is closed; running task inline");
+            function();
+            return;
+        };
+        if let Err(error) = sender.send(Job(Box::new(function))) {
+            tracing::error!("language-server worker pool stopped; running task inline");
+            error.0.run();
+        }
+    }
+}
+
+impl Drop for Pool {
+    fn drop(&mut self) {
+        self.sender.take();
+        join_handles(std::mem::take(&mut self.handles));
+    }
+}
+
+fn worker_loop(receiver: &Receiver<Job>) {
+    while let Ok(job) = receiver.recv() {
+        if catch_unwind(AssertUnwindSafe(|| job.run())).is_err() {
+            tracing::error!("language-server background task panicked");
+        }
+    }
+}
+
+fn join_handles(handles: Vec<JoinHandle<()>>) {
+    for handle in handles {
+        if handle.join().is_err() {
+            tracing::error!("language-server worker thread panicked");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::Pool;
+
+    #[test]
+    fn dispatches_jobs_and_joins_workers() -> std::io::Result<()> {
+        let completed = Arc::new(AtomicUsize::new(0));
+        let pool = Pool::new(std::num::NonZeroUsize::MIN)?;
+
+        for _ in 0..3 {
+            let completed = Arc::clone(&completed);
+            pool.spawn(move || {
+                completed.fetch_add(1, Ordering::Relaxed);
+            });
+        }
+
+        drop(pool);
+        assert_eq!(completed.load(Ordering::Relaxed), 3);
+        Ok(())
+    }
+}

--- a/crates/karva_language_server/src/session.rs
+++ b/crates/karva_language_server/src/session.rs
@@ -24,6 +24,8 @@ use crate::{PositionEncoding, TextDocument};
 use self::index::Index;
 use self::request_queue::RequestQueue;
 
+pub use self::request_queue::RequestCancellationToken;
+
 /// Failure to apply a document or workspace notification.
 #[derive(Debug, thiserror::Error)]
 pub enum SessionError {
@@ -104,6 +106,10 @@ impl Session {
 
     pub(super) fn request_queue_mut(&mut self) -> &mut RequestQueue {
         &mut self.request_queue
+    }
+
+    pub(super) fn request_queue(&self) -> &RequestQueue {
+        &self.request_queue
     }
 
     pub(super) fn position_encoding(&self) -> PositionEncoding {

--- a/crates/karva_language_server/src/session.rs
+++ b/crates/karva_language_server/src/session.rs
@@ -67,6 +67,63 @@ pub(super) struct SourceAnalysisSnapshot {
     pub(super) sources: HashMap<Utf8PathBuf, String>,
 }
 
+/// Owned inputs for source analysis that can move off the event-loop thread.
+#[derive(Debug)]
+pub(super) struct PreparedSourceAnalysis {
+    current: SourceDocument,
+    parent_paths: Vec<Utf8PathBuf>,
+    open_sources: HashMap<Utf8PathBuf, String>,
+    project_root: Utf8PathBuf,
+    settings: SourceAnalysisSettings,
+    document_uri: Uri,
+    document_version: i32,
+}
+
+impl PreparedSourceAnalysis {
+    pub(super) fn source_text(&self) -> &str {
+        self.current.source_text()
+    }
+
+    pub(super) fn document_uri(&self) -> &Uri {
+        &self.document_uri
+    }
+
+    pub(super) fn document_version(&self) -> i32 {
+        self.document_version
+    }
+
+    /// Reads provider files and computes source semantics away from the event loop.
+    pub(super) fn analyze(self) -> Result<Option<SourceAnalysisSnapshot>, SessionError> {
+        let current_path = self.current.path().to_path_buf();
+        let current_source = self.current.source_text().to_owned();
+        let mut sources = HashMap::from([(current_path, current_source)]);
+        let mut parents = Vec::new();
+
+        for path in self.parent_paths {
+            let source_text = if let Some(source_text) = self.open_sources.get(&path) {
+                source_text.clone()
+            } else {
+                if !path.is_file() {
+                    continue;
+                }
+                fs::read_to_string(&path).map_err(|source| SessionError::SourceRead {
+                    path: path.clone(),
+                    source,
+                })?
+            };
+            sources.insert(path.clone(), source_text.clone());
+            parents.push(SourceDocument::new(path, source_text));
+        }
+
+        let Some(analysis) =
+            analyze_source_with_parents(self.current, parents, &self.project_root, &self.settings)
+        else {
+            return Ok(None);
+        };
+        Ok(Some(SourceAnalysisSnapshot { analysis, sources }))
+    }
+}
+
 /// Mutable state owned by the language-server event loop.
 #[derive(Debug)]
 pub struct Session {
@@ -151,6 +208,18 @@ impl Session {
         &mut self,
         uri: &Uri,
     ) -> Result<Option<SourceAnalysisSnapshot>, SessionError> {
+        let Some(prepared) = self.prepare_source_analysis(uri)? else {
+            return Ok(None);
+        };
+        prepared.analyze()
+    }
+
+    /// Captures open-document and project state without reading or parsing
+    /// provider source files.
+    pub(super) fn prepare_source_analysis(
+        &mut self,
+        uri: &Uri,
+    ) -> Result<Option<PreparedSourceAnalysis>, SessionError> {
         let document = self
             .index
             .document(uri)
@@ -170,8 +239,6 @@ impl Session {
         };
 
         let current = SourceDocument::new(path.clone(), document.contents().to_owned());
-        let mut parents = Vec::new();
-        let mut source_texts = HashMap::from([(path.clone(), document.contents().to_owned())]);
         let parent_directory = path
             .parent()
             .ok_or_else(|| WorkspaceError::MissingParent(path.clone()))?;
@@ -180,28 +247,29 @@ impl Session {
             .filter(|directory| directory.starts_with(&project_root))
             .collect::<Vec<_>>();
         directories.reverse();
+        let parent_paths = directories
+            .into_iter()
+            .map(|directory| directory.join("conftest.py"))
+            .filter(|conftest_path| conftest_path != &path)
+            .collect();
+        let open_sources = self
+            .index
+            .documents()
+            .filter_map(|document| {
+                uri_to_path(document.uri())
+                    .ok()
+                    .map(|path| (path, document.contents().to_owned()))
+            })
+            .collect();
 
-        for directory in directories {
-            let conftest_path = directory.join("conftest.py");
-            if conftest_path == path {
-                continue;
-            }
-            let Some(source_text) = self.source_text_for_path(&conftest_path)? else {
-                continue;
-            };
-            source_texts.insert(conftest_path.clone(), source_text.clone());
-            parents.push(SourceDocument::new(conftest_path, source_text));
-        }
-
-        let Some(analysis) =
-            analyze_source_with_parents(current, parents, &project_root, &settings)
-        else {
-            return Ok(None);
-        };
-
-        Ok(Some(SourceAnalysisSnapshot {
-            analysis,
-            sources: source_texts,
+        Ok(Some(PreparedSourceAnalysis {
+            current,
+            parent_paths,
+            open_sources,
+            project_root,
+            settings,
+            document_uri: uri.clone(),
+            document_version: document.version(),
         }))
     }
 
@@ -222,21 +290,6 @@ impl Session {
 
     pub(super) fn close_document(&mut self, uri: &Uri) -> Result<(), SessionError> {
         self.index.close_document(uri)
-    }
-
-    fn source_text_for_path(&self, path: &Utf8Path) -> Result<Option<String>, SessionError> {
-        if let Some(document) = self.index.document_for_path(path) {
-            return Ok(Some(document.contents().to_owned()));
-        }
-        if !path.is_file() {
-            return Ok(None);
-        }
-        fs::read_to_string(path)
-            .map(Some)
-            .map_err(|source| SessionError::SourceRead {
-                path: path.to_path_buf(),
-                source,
-            })
     }
 
     pub(super) fn open_workspace_folder(

--- a/crates/karva_language_server/src/session/client.rs
+++ b/crates/karva_language_server/src/session/client.rs
@@ -1,16 +1,26 @@
 use crossbeam_channel::Sender;
-use lsp_server::{Message, RequestId};
+use lsp_server::{ErrorCode, Message, RequestId, Response, ResponseError};
 use lsp_types::{Notification, Request};
+
+use crate::server::{Action, Event, MainLoopSender};
+use crate::session::Session;
 
 /// Typed access to messages sent from the server to the editor client.
 #[derive(Clone)]
 pub(crate) struct Client {
-    sender: Sender<Message>,
+    main_loop_sender: MainLoopSender,
+    connection_sender: Sender<Message>,
 }
 
 impl Client {
-    pub(crate) fn new(sender: Sender<Message>) -> Self {
-        Self { sender }
+    pub(crate) fn new(
+        main_loop_sender: MainLoopSender,
+        connection_sender: Sender<Message>,
+    ) -> Self {
+        Self {
+            main_loop_sender,
+            connection_sender,
+        }
     }
 
     pub(crate) fn send_request<R: Request>(
@@ -23,7 +33,7 @@ impl Client {
             method: R::METHOD.as_str().to_owned(),
             params: serde_json::to_value(params)?,
         };
-        self.sender.send(Message::Request(request))?;
+        self.connection_sender.send(Message::Request(request))?;
         Ok(())
     }
 
@@ -35,7 +45,101 @@ impl Client {
             method: N::METHOD.as_str().to_owned(),
             params: serde_json::to_value(params)?,
         };
-        self.sender.send(Message::Notification(notification))?;
+        self.connection_sender
+            .send(Message::Notification(notification))?;
+        Ok(())
+    }
+
+    /// Queues a response for cancellation-aware delivery on the main loop.
+    pub(crate) fn respond(&self, response: Response) -> anyhow::Result<()> {
+        self.main_loop_sender
+            .send(Event::Action(Action::SendResponse(response)))?;
+        Ok(())
+    }
+
+    /// Cancels a pending editor request and sends its sole response directly.
+    pub(crate) fn cancel(&self, session: &mut Session, id: RequestId) -> anyhow::Result<()> {
+        let method = session.request_queue_mut().incoming_mut().cancel(&id);
+        let Some(method) = method else {
+            return Ok(());
+        };
+
+        tracing::debug!(%id, %method, "cancelled request");
+        self.connection_sender.send(Message::Response(Response {
+            id,
+            response_result: Err(ResponseError {
+                code: ErrorCode::RequestCanceled as i32,
+                message: "request was cancelled by client".to_owned(),
+                data: None,
+            }),
+        }))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::{Context, bail};
+    use crossbeam_channel::{TryRecvError, unbounded};
+    use lsp_server::{ErrorCode, Message, RequestId, Response};
+    use ruff_python_ast::PythonVersion;
+
+    use super::Client;
+    use crate::PositionEncoding;
+    use crate::server::{Action, Event};
+    use crate::session::Session;
+    use crate::workspace::Workspaces;
+
+    #[test]
+    fn cancellation_sends_one_response_and_filters_late_result() -> anyhow::Result<()> {
+        let (event_sender, event_receiver) = unbounded();
+        let (connection_sender, connection_receiver) = unbounded();
+        let client = Client::new(event_sender, connection_sender);
+        let mut session = Session::new(
+            PositionEncoding::UTF16,
+            false,
+            Workspaces::new(Vec::new(), PythonVersion::PY312, None)?,
+        );
+        let id = RequestId::from(7);
+        session
+            .request_queue_mut()
+            .incoming_mut()
+            .register(id.clone(), "example/request".to_owned());
+        let cancellation = session
+            .request_queue()
+            .incoming()
+            .cancellation_token(&id)
+            .context("pending request should expose cancellation")?;
+
+        client.cancel(&mut session, id.clone())?;
+
+        let Message::Response(cancelled) = connection_receiver.recv()? else {
+            bail!("cancellation should send a response");
+        };
+        assert_eq!(cancelled.id, id);
+        assert_eq!(
+            cancelled.response_result.map_err(|error| error.code),
+            Err(ErrorCode::RequestCanceled as i32)
+        );
+        assert!(cancellation.is_cancelled());
+
+        client.respond(Response {
+            id: id.clone(),
+            response_result: Ok(serde_json::Value::Null),
+        })?;
+        let Event::Action(Action::SendResponse(late)) = event_receiver.recv()?;
+        assert_eq!(late.id, id);
+        assert!(
+            session
+                .request_queue_mut()
+                .incoming_mut()
+                .complete(&late.id)
+                .is_none()
+        );
+        assert!(matches!(
+            connection_receiver.try_recv(),
+            Err(TryRecvError::Empty)
+        ));
         Ok(())
     }
 }

--- a/crates/karva_language_server/src/session/client.rs
+++ b/crates/karva_language_server/src/session/client.rs
@@ -1,6 +1,6 @@
 use crossbeam_channel::Sender;
 use lsp_server::{ErrorCode, Message, RequestId, Response, ResponseError};
-use lsp_types::{Notification, Request};
+use lsp_types::{Notification, Request, Uri};
 
 use crate::server::{Action, Event, MainLoopSender};
 use crate::session::Session;
@@ -54,6 +54,22 @@ impl Client {
     pub(crate) fn respond(&self, response: Response) -> anyhow::Result<()> {
         self.main_loop_sender
             .send(Event::Action(Action::SendResponse(response)))?;
+        Ok(())
+    }
+
+    /// Queues a response that is valid only while a document version remains current.
+    pub(crate) fn respond_versioned(
+        &self,
+        response: Response,
+        uri: Uri,
+        version: i32,
+    ) -> anyhow::Result<()> {
+        self.main_loop_sender
+            .send(Event::Action(Action::SendVersionedResponse {
+                response,
+                uri,
+                version,
+            }))?;
         Ok(())
     }
 
@@ -127,7 +143,10 @@ mod tests {
             id: id.clone(),
             response_result: Ok(serde_json::Value::Null),
         })?;
-        let Event::Action(Action::SendResponse(late)) = event_receiver.recv()?;
+        let Event::Action(action) = event_receiver.recv()?;
+        let Action::SendResponse(late) = action else {
+            bail!("late response should use the unversioned response action");
+        };
         assert_eq!(late.id, id);
         assert!(
             session

--- a/crates/karva_language_server/src/session/request_queue.rs
+++ b/crates/karva_language_server/src/session/request_queue.rs
@@ -1,19 +1,137 @@
-use std::collections::HashSet;
+//! Pending requests exchanged with the editor client.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
 
 use lsp_server::RequestId;
 
-/// Tracks server requests awaiting a client response.
+/// Tracks requests in both protocol directions.
 #[derive(Debug, Default)]
 pub struct RequestQueue {
+    incoming: Incoming,
     outgoing: HashSet<RequestId>,
 }
 
 impl RequestQueue {
+    pub(crate) fn incoming(&self) -> &Incoming {
+        &self.incoming
+    }
+
+    pub(crate) fn incoming_mut(&mut self) -> &mut Incoming {
+        &mut self.incoming
+    }
+
     pub(crate) fn register_outgoing(&mut self, id: RequestId) {
         self.outgoing.insert(id);
     }
 
     pub(crate) fn complete_outgoing(&mut self, id: &RequestId) -> bool {
         self.outgoing.remove(id)
+    }
+}
+
+/// Requests sent by the editor that have not completed or been cancelled.
+#[derive(Debug, Default)]
+pub struct Incoming {
+    pending: HashMap<RequestId, PendingRequest>,
+}
+
+impl Incoming {
+    pub(crate) fn register(&mut self, id: RequestId, method: String) {
+        self.pending.insert(id, PendingRequest::new(method));
+    }
+
+    pub(super) fn cancel(&mut self, id: &RequestId) -> Option<String> {
+        self.pending.remove(id).map(|pending| {
+            if let Some(token) = pending.cancellation_token.get() {
+                token.cancel();
+            }
+            pending.method
+        })
+    }
+
+    pub(crate) fn cancellation_token(&self, id: &RequestId) -> Option<RequestCancellationToken> {
+        let pending = self.pending.get(id)?;
+        Some(
+            pending
+                .cancellation_token
+                .get_or_init(RequestCancellationToken::default)
+                .clone(),
+        )
+    }
+
+    pub(crate) fn complete(&mut self, id: &RequestId) -> Option<(Instant, String)> {
+        self.pending
+            .remove(id)
+            .map(|pending| (pending.started, pending.method))
+    }
+}
+
+#[derive(Debug)]
+struct PendingRequest {
+    started: Instant,
+    method: String,
+    cancellation_token: OnceLock<RequestCancellationToken>,
+}
+
+impl PendingRequest {
+    fn new(method: String) -> Self {
+        Self {
+            started: Instant::now(),
+            method,
+            cancellation_token: OnceLock::new(),
+        }
+    }
+}
+
+/// Cooperative cancellation state shared with a background task.
+#[derive(Clone, Debug, Default)]
+pub struct RequestCancellationToken(Arc<AtomicBool>);
+
+impl RequestCancellationToken {
+    pub(crate) fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::Relaxed)
+    }
+
+    fn cancel(&self) {
+        self.0.store(true, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn completes_pending_request_once() {
+        let id = RequestId::from(1);
+        let mut incoming = Incoming::default();
+        incoming.register(id.clone(), "example/request".to_owned());
+
+        assert!(incoming.cancellation_token(&id).is_some());
+        let completed = incoming.complete(&id);
+        assert_eq!(
+            completed.as_ref().map(|(_, method)| method.as_str()),
+            Some("example/request")
+        );
+        assert!(incoming.cancellation_token(&id).is_none());
+        assert!(incoming.complete(&id).is_none());
+        assert!(incoming.cancel(&id).is_none());
+    }
+
+    #[test]
+    fn cancellation_marks_shared_token_and_completes_request() {
+        let id = RequestId::from("request".to_owned());
+        let mut incoming = Incoming::default();
+        incoming.register(id.clone(), "example/request".to_owned());
+        let token = incoming.cancellation_token(&id);
+
+        assert_eq!(incoming.cancel(&id).as_deref(), Some("example/request"));
+        assert!(token.is_some_and(|token| token.is_cancelled()));
+        assert!(incoming.cancellation_token(&id).is_none());
+        assert!(incoming.complete(&id).is_none());
     }
 }

--- a/crates/karva_language_server/tests/e2e/completion.rs
+++ b/crates/karva_language_server/tests/e2e/completion.rs
@@ -1,0 +1,353 @@
+use std::fs;
+
+use insta::assert_json_snapshot;
+use lsp_types::{
+    ClientCapabilities, CompletionParams, CompletionRequest, DidChangeTextDocumentNotification,
+    DidChangeTextDocumentParams, DidOpenTextDocumentNotification, DidOpenTextDocumentParams,
+    LanguageKind, PartialResultParams, Position, PublishDiagnosticsNotification,
+    TextDocumentContentChangeEvent, TextDocumentContentChangeWholeDocument, TextDocumentIdentifier,
+    TextDocumentItem, TextDocumentPositionParams, Uri, VersionedTextDocumentIdentifier,
+    WorkDoneProgressParams, WorkspaceFolder,
+};
+use serde_json::Value;
+use tempfile::TempDir;
+
+use super::TestServer;
+
+#[test]
+fn completes_disk_and_builtin_fixtures_in_unsaved_test_parameters() {
+    let workspace = Workspace::new();
+    workspace.write(
+        "conftest.py",
+        "from karva import fixture\n\n@fixture(scope=\"session\")\ndef tmp_data(): pass\n",
+    );
+    let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
+    let uri = workspace.uri("test_example.py");
+    let source = "def test_example(tmp): pass\n";
+
+    server.notify::<DidOpenTextDocumentNotification>(DidOpenTextDocumentParams {
+        text_document: TextDocumentItem {
+            uri: uri.clone(),
+            language_id: LanguageKind::Python,
+            version: 1,
+            text: source.to_owned(),
+        },
+    });
+    server.receive_notification::<PublishDiagnosticsNotification>();
+
+    let response =
+        server.request::<CompletionRequest>(completion_params(uri, Position::new(0, 20)));
+
+    assert_json_snapshot!(workspace.normalize(response), @r###"
+    {
+      "isIncomplete": false,
+      "items": [
+        {
+          "detail": "fixture · /project/conftest.py · scope=session · autouse=false",
+          "kind": 6,
+          "label": "tmp_data",
+          "textEdit": {
+            "newText": "tmp_data",
+            "range": {
+              "end": {
+                "character": 20,
+                "line": 0
+              },
+              "start": {
+                "character": 17,
+                "line": 0
+              }
+            }
+          }
+        },
+        {
+          "detail": "fixture · Karva built-in · scope=function · autouse=false",
+          "kind": 6,
+          "label": "tmp_path",
+          "textEdit": {
+            "newText": "tmp_path",
+            "range": {
+              "end": {
+                "character": 20,
+                "line": 0
+              },
+              "start": {
+                "character": 17,
+                "line": 0
+              }
+            }
+          }
+        },
+        {
+          "detail": "fixture · Karva built-in · scope=session · autouse=false",
+          "kind": 6,
+          "label": "tmp_path_factory",
+          "textEdit": {
+            "newText": "tmp_path_factory",
+            "range": {
+              "end": {
+                "character": 20,
+                "line": 0
+              },
+              "start": {
+                "character": 17,
+                "line": 0
+              }
+            }
+          }
+        },
+        {
+          "detail": "fixture · Karva built-in · scope=function · autouse=false",
+          "kind": 6,
+          "label": "tmpdir",
+          "textEdit": {
+            "newText": "tmpdir",
+            "range": {
+              "end": {
+                "character": 20,
+                "line": 0
+              },
+              "start": {
+                "character": 17,
+                "line": 0
+              }
+            }
+          }
+        },
+        {
+          "detail": "fixture · Karva built-in · scope=session · autouse=false",
+          "kind": 6,
+          "label": "tmpdir_factory",
+          "textEdit": {
+            "newText": "tmpdir_factory",
+            "range": {
+              "end": {
+                "character": 20,
+                "line": 0
+              },
+              "start": {
+                "character": 17,
+                "line": 0
+              }
+            }
+          }
+        }
+      ]
+    }
+    "###);
+}
+
+#[test]
+fn completes_use_fixtures_strings() {
+    let workspace = Workspace::new();
+    workspace.write(
+        "conftest.py",
+        "from karva import fixture\n\n@fixture\ndef database(): pass\n",
+    );
+    let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
+    let uri = workspace.uri("test_example.py");
+    let source = "import karva\n\n@karva.tags.use_fixtures(\"dat\")\ndef test_example(): pass\n";
+
+    server.notify::<DidOpenTextDocumentNotification>(DidOpenTextDocumentParams {
+        text_document: TextDocumentItem {
+            uri: uri.clone(),
+            language_id: LanguageKind::Python,
+            version: 1,
+            text: source.to_owned(),
+        },
+    });
+    server.receive_notification::<PublishDiagnosticsNotification>();
+
+    let response =
+        server.request::<CompletionRequest>(completion_params(uri, Position::new(2, 28)));
+
+    assert_json_snapshot!(workspace.normalize(response), @r###"
+    {
+      "isIncomplete": false,
+      "items": [
+        {
+          "detail": "fixture · /project/conftest.py · scope=function · autouse=false",
+          "kind": 6,
+          "label": "database",
+          "textEdit": {
+            "newText": "database",
+            "range": {
+              "end": {
+                "character": 29,
+                "line": 2
+              },
+              "start": {
+                "character": 26,
+                "line": 2
+              }
+            }
+          }
+        }
+      ]
+    }
+    "###);
+}
+
+#[test]
+fn returns_no_completion_outside_fixture_context() {
+    let workspace = Workspace::new();
+    let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
+    let uri = workspace.uri("helpers.py");
+    let source = "def helper(dat): pass\n";
+
+    server.notify::<DidOpenTextDocumentNotification>(DidOpenTextDocumentParams {
+        text_document: TextDocumentItem {
+            uri: uri.clone(),
+            language_id: LanguageKind::Python,
+            version: 1,
+            text: source.to_owned(),
+        },
+    });
+    server.receive_notification::<PublishDiagnosticsNotification>();
+
+    let response =
+        server.request::<CompletionRequest>(completion_params(uri, Position::new(0, 14)));
+
+    assert_eq!(response, None);
+}
+
+#[test]
+fn cancels_a_background_completion_once() {
+    let workspace = Workspace::new();
+    let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
+    let uri = workspace.uri("test_example.py");
+    open(&server, uri.clone(), "def test_example(tmp): pass\n");
+
+    let request_id = server
+        .send_request::<CompletionRequest>(completion_params(uri.clone(), Position::new(0, 20)));
+    server.cancel(&request_id);
+    let response = server.receive_response(&request_id);
+
+    let error = response
+        .response_result
+        .expect_err("cancelled completion should fail");
+    assert_eq!(error.code, lsp_server::ErrorCode::RequestCanceled as i32);
+
+    let completion =
+        server.request::<CompletionRequest>(completion_params(uri, Position::new(0, 20)));
+    assert!(completion.is_some());
+}
+
+#[test]
+fn rejects_completion_from_a_stale_document_version() {
+    let workspace = Workspace::new();
+    let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
+    let uri = workspace.uri("test_example.py");
+    open(&server, uri.clone(), "def test_example(tmp): pass\n");
+
+    let request_id = server
+        .send_request::<CompletionRequest>(completion_params(uri.clone(), Position::new(0, 20)));
+    server.notify::<DidChangeTextDocumentNotification>(DidChangeTextDocumentParams {
+        text_document: VersionedTextDocumentIdentifier {
+            text_document_identifier: TextDocumentIdentifier::new(uri.clone()),
+            version: 2,
+        },
+        content_changes: vec![
+            TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                TextDocumentContentChangeWholeDocument {
+                    text: "def test_example(cap): pass\n".to_owned(),
+                },
+            ),
+        ],
+    });
+    let response = server.receive_response(&request_id);
+
+    let error = response
+        .response_result
+        .expect_err("stale completion should fail");
+    assert_eq!(error.code, lsp_server::ErrorCode::ContentModified as i32);
+
+    let completion =
+        server.request::<CompletionRequest>(completion_params(uri, Position::new(0, 20)));
+    assert!(completion.is_some());
+}
+
+fn open(server: &TestServer, uri: Uri, source: &str) {
+    server.notify::<DidOpenTextDocumentNotification>(DidOpenTextDocumentParams {
+        text_document: TextDocumentItem {
+            uri,
+            language_id: LanguageKind::Python,
+            version: 1,
+            text: source.to_owned(),
+        },
+    });
+    server.receive_notification::<PublishDiagnosticsNotification>();
+}
+
+fn completion_params(uri: Uri, position: Position) -> CompletionParams {
+    CompletionParams::new(
+        None,
+        WorkDoneProgressParams::default(),
+        PartialResultParams::default(),
+        TextDocumentPositionParams::new(TextDocumentIdentifier::new(uri), position),
+    )
+}
+
+struct Workspace {
+    directory: TempDir,
+    root_uri: Uri,
+}
+
+impl Workspace {
+    fn new() -> Self {
+        let directory = tempfile::tempdir().expect("temporary workspace should be created");
+        fs::create_dir(directory.path().join(".git")).expect("workspace marker should be created");
+        let root_uri =
+            Uri::from_file_path(directory.path()).expect("workspace URI should be valid");
+        Self {
+            directory,
+            root_uri,
+        }
+    }
+
+    fn folder(&self) -> WorkspaceFolder {
+        WorkspaceFolder {
+            uri: self.root_uri.clone(),
+            name: "project".to_owned(),
+        }
+    }
+
+    fn uri(&self, relative: &str) -> Uri {
+        Uri::from_file_path(self.directory.path().join(relative))
+            .expect("document URI should be valid")
+    }
+
+    fn write(&self, relative: &str, source: &str) {
+        fs::write(self.directory.path().join(relative), source)
+            .expect("workspace source should be written");
+    }
+
+    fn normalize(&self, value: impl serde::Serialize) -> Value {
+        let mut value = serde_json::to_value(value).expect("completion should serialize");
+        let workspace_path = self.directory.path().to_string_lossy();
+        normalize_paths(&mut value, self.root_uri.as_str(), &workspace_path);
+        value
+    }
+}
+
+fn normalize_paths(value: &mut Value, workspace_uri: &str, workspace_path: &str) {
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                normalize_paths(value, workspace_uri, workspace_path);
+            }
+        }
+        Value::Object(values) => {
+            for value in values.values_mut() {
+                normalize_paths(value, workspace_uri, workspace_path);
+            }
+        }
+        Value::String(value) => {
+            *value = value
+                .replace(workspace_uri, "file:///project")
+                .replace(workspace_path, "/project")
+                .replace('\\', "/");
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) => {}
+    }
+}

--- a/crates/karva_language_server/tests/e2e/initialize.rs
+++ b/crates/karva_language_server/tests/e2e/initialize.rs
@@ -75,6 +75,7 @@ fn initialization_advertises_document_and_workspace_sync() {
 
     assert_eq!(sync.open_close, Some(true));
     assert_eq!(sync.change, Some(TextDocumentSyncKind::Incremental));
+    assert!(capabilities.completion_provider.is_some());
     assert_eq!(
         capabilities
             .workspace

--- a/crates/karva_language_server/tests/e2e/initialize.rs
+++ b/crates/karva_language_server/tests/e2e/initialize.rs
@@ -1,9 +1,25 @@
+use anyhow::Context;
 use lsp_types::{
     ClientCapabilities, GeneralClientCapabilities, PositionEncodingKind, TextDocumentSync,
     TextDocumentSyncKind,
 };
 
 use super::TestServer;
+
+#[test]
+fn unknown_request_receives_method_not_found() -> anyhow::Result<()> {
+    let mut server = TestServer::new(ClientCapabilities::default());
+
+    let response = server.request_raw("karva/unknown", serde_json::Value::Null);
+
+    let error = response
+        .response_result
+        .err()
+        .context("request should fail")?;
+    assert_eq!(error.code, lsp_server::ErrorCode::MethodNotFound as i32);
+    assert_eq!(error.message, "unknown request: karva/unknown");
+    Ok(())
+}
 
 #[test]
 fn initialization_reports_server_info() {

--- a/crates/karva_language_server/tests/e2e/main.rs
+++ b/crates/karva_language_server/tests/e2e/main.rs
@@ -76,6 +76,17 @@ impl TestServer {
         serde_json::from_value(value).expect("response should match the request result type")
     }
 
+    fn request_raw(&mut self, method: &str, params: serde_json::Value) -> Response {
+        let id = RequestId::from(self.next_request_id);
+        self.next_request_id += 1;
+        self.send(Message::Request(lsp_server::Request {
+            id: id.clone(),
+            method: method.to_owned(),
+            params,
+        }));
+        self.receive_response(&id)
+    }
+
     fn notify<N: Notification>(&self, params: N::Params) {
         self.send(Message::Notification(lsp_server::Notification::new(
             N::METHOD.as_str().to_owned(),

--- a/crates/karva_language_server/tests/e2e/main.rs
+++ b/crates/karva_language_server/tests/e2e/main.rs
@@ -1,5 +1,6 @@
 //! End-to-end language-server tests over an in-memory LSP connection.
 
+mod completion;
 mod config_reload;
 mod diagnostics;
 mod document_sync;
@@ -9,9 +10,9 @@ use std::thread::JoinHandle;
 
 use lsp_server::{Connection, Message, RequestId, Response};
 use lsp_types::{
-    ClientCapabilities, ExitNotification, InitializeParams, InitializeRequest, InitializeResult,
-    InitializedNotification, InitializedParams, Notification, Request, ShutdownRequest,
-    WorkspaceFolder, WorkspaceFolders,
+    CancelNotification, CancelParams, ClientCapabilities, ExitNotification, InitializeParams,
+    InitializeRequest, InitializeResult, InitializedNotification, InitializedParams, Notification,
+    Request, ShutdownRequest, WorkspaceFolder, WorkspaceFolders,
 };
 
 use karva_language_server::{ConnectionInitializer, Server};
@@ -61,14 +62,23 @@ impl TestServer {
         &self.initialization_result
     }
 
-    fn request<R: Request>(&mut self, params: R::Params) -> R::Result {
+    fn send_request<R: Request>(&mut self, params: R::Params) -> RequestId {
+        self.send_request_raw(R::METHOD.as_str(), params)
+    }
+
+    fn send_request_raw<T: serde::Serialize>(&mut self, method: &str, params: T) -> RequestId {
         let id = RequestId::from(self.next_request_id);
         self.next_request_id += 1;
         self.send(Message::Request(lsp_server::Request::new(
             id.clone(),
-            R::METHOD.as_str().to_owned(),
+            method.to_owned(),
             params,
         )));
+        id
+    }
+
+    fn request<R: Request>(&mut self, params: R::Params) -> R::Result {
+        let id = self.send_request::<R>(params);
         let response = self.receive_response(&id);
         let value = response
             .response_result
@@ -77,14 +87,16 @@ impl TestServer {
     }
 
     fn request_raw(&mut self, method: &str, params: serde_json::Value) -> Response {
-        let id = RequestId::from(self.next_request_id);
-        self.next_request_id += 1;
-        self.send(Message::Request(lsp_server::Request {
-            id: id.clone(),
-            method: method.to_owned(),
-            params,
-        }));
+        let id = self.send_request_raw(method, params);
         self.receive_response(&id)
+    }
+
+    fn cancel(&self, request_id: &RequestId) {
+        let id = serde_json::from_value(
+            serde_json::to_value(request_id).expect("request ID should serialize"),
+        )
+        .expect("request ID should match the LSP cancellation ID");
+        self.notify::<CancelNotification>(CancelParams { id });
     }
 
     fn notify<N: Notification>(&self, params: N::Params) {


### PR DESCRIPTION
Schedules background language-server work without blocking the event loop and completes visible fixture parameters and references from the static fixture graph.

Test plan: ci