### PR TITLE
Fix custom tag stub typing

### DIFF
--- a/python/karva/_karva/tags.pyi
+++ b/python/karva/_karva/tags.pyi
@@ -7,6 +7,16 @@ _T = TypeVar("_T")
 _P = ParamSpec("_P")
 
 
+class _CustomTagBuilder:
+    @overload
+    def __call__(self, function: Callable[_P, _T], /) -> TestFunction[_P, _T]: ...
+    @overload
+    def __call__(self, *args: object, **kwargs: object) -> Tags: ...
+
+
+def __getattr__(name: str, /) -> _CustomTagBuilder: ...
+
+
 def parametrize(
     arg_names: Sequence[str] | str,
     arg_values: Sequence[Sequence[object]] | Sequence[object],

--- a/python/typing_tests/test_custom_tags.py
+++ b/python/typing_tests/test_custom_tags.py
@@ -1,0 +1,19 @@
+from typing import assert_type
+
+import karva
+
+
+@karva.tags.smoke
+def smoke_test(value: int) -> str:
+    """Keep the decorated callable's signature."""
+    return str(value)
+
+
+@karva.tags.integration("database", owner="checkout")
+def integration_test(value: int) -> str:
+    """Keep signatures for custom tags called with metadata."""
+    return str(value)
+
+
+assert_type(smoke_test(1), str)
+assert_type(integration_test(1), str)


### PR DESCRIPTION
## Summary

Declare the dynamic `karva.tags` module hook in the type stub while preserving precise built-in tag signatures. Add typing coverage for bare and metadata-bearing custom decorators. Closes #1337.

## Test plan

`uv run ty check` and `uvx prek run -a`