### PR TITLE
Cancel obsolete language-server work

### DIFF
--- a/crates/karva_language_server/src/server/api.rs
+++ b/crates/karva_language_server/src/server/api.rs
@@ -9,8 +9,8 @@ use lsp_types::{
 };
 
 use crate::server::schedule::{BackgroundSchedule, Task};
+use crate::session::Session;
 use crate::session::client::Client;
-use crate::session::{RequestCancellationToken, Session};
 
 mod diagnostics;
 mod notifications;
@@ -122,15 +122,16 @@ where
         let document_version = snapshot.as_ref().ok().and_then(H::document_version);
 
         Box::new(move |client| {
-            if cancellation
-                .as_ref()
-                .is_some_and(RequestCancellationToken::is_cancelled)
-            {
+            let Some(cancellation) = cancellation else {
+                return;
+            };
+            if cancellation.is_cancelled() {
                 return;
             }
             let response = if let Ok(response) =
                 std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    let result = snapshot.and_then(|snapshot| H::run(snapshot, client, params));
+                    let result = snapshot
+                        .and_then(|snapshot| H::run(snapshot, client, params, &cancellation));
                     result_response(id.clone(), result)
                 })) {
                 response
@@ -142,6 +143,9 @@ where
                     "background request handler panicked".to_owned(),
                 )
             };
+            if cancellation.is_cancelled() {
+                return;
+            }
             let send_result = if let Some((uri, version)) = document_version {
                 client.respond_versioned(response, uri, version)
             } else {

--- a/crates/karva_language_server/src/server/api/requests/completion.rs
+++ b/crates/karva_language_server/src/server/api/requests/completion.rs
@@ -11,7 +11,7 @@ use super::super::traits::{BackgroundRequestHandler, RequestHandler};
 use crate::PositionEncoding;
 use crate::document::{position_to_text_size, text_range_to_range};
 use crate::session::client::Client;
-use crate::session::{PreparedSourceAnalysis, Session};
+use crate::session::{PreparedSourceAnalysis, RequestCancellationToken, Session};
 
 pub(in crate::server::api) struct Completion;
 
@@ -39,6 +39,7 @@ impl BackgroundRequestHandler for Completion {
         snapshot: Self::Snapshot,
         _client: &Client,
         params: CompletionParams,
+        _cancellation: &RequestCancellationToken,
     ) -> anyhow::Result<Option<CompletionResponse>> {
         let Some(prepared) = snapshot.analysis else {
             return Ok(None);

--- a/crates/karva_language_server/src/server/api/requests/definition.rs
+++ b/crates/karva_language_server/src/server/api/requests/definition.rs
@@ -8,7 +8,7 @@ use super::super::traits::{BackgroundRequestHandler, RequestHandler};
 use crate::PositionEncoding;
 use crate::document::{position_to_text_size, text_range_to_range};
 use crate::session::client::Client;
-use crate::session::{PreparedSourceAnalysis, Session};
+use crate::session::{PreparedSourceAnalysis, RequestCancellationToken, Session};
 
 pub(in crate::server::api) struct Definition;
 
@@ -36,6 +36,7 @@ impl BackgroundRequestHandler for Definition {
         snapshot: Self::Snapshot,
         _client: &Client,
         params: DefinitionParams,
+        _cancellation: &RequestCancellationToken,
     ) -> anyhow::Result<Option<DefinitionResponse>> {
         let Some(prepared) = snapshot.analysis else {
             return Ok(None);

--- a/crates/karva_language_server/src/server/api/requests/hover.rs
+++ b/crates/karva_language_server/src/server/api/requests/hover.rs
@@ -8,7 +8,7 @@ use super::super::traits::{BackgroundRequestHandler, RequestHandler};
 use crate::PositionEncoding;
 use crate::document::{position_to_text_size, text_range_to_range};
 use crate::session::client::Client;
-use crate::session::{PreparedSourceAnalysis, Session};
+use crate::session::{PreparedSourceAnalysis, RequestCancellationToken, Session};
 
 pub(in crate::server::api) struct Hover;
 
@@ -38,6 +38,7 @@ impl BackgroundRequestHandler for Hover {
         snapshot: Self::Snapshot,
         _client: &Client,
         params: HoverParams,
+        _cancellation: &RequestCancellationToken,
     ) -> anyhow::Result<Option<lsp_types::Hover>> {
         let Some(prepared) = snapshot.analysis else {
             return Ok(None);

--- a/crates/karva_language_server/src/server/api/traits.rs
+++ b/crates/karva_language_server/src/server/api/traits.rs
@@ -1,7 +1,7 @@
 use lsp_types::{Notification, Request};
 
-use crate::session::Session;
 use crate::session::client::Client;
+use crate::session::{RequestCancellationToken, Session};
 
 pub(super) trait RequestHandler {
     type RequestType: Request;
@@ -28,6 +28,7 @@ pub(super) trait BackgroundRequestHandler: RequestHandler {
         snapshot: Self::Snapshot,
         client: &Client,
         params: <<Self as RequestHandler>::RequestType as Request>::Params,
+        cancellation: &RequestCancellationToken,
     ) -> anyhow::Result<<<Self as RequestHandler>::RequestType as Request>::Result>;
 
     fn document_version(_snapshot: &Self::Snapshot) -> Option<(lsp_types::Uri, i32)> {


### PR DESCRIPTION
Propagates request cancellation through queued analysis work and stale-result handling.

Test plan: ci