### PR TITLE
Fix tmpdir legacy path compatibility

### DIFF
--- a/crates/karva/tests/it/extensions/fixtures/builtins.rs
+++ b/crates/karva/tests/it/extensions/fixtures/builtins.rs
@@ -43,9 +43,13 @@ import pathlib
 
 def test_tmpdir(tmpdir):
     assert isinstance(tmpdir, pathlib.Path)
-    f = tmpdir / 'hello.txt'
-    f.write_text('world')
-    assert f.read_text() == 'world'
+    f = tmpdir.join('hello.txt')
+    f.write('world')
+    assert f.strpath == str(f)
+    assert f.read() == 'world'
+    binary = tmpdir.join('hello.bin')
+    binary.write_binary(b'world')
+    assert binary.read_binary() == b'world'
         ",
     );
 

--- a/python/karva/_builtins.py
+++ b/python/karva/_builtins.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
 from karva._fixtures.monkeypatch import MockEnv
 from karva._fixtures.recwarn import WarningsRecorder
-from karva._fixtures.tmpdir import TempPathFactory
+from karva._fixtures.tmpdir import LegacyPath, TempPathFactory
 from karva._karva import fixture
 
 __all__ = [
@@ -503,9 +503,9 @@ def temp_dir(tmp_path_factory: TempPathFactory) -> Path:
 
 
 @fixture
-def tmpdir(tmp_path_factory: TempPathFactory) -> Path:
-    """Provide a temporary directory as a :class:`pathlib.Path`."""
-    return tmp_path_factory.mktemp("test")
+def tmpdir(tmp_path_factory: TempPathFactory) -> LegacyPath:
+    """Provide a temporary directory with pytest's legacy path methods."""
+    return LegacyPath(tmp_path_factory.mktemp("test"))
 
 
 @fixture(scope="session")

--- a/python/karva/_fixtures/tmpdir.py
+++ b/python/karva/_fixtures/tmpdir.py
@@ -30,6 +30,11 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Literal, final
 
+if os.name == "nt":
+    from pathlib import WindowsPath as PlatformPath
+else:
+    from pathlib import PosixPath as PlatformPath
+
 from karva._fixtures.pathlib import (
     LOCK_TIMEOUT,
     make_numbered_dir,
@@ -38,6 +43,35 @@ from karva._fixtures.pathlib import (
 )
 
 RetentionType = Literal["all", "failed", "none"]
+
+
+class LegacyPath(PlatformPath):
+    """Path with the legacy methods exposed by pytest's ``tmpdir`` fixture."""
+
+    @property
+    def strpath(self) -> str:
+        """Return the path as a string."""
+        return str(self)
+
+    def join(self, *parts: str | os.PathLike[str]) -> LegacyPath:
+        """Return a path formed by appending path components."""
+        return self.joinpath(*parts)
+
+    def write(self, data: str) -> None:
+        """Write UTF-8 text to the path."""
+        self.write_text(data, encoding="utf-8")
+
+    def read(self) -> str:
+        """Read UTF-8 text from the path."""
+        return self.read_text(encoding="utf-8")
+
+    def write_binary(self, data: bytes) -> None:
+        """Write bytes to the path."""
+        self.write_bytes(data)
+
+    def read_binary(self) -> bytes:
+        """Read bytes from the path."""
+        return self.read_bytes()
 
 
 def _noop_trace(*_args: object, **_kwargs: object) -> None:


### PR DESCRIPTION
## Summary

Return a pathlib-compatible legacy path from `tmpdir`, restoring pytest-style `join`, `strpath`, and text/binary read/write methods used by existing test suites.

## Test Plan

`just test -p karva test_tmpdir_fixture` and `uvx prek run -a`