### PR TITLE
Resolve nearest fixtures by provider identity

### DIFF
--- a/crates/karva/tests/it/extensions/fixtures/autouse.rs
+++ b/crates/karva/tests/it/extensions/fixtures/autouse.rs
@@ -450,6 +450,60 @@ def test_second():
     "#);
 }
 
+#[rstest]
+fn test_nearest_conftest_auto_use_fixture_shadows_outer_fixture(
+    #[values("pytest", "karva")] framework: &str,
+) {
+    let context = TestContext::new();
+    context.write_file(
+        "conftest.py",
+        &format!(
+            r#"
+import {framework}
+
+@{framework}.fixture({auto_use_kw}=True)
+def selected_fixture():
+    return "outer"
+"#,
+            auto_use_kw = get_auto_use_kw(framework),
+        ),
+    );
+    context.write_file(
+        "nested/conftest.py",
+        &format!(
+            r#"
+import {framework}
+
+@{framework}.fixture({auto_use_kw}=True)
+def selected_fixture():
+    return "inner"
+"#,
+            auto_use_kw = get_auto_use_kw(framework),
+        ),
+    );
+    context.write_file(
+        "nested/test_example.py",
+        r#"
+def test_selected_fixture(selected_fixture):
+    assert selected_fixture == "inner"
+"#,
+    );
+
+    allow_duplicates! {
+        assert_cmd_snapshot!(context.command_no_parallel(), @"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+            Starting 1 test across 1 worker
+                PASS [TIME] nested.test_example::test_selected_fixture(selected_fixture='inner')
+        ────────────
+             Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+        ----- stderr -----
+        ");
+    }
+}
+
 /// Mirrors the cibuildwheel scenario exactly: multiple autouse fixtures in a subdirectory
 /// conftest, where one depends on a non-autouse fixture from the parent conftest.
 ///

--- a/crates/karva/tests/it/extensions/fixtures/basic.rs
+++ b/crates/karva/tests/it/extensions/fixtures/basic.rs
@@ -518,6 +518,51 @@ def test_username(username):
     ");
 }
 
+#[test]
+fn test_nearest_conftest_fixture_shadows_outer_fixture() {
+    let context = TestContext::with_files([
+        (
+            "conftest.py",
+            r#"
+import karva
+
+@karva.fixture
+def database():
+    return "outer"
+"#,
+        ),
+        (
+            "nested/conftest.py",
+            r#"
+import karva
+
+@karva.fixture
+def database(database):
+    return "inner-" + database
+"#,
+        ),
+        (
+            "nested/test_example.py",
+            r#"
+def test_database(database):
+    assert database == "inner-outer"
+"#,
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] nested.test_example::test_database(database='inner-outer')
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
 #[rstest]
 fn test_fixture_initialization_order(#[values("pytest", "karva")] framework: &str) {
     let context = TestContext::with_file(

--- a/crates/karva/tests/it/extensions/fixtures/invalid.rs
+++ b/crates/karva/tests/it/extensions/fixtures/invalid.rs
@@ -164,6 +164,77 @@ def test_ok():
 }
 
 #[test]
+fn test_duplicate_nested_fixture_blocks_valid_outer_fixture() {
+    let context = TestContext::with_files([
+        (
+            "conftest.py",
+            r#"
+import karva
+from pathlib import Path
+
+@karva.fixture
+def config():
+    Path("outer-ran").touch()
+    return {}
+"#,
+        ),
+        (
+            "nested/conftest.py",
+            r#"
+import karva
+
+@karva.fixture(name="config")
+def first():
+    return {}
+
+@karva.fixture(name="config")
+def second():
+    return {}
+"#,
+        ),
+        ("nested/test_example.py", "def test_config(config): pass\n"),
+    ]);
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+           ERROR [TIME] nested.test_example::test_config
+
+    failures:
+
+    nested.test_example::test_config:
+
+    error[missing-fixtures]: Test `test_config` has missing fixtures
+     --> nested/test_example.py:1:5
+      |
+    1 | def test_config(config): pass
+      |     ^^^^^^^^^^^
+    info: Missing fixtures: `config`
+
+    diagnostics:
+
+    error[duplicate-fixture]: Fixture `config` is defined more than once
+     --> nested/conftest.py:9:5
+      |
+    9 | def second():
+      |     ^^^^^^
+    info: First definition of `config` is here
+     --> nested/conftest.py:5:5
+      |
+    5 | def first():
+      |     ^^^^^
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
+
+    ----- stderr -----
+    ");
+    assert!(!context.root().join("outer-ran").exists());
+}
+
+#[test]
 fn test_missing_fixture() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva_ide/src/completion.rs
+++ b/crates/karva_ide/src/completion.rs
@@ -145,7 +145,7 @@ fn use_fixtures_context(analysis: &SourceAnalysis, offset: TextSize) -> Option<T
                 let Expr::StringLiteral(literal) = argument else {
                     return None;
                 };
-                let interior = string_interior(source, literal.range)?;
+                let interior = crate::fixture::single_string_content_range(literal)?;
                 if interior.contains_inclusive(offset) {
                     return Some(
                         identifier_range(source, offset, interior)
@@ -156,23 +156,6 @@ fn use_fixtures_context(analysis: &SourceAnalysis, offset: TextSize) -> Option<T
         }
     }
     None
-}
-
-fn string_interior(source: &str, range: TextRange) -> Option<TextRange> {
-    let text = source.get(range.start().to_usize()..range.end().to_usize())?;
-    let quote = text
-        .bytes()
-        .position(|byte| byte == b'\'' || byte == b'"')?;
-    let end_quote = text
-        .bytes()
-        .rposition(|byte| byte == b'\'' || byte == b'"')?;
-    if quote >= end_quote {
-        return None;
-    }
-    Some(TextRange::new(
-        range.start() + size(quote + 1)?,
-        range.start() + size(end_quote)?,
-    ))
 }
 
 fn identifier_range(source: &str, offset: TextSize, boundary: TextRange) -> Option<TextRange> {

--- a/crates/karva_ide/src/fixture.rs
+++ b/crates/karva_ide/src/fixture.rs
@@ -18,7 +18,7 @@ pub struct FixtureId {
     /// File containing the fixture.
     pub path: Utf8PathBuf,
 
-    /// Range of the fixture definition.
+    /// Function-name range anchoring the fixture declaration.
     range: TextRange,
 }
 
@@ -117,6 +117,19 @@ pub(super) struct FixtureDefinition {
     /// Function-name source range.
     pub(super) name_range: TextRange,
 
+    /// Source range representing the public fixture name.
+    ///
+    /// This is the function name for ordinary fixtures, the string contents
+    /// for a single literal `name=`, or the complete expression for implicit
+    /// string concatenation.
+    pub(super) public_name_range: TextRange,
+
+    /// Range that can be replaced with another public fixture name.
+    ///
+    /// Implicitly concatenated string literals have no syntax-preserving
+    /// single replacement range.
+    pub(super) public_name_edit_range: Option<TextRange>,
+
     /// Source signature of the provider function.
     pub(super) signature: String,
 
@@ -138,6 +151,13 @@ struct ParsedFixture {
     definition: FixtureDefinition,
     public_name_known: bool,
     invalid: Vec<InvalidMetadata>,
+}
+
+/// Source ranges used to locate and safely replace one public fixture name.
+#[derive(Clone, Copy, Debug)]
+struct PublicNameRanges {
+    occurrence: TextRange,
+    edit: Option<TextRange>,
 }
 
 #[derive(Clone, Debug)]
@@ -581,6 +601,16 @@ pub(super) fn is_use_fixtures_reference(module: &CollectedModule, expression: &E
     FixtureBindings::from_statements(&module.module_body).is_use_fixtures_reference(expression)
 }
 
+/// Returns the replaceable contents of a non-concatenated string literal.
+pub(super) fn single_string_content_range(
+    expression: &ruff_python_ast::ExprStringLiteral,
+) -> Option<TextRange> {
+    let [literal] = expression.value.as_slice() else {
+        return None;
+    };
+    Some(literal.content_range())
+}
+
 fn parse_fixture(
     function: &StmtFunctionDef,
     path: &Utf8PathBuf,
@@ -588,6 +618,10 @@ fn parse_fixture(
     source: &str,
 ) -> ParsedFixture {
     let mut public_name = function.name.to_string();
+    let mut public_name_ranges = PublicNameRanges {
+        occurrence: function.name.range,
+        edit: Some(function.name.range),
+    };
     let mut public_name_known = false;
     let mut scope = None;
     let mut auto_use = None;
@@ -610,6 +644,7 @@ fn parse_fixture(
                     function,
                     path,
                     public_name,
+                    public_name_ranges,
                     scope,
                     auto_use,
                     source,
@@ -638,6 +673,11 @@ fn parse_fixture(
                 "name" => match &keyword.value {
                     Expr::StringLiteral(value) => {
                         value.value.to_str().clone_into(&mut public_name);
+                        let edit = single_string_content_range(value);
+                        public_name_ranges = PublicNameRanges {
+                            occurrence: edit.unwrap_or_else(|| value.range()),
+                            edit,
+                        };
                     }
                     Expr::NoneLiteral(_) => {}
                     Expr::NumberLiteral(_) | Expr::BooleanLiteral(_) => {
@@ -686,7 +726,15 @@ fn parse_fixture(
     }
 
     ParsedFixture {
-        definition: fixture_definition(function, path, public_name, scope, auto_use, source),
+        definition: fixture_definition(
+            function,
+            path,
+            public_name,
+            public_name_ranges,
+            scope,
+            auto_use,
+            source,
+        ),
         public_name_known,
         invalid,
     }
@@ -696,6 +744,7 @@ fn fixture_definition(
     function: &StmtFunctionDef,
     path: &Utf8PathBuf,
     name: String,
+    public_name_ranges: PublicNameRanges,
     scope: Option<FixtureScope>,
     auto_use: Option<bool>,
     source: &str,
@@ -703,11 +752,13 @@ fn fixture_definition(
     FixtureDefinition {
         id: FixtureId {
             path: path.clone(),
-            range: function.range,
+            range: function.name.range,
         },
         name,
         defining_name: function.name.to_string(),
         name_range: function.name.range,
+        public_name_range: public_name_ranges.occurrence,
+        public_name_edit_range: public_name_ranges.edit,
         signature: function_signature(function, source),
         docstring: function_docstring(function),
         scope,

--- a/crates/karva_ide/src/fixture.rs
+++ b/crates/karva_ide/src/fixture.rs
@@ -275,6 +275,7 @@ pub(super) fn analyze_modules(
 ) -> (Vec<FixtureDefinition>, Vec<SourceDiagnostic>) {
     let mut providers = parents
         .iter()
+        .rev()
         .map(|module| parse_provider(module, try_import_fixtures))
         .collect::<Vec<_>>();
     let current_provider = parse_provider(current, try_import_fixtures);
@@ -377,6 +378,7 @@ pub(super) fn visible_fixtures(
 ) -> VisibleFixtures {
     let mut providers = parents
         .iter()
+        .rev()
         .map(|module| parse_provider(module, try_import_fixtures))
         .collect::<Vec<_>>();
     providers.insert(0, parse_provider(current, try_import_fixtures));
@@ -1378,6 +1380,29 @@ mod tests {
         let dependency = &analysis.fixtures[0].dependencies[0].resolution;
         assert!(
             matches!(dependency, FixtureResolution::Resolved(id) if id.path == "/project/conftest.py")
+        );
+    }
+
+    #[test]
+    fn same_name_fixture_uses_nearest_parent_across_multiple_levels() {
+        let root = module(
+            "/project/conftest.py",
+            "from karva import fixture\n\n@fixture\ndef database(): pass\n",
+        );
+        let nearest = module(
+            "/project/pkg/conftest.py",
+            "from karva import fixture\n\n@fixture\ndef database(): pass\n",
+        );
+        let current = module(
+            "/project/pkg/test_example.py",
+            "from karva import fixture\n\n@fixture\ndef database(database): pass\n\ndef test_example(database): pass\n",
+        );
+        let analysis = analyze_sources(current, &[root, nearest], &settings());
+
+        assert!(analysis.diagnostics.is_empty());
+        let dependency = &analysis.fixtures[0].dependencies[0].resolution;
+        assert!(
+            matches!(dependency, FixtureResolution::Resolved(id) if id.path == "/project/pkg/conftest.py")
         );
     }
 

--- a/crates/karva_ide/src/hover.rs
+++ b/crates/karva_ide/src/hover.rs
@@ -173,7 +173,6 @@ fn use_fixtures_reference(
     function: &StmtFunctionDef,
     offset: TextSize,
 ) -> Option<(String, TextRange)> {
-    let source = &analysis.module.source_text;
     for decorator in &function.decorator_list {
         if !decorator.range().contains_inclusive(offset) {
             continue;
@@ -188,70 +187,14 @@ fn use_fixtures_reference(
             let Expr::StringLiteral(literal) = argument else {
                 return None;
             };
-            let interior = string_interior(source, literal.range())?;
+            let interior = crate::fixture::single_string_content_range(literal)?;
             if !interior.contains_inclusive(offset) {
                 continue;
             }
-            let range = identifier_range(source, offset, interior)?;
-            let name = source
-                .get(range.start().to_usize()..range.end().to_usize())?
-                .to_owned();
-            return Some((name, range));
+            return Some((literal.value.to_str().to_owned(), interior));
         }
     }
     None
-}
-
-fn string_interior(source: &str, range: TextRange) -> Option<TextRange> {
-    let text = source.get(range.start().to_usize()..range.end().to_usize())?;
-    let quote = text
-        .bytes()
-        .position(|byte| byte == b'\'' || byte == b'"')?;
-    let end_quote = text
-        .bytes()
-        .rposition(|byte| byte == b'\'' || byte == b'"')?;
-    if quote >= end_quote {
-        return None;
-    }
-    Some(TextRange::new(
-        size(range.start().to_usize() + quote + 1)?,
-        size(range.start().to_usize() + end_quote)?,
-    ))
-}
-
-fn identifier_range(source: &str, offset: TextSize, boundary: TextRange) -> Option<TextRange> {
-    let offset = offset.to_usize();
-    let start = boundary.start().to_usize();
-    let end = boundary.end().to_usize().min(source.len());
-    if offset < start || offset > end || !source.is_char_boundary(offset) {
-        return None;
-    }
-    let mut token_start = offset;
-    for (index, character) in source.get(start..offset)?.char_indices().rev() {
-        if !is_identifier_character(character) {
-            break;
-        }
-        token_start = start + index;
-    }
-    let mut token_end = offset;
-    for (index, character) in source.get(offset..end)?.char_indices() {
-        if !is_identifier_character(character) {
-            break;
-        }
-        token_end = offset + index + character.len_utf8();
-    }
-    if token_start >= token_end {
-        return None;
-    }
-    Some(TextRange::new(size(token_start)?, size(token_end)?))
-}
-
-fn is_identifier_character(character: char) -> bool {
-    character == '_' || character.is_alphanumeric()
-}
-
-fn size(value: usize) -> Option<TextSize> {
-    u32::try_from(value).ok().map(TextSize::from)
 }
 
 #[cfg(test)]
@@ -283,7 +226,7 @@ mod tests {
     }
 
     fn at(source: &str, marker: &str) -> TextSize {
-        size(source.find(marker).expect("marker exists")).expect("source fits")
+        TextSize::try_from(source.find(marker).expect("marker exists")).expect("source fits")
     }
 
     #[test]
@@ -375,9 +318,26 @@ mod tests {
     }
 
     #[test]
+    fn hovers_escaped_use_fixtures_string() {
+        let source = "import pytest\nfrom karva import fixture\n@fixture\ndef database(): pass\n@pytest.mark.usefixtures(\"data\\x62ase\")\ndef test_example(): pass\n";
+        let result =
+            hover_fixture(&analysis(source), at(source, "x62")).expect("escaped usefixtures hover");
+
+        assert_eq!(result.name, "database");
+        assert_eq!(
+            result.range,
+            TextRange::new(
+                at(source, "data\\x62ase"),
+                at(source, "data\\x62ase") + TextSize::from(11),
+            )
+        );
+    }
+
+    #[test]
     fn hovers_unicode_fixture_name_by_utf8_offset() {
         let source = "from karva import fixture\n@fixture\ndef δεδομενα(): pass\ndef test_example(δεδομενα): pass\n";
-        let offset = at(source, "δεδομενα):") + size("δεδομενα".len()).expect("source fits");
+        let offset =
+            at(source, "δεδομενα):") + TextSize::try_from("δεδομενα".len()).expect("source fits");
         let result = hover_fixture(&analysis(source), offset).expect("unicode hover");
         assert_eq!(result.name, "δεδομενα");
     }

--- a/crates/karva_ide/src/lib.rs
+++ b/crates/karva_ide/src/lib.rs
@@ -4,6 +4,7 @@ mod completion;
 mod definition;
 mod fixture;
 mod hover;
+mod occurrences;
 
 use camino::{Utf8Path, Utf8PathBuf};
 use karva_collector::{CollectedModule, CollectionSettings, collect_source};
@@ -12,10 +13,9 @@ use ruff_text_size::TextRange;
 
 pub use completion::{FixtureCompletion, complete_fixtures};
 pub use definition::{FixtureDefinitionTarget, fixture_definition};
+use fixture::{FixtureDefinition, FixtureResolution};
 pub use fixture::{FixtureId, FixtureScope};
 pub use hover::{FixtureHover, hover_fixture};
-
-use fixture::{FixtureDefinition, FixtureResolution};
 
 /// Owned Python source used as an input to source-only analysis.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/karva_ide/src/occurrences.rs
+++ b/crates/karva_ide/src/occurrences.rs
@@ -1,0 +1,338 @@
+#![cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "language-server occurrence consumers land in a later stack layer"
+    )
+)]
+
+use ruff_python_ast::{Expr, StmtFunctionDef};
+use ruff_text_size::{Ranged, TextRange, TextSize};
+
+use crate::{FixtureId, FixtureResolution, SourceAnalysis};
+
+/// The source construct containing a fixture occurrence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FixtureOccurrenceKind {
+    /// A fixture provider declaration.
+    Definition,
+
+    /// A fixture dependency parameter.
+    Dependency,
+
+    /// A test function parameter supplied by a fixture.
+    TestParameter,
+
+    /// A fixture name in `usefixtures` metadata.
+    UseFixtures,
+}
+
+/// A source occurrence resolved to one fixture provider.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct FixtureOccurrence {
+    /// The occurrence's source range.
+    range: TextRange,
+
+    /// Range that can be replaced with another fixture name.
+    ///
+    /// This is `None` when implicit string concatenation prevents a safe
+    /// single edit.
+    edit_range: Option<TextRange>,
+
+    /// The kind of source construct containing the occurrence.
+    kind: FixtureOccurrenceKind,
+
+    /// The fixture provider selected by static analysis.
+    fixture: FixtureId,
+}
+
+/// Enumerates statically resolved fixture occurrences in the current source.
+fn fixture_occurrences(analysis: &SourceAnalysis) -> Vec<FixtureOccurrence> {
+    let mut occurrences = Vec::new();
+
+    occurrences.extend(
+        analysis
+            .fixtures
+            .iter()
+            .map(|definition| FixtureOccurrence {
+                range: definition.public_name_range,
+                edit_range: definition.public_name_edit_range,
+                kind: FixtureOccurrenceKind::Definition,
+                fixture: definition.id.clone(),
+            }),
+    );
+
+    occurrences.extend(analysis.fixtures.iter().flat_map(|definition| {
+        definition.dependencies.iter().filter_map(|reference| {
+            let FixtureResolution::Resolved(fixture) = &reference.resolution else {
+                return None;
+            };
+            Some(FixtureOccurrence {
+                range: reference.range,
+                edit_range: Some(reference.range),
+                kind: FixtureOccurrenceKind::Dependency,
+                fixture: fixture.clone(),
+            })
+        })
+    }));
+
+    for function in &analysis.module.test_function_defs {
+        occurrences.extend(function.parameters.iter_non_variadic_params().filter_map(
+            |parameter| {
+                let name = parameter.parameter.name.as_str();
+                if !crate::fixture::test_parameter_is_fixture(&analysis.module, function, name) {
+                    return None;
+                }
+                Some(FixtureOccurrence {
+                    range: parameter.parameter.name.range,
+                    edit_range: Some(parameter.parameter.name.range),
+                    kind: FixtureOccurrenceKind::TestParameter,
+                    fixture: resolve_source_fixture(analysis, name)?,
+                })
+            },
+        ));
+        occurrences.extend(use_fixtures_occurrences(analysis, function));
+    }
+
+    occurrences.sort_by_key(|occurrence| occurrence.range.start());
+    occurrences
+}
+
+/// Returns the resolved fixture occurrence containing `offset`, if any.
+fn fixture_occurrence(analysis: &SourceAnalysis, offset: TextSize) -> Option<FixtureOccurrence> {
+    fixture_occurrences(analysis)
+        .into_iter()
+        .find(|occurrence| occurrence.range.contains_inclusive(offset))
+}
+
+fn resolve_source_fixture(analysis: &SourceAnalysis, name: &str) -> Option<FixtureId> {
+    if analysis
+        .visible_fixtures
+        .iter()
+        .any(|fixture| fixture.name == name)
+        && !analysis.fixture_completion_blocked_names.contains(name)
+    {
+        return analysis
+            .visible_fixtures
+            .iter()
+            .find(|fixture| fixture.name == name)
+            .map(|fixture| fixture.id.clone());
+    }
+    None
+}
+
+fn use_fixtures_occurrences(
+    analysis: &SourceAnalysis,
+    function: &StmtFunctionDef,
+) -> Vec<FixtureOccurrence> {
+    function
+        .decorator_list
+        .iter()
+        .filter_map(|decorator| {
+            let Expr::Call(call) = &decorator.expression else {
+                return None;
+            };
+            crate::fixture::is_use_fixtures_reference(&analysis.module, &call.func).then_some(call)
+        })
+        .flat_map(move |call| {
+            call.arguments.args.iter().filter_map(move |argument| {
+                let Expr::StringLiteral(literal) = argument else {
+                    return None;
+                };
+                let edit_range = crate::fixture::single_string_content_range(literal);
+                let range = edit_range.unwrap_or_else(|| literal.range());
+                let name = literal.value.to_str();
+                Some(FixtureOccurrence {
+                    range,
+                    edit_range,
+                    kind: FixtureOccurrenceKind::UseFixtures,
+                    fixture: resolve_source_fixture(analysis, name)?,
+                })
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use camino::{Utf8Path, Utf8PathBuf};
+    use ruff_python_ast::PythonVersion;
+    use ruff_text_size::TextSize;
+
+    use super::*;
+    use crate::{
+        SourceAnalysisSettings, SourceDocument, analyze_source, analyze_source_with_parents,
+    };
+
+    fn analysis(source: &str) -> crate::SourceAnalysis {
+        analyze_source(
+            &Utf8PathBuf::from("/project/test_example.py"),
+            Utf8Path::new("/project"),
+            source.to_owned(),
+            &SourceAnalysisSettings {
+                python_version: PythonVersion::PY312,
+                test_function_prefix: "test".to_owned(),
+                try_import_fixtures: false,
+            },
+        )
+        .expect("source should analyze")
+    }
+
+    fn at(source: &str, marker: &str) -> TextSize {
+        TextSize::try_from(source.find(marker).expect("marker exists")).expect("source fits")
+    }
+
+    fn at_last(source: &str, marker: &str) -> TextSize {
+        TextSize::try_from(source.rfind(marker).expect("marker exists")).expect("source fits")
+    }
+
+    #[test]
+    fn enumerates_declarations_dependencies_parameters_and_metadata() {
+        let source = "import pytest\nfrom karva import fixture\n@fixture(name='database')\ndef provider(): pass\n@fixture\ndef wrapper(database): pass\n@pytest.mark.usefixtures('database')\ndef test_example(wrapper): pass\n";
+        let occurrences = fixture_occurrences(&analysis(source));
+        assert_eq!(
+            occurrences
+                .iter()
+                .map(|occurrence| occurrence.kind)
+                .collect::<Vec<_>>(),
+            [
+                FixtureOccurrenceKind::Definition,
+                FixtureOccurrenceKind::Definition,
+                FixtureOccurrenceKind::Dependency,
+                FixtureOccurrenceKind::UseFixtures,
+                FixtureOccurrenceKind::TestParameter,
+            ]
+        );
+        assert_eq!(
+            occurrences[0].range,
+            TextRange::new(
+                at(source, "database'"),
+                at(source, "database'") + TextSize::from(8)
+            )
+        );
+        assert_eq!(occurrences[0].fixture, occurrences[2].fixture);
+        assert_eq!(occurrences[0].fixture, occurrences[3].fixture);
+        assert_eq!(occurrences[0].edit_range, Some(occurrences[0].range));
+    }
+
+    #[test]
+    fn excludes_builtins_missing_rejected_and_parametrized_parameters() {
+        let source = "import pytest\nfrom karva import fixture\n@fixture\ndef database(): pass\n@pytest.mark.parametrize('value', [1])\ndef test_example(value, database, tmp_path, missing): pass\n";
+        let occurrences = fixture_occurrences(&analysis(source));
+        assert_eq!(
+            occurrences
+                .iter()
+                .filter(|occurrence| occurrence.kind == FixtureOccurrenceKind::TestParameter)
+                .count(),
+            1
+        );
+        assert!(fixture_occurrence(&analysis(source), at(source, "tmp_path")).is_none());
+    }
+
+    #[test]
+    fn custom_name_declaration_targets_string_not_python_name() {
+        let source = "from karva import fixture\n@fixture(name=\"данные\")\ndef provider(): pass\n";
+        let occurrence = fixture_occurrences(&analysis(source))
+            .into_iter()
+            .find(|occurrence| occurrence.kind == FixtureOccurrenceKind::Definition)
+            .expect("declaration occurrence");
+        assert_eq!(
+            occurrence.range,
+            TextRange::new(
+                at(source, "данные\""),
+                at(source, "данные\"") + TextSize::from(12)
+            )
+        );
+        assert!(fixture_occurrence(&analysis(source), at(source, "provider")).is_none());
+    }
+
+    #[test]
+    fn resolves_escaped_karva_use_fixtures_name() {
+        let source = "import karva\nfrom karva import fixture\n@fixture\ndef database(): pass\n@karva.tags.use_fixtures(\"data\\x62ase\")\ndef test_example(): pass\n";
+        let occurrence = fixture_occurrence(&analysis(source), at(source, "x62"))
+            .expect("escaped use-fixtures occurrence");
+
+        assert_eq!(occurrence.kind, FixtureOccurrenceKind::UseFixtures);
+        assert_eq!(occurrence.fixture.path, "/project/test_example.py");
+        assert_eq!(
+            occurrence.range,
+            TextRange::new(
+                at(source, "data\\x62ase"),
+                at(source, "data\\x62ase") + TextSize::from(11),
+            )
+        );
+    }
+
+    #[test]
+    fn marks_implicitly_concatenated_names_uneditable() {
+        let source = "import pytest\nfrom karva import fixture\n@fixture(name='data' 'base')\ndef provider(): pass\n@pytest.mark.usefixtures('data' 'base')\ndef test_example(database): pass\n";
+        let occurrences = fixture_occurrences(&analysis(source));
+        let definition = occurrences
+            .iter()
+            .find(|occurrence| occurrence.kind == FixtureOccurrenceKind::Definition)
+            .expect("definition occurrence");
+        let metadata = occurrences
+            .iter()
+            .find(|occurrence| occurrence.kind == FixtureOccurrenceKind::UseFixtures)
+            .expect("metadata occurrence");
+
+        assert_eq!(definition.fixture, metadata.fixture);
+        assert_eq!(definition.edit_range, None);
+        assert_eq!(metadata.edit_range, None);
+        assert!(definition.range.contains(at(source, "'data' 'base'")));
+        assert!(metadata.range.contains(at_last(source, "'data' 'base'")));
+    }
+
+    #[test]
+    fn keeps_overridden_fixture_identities_separate() {
+        let root_source = "from karva import fixture\n@fixture\ndef database(): pass\n";
+        let nested_source = "from karva import fixture\n@fixture\ndef database(database): pass\n";
+        let test_source = "def test_example(database): pass\n";
+        let root = SourceDocument::new(
+            Utf8PathBuf::from("/project/conftest.py"),
+            root_source.to_owned(),
+        );
+        let nested = SourceDocument::new(
+            Utf8PathBuf::from("/project/pkg/conftest.py"),
+            nested_source.to_owned(),
+        );
+        let test = SourceDocument::new(
+            Utf8PathBuf::from("/project/pkg/test_example.py"),
+            test_source.to_owned(),
+        );
+        let settings = SourceAnalysisSettings {
+            python_version: PythonVersion::PY312,
+            test_function_prefix: "test".to_owned(),
+            try_import_fixtures: false,
+        };
+
+        let nested_analysis = analyze_source_with_parents(
+            nested.clone(),
+            [root.clone()],
+            Utf8Path::new("/project"),
+            &settings,
+        )
+        .expect("nested source should analyze");
+        let test_analysis =
+            analyze_source_with_parents(test, [root, nested], Utf8Path::new("/project"), &settings)
+                .expect("test source should analyze");
+        let nested_occurrences = fixture_occurrences(&nested_analysis);
+        let declaration = nested_occurrences
+            .iter()
+            .find(|occurrence| occurrence.kind == FixtureOccurrenceKind::Definition)
+            .expect("nested declaration");
+        let dependency = nested_occurrences
+            .iter()
+            .find(|occurrence| occurrence.kind == FixtureOccurrenceKind::Dependency)
+            .expect("outer dependency");
+        let test_parameter = fixture_occurrences(&test_analysis)
+            .into_iter()
+            .find(|occurrence| occurrence.kind == FixtureOccurrenceKind::TestParameter)
+            .expect("test parameter");
+
+        assert_eq!(declaration.fixture.path, "/project/pkg/conftest.py");
+        assert_eq!(dependency.fixture.path, "/project/conftest.py");
+        assert_eq!(test_parameter.fixture, declaration.fixture);
+        assert_ne!(declaration.fixture, dependency.fixture);
+    }
+}

--- a/crates/karva_language_server/tests/e2e/definition.rs
+++ b/crates/karva_language_server/tests/e2e/definition.rs
@@ -81,7 +81,7 @@ fn goes_to_unsaved_nested_ancestor_override() {
     let workspace = Workspace::new();
     workspace.write(
         "conftest.py",
-        "from karva import fixture\n\n@fixture\ndef root_only(): pass\n",
+        "from karva import fixture\n\n@fixture\ndef database(): pass\n",
     );
     workspace.write(
         "package/conftest.py",
@@ -163,6 +163,31 @@ fn resolves_nested_package_fixture_shadowing() {
       "uri": "file:///project/package/conftest.py"
     }
     "#);
+}
+
+#[test]
+fn resolves_nearest_fixture_across_multiple_nested_conftests() {
+    let workspace = Workspace::new();
+    workspace.write(
+        "conftest.py",
+        "from karva import fixture\n\n@fixture\ndef database(): pass\n",
+    );
+    workspace.write(
+        "package/conftest.py",
+        "from karva import fixture\n\n@fixture\ndef database(): pass\n",
+    );
+    workspace.write(
+        "package/inner/conftest.py",
+        "from karva import fixture\n\n@fixture\ndef database(): pass\n",
+    );
+    let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
+    let uri = workspace.uri("package/inner/test_example.py");
+    open(&server, uri.clone(), "def test_example(database): pass\n");
+
+    let response =
+        server.request::<DefinitionRequest>(definition_params(uri, Position::new(0, 20)));
+
+    assert_json_snapshot!(workspace.normalize(response));
 }
 
 #[test]

--- a/crates/karva_language_server/tests/e2e/diagnostics.rs
+++ b/crates/karva_language_server/tests/e2e/diagnostics.rs
@@ -82,6 +82,50 @@ fn publishes_cross_file_related_information() {
 }
 
 #[test]
+fn publishes_related_information_for_the_nearest_nested_fixture() {
+    let workspace = Workspace::new();
+    workspace.write(
+        "conftest.py",
+        "from karva import fixture\n\n@fixture\ndef database(): pass\n",
+    );
+    workspace.write(
+        "package/conftest.py",
+        "from karva import fixture\n\n@fixture\ndef database(): pass\n",
+    );
+    let server = TestServer::with_workspace(capabilities(), workspace.folder());
+    let uri = workspace.uri("package/test_example.py");
+
+    server.notify::<DidOpenTextDocumentNotification>(DidOpenTextDocumentParams {
+        text_document: TextDocumentItem {
+            uri,
+            language_id: LanguageKind::Python,
+            version: 1,
+            text: concat!(
+                "from karva import fixture\n\n",
+                "@fixture(scope=\"session\")\n",
+                "def shared(database): pass\n",
+            )
+            .to_owned(),
+        },
+    });
+    let diagnostics = server.receive_notification::<PublishDiagnosticsNotification>();
+    let diagnostic = diagnostics
+        .diagnostics
+        .first()
+        .expect("nearest fixture should produce a scope diagnostic");
+    let related = diagnostic
+        .related_information
+        .as_ref()
+        .expect("scope diagnostic should include related information");
+    let database = related
+        .iter()
+        .find(|information| information.message.contains("Fixture `database`"))
+        .expect("scope diagnostic should identify the database fixture");
+
+    assert_eq!(database.location.uri, workspace.uri("package/conftest.py"));
+}
+
+#[test]
 fn does_not_analyze_an_open_conftest_as_its_own_parent() {
     let workspace = Workspace::new();
     let server = TestServer::with_workspace(capabilities(), workspace.folder());
@@ -146,8 +190,11 @@ impl Workspace {
     }
 
     fn write(&self, relative: &str, source: &str) {
-        fs::write(self.directory.path().join(relative), source)
-            .expect("workspace source should be written");
+        let path = self.directory.path().join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("workspace directory should be created");
+        }
+        fs::write(path, source).expect("workspace source should be written");
     }
 
     fn normalize(&self, value: impl serde::Serialize) -> Value {

--- a/crates/karva_language_server/tests/e2e/hover.rs
+++ b/crates/karva_language_server/tests/e2e/hover.rs
@@ -131,6 +131,30 @@ fn hovers_pytest_usefixtures_string() {
 }
 
 #[test]
+fn hovers_nearest_nested_fixture_provider() {
+    let workspace = Workspace::new();
+    workspace.write(
+        "conftest.py",
+        "from karva import fixture\n\n@fixture\ndef database(): pass\n",
+    );
+    workspace.write(
+        "package/conftest.py",
+        "from karva import fixture\n\n@fixture\ndef database(): pass\n",
+    );
+    let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
+    let uri = workspace.uri("package/test_example.py");
+    open(&server, uri.clone(), "def test_example(database): pass\n");
+
+    let response = server.request::<HoverRequest>(hover_params(uri, Position::new(0, 20)));
+    let response = workspace.normalize(response);
+
+    assert_eq!(
+        response["contents"]["value"],
+        "def database():\n\nKarva fixture: database\nScope: function\nAutouse: false\nProvider: /project/package/conftest.py"
+    );
+}
+
+#[test]
 fn returns_no_hover_for_dynamic_fixture_provider() {
     let workspace = Workspace::new();
     let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
@@ -198,8 +222,11 @@ impl Workspace {
     }
 
     fn write(&self, relative: &str, source: &str) {
-        fs::write(self.directory.path().join(relative), source)
-            .expect("workspace source should be written");
+        let path = self.directory.path().join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("workspace directory should be created");
+        }
+        fs::write(path, source).expect("workspace source should be written");
     }
 
     fn normalize(&self, value: impl serde::Serialize) -> Value {

--- a/crates/karva_language_server/tests/e2e/snapshots/e2e__definition__resolves_nearest_fixture_across_multiple_nested_conftests.snap
+++ b/crates/karva_language_server/tests/e2e/snapshots/e2e__definition__resolves_nearest_fixture_across_multiple_nested_conftests.snap
@@ -1,0 +1,17 @@
+---
+source: crates/karva_language_server/tests/e2e/definition.rs
+expression: workspace.normalize(response)
+---
+{
+  "range": {
+    "end": {
+      "character": 12,
+      "line": 3
+    },
+    "start": {
+      "character": 4,
+      "line": 3
+    }
+  },
+  "uri": "file:///project/package/inner/conftest.py"
+}

--- a/crates/karva_test_semantic/src/discovery/models/module.rs
+++ b/crates/karva_test_semantic/src/discovery/models/module.rs
@@ -73,6 +73,13 @@ impl DiscoveredModule {
             .find(|fixture| fixture.name() == name)
     }
 
+    /// Finds a rejected fixture by its defining Python symbol rather than its public name.
+    pub(crate) fn rejected_fixture_symbol(&self, name: &str) -> Option<&RejectedFixture> {
+        self.rejected_fixtures
+            .iter()
+            .find(|fixture| fixture.statement().name.as_str() == name)
+    }
+
     pub(crate) fn add_rejected_fixture(&mut self, fixture: RejectedFixture) {
         self.rejected_fixtures.push(fixture);
     }

--- a/crates/karva_test_semantic/src/discovery/visitor.rs
+++ b/crates/karva_test_semantic/src/discovery/visitor.rs
@@ -352,6 +352,10 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
             return None;
         }
 
+        if self.module.rejected_fixture_symbol(name).is_some() {
+            return None;
+        }
+
         let mut module_name = value.getattr("__module__").ok()?.extract::<String>().ok()?;
 
         if module_name == "builtins" {
@@ -512,6 +516,16 @@ pub fn discover(
 
     for (index, fixture) in fixtures.into_iter().enumerate() {
         if duplicate_fixture_indices.contains(&index) {
+            let name = fixture.name().function_name().to_owned();
+            let source_file = visitor.module.source_file();
+            let module_path = visitor.module.module_path().clone();
+            visitor.module.add_rejected_fixture(RejectedFixture::new(
+                name.clone(),
+                format!("Fixture `{name}` is defined more than once"),
+                Rc::clone(fixture.stmt_function_def()),
+                source_file,
+                module_path,
+            ));
             continue;
         }
 

--- a/crates/karva_test_semantic/src/extensions/fixtures/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/mod.rs
@@ -295,6 +295,7 @@ pub fn get_auto_use_fixtures<'a>(
     let current_fixtures = current.auto_use_fixtures(scope.scopes_above());
     let parent_fixtures = parents
         .iter()
+        .rev()
         .flat_map(|parent| parent.auto_use_fixtures(&[scope]));
 
     let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();

--- a/crates/karva_test_semantic/src/runner/fixture_resolver.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_resolver.rs
@@ -183,6 +183,7 @@ impl<'a> FixturePlanCompiler<'a> {
 
         self.parents
             .iter()
+            .rev()
             .find(|package| {
                 package
                     .get_fixture(name)
@@ -375,7 +376,7 @@ fn find_fixture<'a>(
         return None;
     }
 
-    for parent in parents {
+    for parent in parents.iter().rev() {
         if let Some(fixture) = parent.get_fixture(name)
             && current_fixture
                 .is_none_or(|current_fixture| current_fixture.name() != fixture.name())
@@ -402,5 +403,6 @@ fn find_rejected_fixture<'a>(
 
     parents
         .iter()
+        .rev()
         .find_map(|parent| parent.get_rejected_fixture(name))
 }


### PR DESCRIPTION
Corrects nested conftest provider precedence and gives fixture references stable provider-aware identities for navigation and edits.

Test plan: ci