### PR TITLE
Rename and highlight fixture occurrences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1164,6 +1164,7 @@ dependencies = [
  "camino",
  "karva_collector",
  "ruff_python_ast",
+ "ruff_python_stdlib",
  "ruff_text_size",
 ]
 

--- a/crates/karva_ide/Cargo.toml
+++ b/crates/karva_ide/Cargo.toml
@@ -18,6 +18,7 @@ doctest = false
 camino = { workspace = true }
 karva_collector = { workspace = true }
 ruff_python_ast = { workspace = true }
+ruff_python_stdlib = { workspace = true }
 ruff_text_size = { workspace = true }
 
 [lints]

--- a/crates/karva_ide/src/fixture.rs
+++ b/crates/karva_ide/src/fixture.rs
@@ -1189,6 +1189,35 @@ pub(super) fn test_parameter_is_fixture(
     true
 }
 
+/// Returns whether recognized parametrization may capture unknown parameter names.
+pub(super) fn test_parametrization_is_dynamic(
+    module: &CollectedModule,
+    function: &StmtFunctionDef,
+) -> bool {
+    let bindings = FixtureBindings::from_statements(&module.module_body);
+    function.decorator_list.iter().any(|decorator| {
+        let Expr::Call(call) = &decorator.expression else {
+            return false;
+        };
+        if !bindings.is_parametrize_reference(call.func.as_ref()) {
+            return false;
+        }
+        let argnames = call.arguments.args.first().or_else(|| {
+            call.arguments
+                .keywords
+                .iter()
+                .find(|keyword| {
+                    keyword
+                        .arg
+                        .as_ref()
+                        .is_some_and(|argument| argument == "argnames")
+                })
+                .map(|keyword| &keyword.value)
+        });
+        argnames.is_none_or(|argnames| literal_names(argnames).is_none())
+    })
+}
+
 /// Returns `None` when a decorator may supply arguments dynamically.
 fn parametrized_names(
     module: &CollectedModule,

--- a/crates/karva_ide/src/lib.rs
+++ b/crates/karva_ide/src/lib.rs
@@ -6,6 +6,7 @@ mod fixture;
 mod hover;
 mod occurrences;
 mod references;
+mod rename;
 mod source_index;
 
 use camino::{Utf8Path, Utf8PathBuf};
@@ -21,6 +22,7 @@ pub use hover::{FixtureHover, hover_fixture};
 pub use occurrences::{FixtureOccurrence, fixture_target};
 pub(crate) use occurrences::{FixtureOccurrenceKind, fixture_occurrences};
 pub use references::{LocatedFixtureOccurrence, fixture_references};
+pub use rename::prepare_fixture_rename;
 pub use source_index::WorkspaceSourceIndex;
 
 /// Owned Python source used as an input to source-only analysis.

--- a/crates/karva_ide/src/lib.rs
+++ b/crates/karva_ide/src/lib.rs
@@ -19,11 +19,10 @@ pub use definition::{FixtureDefinitionTarget, fixture_definition};
 use fixture::{FixtureDefinition, FixtureResolution};
 pub use fixture::{FixtureId, FixtureScope};
 pub use hover::{FixtureHover, hover_fixture};
+pub(crate) use occurrences::fixture_occurrences;
 pub use occurrences::{
-    FixtureOccurrence, FixtureRenameTarget, fixture_rename_target, fixture_target,
-};
-pub(crate) use occurrences::{
-    FixtureOccurrenceKind, fixture_occurrence, fixture_occurrences,
+    FixtureOccurrence, FixtureOccurrenceKind, FixtureRenameTarget, fixture_document_highlights,
+    fixture_rename_target, fixture_target,
 };
 pub use references::{LocatedFixtureOccurrence, fixture_references};
 pub use rename::{is_valid_fixture_name, prepare_fixture_rename, rename_fixture};

--- a/crates/karva_ide/src/lib.rs
+++ b/crates/karva_ide/src/lib.rs
@@ -19,10 +19,14 @@ pub use definition::{FixtureDefinitionTarget, fixture_definition};
 use fixture::{FixtureDefinition, FixtureResolution};
 pub use fixture::{FixtureId, FixtureScope};
 pub use hover::{FixtureHover, hover_fixture};
-pub use occurrences::{FixtureOccurrence, fixture_target};
-pub(crate) use occurrences::{FixtureOccurrenceKind, fixture_occurrences};
+pub use occurrences::{
+    FixtureOccurrence, FixtureRenameTarget, fixture_rename_target, fixture_target,
+};
+pub(crate) use occurrences::{
+    FixtureOccurrenceKind, fixture_occurrence, fixture_occurrences,
+};
 pub use references::{LocatedFixtureOccurrence, fixture_references};
-pub use rename::prepare_fixture_rename;
+pub use rename::{is_valid_fixture_name, prepare_fixture_rename, rename_fixture};
 pub use source_index::WorkspaceSourceIndex;
 
 /// Owned Python source used as an input to source-only analysis.

--- a/crates/karva_ide/src/occurrences.rs
+++ b/crates/karva_ide/src/occurrences.rs
@@ -34,10 +34,10 @@ pub struct FixtureOccurrence {
     ///
     /// This is `None` when implicit string concatenation prevents a safe
     /// single edit.
-    edit_range: Option<TextRange>,
+    pub edit_range: Option<TextRange>,
 
     /// The kind of source construct containing the occurrence.
-    pub(super) kind: FixtureOccurrenceKind,
+    pub kind: FixtureOccurrenceKind,
 
     /// The fixture provider selected by static analysis.
     pub(super) fixture: FixtureId,
@@ -129,6 +129,37 @@ pub fn fixture_target(analysis: &SourceAnalysis, offset: TextSize) -> Option<Fix
                 .find(|definition| definition.name_range.contains_inclusive(offset))
                 .map(|definition| definition.id.clone())
         })
+}
+
+/// Returns fixture highlights in the current document for the provider under `offset`.
+///
+/// Fixture declarations and custom provider function names are writes. Fixture
+/// dependencies, test parameters, and `usefixtures` metadata are reads.
+pub fn fixture_document_highlights(
+    analysis: &SourceAnalysis,
+    offset: TextSize,
+) -> Option<Vec<FixtureOccurrence>> {
+    let fixture = fixture_target(analysis, offset)?;
+    let mut highlights: Vec<_> = fixture_occurrences(analysis)
+        .into_iter()
+        .filter(|occurrence| occurrence.fixture == fixture)
+        .collect();
+
+    if let Some(definition) = analysis
+        .fixtures
+        .iter()
+        .find(|definition| definition.id == fixture)
+        && definition.name_range != definition.public_name_range
+    {
+        highlights.push(FixtureOccurrence {
+            range: definition.name_range,
+            edit_range: None,
+            kind: FixtureOccurrenceKind::Definition,
+            fixture,
+        });
+    }
+    highlights.sort_by_key(|occurrence| occurrence.range.start());
+    Some(highlights)
 }
 
 /// Resolves a rename selection, including custom fixture provider anchors.
@@ -324,6 +355,90 @@ mod tests {
             .edit_range
             .expect("custom public name should be editable");
         assert_eq!(&source[edit_range.to_std_range()], "данные");
+    }
+
+    #[test]
+    fn highlights_custom_provider_anchor_and_consumers() {
+        let source = "from karva import fixture\n@fixture(name=\"database\")\ndef provider(): pass\ndef test_example(database): pass\n";
+        let highlights = fixture_document_highlights(&analysis(source), at(source, "provider"))
+            .expect("custom fixture should highlight");
+
+        assert_eq!(
+            highlights
+                .iter()
+                .map(|occurrence| occurrence.kind)
+                .collect::<Vec<_>>(),
+            [
+                FixtureOccurrenceKind::Definition,
+                FixtureOccurrenceKind::Definition,
+                FixtureOccurrenceKind::TestParameter,
+            ]
+        );
+        assert_eq!(
+            highlights[0].range,
+            TextRange::at(at(source, "database"), TextSize::from(8)),
+        );
+        assert_eq!(
+            highlights[1].range,
+            TextRange::at(at(source, "provider"), TextSize::from(8)),
+        );
+    }
+
+    #[test]
+    fn highlights_only_the_selected_nested_provider() {
+        let root_source = "from karva import fixture\n@fixture\ndef database(): pass\n";
+        let nested_source = "from karva import fixture\n@fixture\ndef database(): pass\n";
+        let test_source = "def test_example(database): pass\n";
+        let root = SourceDocument::new(
+            Utf8PathBuf::from("/project/conftest.py"),
+            root_source.to_owned(),
+        );
+        let nested = SourceDocument::new(
+            Utf8PathBuf::from("/project/pkg/conftest.py"),
+            nested_source.to_owned(),
+        );
+        let test = SourceDocument::new(
+            Utf8PathBuf::from("/project/pkg/test_example.py"),
+            test_source.to_owned(),
+        );
+        let settings = SourceAnalysisSettings {
+            python_version: PythonVersion::PY312,
+            test_function_prefix: "test".to_owned(),
+            try_import_fixtures: false,
+        };
+        let analysis =
+            analyze_source_with_parents(test, [root, nested], Utf8Path::new("/project"), &settings)
+                .expect("test source should analyze");
+
+        let highlights = fixture_document_highlights(&analysis, at(test_source, "database"))
+            .expect("nested fixture should highlight");
+        assert_eq!(highlights.len(), 1);
+        assert_eq!(highlights[0].kind, FixtureOccurrenceKind::TestParameter);
+    }
+
+    #[test]
+    fn highlights_inherited_fixture_consumers_without_local_definition() {
+        let root = SourceDocument::new(
+            Utf8PathBuf::from("/project/conftest.py"),
+            "from karva import fixture\n@fixture\ndef database(): pass\n".to_owned(),
+        );
+        let test = SourceDocument::new(
+            Utf8PathBuf::from("/project/test_example.py"),
+            "def test_example(database): pass\n".to_owned(),
+        );
+        let settings = SourceAnalysisSettings {
+            python_version: PythonVersion::PY312,
+            test_function_prefix: "test".to_owned(),
+            try_import_fixtures: false,
+        };
+        let analysis =
+            analyze_source_with_parents(test, [root], Utf8Path::new("/project"), &settings)
+                .expect("test source should analyze");
+
+        let highlights = fixture_document_highlights(&analysis, TextSize::from(20))
+            .expect("inherited fixture should highlight");
+        assert_eq!(highlights.len(), 1);
+        assert_eq!(highlights[0].kind, FixtureOccurrenceKind::TestParameter);
     }
 
     #[test]

--- a/crates/karva_ide/src/occurrences.rs
+++ b/crates/karva_ide/src/occurrences.rs
@@ -43,6 +43,16 @@ pub struct FixtureOccurrence {
     pub(super) fixture: FixtureId,
 }
 
+/// Fixture selected for rename plus its public-name placeholder.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FixtureRenameTarget {
+    /// Resolved fixture selection under the cursor.
+    pub occurrence: FixtureOccurrence,
+
+    /// Public fixture name shown by rename-capable clients.
+    pub placeholder: String,
+}
+
 /// Enumerates statically resolved fixture occurrences in the current source.
 pub(crate) fn fixture_occurrences(analysis: &SourceAnalysis) -> Vec<FixtureOccurrence> {
     let mut occurrences = Vec::new();
@@ -119,6 +129,47 @@ pub fn fixture_target(analysis: &SourceAnalysis, offset: TextSize) -> Option<Fix
                 .find(|definition| definition.name_range.contains_inclusive(offset))
                 .map(|definition| definition.id.clone())
         })
+}
+
+/// Resolves a rename selection, including custom fixture provider anchors.
+///
+/// For `@fixture(name="public") def provider`, definition navigation lands on
+/// `provider`. Rename still edits only the public decorator name and its
+/// references, while the placeholder tells the client which name is changing.
+pub fn fixture_rename_target(
+    analysis: &SourceAnalysis,
+    offset: TextSize,
+) -> Option<FixtureRenameTarget> {
+    if let Some(occurrence) = fixture_occurrence(analysis, offset) {
+        let placeholder = fixture_name(analysis, &occurrence.fixture)?;
+        return Some(FixtureRenameTarget {
+            occurrence,
+            placeholder,
+        });
+    }
+
+    let definition = analysis
+        .fixtures
+        .iter()
+        .find(|definition| definition.name_range.contains_inclusive(offset))?;
+    Some(FixtureRenameTarget {
+        occurrence: FixtureOccurrence {
+            range: definition.name_range,
+            edit_range: definition.public_name_edit_range,
+            kind: FixtureOccurrenceKind::Definition,
+            fixture: definition.id.clone(),
+        },
+        placeholder: definition.name.clone(),
+    })
+}
+
+fn fixture_name(analysis: &SourceAnalysis, fixture: &FixtureId) -> Option<String> {
+    analysis
+        .fixtures
+        .iter()
+        .chain(&analysis.visible_fixtures)
+        .find(|definition| &definition.id == fixture)
+        .map(|definition| definition.name.clone())
 }
 
 fn resolve_source_fixture(analysis: &SourceAnalysis, name: &str) -> Option<FixtureId> {
@@ -264,6 +315,15 @@ mod tests {
             fixture_target(&analysis(source), at(source, "provider")).map(|fixture| fixture.path),
             Some("/project/test_example.py".into())
         );
+        let rename = fixture_rename_target(&analysis(source), at(source, "provider"))
+            .expect("custom provider should be a rename target");
+        assert_eq!(rename.placeholder, "данные");
+        assert_eq!(&source[rename.occurrence.range.to_std_range()], "provider");
+        let edit_range = rename
+            .occurrence
+            .edit_range
+            .expect("custom public name should be editable");
+        assert_eq!(&source[edit_range.to_std_range()], "данные");
     }
 
     #[test]

--- a/crates/karva_ide/src/rename.rs
+++ b/crates/karva_ide/src/rename.rs
@@ -166,7 +166,8 @@ mod tests {
     use ruff_text_size::TextSize;
 
     use super::*;
-    use crate::{SourceAnalysisSettings, SourceDocument, fixture_occurrence};
+    use crate::occurrences::fixture_occurrence;
+    use crate::{SourceAnalysisSettings, SourceDocument};
 
     fn settings() -> SourceAnalysisSettings {
         SourceAnalysisSettings {

--- a/crates/karva_ide/src/rename.rs
+++ b/crates/karva_ide/src/rename.rs
@@ -1,0 +1,85 @@
+use ruff_text_size::TextRange;
+
+use crate::{FixtureOccurrence, WorkspaceSourceIndex, fixture_references};
+
+/// Returns the current occurrence range when a fixture can be renamed safely.
+///
+/// Every occurrence resolving to the same provider must have one complete edit
+/// range. Implicitly concatenated string literals therefore disable the whole
+/// rename instead of producing a partial workspace edit.
+pub fn prepare_fixture_rename(
+    index: &WorkspaceSourceIndex,
+    current: &FixtureOccurrence,
+) -> Option<TextRange> {
+    let current_range = current.edit_range?;
+    let occurrences = fixture_references(index, &current.fixture, true);
+    (!occurrences.is_empty()
+        && occurrences
+            .iter()
+            .all(|occurrence| occurrence.occurrence.edit_range.is_some()))
+    .then_some(current_range)
+}
+
+#[cfg(test)]
+mod tests {
+    use camino::{Utf8Path, Utf8PathBuf};
+    use ruff_python_ast::PythonVersion;
+    use ruff_text_size::TextSize;
+
+    use super::*;
+    use crate::{SourceAnalysisSettings, SourceDocument, fixture_occurrence};
+
+    fn settings() -> SourceAnalysisSettings {
+        SourceAnalysisSettings {
+            python_version: PythonVersion::PY312,
+            test_function_prefix: "test_".to_owned(),
+            try_import_fixtures: false,
+        }
+    }
+
+    fn offset(source: &str, marker: &str) -> TextSize {
+        TextSize::try_from(source.find(marker).expect("marker should exist"))
+            .expect("source should fit")
+    }
+
+    #[test]
+    fn prepares_custom_fixture_name() {
+        let source = "import pytest\nfrom karva import fixture\n@fixture(name=\"database\")\ndef provider(): pass\n@pytest.mark.usefixtures(\"database\")\ndef test_example(): pass\n";
+        let path = Utf8PathBuf::from("/project/test_example.py");
+        let index = WorkspaceSourceIndex::from_documents(
+            "/project".into(),
+            [SourceDocument::new(path.clone(), source.to_owned())],
+            settings(),
+        )
+        .expect("source should index");
+        let analysis = index.analyze(&path).expect("source should analyze");
+        let occurrence = fixture_occurrence(&analysis, offset(source, "database\")\ndef test"))
+            .expect("metadata should resolve");
+
+        let range = prepare_fixture_rename(&index, &occurrence).expect("fixture should rename");
+
+        assert_eq!(&source[range.to_std_range()], "database");
+    }
+
+    #[test]
+    fn rejects_rename_when_any_occurrence_is_not_editable() {
+        let provider =
+            "from karva import fixture\n@fixture(name='data' 'base')\ndef provider(): pass\n";
+        let test = "def test_example(database): pass\n";
+        let path = Utf8Path::new("/project/test_example.py");
+        let index = WorkspaceSourceIndex::from_documents(
+            "/project".into(),
+            [
+                SourceDocument::new("/project/conftest.py".into(), provider.to_owned()),
+                SourceDocument::new(path.to_path_buf(), test.to_owned()),
+            ],
+            settings(),
+        )
+        .expect("sources should index");
+        let analysis = index.analyze(path).expect("test should analyze");
+        let occurrence = fixture_occurrence(&analysis, offset(test, "database"))
+            .expect("parameter should resolve");
+
+        assert!(prepare_fixture_rename(&index, &occurrence).is_none());
+    }
+}

--- a/crates/karva_ide/src/rename.rs
+++ b/crates/karva_ide/src/rename.rs
@@ -1,6 +1,18 @@
 use ruff_text_size::TextRange;
 
-use crate::{FixtureOccurrence, WorkspaceSourceIndex, fixture_references};
+use crate::{
+    FixtureId, FixtureOccurrence, FixtureOccurrenceKind, LocatedFixtureOccurrence, SourceAnalysis,
+    WorkspaceSourceIndex, fixture_occurrences,
+};
+
+/// Returns whether `name` is a valid public name for a fixture rename.
+///
+/// Renames can update Python parameters, so every new name must be a
+/// non-keyword Python identifier even when the selected occurrence is a
+/// decorator string.
+pub fn is_valid_fixture_name(name: &str) -> bool {
+    ruff_python_stdlib::identifiers::is_identifier(name)
+}
 
 /// Returns the current occurrence range when a fixture can be renamed safely.
 ///
@@ -11,13 +23,140 @@ pub fn prepare_fixture_rename(
     index: &WorkspaceSourceIndex,
     current: &FixtureOccurrence,
 ) -> Option<TextRange> {
-    let current_range = current.edit_range?;
-    let occurrences = fixture_references(index, &current.fixture, true);
-    (!occurrences.is_empty()
-        && occurrences
+    current.edit_range?;
+    editable_fixture_occurrences(index, current, None).map(|_| current.range)
+}
+
+/// Returns every edit needed to rename one fixture provider.
+///
+/// Invalid Python identifiers and targets with any uneditable occurrence are
+/// rejected before edits are returned.
+pub fn rename_fixture(
+    index: &WorkspaceSourceIndex,
+    current: &FixtureOccurrence,
+    new_name: &str,
+) -> Option<Vec<LocatedFixtureOccurrence>> {
+    if !is_valid_fixture_name(new_name) {
+        return None;
+    }
+    editable_fixture_occurrences(index, current, Some(new_name))
+}
+
+fn editable_fixture_occurrences(
+    index: &WorkspaceSourceIndex,
+    current: &FixtureOccurrence,
+    new_name: Option<&str>,
+) -> Option<Vec<LocatedFixtureOccurrence>> {
+    let mut occurrences = Vec::new();
+    for path in index.paths() {
+        let analysis = index.analyze(path)?;
+        let matching = fixture_occurrences(&analysis)
+            .into_iter()
+            .filter(|occurrence| occurrence.fixture == current.fixture)
+            .collect::<Vec<_>>();
+        if matching.is_empty() {
+            continue;
+        }
+        if matching
             .iter()
-            .all(|occurrence| occurrence.occurrence.edit_range.is_some()))
-    .then_some(current_range)
+            .any(|occurrence| occurrence.edit_range.is_none())
+            || new_name.is_some_and(|new_name| {
+                fixture_name_conflicts(&analysis, &matching, &current.fixture, new_name)
+            })
+        {
+            return None;
+        }
+        occurrences.extend(
+            matching
+                .into_iter()
+                .map(|occurrence| LocatedFixtureOccurrence {
+                    path: path.to_path_buf(),
+                    occurrence,
+                }),
+        );
+    }
+    (!occurrences.is_empty()).then_some(occurrences)
+}
+
+fn fixture_name_conflicts(
+    analysis: &SourceAnalysis,
+    occurrences: &[FixtureOccurrence],
+    target: &FixtureId,
+    new_name: &str,
+) -> bool {
+    let target_name = analysis
+        .fixtures
+        .iter()
+        .chain(&analysis.visible_fixtures)
+        .find(|definition| &definition.id == target)
+        .map(|definition| definition.name.as_str());
+    if target_name == Some(new_name) {
+        return false;
+    }
+
+    analysis.fixture_completion_blocked_names.contains(new_name)
+        || analysis
+            .visible_fixtures
+            .iter()
+            .any(|definition| definition.name == new_name && &definition.id != target)
+        || crate::fixture::builtin_info(new_name).is_some()
+        || target_name.is_some_and(|target_name| {
+            analysis
+                .visible_fixtures
+                .iter()
+                .any(|definition| &definition.id == target && definition.name == target_name)
+                && analysis.module.test_function_defs.iter().any(|function| {
+                    crate::fixture::test_parametrization_is_dynamic(&analysis.module, function)
+                        && function
+                            .parameters
+                            .iter_non_variadic_params()
+                            .any(|parameter| parameter.parameter.name.as_str() == target_name)
+                })
+        })
+        || analysis
+            .module
+            .test_function_defs
+            .iter()
+            .map(|function| (function, true))
+            .chain(
+                analysis
+                    .module
+                    .fixture_function_defs
+                    .iter()
+                    .map(|function| (function, false)),
+            )
+            .any(|(function, is_test)| {
+                let target_parameters = function
+                    .parameters
+                    .iter_non_variadic_params()
+                    .filter(|parameter| {
+                        occurrences.iter().any(|occurrence| {
+                            matches!(
+                                occurrence.kind,
+                                FixtureOccurrenceKind::Dependency
+                                    | FixtureOccurrenceKind::TestParameter
+                            ) && occurrence.range == parameter.parameter.name.range
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                !target_parameters.is_empty()
+                    && (function
+                        .parameters
+                        .iter_non_variadic_params()
+                        .any(|parameter| {
+                            parameter.parameter.name.as_str() == new_name
+                                && target_parameters.iter().all(|target_parameter| {
+                                    target_parameter.parameter.name.range
+                                        != parameter.parameter.name.range
+                                })
+                        })
+                        || is_test
+                            && !crate::fixture::test_parameter_is_fixture(
+                                &analysis.module,
+                                function,
+                                new_name,
+                            ))
+            })
 }
 
 #[cfg(test)]
@@ -81,5 +220,147 @@ mod tests {
             .expect("parameter should resolve");
 
         assert!(prepare_fixture_rename(&index, &occurrence).is_none());
+        assert!(rename_fixture(&index, &occurrence, "renamed").is_none());
+    }
+
+    #[test]
+    fn returns_every_edit_for_a_valid_name() {
+        let source = "from karva import fixture\n@fixture(name=\"database\")\ndef provider(): pass\ndef test_example(database): pass\n";
+        let path = Utf8PathBuf::from("/project/test_example.py");
+        let index = WorkspaceSourceIndex::from_documents(
+            "/project".into(),
+            [SourceDocument::new(path.clone(), source.to_owned())],
+            settings(),
+        )
+        .expect("source should index");
+        let analysis = index.analyze(&path).expect("source should analyze");
+        let occurrence = fixture_occurrence(&analysis, offset(source, "database):"))
+            .expect("parameter should resolve");
+
+        let edits = rename_fixture(&index, &occurrence, "данные")
+            .expect("valid Unicode identifier should rename");
+
+        assert_eq!(edits.len(), 2);
+        assert!(edits.iter().all(|edit| {
+            let range = edit
+                .occurrence
+                .edit_range
+                .expect("rename result should be editable");
+            &source[range.to_std_range()] == "database"
+        }));
+    }
+
+    #[test]
+    fn rejects_invalid_python_identifiers() {
+        assert!(!is_valid_fixture_name(""));
+        assert!(!is_valid_fixture_name("class"));
+        assert!(!is_valid_fixture_name("1database"));
+        assert!(!is_valid_fixture_name("data-base"));
+        assert!(!is_valid_fixture_name("data base"));
+    }
+
+    #[test]
+    fn rejects_existing_fixture_and_builtin_names() {
+        let source = "from karva import fixture\n@fixture\ndef database(): pass\n@fixture\ndef replacement(): pass\ndef test_example(database): pass\n";
+        let path = Utf8PathBuf::from("/project/test_example.py");
+        let index = WorkspaceSourceIndex::from_documents(
+            "/project".into(),
+            [SourceDocument::new(path.clone(), source.to_owned())],
+            settings(),
+        )
+        .expect("source should index");
+        let analysis = index.analyze(&path).expect("source should analyze");
+        let occurrence = fixture_occurrence(&analysis, offset(source, "database):"))
+            .expect("parameter should resolve");
+
+        assert!(rename_fixture(&index, &occurrence, "replacement").is_none());
+        assert!(rename_fixture(&index, &occurrence, "tmp_path").is_none());
+    }
+
+    #[test]
+    fn rejects_parametrized_argument_name() {
+        let source = "import pytest\nfrom karva import fixture\n@fixture\ndef database(): pass\n@pytest.mark.parametrize('replacement', [1])\ndef test_example(database, replacement): pass\n";
+        let path = Utf8PathBuf::from("/project/test_example.py");
+        let index = WorkspaceSourceIndex::from_documents(
+            "/project".into(),
+            [SourceDocument::new(path.clone(), source.to_owned())],
+            settings(),
+        )
+        .expect("source should index");
+        let analysis = index.analyze(&path).expect("source should analyze");
+        let occurrence = fixture_occurrence(&analysis, offset(source, "database,"))
+            .expect("parameter should resolve");
+
+        assert!(rename_fixture(&index, &occurrence, "replacement").is_none());
+    }
+
+    #[test]
+    fn rejects_dynamic_parametrization_for_the_visible_provider() {
+        let source = "import pytest\nfrom karva import fixture\n@fixture\ndef database(): pass\n@pytest.mark.parametrize(names, [1])\ndef test_example(database): pass\n";
+        let path = Utf8PathBuf::from("/project/test_example.py");
+        let index = WorkspaceSourceIndex::from_documents(
+            "/project".into(),
+            [SourceDocument::new(path.clone(), source.to_owned())],
+            settings(),
+        )
+        .expect("source should index");
+        let analysis = index.analyze(&path).expect("source should analyze");
+        let occurrence = fixture_occurrence(&analysis, offset(source, "database():"))
+            .expect("definition should resolve");
+
+        assert!(rename_fixture(&index, &occurrence, "replacement").is_none());
+    }
+
+    #[test]
+    fn allows_an_unrelated_known_parametrized_name() {
+        let source = "import pytest\nfrom karva import fixture\n@fixture\ndef database(): pass\n@pytest.mark.parametrize('database', [1])\ndef test_unrelated(database): pass\ndef test_fixture(database): pass\n";
+        let path = Utf8PathBuf::from("/project/test_example.py");
+        let index = WorkspaceSourceIndex::from_documents(
+            "/project".into(),
+            [SourceDocument::new(path.clone(), source.to_owned())],
+            settings(),
+        )
+        .expect("source should index");
+        let analysis = index.analyze(&path).expect("source should analyze");
+        let occurrence = fixture_occurrence(&analysis, offset(source, "database():"))
+            .expect("fixture definition should resolve");
+
+        let edits = rename_fixture(&index, &occurrence, "replacement")
+            .expect("known parametrization should be unrelated");
+        assert_eq!(edits.len(), 2);
+    }
+
+    #[test]
+    fn rejects_duplicate_test_parameters() {
+        let source = "from karva import fixture\n@fixture\ndef database(): pass\ndef test_example(database, replacement): pass\n";
+        let path = Utf8PathBuf::from("/project/test_example.py");
+        let index = WorkspaceSourceIndex::from_documents(
+            "/project".into(),
+            [SourceDocument::new(path.clone(), source.to_owned())],
+            settings(),
+        )
+        .expect("source should index");
+        let analysis = index.analyze(&path).expect("source should analyze");
+        let occurrence = fixture_occurrence(&analysis, offset(source, "database, replacement"))
+            .expect("fixture parameter should resolve");
+
+        assert!(rename_fixture(&index, &occurrence, "replacement").is_none());
+    }
+
+    #[test]
+    fn rejects_duplicate_fixture_parameters() {
+        let source = "from karva import fixture\n@fixture\ndef database(): pass\n@fixture\ndef wrapper(database, replacement): pass\n";
+        let path = Utf8PathBuf::from("/project/test_example.py");
+        let index = WorkspaceSourceIndex::from_documents(
+            "/project".into(),
+            [SourceDocument::new(path.clone(), source.to_owned())],
+            settings(),
+        )
+        .expect("source should index");
+        let analysis = index.analyze(&path).expect("source should analyze");
+        let occurrence = fixture_occurrence(&analysis, offset(source, "database, replacement"))
+            .expect("fixture dependency should resolve");
+
+        assert!(rename_fixture(&index, &occurrence, "replacement").is_none());
     }
 }

--- a/crates/karva_language_server/src/capabilities.rs
+++ b/crates/karva_language_server/src/capabilities.rs
@@ -68,6 +68,7 @@ pub(super) fn server_capabilities(position_encoding: PositionEncoding) -> Server
         definition_provider: Some(true.into()),
         hover_provider: Some(true.into()),
         references_provider: Some(true.into()),
+        document_highlight_provider: Some(true.into()),
         rename_provider: Some(
             RenameOptions::new(Some(true), WorkDoneProgressOptions::default()).into(),
         ),

--- a/crates/karva_language_server/src/capabilities.rs
+++ b/crates/karva_language_server/src/capabilities.rs
@@ -4,8 +4,9 @@
 )]
 
 use lsp_types::{
-    ClientCapabilities, CompletionOptions, MarkupKind, ServerCapabilities, TextDocumentSyncKind,
-    TextDocumentSyncOptions, WorkspaceFoldersServerCapabilities,
+    ClientCapabilities, CompletionOptions, MarkupKind, RenameOptions, ServerCapabilities,
+    TextDocumentSyncKind, TextDocumentSyncOptions, WorkDoneProgressOptions,
+    WorkspaceFoldersServerCapabilities,
 };
 
 use crate::PositionEncoding;
@@ -67,6 +68,9 @@ pub(super) fn server_capabilities(position_encoding: PositionEncoding) -> Server
         definition_provider: Some(true.into()),
         hover_provider: Some(true.into()),
         references_provider: Some(true.into()),
+        rename_provider: Some(
+            RenameOptions::new(Some(true), WorkDoneProgressOptions::default()).into(),
+        ),
         workspace: Some(lsp_types::WorkspaceOptions {
             workspace_folders: Some(WorkspaceFoldersServerCapabilities {
                 supported: Some(true),

--- a/crates/karva_language_server/src/server/api.rs
+++ b/crates/karva_language_server/src/server/api.rs
@@ -4,8 +4,8 @@ use lsp_server::{ErrorCode, Notification, Request, Response};
 use lsp_types::{
     CancelNotification, CompletionRequest, DefinitionRequest, DidChangeTextDocumentNotification,
     DidChangeWatchedFilesNotification, DidChangeWorkspaceFoldersNotification,
-    DidCloseTextDocumentNotification, DidOpenTextDocumentNotification, HoverRequest,
-    LspNotificationMethod, LspRequestMethod, Notification as _, PrepareRenameRequest,
+    DidCloseTextDocumentNotification, DidOpenTextDocumentNotification, DocumentHighlightRequest,
+    HoverRequest, LspNotificationMethod, LspRequestMethod, Notification as _, PrepareRenameRequest,
     ReferencesRequest, RenameRequest, Request as _, ShutdownRequest,
 };
 
@@ -42,6 +42,9 @@ pub(super) fn request(request: Request) -> Task {
         CompletionRequest::METHOD => background_request_task::<requests::Completion>(request),
         DefinitionRequest::METHOD => background_request_task::<requests::Definition>(request),
         HoverRequest::METHOD => background_request_task::<requests::Hover>(request),
+        DocumentHighlightRequest::METHOD => {
+            background_request_task::<requests::DocumentHighlight>(request)
+        }
         PrepareRenameRequest::METHOD => background_request_task::<requests::PrepareRename>(request),
         ReferencesRequest::METHOD => background_request_task::<requests::References>(request),
         RenameRequest::METHOD => background_request_task::<requests::Rename>(request),

--- a/crates/karva_language_server/src/server/api.rs
+++ b/crates/karva_language_server/src/server/api.rs
@@ -5,8 +5,8 @@ use lsp_types::{
     CancelNotification, CompletionRequest, DefinitionRequest, DidChangeTextDocumentNotification,
     DidChangeWatchedFilesNotification, DidChangeWorkspaceFoldersNotification,
     DidCloseTextDocumentNotification, DidOpenTextDocumentNotification, HoverRequest,
-    LspNotificationMethod, LspRequestMethod, Notification as _, ReferencesRequest, Request as _,
-    ShutdownRequest,
+    LspNotificationMethod, LspRequestMethod, Notification as _, PrepareRenameRequest,
+    ReferencesRequest, RenameRequest, Request as _, ShutdownRequest,
 };
 
 use crate::server::schedule::{BackgroundSchedule, Task};
@@ -20,13 +20,31 @@ mod traits;
 
 use self::traits::{BackgroundRequestHandler, SyncNotificationHandler, SyncRequestHandler};
 
+#[derive(Debug, thiserror::Error)]
+#[error("{message}")]
+pub(in crate::server::api) struct RequestError {
+    code: i32,
+    message: String,
+}
+
+impl RequestError {
+    fn invalid_params(message: impl Into<String>) -> Self {
+        Self {
+            code: ErrorCode::InvalidParams as i32,
+            message: message.into(),
+        }
+    }
+}
+
 pub(super) fn request(request: Request) -> Task {
     match LspRequestMethod::from(request.method.as_str()) {
         ShutdownRequest::METHOD => sync_request_task::<requests::Shutdown>(request),
         CompletionRequest::METHOD => background_request_task::<requests::Completion>(request),
         DefinitionRequest::METHOD => background_request_task::<requests::Definition>(request),
         HoverRequest::METHOD => background_request_task::<requests::Hover>(request),
+        PrepareRenameRequest::METHOD => background_request_task::<requests::PrepareRename>(request),
         ReferencesRequest::METHOD => background_request_task::<requests::References>(request),
+        RenameRequest::METHOD => background_request_task::<requests::Rename>(request),
         method => Task::immediate(Response::new_err(
             request.id,
             ErrorCode::MethodNotFound as i32,
@@ -172,7 +190,13 @@ fn result_response<R: serde::Serialize>(
             },
             Err(error) => Response::new_err(id, ErrorCode::InternalError as i32, error.to_string()),
         },
-        Err(error) => Response::new_err(id, ErrorCode::InternalError as i32, error.to_string()),
+        Err(error) => {
+            if let Some(error) = error.downcast_ref::<RequestError>() {
+                Response::new_err(id, error.code, error.message.clone())
+            } else {
+                Response::new_err(id, ErrorCode::InternalError as i32, error.to_string())
+            }
+        }
     }
 }
 

--- a/crates/karva_language_server/src/server/api/requests.rs
+++ b/crates/karva_language_server/src/server/api/requests.rs
@@ -7,12 +7,16 @@ use crate::session::client::Client;
 mod completion;
 mod definition;
 mod hover;
+mod prepare_rename;
 mod references;
+mod rename;
 
 pub(super) use completion::Completion;
 pub(super) use definition::Definition;
 pub(super) use hover::Hover;
+pub(super) use prepare_rename::PrepareRename;
 pub(super) use references::References;
+pub(super) use rename::Rename;
 
 pub(super) struct Shutdown;
 

--- a/crates/karva_language_server/src/server/api/requests.rs
+++ b/crates/karva_language_server/src/server/api/requests.rs
@@ -6,6 +6,7 @@ use crate::session::client::Client;
 
 mod completion;
 mod definition;
+mod document_highlight;
 mod hover;
 mod prepare_rename;
 mod references;
@@ -13,6 +14,7 @@ mod rename;
 
 pub(super) use completion::Completion;
 pub(super) use definition::Definition;
+pub(super) use document_highlight::DocumentHighlight;
 pub(super) use hover::Hover;
 pub(super) use prepare_rename::PrepareRename;
 pub(super) use references::References;

--- a/crates/karva_language_server/src/server/api/requests/document_highlight.rs
+++ b/crates/karva_language_server/src/server/api/requests/document_highlight.rs
@@ -1,0 +1,94 @@
+//! Same-document highlighting for statically resolved Karva fixtures.
+
+use karva_ide::{FixtureOccurrenceKind, fixture_document_highlights};
+use lsp_types::{DocumentHighlightKind, DocumentHighlightParams, DocumentHighlightRequest};
+use ruff_source_file::LineIndex;
+
+use super::super::traits::{BackgroundRequestHandler, RequestHandler};
+use crate::PositionEncoding;
+use crate::document::{position_to_text_size, text_range_to_range};
+use crate::session::client::Client;
+use crate::session::{
+    DocumentSnapshotVersion, PreparedSourceAnalysis, RequestCancellationToken, Session,
+};
+
+pub(in crate::server::api) struct DocumentHighlight;
+
+pub(in crate::server::api) struct DocumentHighlightSnapshot {
+    analysis: Option<PreparedSourceAnalysis>,
+    position_encoding: PositionEncoding,
+}
+
+impl RequestHandler for DocumentHighlight {
+    type RequestType = DocumentHighlightRequest;
+}
+
+impl BackgroundRequestHandler for DocumentHighlight {
+    type Snapshot = DocumentHighlightSnapshot;
+
+    fn prepare(
+        session: &mut Session,
+        params: &DocumentHighlightParams,
+    ) -> anyhow::Result<Self::Snapshot> {
+        let uri = &params.text_document_position_params.text_document.uri;
+        Ok(DocumentHighlightSnapshot {
+            analysis: session.prepare_source_analysis(uri)?,
+            position_encoding: session.position_encoding(),
+        })
+    }
+
+    fn run(
+        snapshot: Self::Snapshot,
+        _client: &Client,
+        params: DocumentHighlightParams,
+        cancellation: &RequestCancellationToken,
+    ) -> anyhow::Result<Option<Vec<lsp_types::DocumentHighlight>>> {
+        let Some(prepared) = snapshot.analysis else {
+            return Ok(None);
+        };
+        let source_text = prepared.source_text().to_owned();
+        let line_index = LineIndex::from_source_text(&source_text);
+        let offset = position_to_text_size(
+            params.text_document_position_params.position,
+            &source_text,
+            &line_index,
+            snapshot.position_encoding,
+        );
+        let Some(analysis) = prepared.analyze(cancellation)? else {
+            return Ok(None);
+        };
+        let Some(highlights) = fixture_document_highlights(&analysis.analysis, offset) else {
+            return Ok(None);
+        };
+        let highlights = highlights
+            .into_iter()
+            .filter_map(|occurrence| {
+                let range = text_range_to_range(
+                    occurrence.range,
+                    &source_text,
+                    &line_index,
+                    snapshot.position_encoding,
+                )?;
+                let kind = match occurrence.kind {
+                    FixtureOccurrenceKind::Definition => DocumentHighlightKind::Write,
+                    FixtureOccurrenceKind::Dependency
+                    | FixtureOccurrenceKind::TestParameter
+                    | FixtureOccurrenceKind::UseFixtures => DocumentHighlightKind::Read,
+                };
+                Some(lsp_types::DocumentHighlight {
+                    range,
+                    kind: Some(kind),
+                })
+            })
+            .collect();
+
+        Ok(Some(highlights))
+    }
+
+    fn document_version(snapshot: &Self::Snapshot) -> Option<DocumentSnapshotVersion> {
+        snapshot
+            .analysis
+            .as_ref()
+            .map(PreparedSourceAnalysis::response_version)
+    }
+}

--- a/crates/karva_language_server/src/server/api/requests/prepare_rename.rs
+++ b/crates/karva_language_server/src/server/api/requests/prepare_rename.rs
@@ -1,0 +1,85 @@
+//! Rename preflight for statically resolved Karva fixtures.
+
+use karva_ide::{fixture_rename_target, prepare_fixture_rename};
+use lsp_types::{
+    PrepareRenameParams, PrepareRenamePlaceholder, PrepareRenameRequest, PrepareRenameResult,
+};
+use ruff_source_file::LineIndex;
+
+use super::super::traits::{BackgroundRequestHandler, RequestHandler};
+use crate::PositionEncoding;
+use crate::document::{position_to_text_size, text_range_to_range};
+use crate::session::client::Client;
+use crate::session::{
+    DocumentSnapshotVersion, PreparedSourceAnalysis, RequestCancellationToken, Session,
+};
+
+pub(in crate::server::api) struct PrepareRename;
+
+pub(in crate::server::api) struct PrepareRenameSnapshot {
+    analysis: Option<PreparedSourceAnalysis>,
+    position_encoding: PositionEncoding,
+}
+
+impl RequestHandler for PrepareRename {
+    type RequestType = PrepareRenameRequest;
+}
+
+impl BackgroundRequestHandler for PrepareRename {
+    type Snapshot = PrepareRenameSnapshot;
+
+    fn prepare(
+        session: &mut Session,
+        params: &PrepareRenameParams,
+    ) -> anyhow::Result<Self::Snapshot> {
+        let uri = &params.text_document_position_params.text_document.uri;
+        Ok(PrepareRenameSnapshot {
+            analysis: session.prepare_project_source_analysis(uri)?,
+            position_encoding: session.position_encoding(),
+        })
+    }
+
+    fn run(
+        snapshot: Self::Snapshot,
+        _client: &Client,
+        params: PrepareRenameParams,
+        cancellation: &RequestCancellationToken,
+    ) -> anyhow::Result<Option<PrepareRenameResult>> {
+        let Some(prepared) = snapshot.analysis else {
+            return Ok(None);
+        };
+        let source_text = prepared.source_text().to_owned();
+        let line_index = LineIndex::from_source_text(&source_text);
+        let offset = position_to_text_size(
+            params.text_document_position_params.position,
+            &source_text,
+            &line_index,
+            snapshot.position_encoding,
+        );
+        let Some(analysis) = prepared.analyze(cancellation)? else {
+            return Ok(None);
+        };
+        let Some(target) = fixture_rename_target(&analysis.analysis, offset) else {
+            return Ok(None);
+        };
+        let Some(range) = prepare_fixture_rename(&analysis.source_index, &target.occurrence) else {
+            return Ok(None);
+        };
+        let Some(range) =
+            text_range_to_range(range, &source_text, &line_index, snapshot.position_encoding)
+        else {
+            return Ok(None);
+        };
+
+        Ok(Some(PrepareRenameResult::PrepareRenamePlaceholder(
+            PrepareRenamePlaceholder::new(range, target.placeholder),
+        )))
+    }
+
+    fn document_version(snapshot: &Self::Snapshot) -> Option<DocumentSnapshotVersion> {
+        snapshot
+            .analysis
+            .as_ref()
+            .map(PreparedSourceAnalysis::response_version)
+    }
+}

--- a/crates/karva_language_server/src/server/api/requests/rename.rs
+++ b/crates/karva_language_server/src/server/api/requests/rename.rs
@@ -1,0 +1,117 @@
+//! Workspace edits for statically resolved Karva fixture renames.
+
+use std::collections::HashMap;
+
+use anyhow::{Context, anyhow};
+use karva_ide::{fixture_rename_target, is_valid_fixture_name, rename_fixture};
+use lsp_types::{RenameParams, RenameRequest, TextEdit, Uri, WorkspaceEdit};
+use ruff_source_file::LineIndex;
+
+use super::super::RequestError;
+use super::super::traits::{BackgroundRequestHandler, RequestHandler};
+use crate::PositionEncoding;
+use crate::document::{position_to_text_size, text_range_to_range};
+use crate::session::client::Client;
+use crate::session::{
+    DocumentSnapshotVersion, PreparedSourceAnalysis, RequestCancellationToken, Session,
+};
+
+pub(in crate::server::api) struct Rename;
+
+pub(in crate::server::api) struct RenameSnapshot {
+    analysis: Option<PreparedSourceAnalysis>,
+    position_encoding: PositionEncoding,
+}
+
+impl RequestHandler for Rename {
+    type RequestType = RenameRequest;
+}
+
+impl BackgroundRequestHandler for Rename {
+    type Snapshot = RenameSnapshot;
+
+    fn prepare(session: &mut Session, params: &RenameParams) -> anyhow::Result<Self::Snapshot> {
+        let uri = &params.text_document_position_params.text_document.uri;
+        Ok(RenameSnapshot {
+            analysis: session.prepare_project_source_analysis(uri)?,
+            position_encoding: session.position_encoding(),
+        })
+    }
+
+    fn run(
+        snapshot: Self::Snapshot,
+        _client: &Client,
+        params: RenameParams,
+        cancellation: &RequestCancellationToken,
+    ) -> anyhow::Result<Option<WorkspaceEdit>> {
+        if !is_valid_fixture_name(&params.new_name) {
+            return Err(RequestError::invalid_params(format!(
+                "fixture rename `{}` is not a valid Python identifier",
+                params.new_name
+            ))
+            .into());
+        }
+        let Some(prepared) = snapshot.analysis else {
+            return Ok(None);
+        };
+        let source_text = prepared.source_text().to_owned();
+        let line_index = LineIndex::from_source_text(&source_text);
+        let offset = position_to_text_size(
+            params.text_document_position_params.position,
+            &source_text,
+            &line_index,
+            snapshot.position_encoding,
+        );
+        let Some(analysis) = prepared.analyze(cancellation)? else {
+            return Ok(None);
+        };
+        let Some(target) = fixture_rename_target(&analysis.analysis, offset) else {
+            return Ok(None);
+        };
+        let Some(occurrences) =
+            rename_fixture(&analysis.source_index, &target.occurrence, &params.new_name)
+        else {
+            return Ok(None);
+        };
+
+        let mut changes = HashMap::new();
+        for occurrence in occurrences {
+            let edit_range = occurrence
+                .occurrence
+                .edit_range
+                .context("fixture rename preflight returned an uneditable occurrence")?;
+            let source = analysis
+                .source_index
+                .module(&occurrence.path)
+                .context("fixture rename source is missing from the project snapshot")?
+                .source_text
+                .as_str();
+            let range = text_range_to_range(
+                edit_range,
+                source,
+                &LineIndex::from_source_text(source),
+                snapshot.position_encoding,
+            )
+            .context("fixture rename range is outside its source")?;
+            let uri = Uri::from_file_path(occurrence.path.as_std_path())
+                .map_err(|()| anyhow!("fixture rename path cannot be converted to a file URI"))?;
+            changes
+                .entry(uri)
+                .or_insert_with(Vec::new)
+                .push(TextEdit::new(range, params.new_name.clone()));
+        }
+
+        Ok(Some(WorkspaceEdit {
+            changes: Some(changes),
+            document_changes: None,
+            change_annotations: None,
+        }))
+    }
+
+    fn document_version(snapshot: &Self::Snapshot) -> Option<DocumentSnapshotVersion> {
+        snapshot
+            .analysis
+            .as_ref()
+            .map(PreparedSourceAnalysis::response_version)
+    }
+}

--- a/crates/karva_language_server/tests/e2e/document_highlight.rs
+++ b/crates/karva_language_server/tests/e2e/document_highlight.rs
@@ -1,0 +1,208 @@
+use std::fs;
+
+use insta::assert_json_snapshot;
+use lsp_types::{
+    ClientCapabilities, DidOpenTextDocumentNotification, DidOpenTextDocumentParams,
+    DocumentHighlightParams, DocumentHighlightRequest, LanguageKind, PartialResultParams, Position,
+    PublishDiagnosticsNotification, TextDocumentIdentifier, TextDocumentItem,
+    TextDocumentPositionParams, Uri, WorkDoneProgressParams, WorkspaceFolder,
+};
+use serde_json::Value;
+use tempfile::TempDir;
+
+use super::TestServer;
+
+#[test]
+fn highlights_fixture_declarations_reads_nested_providers_and_unsupported_targets() {
+    let workspace = Workspace::new();
+    workspace.write(
+        "conftest.py",
+        "from karva import fixture\n@fixture\ndef database(): pass\n",
+    );
+    workspace.write(
+        "tests/pkg/conftest.py",
+        "from karva import fixture\n@fixture\ndef database(): pass\n",
+    );
+    workspace.write(
+        "tests/pkg/test_nested.py",
+        "def test_nested(tmp_path, database, missing): pass\n",
+    );
+    let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
+
+    let custom_uri = workspace.uri("custom.py");
+    let custom_source = "from karva import fixture\n@fixture(name=\"данные\")\ndef provider(): pass\ndef test_example(данные): pass\n";
+    open(&server, custom_uri.clone(), custom_source);
+    let custom = server
+        .request::<DocumentHighlightRequest>(highlight_params(custom_uri, Position::new(3, 18)));
+
+    let nested_uri = workspace.uri("tests/pkg/test_nested.py");
+    open(
+        &server,
+        nested_uri.clone(),
+        "def test_nested(database): pass\n",
+    );
+    let nested = server.request::<DocumentHighlightRequest>(highlight_params(
+        nested_uri.clone(),
+        Position::new(0, 27),
+    ));
+    let unsupported = server.request::<DocumentHighlightRequest>(highlight_params(
+        nested_uri.clone(),
+        Position::new(0, 17),
+    ));
+    let missing = server
+        .request::<DocumentHighlightRequest>(highlight_params(nested_uri, Position::new(0, 37)));
+
+    assert_json_snapshot!(workspace.normalize([custom, nested, unsupported, missing]), @r#"
+    [
+      [
+        {
+          "kind": 3,
+          "range": {
+            "end": {
+              "character": 21,
+              "line": 1
+            },
+            "start": {
+              "character": 15,
+              "line": 1
+            }
+          }
+        },
+        {
+          "kind": 3,
+          "range": {
+            "end": {
+              "character": 12,
+              "line": 2
+            },
+            "start": {
+              "character": 4,
+              "line": 2
+            }
+          }
+        },
+        {
+          "kind": 2,
+          "range": {
+            "end": {
+              "character": 23,
+              "line": 3
+            },
+            "start": {
+              "character": 17,
+              "line": 3
+            }
+          }
+        }
+      ],
+      null,
+      [
+        {
+          "kind": 2,
+          "range": {
+            "end": {
+              "character": 24,
+              "line": 0
+            },
+            "start": {
+              "character": 16,
+              "line": 0
+            }
+          }
+        }
+      ],
+      null
+    ]
+    "#);
+}
+
+fn open(server: &TestServer, uri: Uri, source: &str) {
+    server.notify::<DidOpenTextDocumentNotification>(DidOpenTextDocumentParams {
+        text_document: TextDocumentItem {
+            uri,
+            language_id: LanguageKind::Python,
+            version: 1,
+            text: source.to_owned(),
+        },
+    });
+    server.receive_notification::<PublishDiagnosticsNotification>();
+}
+
+fn highlight_params(uri: Uri, position: Position) -> DocumentHighlightParams {
+    DocumentHighlightParams::new(
+        WorkDoneProgressParams::default(),
+        PartialResultParams::default(),
+        TextDocumentPositionParams::new(TextDocumentIdentifier::new(uri), position),
+    )
+}
+
+struct Workspace {
+    directory: TempDir,
+    root_uri: Uri,
+}
+
+impl Workspace {
+    fn new() -> Self {
+        let directory = tempfile::tempdir().expect("temporary workspace should be created");
+        fs::create_dir(directory.path().join(".git")).expect("workspace marker should be created");
+        let root_uri =
+            Uri::from_file_path(directory.path()).expect("workspace URI should be valid");
+        Self {
+            directory,
+            root_uri,
+        }
+    }
+
+    fn folder(&self) -> WorkspaceFolder {
+        WorkspaceFolder {
+            uri: self.root_uri.clone(),
+            name: "project".to_owned(),
+        }
+    }
+
+    fn uri(&self, relative: &str) -> Uri {
+        Uri::from_file_path(self.directory.path().join(relative))
+            .expect("document URI should be valid")
+    }
+
+    fn write(&self, relative: &str, source: &str) {
+        let path = self.directory.path().join(relative);
+        fs::create_dir_all(
+            path.parent()
+                .expect("workspace source should have a parent"),
+        )
+        .expect("workspace source parent should be created");
+        fs::write(path, source).expect("workspace source should be written");
+    }
+
+    fn normalize(&self, value: impl serde::Serialize) -> Value {
+        let mut value = serde_json::to_value(value).expect("highlights should serialize");
+        normalize_paths(
+            &mut value,
+            self.root_uri.as_str(),
+            &self.directory.path().to_string_lossy(),
+        );
+        value
+    }
+}
+
+fn normalize_paths(value: &mut Value, workspace_uri: &str, workspace_path: &str) {
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                normalize_paths(value, workspace_uri, workspace_path);
+            }
+        }
+        Value::Object(values) => {
+            for value in values.values_mut() {
+                normalize_paths(value, workspace_uri, workspace_path);
+            }
+        }
+        Value::String(value) => {
+            *value = value
+                .replace(workspace_uri, "file:///project")
+                .replace(workspace_path, "/project");
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) => {}
+    }
+}

--- a/crates/karva_language_server/tests/e2e/initialize.rs
+++ b/crates/karva_language_server/tests/e2e/initialize.rs
@@ -79,6 +79,11 @@ fn initialization_advertises_document_and_workspace_sync() {
     assert!(capabilities.definition_provider.is_some());
     assert!(capabilities.hover_provider.is_some());
     assert!(capabilities.references_provider.is_some());
+    assert!(matches!(
+        capabilities.rename_provider,
+        Some(lsp_types::RenameProvider::RenameOptions(options))
+            if options.prepare_provider == Some(true)
+    ));
     assert_eq!(
         capabilities
             .workspace

--- a/crates/karva_language_server/tests/e2e/initialize.rs
+++ b/crates/karva_language_server/tests/e2e/initialize.rs
@@ -78,6 +78,7 @@ fn initialization_advertises_document_and_workspace_sync() {
     assert!(capabilities.completion_provider.is_some());
     assert!(capabilities.definition_provider.is_some());
     assert!(capabilities.hover_provider.is_some());
+    assert!(capabilities.document_highlight_provider.is_some());
     assert!(capabilities.references_provider.is_some());
     assert!(matches!(
         capabilities.rename_provider,

--- a/crates/karva_language_server/tests/e2e/main.rs
+++ b/crates/karva_language_server/tests/e2e/main.rs
@@ -4,6 +4,7 @@ mod completion;
 mod config_reload;
 mod definition;
 mod diagnostics;
+mod document_highlight;
 mod document_sync;
 mod hover;
 mod initialize;

--- a/crates/karva_language_server/tests/e2e/main.rs
+++ b/crates/karva_language_server/tests/e2e/main.rs
@@ -8,6 +8,7 @@ mod document_sync;
 mod hover;
 mod initialize;
 mod references;
+mod rename;
 
 use std::thread::JoinHandle;
 

--- a/crates/karva_language_server/tests/e2e/rename.rs
+++ b/crates/karva_language_server/tests/e2e/rename.rs
@@ -1,0 +1,222 @@
+use std::fs;
+
+use insta::assert_json_snapshot;
+use lsp_types::{
+    ClientCapabilities, DidOpenTextDocumentNotification, DidOpenTextDocumentParams, LanguageKind,
+    Position, PrepareRenameParams, PrepareRenameRequest, PublishDiagnosticsNotification,
+    RenameParams, RenameRequest, TextDocumentIdentifier, TextDocumentItem,
+    TextDocumentPositionParams, Uri, WorkDoneProgressParams, WorkspaceFolder,
+};
+use serde_json::Value;
+use tempfile::TempDir;
+
+use super::TestServer;
+
+#[test]
+fn prepares_and_renames_fixture_occurrences_across_files() {
+    let workspace = Workspace::new();
+    let provider_source =
+        "from karva import fixture\n@fixture(name=\"data\\x62ase\")\ndef provider(): pass\n";
+    workspace.write("conftest.py", provider_source);
+    workspace.write("tests/test_other.py", "def test_other(database): pass\n");
+    let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
+    let provider_uri = workspace.uri("conftest.py");
+    open(&server, provider_uri.clone(), provider_source);
+    let uri = workspace.uri("tests/test_example.py");
+    open(
+        &server,
+        uri.clone(),
+        "import pytest\n\n@pytest.mark.usefixtures(\"data\\x62ase\")\ndef test_example(database): pass\n",
+    );
+
+    let position = Position::new(3, 20);
+    let prepared = server.request::<PrepareRenameRequest>(prepare_params(uri.clone(), position));
+    let edit = server.request::<RenameRequest>(rename_params(uri, position, "данные"));
+    let provider_prepared = server
+        .request::<PrepareRenameRequest>(prepare_params(provider_uri.clone(), Position::new(2, 6)));
+    let provider_edit =
+        server.request::<RenameRequest>(rename_params(provider_uri, Position::new(2, 6), "данные"));
+
+    assert_eq!(provider_edit, edit);
+    assert_json_snapshot!(workspace.normalize((prepared, provider_prepared, edit)));
+}
+
+#[test]
+fn renames_only_the_selected_nested_provider() {
+    let workspace = Workspace::new();
+    workspace.write(
+        "conftest.py",
+        "from karva import fixture\n@fixture\ndef database(): pass\n",
+    );
+    workspace.write("tests/test_root.py", "def test_root(database): pass\n");
+    workspace.write(
+        "tests/pkg/conftest.py",
+        "from karva import fixture\n@fixture\ndef database(): pass\n",
+    );
+    let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
+    let uri = workspace.uri("tests/pkg/test_nested.py");
+    open(&server, uri.clone(), "def test_nested(database): pass\n");
+
+    let edit = server.request::<RenameRequest>(rename_params(
+        uri,
+        Position::new(0, 20),
+        "nested_database",
+    ));
+
+    assert_json_snapshot!(workspace.normalize(edit));
+}
+
+#[test]
+fn rejects_partial_and_invalid_fixture_renames() {
+    let workspace = Workspace::new();
+    workspace.write(
+        "conftest.py",
+        "from karva import fixture\n@fixture(name='data' 'base')\ndef provider(): pass\n",
+    );
+    let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
+    let uri = workspace.uri("test_example.py");
+    open(&server, uri.clone(), "def test_example(database): pass\n");
+    let position = Position::new(0, 20);
+
+    let prepared = server.request::<PrepareRenameRequest>(prepare_params(uri.clone(), position));
+    let partial =
+        server.request::<RenameRequest>(rename_params(uri.clone(), position, "renamed_database"));
+    let invalid_id = server.send_request::<RenameRequest>(rename_params(uri, position, "class"));
+    let invalid = server.receive_response(&invalid_id);
+
+    assert_eq!(prepared, None);
+    assert_eq!(partial, None);
+    let error = invalid
+        .response_result
+        .expect_err("invalid identifier should fail");
+    assert_eq!(error.code, lsp_server::ErrorCode::InvalidParams as i32);
+    assert_eq!(
+        error.message,
+        "fixture rename `class` is not a valid Python identifier"
+    );
+}
+
+#[test]
+fn rejects_name_that_would_select_a_nested_provider() {
+    let workspace = Workspace::new();
+    workspace.write(
+        "conftest.py",
+        "from karva import fixture\n@fixture\ndef database(): pass\n",
+    );
+    workspace.write(
+        "tests/pkg/conftest.py",
+        "from karva import fixture\n@fixture\ndef replacement(): pass\n",
+    );
+    let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
+    let uri = workspace.uri("tests/pkg/test_nested.py");
+    open(&server, uri.clone(), "def test_nested(database): pass\n");
+
+    let edit =
+        server.request::<RenameRequest>(rename_params(uri, Position::new(0, 20), "replacement"));
+
+    assert_eq!(edit, None);
+}
+
+fn open(server: &TestServer, uri: Uri, source: &str) {
+    server.notify::<DidOpenTextDocumentNotification>(DidOpenTextDocumentParams {
+        text_document: TextDocumentItem {
+            uri,
+            language_id: LanguageKind::Python,
+            version: 1,
+            text: source.to_owned(),
+        },
+    });
+    server.receive_notification::<PublishDiagnosticsNotification>();
+}
+
+fn prepare_params(uri: Uri, position: Position) -> PrepareRenameParams {
+    PrepareRenameParams::new(
+        WorkDoneProgressParams::default(),
+        TextDocumentPositionParams::new(TextDocumentIdentifier::new(uri), position),
+    )
+}
+
+fn rename_params(uri: Uri, position: Position, new_name: &str) -> RenameParams {
+    RenameParams::new(
+        new_name.to_owned(),
+        WorkDoneProgressParams::default(),
+        TextDocumentPositionParams::new(TextDocumentIdentifier::new(uri), position),
+    )
+}
+
+struct Workspace {
+    directory: TempDir,
+    root_uri: Uri,
+}
+
+impl Workspace {
+    fn new() -> Self {
+        let directory = tempfile::tempdir().expect("temporary workspace should be created");
+        fs::create_dir(directory.path().join(".git")).expect("workspace marker should be created");
+        let root_uri =
+            Uri::from_file_path(directory.path()).expect("workspace URI should be valid");
+        Self {
+            directory,
+            root_uri,
+        }
+    }
+
+    fn folder(&self) -> WorkspaceFolder {
+        WorkspaceFolder {
+            uri: self.root_uri.clone(),
+            name: "project".to_owned(),
+        }
+    }
+
+    fn uri(&self, relative: &str) -> Uri {
+        Uri::from_file_path(self.directory.path().join(relative))
+            .expect("document URI should be valid")
+    }
+
+    fn write(&self, relative: &str, source: &str) {
+        let path = self.directory.path().join(relative);
+        fs::create_dir_all(
+            path.parent()
+                .expect("workspace source should have a parent"),
+        )
+        .expect("workspace source parent should be created");
+        fs::write(path, source).expect("workspace source should be written");
+    }
+
+    fn normalize(&self, value: impl serde::Serialize) -> Value {
+        let mut value = serde_json::to_value(value).expect("rename should serialize");
+        normalize_paths(
+            &mut value,
+            self.root_uri.as_str(),
+            &self.directory.path().to_string_lossy(),
+        );
+        value
+    }
+}
+
+fn normalize_paths(value: &mut Value, workspace_uri: &str, workspace_path: &str) {
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                normalize_paths(value, workspace_uri, workspace_path);
+            }
+        }
+        Value::Object(values) => {
+            let original = std::mem::take(values);
+            for (key, mut value) in original {
+                normalize_paths(&mut value, workspace_uri, workspace_path);
+                values.insert(
+                    key.replace(workspace_uri, "file:///project")
+                        .replace(workspace_path, "/project"),
+                    value,
+                );
+            }
+        }
+        Value::String(value) => {
+            *value = value
+                .replace(workspace_uri, "file:///project")
+                .replace(workspace_path, "/project");
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) => {}
+    }
+}

--- a/crates/karva_language_server/tests/e2e/snapshots/e2e__rename__prepares_and_renames_fixture_occurrences_across_files.snap
+++ b/crates/karva_language_server/tests/e2e/snapshots/e2e__rename__prepares_and_renames_fixture_occurrences_across_files.snap
@@ -1,0 +1,94 @@
+---
+source: crates/karva_language_server/tests/e2e/rename.rs
+expression: "workspace.normalize((prepared, provider_prepared, edit))"
+---
+[
+  {
+    "placeholder": "database",
+    "range": {
+      "end": {
+        "character": 25,
+        "line": 3
+      },
+      "start": {
+        "character": 17,
+        "line": 3
+      }
+    }
+  },
+  {
+    "placeholder": "database",
+    "range": {
+      "end": {
+        "character": 12,
+        "line": 2
+      },
+      "start": {
+        "character": 4,
+        "line": 2
+      }
+    }
+  },
+  {
+    "changes": {
+      "file:///project/conftest.py": [
+        {
+          "newText": "данные",
+          "range": {
+            "end": {
+              "character": 26,
+              "line": 1
+            },
+            "start": {
+              "character": 15,
+              "line": 1
+            }
+          }
+        }
+      ],
+      "file:///project/tests/test_example.py": [
+        {
+          "newText": "данные",
+          "range": {
+            "end": {
+              "character": 37,
+              "line": 2
+            },
+            "start": {
+              "character": 26,
+              "line": 2
+            }
+          }
+        },
+        {
+          "newText": "данные",
+          "range": {
+            "end": {
+              "character": 25,
+              "line": 3
+            },
+            "start": {
+              "character": 17,
+              "line": 3
+            }
+          }
+        }
+      ],
+      "file:///project/tests/test_other.py": [
+        {
+          "newText": "данные",
+          "range": {
+            "end": {
+              "character": 23,
+              "line": 0
+            },
+            "start": {
+              "character": 15,
+              "line": 0
+            }
+          }
+        }
+      ]
+    }
+  }
+]

--- a/crates/karva_language_server/tests/e2e/snapshots/e2e__rename__renames_only_the_selected_nested_provider.snap
+++ b/crates/karva_language_server/tests/e2e/snapshots/e2e__rename__renames_only_the_selected_nested_provider.snap
@@ -1,0 +1,38 @@
+---
+source: crates/karva_language_server/tests/e2e/rename.rs
+expression: workspace.normalize(edit)
+---
+{
+  "changes": {
+    "file:///project/tests/pkg/conftest.py": [
+      {
+        "newText": "nested_database",
+        "range": {
+          "end": {
+            "character": 12,
+            "line": 2
+          },
+          "start": {
+            "character": 4,
+            "line": 2
+          }
+        }
+      }
+    ],
+    "file:///project/tests/pkg/test_nested.py": [
+      {
+        "newText": "nested_database",
+        "range": {
+          "end": {
+            "character": 24,
+            "line": 0
+          },
+          "start": {
+            "character": 16,
+            "line": 0
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Preflights fixture renames and applies safe workspace-wide edits across declarations, dependencies, test parameters, fixture metadata, and highlighted occurrences. Invalid or dynamically ambiguous renames are rejected before edits are produced.

Test plan: ci