### PR TITLE
Harden language-server end-to-end shutdown

### DIFF
--- a/crates/karva_language_server/tests/e2e/completion.rs
+++ b/crates/karva_language_server/tests/e2e/completion.rs
@@ -1,5 +1,3 @@
-use std::fs;
-
 use insta::assert_json_snapshot;
 use lsp_types::{
     ClientCapabilities, CompletionList, CompletionParams, CompletionRequest, CompletionResponse,
@@ -8,12 +6,9 @@ use lsp_types::{
     Position, PublishDiagnosticsNotification, TextDocumentContentChangeEvent,
     TextDocumentContentChangeWholeDocument, TextDocumentIdentifier, TextDocumentItem,
     TextDocumentPositionParams, Uri, VersionedTextDocumentIdentifier, WorkDoneProgressParams,
-    WorkspaceFolder,
 };
-use serde_json::Value;
-use tempfile::TempDir;
 
-use super::TestServer;
+use super::{TestServer, Workspace};
 
 #[test]
 fn completes_disk_and_builtin_fixtures_in_unsaved_test_parameters() {
@@ -221,7 +216,11 @@ fn refreshes_disk_sources_without_dynamic_file_watching() {
     );
     let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
     let uri = workspace.uri("test_example.py");
-    open(&server, uri.clone(), "def test_example(provider_): pass\n");
+    open(
+        &mut server,
+        uri.clone(),
+        "def test_example(provider_): pass\n",
+    );
 
     let first =
         server.request::<CompletionRequest>(completion_params(uri.clone(), Position::new(0, 26)));
@@ -249,7 +248,7 @@ fn cancels_a_background_completion_once() {
     let workspace = Workspace::new();
     let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
     let uri = workspace.uri("test_example.py");
-    open(&server, uri.clone(), "def test_example(tmp): pass\n");
+    open(&mut server, uri.clone(), "def test_example(tmp): pass\n");
 
     let request_id = server
         .send_request::<CompletionRequest>(completion_params(uri.clone(), Position::new(0, 20)));
@@ -271,7 +270,7 @@ fn rejects_completion_from_a_stale_document_version() {
     let workspace = Workspace::new();
     let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
     let uri = workspace.uri("test_example.py");
-    open(&server, uri.clone(), "def test_example(tmp): pass\n");
+    open(&mut server, uri.clone(), "def test_example(tmp): pass\n");
 
     let request_id = server
         .send_request::<CompletionRequest>(completion_params(uri.clone(), Position::new(0, 20)));
@@ -289,6 +288,7 @@ fn rejects_completion_from_a_stale_document_version() {
         ],
     });
     let response = server.receive_response(&request_id);
+    server.receive_notification::<PublishDiagnosticsNotification>();
 
     let error = response
         .response_result
@@ -300,7 +300,7 @@ fn rejects_completion_from_a_stale_document_version() {
     assert!(completion.is_some());
 }
 
-fn open(server: &TestServer, uri: Uri, source: &str) {
+fn open(server: &mut TestServer, uri: Uri, source: &str) {
     server.notify::<DidOpenTextDocumentNotification>(DidOpenTextDocumentParams {
         text_document: TextDocumentItem {
             uri,
@@ -319,68 +319,4 @@ fn completion_params(uri: Uri, position: Position) -> CompletionParams {
         PartialResultParams::default(),
         TextDocumentPositionParams::new(TextDocumentIdentifier::new(uri), position),
     )
-}
-
-struct Workspace {
-    directory: TempDir,
-    root_uri: Uri,
-}
-
-impl Workspace {
-    fn new() -> Self {
-        let directory = tempfile::tempdir().expect("temporary workspace should be created");
-        fs::create_dir(directory.path().join(".git")).expect("workspace marker should be created");
-        let root_uri =
-            Uri::from_file_path(directory.path()).expect("workspace URI should be valid");
-        Self {
-            directory,
-            root_uri,
-        }
-    }
-
-    fn folder(&self) -> WorkspaceFolder {
-        WorkspaceFolder {
-            uri: self.root_uri.clone(),
-            name: "project".to_owned(),
-        }
-    }
-
-    fn uri(&self, relative: &str) -> Uri {
-        Uri::from_file_path(self.directory.path().join(relative))
-            .expect("document URI should be valid")
-    }
-
-    fn write(&self, relative: &str, source: &str) {
-        fs::write(self.directory.path().join(relative), source)
-            .expect("workspace source should be written");
-    }
-
-    fn normalize(&self, value: impl serde::Serialize) -> Value {
-        let mut value = serde_json::to_value(value).expect("completion should serialize");
-        let workspace_path = self.directory.path().to_string_lossy();
-        normalize_paths(&mut value, self.root_uri.as_str(), &workspace_path);
-        value
-    }
-}
-
-fn normalize_paths(value: &mut Value, workspace_uri: &str, workspace_path: &str) {
-    match value {
-        Value::Array(values) => {
-            for value in values {
-                normalize_paths(value, workspace_uri, workspace_path);
-            }
-        }
-        Value::Object(values) => {
-            for value in values.values_mut() {
-                normalize_paths(value, workspace_uri, workspace_path);
-            }
-        }
-        Value::String(value) => {
-            *value = value
-                .replace(workspace_uri, "file:///project")
-                .replace(workspace_path, "/project")
-                .replace('\\', "/");
-        }
-        Value::Null | Value::Bool(_) | Value::Number(_) => {}
-    }
 }

--- a/crates/karva_language_server/tests/e2e/config_reload.rs
+++ b/crates/karva_language_server/tests/e2e/config_reload.rs
@@ -8,7 +8,7 @@ use super::TestServer;
 
 #[test]
 fn registers_and_accepts_source_file_changes() {
-    let server = TestServer::new(ClientCapabilities {
+    let mut server = TestServer::new(ClientCapabilities {
         workspace: Some(WorkspaceClientCapabilities {
             did_change_watched_files: Some(DidChangeWatchedFilesClientCapabilities {
                 dynamic_registration: Some(true),

--- a/crates/karva_language_server/tests/e2e/definition.rs
+++ b/crates/karva_language_server/tests/e2e/definition.rs
@@ -1,16 +1,12 @@
-use std::fs;
-
 use insta::assert_json_snapshot;
 use lsp_types::{
     ClientCapabilities, DefinitionParams, DefinitionRequest, DidOpenTextDocumentNotification,
     DidOpenTextDocumentParams, LanguageKind, PartialResultParams, Position,
     PublishDiagnosticsNotification, TextDocumentIdentifier, TextDocumentItem,
-    TextDocumentPositionParams, Uri, WorkDoneProgressParams, WorkspaceFolder,
+    TextDocumentPositionParams, Uri, WorkDoneProgressParams,
 };
-use serde_json::Value;
-use tempfile::TempDir;
 
-use super::TestServer;
+use super::{TestServer, Workspace};
 
 #[test]
 fn goes_to_fixture_in_disk_ancestor() {
@@ -21,7 +17,11 @@ fn goes_to_fixture_in_disk_ancestor() {
     );
     let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
     let uri = workspace.uri("test_example.py");
-    open(&server, uri.clone(), "def test_example(database): pass\n");
+    open(
+        &mut server,
+        uri.clone(),
+        "def test_example(database): pass\n",
+    );
 
     let response =
         server.request::<DefinitionRequest>(definition_params(uri, Position::new(0, 20)));
@@ -54,7 +54,7 @@ fn goes_to_unsaved_local_fixture_override() {
         "def local(): pass\n\n",
         "def test_example(local): pass\n",
     );
-    open(&server, uri.clone(), source);
+    open(&mut server, uri.clone(), source);
 
     let response =
         server.request::<DefinitionRequest>(definition_params(uri, Position::new(5, 20)));
@@ -90,7 +90,7 @@ fn goes_to_unsaved_nested_ancestor_override() {
     let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
     let ancestor_uri = workspace.uri("package/conftest.py");
     open(
-        &server,
+        &mut server,
         ancestor_uri,
         concat!(
             "from karva import fixture\n\n",
@@ -101,13 +101,14 @@ fn goes_to_unsaved_nested_ancestor_override() {
     );
     let test_uri = workspace.uri("package/test_example.py");
     open(
-        &server,
+        &mut server,
         test_uri.clone(),
         "def test_example(database): pass\n",
     );
 
     let response =
         server.request::<DefinitionRequest>(definition_params(test_uri, Position::new(0, 20)));
+    server.receive_notification::<PublishDiagnosticsNotification>();
 
     assert_json_snapshot!(workspace.normalize(response), @r#"
     {
@@ -140,7 +141,7 @@ fn resolves_nested_package_fixture_shadowing() {
     let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
     let uri = workspace.uri("package/test_example.py");
     open(
-        &server,
+        &mut server,
         uri.clone(),
         "def test_example(nested_only): pass\n",
     );
@@ -182,7 +183,11 @@ fn resolves_nearest_fixture_across_multiple_nested_conftests() {
     );
     let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
     let uri = workspace.uri("package/inner/test_example.py");
-    open(&server, uri.clone(), "def test_example(database): pass\n");
+    open(
+        &mut server,
+        uri.clone(),
+        "def test_example(database): pass\n",
+    );
 
     let response =
         server.request::<DefinitionRequest>(definition_params(uri, Position::new(0, 20)));
@@ -210,7 +215,7 @@ fn goes_to_fixture_dependencies_and_usefixtures_strings() {
         "@pytest.mark.usefixtures(\"parent\")\n",
         "def test_example(child): pass\n",
     );
-    open(&server, uri.clone(), source);
+    open(&mut server, uri.clone(), source);
 
     let child =
         server.request::<DefinitionRequest>(definition_params(uri.clone(), Position::new(3, 20)));
@@ -254,7 +259,7 @@ fn returns_no_definition_for_builtin_or_unknown_fixture() {
     let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
     let builtin_uri = workspace.uri("builtin.py");
     open(
-        &server,
+        &mut server,
         builtin_uri.clone(),
         "def test_example(tmp_path): pass\n",
     );
@@ -263,18 +268,19 @@ fn returns_no_definition_for_builtin_or_unknown_fixture() {
 
     let unknown_uri = workspace.uri("unknown.py");
     open(
-        &server,
+        &mut server,
         unknown_uri.clone(),
         "def test_example(unknown): pass\n",
     );
     let unknown =
         server.request::<DefinitionRequest>(definition_params(unknown_uri, Position::new(0, 20)));
+    server.receive_notification::<PublishDiagnosticsNotification>();
 
     assert_eq!(builtin, None);
     assert_eq!(unknown, None);
 }
 
-fn open(server: &TestServer, uri: Uri, source: &str) {
+fn open(server: &mut TestServer, uri: Uri, source: &str) {
     server.notify::<DidOpenTextDocumentNotification>(DidOpenTextDocumentParams {
         text_document: TextDocumentItem {
             uri,
@@ -292,78 +298,4 @@ fn definition_params(uri: Uri, position: Position) -> DefinitionParams {
         PartialResultParams::default(),
         TextDocumentPositionParams::new(TextDocumentIdentifier::new(uri), position),
     )
-}
-
-struct Workspace {
-    directory: TempDir,
-    root_uri: Uri,
-}
-
-impl Workspace {
-    fn new() -> Self {
-        let directory = tempfile::tempdir().expect("temporary workspace should be created");
-        fs::create_dir(directory.path().join(".git")).expect("workspace marker should be created");
-        let root_uri =
-            Uri::from_file_path(directory.path()).expect("workspace URI should be valid");
-        Self {
-            directory,
-            root_uri,
-        }
-    }
-
-    fn folder(&self) -> WorkspaceFolder {
-        WorkspaceFolder {
-            uri: self.root_uri.clone(),
-            name: "project".to_owned(),
-        }
-    }
-
-    fn uri(&self, relative: &str) -> Uri {
-        Uri::from_file_path(self.directory.path().join(relative))
-            .expect("document URI should be valid")
-    }
-
-    fn write(&self, relative: &str, source: &str) {
-        fs::create_dir_all(
-            self.directory
-                .path()
-                .join(relative)
-                .parent()
-                .expect("workspace source should have a parent"),
-        )
-        .expect("workspace source parent should be created");
-        fs::write(self.directory.path().join(relative), source)
-            .expect("workspace source should be written");
-    }
-
-    fn normalize(&self, value: impl serde::Serialize) -> Value {
-        let mut value = serde_json::to_value(value).expect("definition should serialize");
-        normalize_paths(
-            &mut value,
-            self.root_uri.as_str(),
-            &self.directory.path().to_string_lossy(),
-        );
-        value
-    }
-}
-
-fn normalize_paths(value: &mut Value, workspace_uri: &str, workspace_path: &str) {
-    match value {
-        Value::Array(values) => {
-            for value in values {
-                normalize_paths(value, workspace_uri, workspace_path);
-            }
-        }
-        Value::Object(values) => {
-            for value in values.values_mut() {
-                normalize_paths(value, workspace_uri, workspace_path);
-            }
-        }
-        Value::String(value) => {
-            *value = value
-                .replace(workspace_uri, "file:///project")
-                .replace(workspace_path, "/project");
-        }
-        Value::Null | Value::Bool(_) | Value::Number(_) => {}
-    }
 }

--- a/crates/karva_language_server/tests/e2e/diagnostics.rs
+++ b/crates/karva_language_server/tests/e2e/diagnostics.rs
@@ -1,23 +1,19 @@
-use std::fs;
-
 use lsp_types::{
     ClientCapabilities, DiagnosticsCapabilities, DidChangeTextDocumentNotification,
     DidChangeTextDocumentParams, DidCloseTextDocumentNotification, DidCloseTextDocumentParams,
     DidOpenTextDocumentNotification, DidOpenTextDocumentParams, LanguageKind,
     PublishDiagnosticsClientCapabilities, PublishDiagnosticsNotification,
     TextDocumentClientCapabilities, TextDocumentContentChangeEvent,
-    TextDocumentContentChangeWholeDocument, TextDocumentIdentifier, TextDocumentItem, Uri,
-    VersionedTextDocumentIdentifier, WorkspaceFolder,
+    TextDocumentContentChangeWholeDocument, TextDocumentIdentifier, TextDocumentItem,
+    VersionedTextDocumentIdentifier,
 };
-use serde_json::Value;
-use tempfile::TempDir;
 
-use super::TestServer;
+use super::{TestServer, Workspace};
 
 #[test]
 fn publishes_updates_and_clears_unsaved_diagnostics() {
     let workspace = Workspace::new();
-    let server = TestServer::with_workspace(capabilities(), workspace.folder());
+    let mut server = TestServer::with_workspace(capabilities(), workspace.folder());
     let uri = workspace.uri("test_example.py");
 
     server.notify::<DidOpenTextDocumentNotification>(DidOpenTextDocumentParams {
@@ -60,7 +56,7 @@ fn publishes_cross_file_related_information() {
         "conftest.py",
         "from karva import fixture\n\n@fixture\ndef database(): pass\n",
     );
-    let server = TestServer::with_workspace(capabilities(), workspace.folder());
+    let mut server = TestServer::with_workspace(capabilities(), workspace.folder());
     let uri = workspace.uri("test_example.py");
 
     server.notify::<DidOpenTextDocumentNotification>(DidOpenTextDocumentParams {
@@ -92,7 +88,7 @@ fn publishes_related_information_for_the_nearest_nested_fixture() {
         "package/conftest.py",
         "from karva import fixture\n\n@fixture\ndef database(): pass\n",
     );
-    let server = TestServer::with_workspace(capabilities(), workspace.folder());
+    let mut server = TestServer::with_workspace(capabilities(), workspace.folder());
     let uri = workspace.uri("package/test_example.py");
 
     server.notify::<DidOpenTextDocumentNotification>(DidOpenTextDocumentParams {
@@ -128,7 +124,7 @@ fn publishes_related_information_for_the_nearest_nested_fixture() {
 #[test]
 fn does_not_analyze_an_open_conftest_as_its_own_parent() {
     let workspace = Workspace::new();
-    let server = TestServer::with_workspace(capabilities(), workspace.folder());
+    let mut server = TestServer::with_workspace(capabilities(), workspace.folder());
     let uri = workspace.uri("conftest.py");
 
     server.notify::<DidOpenTextDocumentNotification>(DidOpenTextDocumentParams {
@@ -157,68 +153,5 @@ fn capabilities() -> ClientCapabilities {
             ..TextDocumentClientCapabilities::default()
         }),
         ..ClientCapabilities::default()
-    }
-}
-
-struct Workspace {
-    directory: TempDir,
-    root_uri: Uri,
-}
-
-impl Workspace {
-    fn new() -> Self {
-        let directory = tempfile::tempdir().expect("temporary workspace should be created");
-        fs::create_dir(directory.path().join(".git")).expect("workspace marker should be created");
-        let root_uri =
-            Uri::from_file_path(directory.path()).expect("workspace URI should be valid");
-        Self {
-            directory,
-            root_uri,
-        }
-    }
-
-    fn folder(&self) -> WorkspaceFolder {
-        WorkspaceFolder {
-            uri: self.root_uri.clone(),
-            name: "project".to_owned(),
-        }
-    }
-
-    fn uri(&self, relative: &str) -> Uri {
-        Uri::from_file_path(self.directory.path().join(relative))
-            .expect("document URI should be valid")
-    }
-
-    fn write(&self, relative: &str, source: &str) {
-        let path = self.directory.path().join(relative);
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).expect("workspace directory should be created");
-        }
-        fs::write(path, source).expect("workspace source should be written");
-    }
-
-    fn normalize(&self, value: impl serde::Serialize) -> Value {
-        let mut value = serde_json::to_value(value).expect("diagnostics should serialize");
-        normalize_uri(&mut value, self.root_uri.as_str());
-        value
-    }
-}
-
-fn normalize_uri(value: &mut Value, workspace_uri: &str) {
-    match value {
-        Value::Array(values) => {
-            for value in values {
-                normalize_uri(value, workspace_uri);
-            }
-        }
-        Value::Object(values) => {
-            for value in values.values_mut() {
-                normalize_uri(value, workspace_uri);
-            }
-        }
-        Value::String(value) => {
-            *value = value.replace(workspace_uri, "file:///project");
-        }
-        Value::Null | Value::Bool(_) | Value::Number(_) => {}
     }
 }

--- a/crates/karva_language_server/tests/e2e/document_highlight.rs
+++ b/crates/karva_language_server/tests/e2e/document_highlight.rs
@@ -1,16 +1,12 @@
-use std::fs;
-
 use insta::assert_json_snapshot;
 use lsp_types::{
     ClientCapabilities, DidOpenTextDocumentNotification, DidOpenTextDocumentParams,
     DocumentHighlightParams, DocumentHighlightRequest, LanguageKind, PartialResultParams, Position,
     PublishDiagnosticsNotification, TextDocumentIdentifier, TextDocumentItem,
-    TextDocumentPositionParams, Uri, WorkDoneProgressParams, WorkspaceFolder,
+    TextDocumentPositionParams, Uri, WorkDoneProgressParams,
 };
-use serde_json::Value;
-use tempfile::TempDir;
 
-use super::TestServer;
+use super::{TestServer, Workspace};
 
 #[test]
 fn highlights_fixture_declarations_reads_nested_providers_and_unsupported_targets() {
@@ -31,13 +27,13 @@ fn highlights_fixture_declarations_reads_nested_providers_and_unsupported_target
 
     let custom_uri = workspace.uri("custom.py");
     let custom_source = "from karva import fixture\n@fixture(name=\"данные\")\ndef provider(): pass\ndef test_example(данные): pass\n";
-    open(&server, custom_uri.clone(), custom_source);
+    open(&mut server, custom_uri.clone(), custom_source);
     let custom = server
         .request::<DocumentHighlightRequest>(highlight_params(custom_uri, Position::new(3, 18)));
 
     let nested_uri = workspace.uri("tests/pkg/test_nested.py");
     open(
-        &server,
+        &mut server,
         nested_uri.clone(),
         "def test_nested(database): pass\n",
     );
@@ -51,6 +47,7 @@ fn highlights_fixture_declarations_reads_nested_providers_and_unsupported_target
     ));
     let missing = server
         .request::<DocumentHighlightRequest>(highlight_params(nested_uri, Position::new(0, 37)));
+    server.receive_notification::<PublishDiagnosticsNotification>();
 
     assert_json_snapshot!(workspace.normalize([custom, nested, unsupported, missing]), @r#"
     [
@@ -116,7 +113,7 @@ fn highlights_fixture_declarations_reads_nested_providers_and_unsupported_target
     "#);
 }
 
-fn open(server: &TestServer, uri: Uri, source: &str) {
+fn open(server: &mut TestServer, uri: Uri, source: &str) {
     server.notify::<DidOpenTextDocumentNotification>(DidOpenTextDocumentParams {
         text_document: TextDocumentItem {
             uri,
@@ -134,75 +131,4 @@ fn highlight_params(uri: Uri, position: Position) -> DocumentHighlightParams {
         PartialResultParams::default(),
         TextDocumentPositionParams::new(TextDocumentIdentifier::new(uri), position),
     )
-}
-
-struct Workspace {
-    directory: TempDir,
-    root_uri: Uri,
-}
-
-impl Workspace {
-    fn new() -> Self {
-        let directory = tempfile::tempdir().expect("temporary workspace should be created");
-        fs::create_dir(directory.path().join(".git")).expect("workspace marker should be created");
-        let root_uri =
-            Uri::from_file_path(directory.path()).expect("workspace URI should be valid");
-        Self {
-            directory,
-            root_uri,
-        }
-    }
-
-    fn folder(&self) -> WorkspaceFolder {
-        WorkspaceFolder {
-            uri: self.root_uri.clone(),
-            name: "project".to_owned(),
-        }
-    }
-
-    fn uri(&self, relative: &str) -> Uri {
-        Uri::from_file_path(self.directory.path().join(relative))
-            .expect("document URI should be valid")
-    }
-
-    fn write(&self, relative: &str, source: &str) {
-        let path = self.directory.path().join(relative);
-        fs::create_dir_all(
-            path.parent()
-                .expect("workspace source should have a parent"),
-        )
-        .expect("workspace source parent should be created");
-        fs::write(path, source).expect("workspace source should be written");
-    }
-
-    fn normalize(&self, value: impl serde::Serialize) -> Value {
-        let mut value = serde_json::to_value(value).expect("highlights should serialize");
-        normalize_paths(
-            &mut value,
-            self.root_uri.as_str(),
-            &self.directory.path().to_string_lossy(),
-        );
-        value
-    }
-}
-
-fn normalize_paths(value: &mut Value, workspace_uri: &str, workspace_path: &str) {
-    match value {
-        Value::Array(values) => {
-            for value in values {
-                normalize_paths(value, workspace_uri, workspace_path);
-            }
-        }
-        Value::Object(values) => {
-            for value in values.values_mut() {
-                normalize_paths(value, workspace_uri, workspace_path);
-            }
-        }
-        Value::String(value) => {
-            *value = value
-                .replace(workspace_uri, "file:///project")
-                .replace(workspace_path, "/project");
-        }
-        Value::Null | Value::Bool(_) | Value::Number(_) => {}
-    }
 }

--- a/crates/karva_language_server/tests/e2e/document_symbols.rs
+++ b/crates/karva_language_server/tests/e2e/document_symbols.rs
@@ -1,15 +1,12 @@
-use std::fs;
-
 use insta::assert_json_snapshot;
 use lsp_types::{
     ClientCapabilities, DidOpenTextDocumentNotification, DidOpenTextDocumentParams,
     DocumentSymbolClientCapabilities, DocumentSymbolParams, DocumentSymbolRequest, LanguageKind,
     PartialResultParams, PublishDiagnosticsNotification, TextDocumentClientCapabilities,
-    TextDocumentIdentifier, TextDocumentItem, Uri, WorkDoneProgressParams, WorkspaceFolder,
+    TextDocumentIdentifier, TextDocumentItem, Uri, WorkDoneProgressParams,
 };
-use tempfile::TempDir;
 
-use super::TestServer;
+use super::{TestServer, Workspace};
 
 const SOURCE: &str = concat!(
     "import pytest\n",
@@ -35,7 +32,7 @@ fn returns_hierarchical_symbols_for_unsaved_karva_source() {
     };
     let mut server = TestServer::with_workspace(capabilities, workspace.folder());
     let uri = workspace.uri("test_symbols.py");
-    open(&server, uri.clone());
+    open(&mut server, uri.clone());
 
     let response = server.request::<DocumentSymbolRequest>(params(uri));
 
@@ -47,7 +44,7 @@ fn falls_back_to_flat_symbols_for_legacy_clients() {
     let workspace = Workspace::new();
     let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
     let uri = workspace.uri("test_symbols.py");
-    open(&server, uri.clone());
+    open(&mut server, uri.clone());
 
     let response = server.request::<DocumentSymbolRequest>(params(uri));
 
@@ -56,7 +53,7 @@ fn falls_back_to_flat_symbols_for_legacy_clients() {
     assert_json_snapshot!(response);
 }
 
-fn open(server: &TestServer, uri: Uri) {
+fn open(server: &mut TestServer, uri: Uri) {
     server.notify::<DidOpenTextDocumentNotification>(DidOpenTextDocumentParams {
         text_document: TextDocumentItem {
             uri,
@@ -92,35 +89,5 @@ fn normalize_uri(value: &mut serde_json::Value, workspace_uri: &str) {
             *value = value.replace(workspace_uri, "file:///project");
         }
         serde_json::Value::Null | serde_json::Value::Bool(_) | serde_json::Value::Number(_) => {}
-    }
-}
-
-struct Workspace {
-    directory: TempDir,
-    root_uri: Uri,
-}
-
-impl Workspace {
-    fn new() -> Self {
-        let directory = tempfile::tempdir().expect("temporary workspace should be created");
-        fs::create_dir(directory.path().join(".git")).expect("workspace marker should be created");
-        let root_uri =
-            Uri::from_file_path(directory.path()).expect("workspace URI should be valid");
-        Self {
-            directory,
-            root_uri,
-        }
-    }
-
-    fn folder(&self) -> WorkspaceFolder {
-        WorkspaceFolder {
-            uri: self.root_uri.clone(),
-            name: "project".to_owned(),
-        }
-    }
-
-    fn uri(&self, relative: &str) -> Uri {
-        Uri::from_file_path(self.directory.path().join(relative))
-            .expect("document URI should be valid")
     }
 }

--- a/crates/karva_language_server/tests/e2e/document_sync.rs
+++ b/crates/karva_language_server/tests/e2e/document_sync.rs
@@ -10,7 +10,7 @@ use super::TestServer;
 
 #[test]
 fn accepts_incremental_unsaved_document_changes() {
-    let server = TestServer::new(lsp_types::ClientCapabilities::default());
+    let mut server = TestServer::new(lsp_types::ClientCapabilities::default());
     let uri = Uri::parse("file:///workspace/test_example.py").expect("test URI should be valid");
     server.notify::<DidOpenTextDocumentNotification>(DidOpenTextDocumentParams {
         text_document: TextDocumentItem {
@@ -20,6 +20,8 @@ fn accepts_incremental_unsaved_document_changes() {
             text: "def test_😀():\n    pas\n".to_owned(),
         },
     });
+    server.receive_notification::<lsp_types::PublishDiagnosticsNotification>();
+
     server.notify::<DidChangeTextDocumentNotification>(DidChangeTextDocumentParams {
         text_document: VersionedTextDocumentIdentifier {
             text_document_identifier: TextDocumentIdentifier { uri: uri.clone() },
@@ -35,7 +37,10 @@ fn accepts_incremental_unsaved_document_changes() {
             ),
         ],
     });
+    server.receive_notification::<lsp_types::PublishDiagnosticsNotification>();
+
     server.notify::<DidCloseTextDocumentNotification>(DidCloseTextDocumentParams {
         text_document: TextDocumentIdentifier { uri },
     });
+    server.receive_notification::<lsp_types::PublishDiagnosticsNotification>();
 }

--- a/crates/karva_language_server/tests/e2e/hover.rs
+++ b/crates/karva_language_server/tests/e2e/hover.rs
@@ -1,16 +1,12 @@
-use std::fs;
-
 use insta::assert_json_snapshot;
 use lsp_types::{
     ClientCapabilities, DidOpenTextDocumentNotification, DidOpenTextDocumentParams,
     HoverClientCapabilities, HoverParams, HoverRequest, LanguageKind, MarkupKind, Position,
     PublishDiagnosticsNotification, TextDocumentClientCapabilities, TextDocumentIdentifier,
-    TextDocumentItem, TextDocumentPositionParams, Uri, WorkDoneProgressParams, WorkspaceFolder,
+    TextDocumentItem, TextDocumentPositionParams, Uri, WorkDoneProgressParams,
 };
-use serde_json::Value;
-use tempfile::TempDir;
 
-use super::TestServer;
+use super::{TestServer, Workspace};
 
 #[test]
 fn hovers_unsaved_fixture_with_metadata_and_dependencies() {
@@ -29,7 +25,7 @@ fn hovers_unsaved_fixture_with_metadata_and_dependencies() {
         "    pass\n\n",
         "def test_example(database): pass\n",
     );
-    open(&server, uri.clone(), source);
+    open(&mut server, uri.clone(), source);
 
     let response = server.request::<HoverRequest>(hover_params(uri, Position::new(7, 19)));
 
@@ -68,7 +64,11 @@ fn hovers_builtin_fixture_with_markdown_preference() {
     };
     let mut server = TestServer::with_workspace(capabilities, workspace.folder());
     let uri = workspace.uri("test_example.py");
-    open(&server, uri.clone(), "def test_example(tmp_path): pass\n");
+    open(
+        &mut server,
+        uri.clone(),
+        "def test_example(tmp_path): pass\n",
+    );
 
     let response = server.request::<HoverRequest>(hover_params(uri, Position::new(0, 20)));
 
@@ -106,7 +106,7 @@ fn hovers_pytest_usefixtures_string() {
         "@pytest.mark.usefixtures(\"database\")\n",
         "def test_example(): pass\n",
     );
-    open(&server, uri.clone(), source);
+    open(&mut server, uri.clone(), source);
 
     let response = server.request::<HoverRequest>(hover_params(uri, Position::new(2, 30)));
 
@@ -143,7 +143,11 @@ fn hovers_nearest_nested_fixture_provider() {
     );
     let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
     let uri = workspace.uri("package/test_example.py");
-    open(&server, uri.clone(), "def test_example(database): pass\n");
+    open(
+        &mut server,
+        uri.clone(),
+        "def test_example(database): pass\n",
+    );
 
     let response = server.request::<HoverRequest>(hover_params(uri, Position::new(0, 20)));
     let response = workspace.normalize(response);
@@ -166,14 +170,14 @@ fn returns_no_hover_for_dynamic_fixture_provider() {
         "def dynamic(): pass\n\n",
         "def test_example(dynamic): pass\n",
     );
-    open(&server, uri.clone(), source);
+    open(&mut server, uri.clone(), source);
 
     let response = server.request::<HoverRequest>(hover_params(uri, Position::new(6, 19)));
 
     assert_eq!(response, None);
 }
 
-fn open(server: &TestServer, uri: Uri, source: &str) {
+fn open(server: &mut TestServer, uri: Uri, source: &str) {
     server.notify::<DidOpenTextDocumentNotification>(DidOpenTextDocumentParams {
         text_document: TextDocumentItem {
             uri,
@@ -190,70 +194,4 @@ fn hover_params(uri: Uri, position: Position) -> HoverParams {
         WorkDoneProgressParams::default(),
         TextDocumentPositionParams::new(TextDocumentIdentifier::new(uri), position),
     )
-}
-
-struct Workspace {
-    directory: TempDir,
-    root_uri: Uri,
-}
-
-impl Workspace {
-    fn new() -> Self {
-        let directory = tempfile::tempdir().expect("temporary workspace should be created");
-        fs::create_dir(directory.path().join(".git")).expect("workspace marker should be created");
-        let root_uri =
-            Uri::from_file_path(directory.path()).expect("workspace URI should be valid");
-        Self {
-            directory,
-            root_uri,
-        }
-    }
-
-    fn folder(&self) -> WorkspaceFolder {
-        WorkspaceFolder {
-            uri: self.root_uri.clone(),
-            name: "project".to_owned(),
-        }
-    }
-
-    fn uri(&self, relative: &str) -> Uri {
-        Uri::from_file_path(self.directory.path().join(relative))
-            .expect("document URI should be valid")
-    }
-
-    fn write(&self, relative: &str, source: &str) {
-        let path = self.directory.path().join(relative);
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).expect("workspace directory should be created");
-        }
-        fs::write(path, source).expect("workspace source should be written");
-    }
-
-    fn normalize(&self, value: impl serde::Serialize) -> Value {
-        let mut value = serde_json::to_value(value).expect("hover should serialize");
-        let workspace_path = self.directory.path().to_string_lossy();
-        normalize_paths(&mut value, self.root_uri.as_str(), &workspace_path);
-        value
-    }
-}
-
-fn normalize_paths(value: &mut Value, workspace_uri: &str, workspace_path: &str) {
-    match value {
-        Value::Array(values) => {
-            for value in values {
-                normalize_paths(value, workspace_uri, workspace_path);
-            }
-        }
-        Value::Object(values) => {
-            for value in values.values_mut() {
-                normalize_paths(value, workspace_uri, workspace_path);
-            }
-        }
-        Value::String(value) => {
-            *value = value
-                .replace(workspace_uri, "file:///project")
-                .replace(workspace_path, "/project");
-        }
-        Value::Null | Value::Bool(_) | Value::Number(_) => {}
-    }
 }

--- a/crates/karva_language_server/tests/e2e/implementation.rs
+++ b/crates/karva_language_server/tests/e2e/implementation.rs
@@ -1,5 +1,3 @@
-use std::fs;
-
 use insta::assert_json_snapshot;
 use lsp_types::{
     ClientCapabilities, DidChangeTextDocumentNotification, DidChangeTextDocumentParams,
@@ -8,12 +6,9 @@ use lsp_types::{
     PublishDiagnosticsNotification, TextDocumentContentChangeEvent,
     TextDocumentContentChangeWholeDocument, TextDocumentIdentifier, TextDocumentItem,
     TextDocumentPositionParams, Uri, VersionedTextDocumentIdentifier, WorkDoneProgressParams,
-    WorkspaceFolder,
 };
-use serde_json::Value;
-use tempfile::TempDir;
 
-use super::TestServer;
+use super::{TestServer, Workspace};
 
 #[test]
 fn navigates_to_generator_and_return_fixture_implementations() {
@@ -32,7 +27,7 @@ fn navigates_to_generator_and_return_fixture_implementations() {
         "@pytest.mark.usefixtures(\"database\")\n",
         "def test_example(database, local, tmp_path): pass\n",
     );
-    open(&server, uri.clone(), source);
+    open(&mut server, uri.clone(), source);
 
     let parameter =
         server.request::<ImplementationRequest>(params(uri.clone(), Position::new(7, 21)));
@@ -53,7 +48,11 @@ fn rejects_an_implementation_from_a_stale_document_version() {
     );
     let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
     let uri = workspace.uri("test_example.py");
-    open(&server, uri.clone(), "def test_example(database): pass\n");
+    open(
+        &mut server,
+        uri.clone(),
+        "def test_example(database): pass\n",
+    );
 
     let id =
         server.send_request::<ImplementationRequest>(params(uri.clone(), Position::new(0, 20)));
@@ -72,13 +71,14 @@ fn rejects_an_implementation_from_a_stale_document_version() {
     });
 
     let response = server.receive_response(&id);
+    server.receive_notification::<PublishDiagnosticsNotification>();
     let error = response
         .response_result
         .expect_err("stale implementation should fail");
     assert_eq!(error.code, lsp_server::ErrorCode::ContentModified as i32);
 }
 
-fn open(server: &TestServer, uri: Uri, source: &str) {
+fn open(server: &mut TestServer, uri: Uri, source: &str) {
     server.notify::<DidOpenTextDocumentNotification>(DidOpenTextDocumentParams {
         text_document: TextDocumentItem {
             uri,
@@ -96,70 +96,4 @@ fn params(uri: Uri, position: Position) -> ImplementationParams {
         PartialResultParams::default(),
         TextDocumentPositionParams::new(TextDocumentIdentifier::new(uri), position),
     )
-}
-
-struct Workspace {
-    directory: TempDir,
-    root_uri: Uri,
-}
-
-impl Workspace {
-    fn new() -> Self {
-        let directory = tempfile::tempdir().expect("temporary workspace should be created");
-        fs::create_dir(directory.path().join(".git")).expect("workspace marker should be created");
-        let root_uri =
-            Uri::from_file_path(directory.path()).expect("workspace URI should be valid");
-        Self {
-            directory,
-            root_uri,
-        }
-    }
-
-    fn folder(&self) -> WorkspaceFolder {
-        WorkspaceFolder {
-            uri: self.root_uri.clone(),
-            name: "project".to_owned(),
-        }
-    }
-
-    fn uri(&self, relative: &str) -> Uri {
-        Uri::from_file_path(self.directory.path().join(relative))
-            .expect("document URI should be valid")
-    }
-
-    fn write(&self, relative: &str, source: &str) {
-        fs::write(self.directory.path().join(relative), source)
-            .expect("workspace source should be written");
-    }
-
-    fn normalize(&self, value: impl serde::Serialize) -> Value {
-        let mut value = serde_json::to_value(value).expect("implementations should serialize");
-        normalize_paths(
-            &mut value,
-            self.root_uri.as_str(),
-            &self.directory.path().to_string_lossy(),
-        );
-        value
-    }
-}
-
-fn normalize_paths(value: &mut Value, workspace_uri: &str, workspace_path: &str) {
-    match value {
-        Value::Array(values) => {
-            for value in values {
-                normalize_paths(value, workspace_uri, workspace_path);
-            }
-        }
-        Value::Object(values) => {
-            for value in values.values_mut() {
-                normalize_paths(value, workspace_uri, workspace_path);
-            }
-        }
-        Value::String(value) => {
-            *value = value
-                .replace(workspace_uri, "file:///project")
-                .replace(workspace_path, "/project");
-        }
-        Value::Null | Value::Bool(_) | Value::Number(_) => {}
-    }
 }

--- a/crates/karva_language_server/tests/e2e/main.rs
+++ b/crates/karva_language_server/tests/e2e/main.rs
@@ -416,7 +416,8 @@ fn normalize_paths(value: &mut Value, workspace_uri: &str, workspace_path: &str)
                 normalize_paths(&mut value, workspace_uri, workspace_path);
                 values.insert(
                     key.replace(workspace_uri, "file:///project")
-                        .replace(workspace_path, "/project"),
+                        .replace(workspace_path, "/project")
+                        .replace('\\', "/"),
                     value,
                 );
             }
@@ -424,7 +425,8 @@ fn normalize_paths(value: &mut Value, workspace_uri: &str, workspace_path: &str)
         Value::String(value) => {
             *value = value
                 .replace(workspace_uri, "file:///project")
-                .replace(workspace_path, "/project");
+                .replace(workspace_path, "/project")
+                .replace('\\', "/");
         }
         Value::Null | Value::Bool(_) | Value::Number(_) => {}
     }

--- a/crates/karva_language_server/tests/e2e/main.rs
+++ b/crates/karva_language_server/tests/e2e/main.rs
@@ -19,6 +19,7 @@ mod rename;
 
 use std::collections::{HashMap, VecDeque};
 use std::fs;
+use std::sync::mpsc;
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
@@ -38,6 +39,7 @@ use karva_language_server::{ConnectionInitializer, Server};
 // Receipt: the full focused suite's slowest test took 70 ms on 2026-08-13. These tripwires leave
 // more than one order of magnitude for slower CI while still making a stalled server fail quickly.
 const RECEIVE_TIMEOUT: Duration = Duration::from_secs(10);
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Errors reported when no matching server message arrives.
 #[derive(Debug, thiserror::Error)]
@@ -302,6 +304,30 @@ impl TestServer {
         }
     }
 
+    fn assert_no_pending_messages(&self) {
+        assert!(
+            self.responses.is_empty(),
+            "language server left unclaimed responses: {:?}",
+            self.responses.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            self.requests.is_empty(),
+            "language server left unclaimed requests: {:?}",
+            self.requests
+                .iter()
+                .map(|request| request.method.as_str())
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            self.notifications.is_empty(),
+            "language server left unclaimed notifications: {:?}",
+            self.notifications
+                .iter()
+                .map(|notification| notification.method.as_str())
+                .collect::<Vec<_>>()
+        );
+    }
+
     pub(crate) fn respond<R: Request>(&self, id: RequestId, result: R::Result) {
         self.send(Message::Response(Response::new_ok(id, result)));
     }
@@ -309,17 +335,62 @@ impl TestServer {
 
 impl Drop for TestServer {
     fn drop(&mut self) {
-        self.request::<ShutdownRequest>(());
-        self.notify::<ExitNotification>(());
-        drop(self.connection.take());
+        if std::thread::panicking() {
+            self.connection.take();
+            return;
+        }
 
-        let result = self
-            .server_thread
-            .take()
-            .expect("server thread should exist")
-            .join()
-            .expect("server thread should not panic");
-        result.expect("server should complete the shutdown sequence");
+        let shutdown_result = if self.server_thread.is_some() {
+            let id = self.send_request::<ShutdownRequest>(());
+            let result = self.try_receive_response(&id, None).map(|_| ());
+            if result.is_ok() {
+                self.notify::<ExitNotification>(());
+            }
+            result
+        } else {
+            Ok(())
+        };
+
+        let server_messages = self.connection.take().map(|connection| {
+            drop(connection.sender);
+            connection.receiver
+        });
+        let Some(server_thread) = self.server_thread.take() else {
+            if let Some(receiver) = server_messages {
+                while let Ok(message) = receiver.try_recv() {
+                    self.queue_message(message);
+                }
+            }
+            self.assert_no_pending_messages();
+            return;
+        };
+        let (join_sender, join_receiver) = mpsc::sync_channel(1);
+        std::thread::spawn(move || {
+            let result = server_thread.join();
+            let _ = join_sender.send(result);
+        });
+        match join_receiver.recv_timeout(SHUTDOWN_TIMEOUT) {
+            Ok(Ok(Ok(()))) => {}
+            Ok(Ok(Err(error))) => panic!("language server shutdown failed: {error}"),
+            Ok(Err(_)) => panic!("language server thread panicked during shutdown"),
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                panic!("language server did not shut down within {SHUTDOWN_TIMEOUT:?}")
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("shutdown waiter disconnected before joining server thread")
+            }
+        }
+
+        if let Some(receiver) = server_messages {
+            while let Ok(message) = receiver.try_recv() {
+                self.queue_message(message);
+            }
+        }
+        self.assert_no_pending_messages();
+
+        if let Err(error) = shutdown_result {
+            panic!("language server shutdown request failed: {error:#}");
+        }
     }
 }
 

--- a/crates/karva_language_server/tests/e2e/references.rs
+++ b/crates/karva_language_server/tests/e2e/references.rs
@@ -1,16 +1,12 @@
-use std::fs;
-
 use insta::assert_json_snapshot;
 use lsp_types::{
     ClientCapabilities, DidOpenTextDocumentNotification, DidOpenTextDocumentParams, LanguageKind,
     PartialResultParams, Position, PublishDiagnosticsNotification, ReferenceContext,
     ReferenceParams, ReferencesRequest, TextDocumentIdentifier, TextDocumentItem,
-    TextDocumentPositionParams, Uri, WorkDoneProgressParams, WorkspaceFolder,
+    TextDocumentPositionParams, Uri, WorkDoneProgressParams,
 };
-use serde_json::Value;
-use tempfile::TempDir;
 
-use super::TestServer;
+use super::{TestServer, Workspace};
 
 #[test]
 fn finds_disk_and_unsaved_fixture_references() {
@@ -24,7 +20,7 @@ fn finds_disk_and_unsaved_fixture_references() {
     let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
     let uri = workspace.uri("tests/test_example.py");
     open(
-        &server,
+        &mut server,
         uri.clone(),
         "import pytest\n\n@pytest.mark.usefixtures(\"database\")\ndef test_example(database): pass\n",
     );
@@ -152,7 +148,11 @@ fn keeps_nested_fixture_references_separate() {
     );
     let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
     let uri = workspace.uri("tests/pkg/test_nested.py");
-    open(&server, uri.clone(), "def test_nested(database): pass\n");
+    open(
+        &mut server,
+        uri.clone(),
+        "def test_nested(database): pass\n",
+    );
 
     let references =
         server.request::<ReferencesRequest>(reference_params(uri, Position::new(0, 20), true));
@@ -197,9 +197,9 @@ fn uses_custom_public_name_and_utf16_ranges() {
     workspace.write("conftest.py", provider_source);
     let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
     let provider_uri = workspace.uri("conftest.py");
-    open(&server, provider_uri.clone(), provider_source);
+    open(&mut server, provider_uri.clone(), provider_source);
     let uri = workspace.uri("test_example.py");
-    open(&server, uri.clone(), "def test_é(database): pass\n");
+    open(&mut server, uri.clone(), "def test_é(database): pass\n");
 
     let references =
         server.request::<ReferencesRequest>(reference_params(uri, Position::new(0, 15), true));
@@ -208,6 +208,7 @@ fn uses_custom_public_name_and_utf16_ranges() {
         Position::new(2, 6),
         true,
     ));
+    server.receive_notification::<PublishDiagnosticsNotification>();
 
     assert_eq!(from_provider, references);
 
@@ -249,7 +250,7 @@ fn returns_none_for_unsupported_fixture_targets() {
     let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
     let uri = workspace.uri("test_example.py");
     open(
-        &server,
+        &mut server,
         uri.clone(),
         "def test_example(tmp_path, missing): pass\n",
     );
@@ -266,7 +267,7 @@ fn returns_none_for_unsupported_fixture_targets() {
     assert_eq!(missing, None);
 }
 
-fn open(server: &TestServer, uri: Uri, source: &str) {
+fn open(server: &mut TestServer, uri: Uri, source: &str) {
     server.notify::<DidOpenTextDocumentNotification>(DidOpenTextDocumentParams {
         text_document: TextDocumentItem {
             uri,
@@ -285,75 +286,4 @@ fn reference_params(uri: Uri, position: Position, include_declaration: bool) -> 
         PartialResultParams::default(),
         TextDocumentPositionParams::new(TextDocumentIdentifier::new(uri), position),
     )
-}
-
-struct Workspace {
-    directory: TempDir,
-    root_uri: Uri,
-}
-
-impl Workspace {
-    fn new() -> Self {
-        let directory = tempfile::tempdir().expect("temporary workspace should be created");
-        fs::create_dir(directory.path().join(".git")).expect("workspace marker should be created");
-        let root_uri =
-            Uri::from_file_path(directory.path()).expect("workspace URI should be valid");
-        Self {
-            directory,
-            root_uri,
-        }
-    }
-
-    fn folder(&self) -> WorkspaceFolder {
-        WorkspaceFolder {
-            uri: self.root_uri.clone(),
-            name: "project".to_owned(),
-        }
-    }
-
-    fn uri(&self, relative: &str) -> Uri {
-        Uri::from_file_path(self.directory.path().join(relative))
-            .expect("document URI should be valid")
-    }
-
-    fn write(&self, relative: &str, source: &str) {
-        let path = self.directory.path().join(relative);
-        fs::create_dir_all(
-            path.parent()
-                .expect("workspace source should have a parent"),
-        )
-        .expect("workspace source parent should be created");
-        fs::write(path, source).expect("workspace source should be written");
-    }
-
-    fn normalize(&self, value: impl serde::Serialize) -> Value {
-        let mut value = serde_json::to_value(value).expect("references should serialize");
-        normalize_paths(
-            &mut value,
-            self.root_uri.as_str(),
-            &self.directory.path().to_string_lossy(),
-        );
-        value
-    }
-}
-
-fn normalize_paths(value: &mut Value, workspace_uri: &str, workspace_path: &str) {
-    match value {
-        Value::Array(values) => {
-            for value in values {
-                normalize_paths(value, workspace_uri, workspace_path);
-            }
-        }
-        Value::Object(values) => {
-            for value in values.values_mut() {
-                normalize_paths(value, workspace_uri, workspace_path);
-            }
-        }
-        Value::String(value) => {
-            *value = value
-                .replace(workspace_uri, "file:///project")
-                .replace(workspace_path, "/project");
-        }
-        Value::Null | Value::Bool(_) | Value::Number(_) => {}
-    }
 }

--- a/crates/karva_language_server/tests/e2e/rename.rs
+++ b/crates/karva_language_server/tests/e2e/rename.rs
@@ -1,16 +1,12 @@
-use std::fs;
-
 use insta::assert_json_snapshot;
 use lsp_types::{
     ClientCapabilities, DidOpenTextDocumentNotification, DidOpenTextDocumentParams, LanguageKind,
     Position, PrepareRenameParams, PrepareRenameRequest, PublishDiagnosticsNotification,
     RenameParams, RenameRequest, TextDocumentIdentifier, TextDocumentItem,
-    TextDocumentPositionParams, Uri, WorkDoneProgressParams, WorkspaceFolder,
+    TextDocumentPositionParams, Uri, WorkDoneProgressParams,
 };
-use serde_json::Value;
-use tempfile::TempDir;
 
-use super::TestServer;
+use super::{TestServer, Workspace};
 
 #[test]
 fn prepares_and_renames_fixture_occurrences_across_files() {
@@ -21,10 +17,10 @@ fn prepares_and_renames_fixture_occurrences_across_files() {
     workspace.write("tests/test_other.py", "def test_other(database): pass\n");
     let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
     let provider_uri = workspace.uri("conftest.py");
-    open(&server, provider_uri.clone(), provider_source);
+    open(&mut server, provider_uri.clone(), provider_source);
     let uri = workspace.uri("tests/test_example.py");
     open(
-        &server,
+        &mut server,
         uri.clone(),
         "import pytest\n\n@pytest.mark.usefixtures(\"data\\x62ase\")\ndef test_example(database): pass\n",
     );
@@ -36,6 +32,7 @@ fn prepares_and_renames_fixture_occurrences_across_files() {
         .request::<PrepareRenameRequest>(prepare_params(provider_uri.clone(), Position::new(2, 6)));
     let provider_edit =
         server.request::<RenameRequest>(rename_params(provider_uri, Position::new(2, 6), "данные"));
+    server.receive_notification::<PublishDiagnosticsNotification>();
 
     assert_eq!(provider_edit, edit);
     assert_json_snapshot!(workspace.normalize((prepared, provider_prepared, edit)));
@@ -55,7 +52,11 @@ fn renames_only_the_selected_nested_provider() {
     );
     let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
     let uri = workspace.uri("tests/pkg/test_nested.py");
-    open(&server, uri.clone(), "def test_nested(database): pass\n");
+    open(
+        &mut server,
+        uri.clone(),
+        "def test_nested(database): pass\n",
+    );
 
     let edit = server.request::<RenameRequest>(rename_params(
         uri,
@@ -75,7 +76,11 @@ fn rejects_partial_and_invalid_fixture_renames() {
     );
     let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
     let uri = workspace.uri("test_example.py");
-    open(&server, uri.clone(), "def test_example(database): pass\n");
+    open(
+        &mut server,
+        uri.clone(),
+        "def test_example(database): pass\n",
+    );
     let position = Position::new(0, 20);
 
     let prepared = server.request::<PrepareRenameRequest>(prepare_params(uri.clone(), position));
@@ -109,7 +114,11 @@ fn rejects_name_that_would_select_a_nested_provider() {
     );
     let mut server = TestServer::with_workspace(ClientCapabilities::default(), workspace.folder());
     let uri = workspace.uri("tests/pkg/test_nested.py");
-    open(&server, uri.clone(), "def test_nested(database): pass\n");
+    open(
+        &mut server,
+        uri.clone(),
+        "def test_nested(database): pass\n",
+    );
 
     let edit =
         server.request::<RenameRequest>(rename_params(uri, Position::new(0, 20), "replacement"));
@@ -117,7 +126,7 @@ fn rejects_name_that_would_select_a_nested_provider() {
     assert_eq!(edit, None);
 }
 
-fn open(server: &TestServer, uri: Uri, source: &str) {
+fn open(server: &mut TestServer, uri: Uri, source: &str) {
     server.notify::<DidOpenTextDocumentNotification>(DidOpenTextDocumentParams {
         text_document: TextDocumentItem {
             uri,
@@ -142,81 +151,4 @@ fn rename_params(uri: Uri, position: Position, new_name: &str) -> RenameParams {
         WorkDoneProgressParams::default(),
         TextDocumentPositionParams::new(TextDocumentIdentifier::new(uri), position),
     )
-}
-
-struct Workspace {
-    directory: TempDir,
-    root_uri: Uri,
-}
-
-impl Workspace {
-    fn new() -> Self {
-        let directory = tempfile::tempdir().expect("temporary workspace should be created");
-        fs::create_dir(directory.path().join(".git")).expect("workspace marker should be created");
-        let root_uri =
-            Uri::from_file_path(directory.path()).expect("workspace URI should be valid");
-        Self {
-            directory,
-            root_uri,
-        }
-    }
-
-    fn folder(&self) -> WorkspaceFolder {
-        WorkspaceFolder {
-            uri: self.root_uri.clone(),
-            name: "project".to_owned(),
-        }
-    }
-
-    fn uri(&self, relative: &str) -> Uri {
-        Uri::from_file_path(self.directory.path().join(relative))
-            .expect("document URI should be valid")
-    }
-
-    fn write(&self, relative: &str, source: &str) {
-        let path = self.directory.path().join(relative);
-        fs::create_dir_all(
-            path.parent()
-                .expect("workspace source should have a parent"),
-        )
-        .expect("workspace source parent should be created");
-        fs::write(path, source).expect("workspace source should be written");
-    }
-
-    fn normalize(&self, value: impl serde::Serialize) -> Value {
-        let mut value = serde_json::to_value(value).expect("rename should serialize");
-        normalize_paths(
-            &mut value,
-            self.root_uri.as_str(),
-            &self.directory.path().to_string_lossy(),
-        );
-        value
-    }
-}
-
-fn normalize_paths(value: &mut Value, workspace_uri: &str, workspace_path: &str) {
-    match value {
-        Value::Array(values) => {
-            for value in values {
-                normalize_paths(value, workspace_uri, workspace_path);
-            }
-        }
-        Value::Object(values) => {
-            let original = std::mem::take(values);
-            for (key, mut value) in original {
-                normalize_paths(&mut value, workspace_uri, workspace_path);
-                values.insert(
-                    key.replace(workspace_uri, "file:///project")
-                        .replace(workspace_path, "/project"),
-                    value,
-                );
-            }
-        }
-        Value::String(value) => {
-            *value = value
-                .replace(workspace_uri, "file:///project")
-                .replace(workspace_path, "/project");
-        }
-        Value::Null | Value::Bool(_) | Value::Number(_) => {}
-    }
 }


### PR DESCRIPTION
## Summary

Makes test server shutdown and failure reporting deterministic. This addresses #1289.

## Test plan

cargo test -p karva_language_server --test e2e