### PR TITLE
Support globs in source includes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,6 +1273,7 @@ dependencies = [
  "anyhow",
  "camino",
  "fs-err",
+ "glob",
  "insta",
  "karva_metadata",
  "karva_python_semantic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ directories = "6.0.0"
 dunce = { version = "1.0.5" }
 fastrand = { version = "2.4" }
 fs-err = { version = "3.2.2" }
+glob = { version = "0.3.3" }
 globset = { version = "0.4" }
 ignore = { version = "0.4.25" }
 insta = { version = "1.47.1" }

--- a/crates/karva/tests/it/configuration/mod.rs
+++ b/crates/karva/tests/it/configuration/mod.rs
@@ -127,6 +127,36 @@ def test_in_other(): pass
 }
 
 #[test]
+fn test_src_include_globs() {
+    let context = TestContext::with_files([
+        (
+            "karva.toml",
+            r#"
+[profile.default.src]
+include = ["tests/**/test_*.py"]
+"#,
+        ),
+        ("tests/unit/test_unit.py", "def test_unit(): pass\n"),
+        (
+            "tests/integration/test_integration.py",
+            "def test_integration(): pass\n",
+        ),
+        ("tests/unit/helper.py", "def test_helper(): pass\n"),
+        ("other/test_other.py", "def test_other(): pass\n"),
+    ]);
+
+    assert_cmd_snapshot!(context.command().arg("--status-level=none"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn explicit_test_path_overrides_configured_src_include() {
     let context = TestContext::with_files([
         (

--- a/crates/karva_language_server/src/session/source_index.rs
+++ b/crates/karva_language_server/src/session/source_index.rs
@@ -135,7 +135,9 @@ impl PreparedSourceIndex {
             }
             SourceIndexScope::TestSelection => include_paths
                 .iter()
-                .map(|path| TestPath::new(absolute(path, &project_root).as_str()))
+                .flat_map(|path| {
+                    karva_project::path::resolve_test_paths(absolute(path, &project_root).as_str())
+                })
                 .collect(),
         };
         for test_path in test_paths {
@@ -742,6 +744,18 @@ mod tests {
         let index = fixture.build(vec!["specs".to_owned()], BTreeMap::new());
 
         assert!(index.module(&test).is_some());
+    }
+
+    #[test]
+    fn resolves_glob_include_from_project_root() {
+        let fixture = Fixture::new();
+        let included = fixture.write("specs/unit/test_sample.py", "def test_example(): pass\n");
+        let excluded = fixture.write("specs/unit/helper.py", "def helper(): pass\n");
+
+        let index = fixture.build(vec!["specs/**/test_*.py".to_owned()], BTreeMap::new());
+
+        assert!(index.module(&included).is_some());
+        assert!(index.module(&excluded).is_none());
     }
 
     #[test]

--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -266,14 +266,16 @@ pub struct SrcOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub respect_ignore_files: Option<bool>,
 
-    /// A list of files and directories to check.
+    /// A list of files, directories, and shell-style glob patterns to check.
     /// Including a file or directory will make it so that it (and its contents)
-    /// are tested.
+    /// are tested. Glob patterns are relative to the project root and support
+    /// `*`, `?`, `[]`, and recursive `**` matching.
     /// When unset, Karva checks the `tests` directory if it exists, otherwise
     /// it checks the project root.
     ///
     /// - `tests` matches a directory named `tests`
     /// - `tests/test.py` matches a file named `test.py` in the `tests` directory
+    /// - `tests/**/test_*.py` matches test files below the `tests` directory
     #[serde(skip_serializing_if = "Option::is_none")]
     #[option(
         default = r#"null"#,

--- a/crates/karva_project/Cargo.toml
+++ b/crates/karva_project/Cargo.toml
@@ -15,6 +15,7 @@ license = { workspace = true }
 anyhow = { workspace = true }
 camino = { workspace = true }
 fs-err = { workspace = true }
+glob = { workspace = true }
 karva_metadata = { workspace = true }
 karva_python_semantic = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/karva_project/src/lib.rs
+++ b/crates/karva_project/src/lib.rs
@@ -7,7 +7,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use fs_err as fs;
 use karva_metadata::{ProjectMetadata, ProjectSettings};
 
-use crate::path::{TestPath, TestPathError, absolute};
+use crate::path::{TestPath, TestPathError, absolute, resolve_test_paths};
 
 /// Find the karva wheel in the target/wheels directory.
 ///
@@ -107,9 +107,9 @@ impl Project {
             .src()
             .include_paths
             .iter()
-            .map(|path| {
+            .flat_map(|path| {
                 let path = absolute(path, self.cwd());
-                TestPath::new(path.as_str())
+                resolve_test_paths(path.as_str())
             })
             .collect()
     }

--- a/crates/karva_project/src/path/mod.rs
+++ b/crates/karva_project/src/path/mod.rs
@@ -3,5 +3,5 @@
 mod test_path;
 mod utils;
 
-pub use test_path::{TestPath, TestPathError, TestPathFunction};
+pub use test_path::{TestPath, TestPathError, TestPathFunction, resolve_test_paths};
 pub use utils::absolute;

--- a/crates/karva_project/src/path/test_path.rs
+++ b/crates/karva_project/src/path/test_path.rs
@@ -1,4 +1,5 @@
 use camino::{Utf8Path, Utf8PathBuf};
+use glob::MatchOptions;
 use karva_python_semantic::is_python_file;
 use thiserror::Error;
 
@@ -149,6 +150,75 @@ impl TestPath {
     }
 }
 
+/// Resolves one path or shell-style glob into concrete test selections.
+///
+/// Existing paths always remain literal. Globs use `*`, `?`, `[]`, and recursive
+/// `**` matching without allowing `*` to cross a path separator.
+pub fn resolve_test_paths(value: &str) -> Vec<Result<TestPath, TestPathError>> {
+    let literal = TestPath::new(value);
+    if literal.is_ok() || value.contains("::") || !value.contains(['*', '?', '[']) {
+        return vec![literal];
+    }
+
+    let options = MatchOptions {
+        case_sensitive: true,
+        require_literal_separator: true,
+        require_literal_leading_dot: true,
+    };
+    let entries = match glob::glob_with(value, options) {
+        Ok(entries) => entries,
+        Err(error) => {
+            return vec![Err(TestPathError::InvalidGlob {
+                pattern: value.to_string(),
+                error: error.to_string(),
+            })];
+        }
+    };
+
+    let mut paths = Vec::new();
+    for entry in entries {
+        let path = match entry {
+            Ok(path) => match Utf8PathBuf::from_path_buf(path) {
+                Ok(path) => path,
+                Err(path) => return vec![Err(TestPathError::NonUtf8GlobMatch(path))],
+            },
+            Err(error) => {
+                return vec![Err(TestPathError::GlobWalk {
+                    path: error.path().to_path_buf(),
+                    error: error.error().to_string(),
+                })];
+            }
+        };
+        let test_path = match TestPath::new(path.as_str()) {
+            Ok(test_path) => test_path,
+            Err(error) => return vec![Err(error)],
+        };
+
+        if let TestPath::Directory(directory) = &test_path {
+            paths.retain(|existing| match existing {
+                TestPath::Directory(path) | TestPath::File(path) => !path.starts_with(directory),
+                TestPath::Function(function) => !function.path.starts_with(directory),
+            });
+        }
+        if paths.iter().any(|existing| match existing {
+            TestPath::Directory(directory) => match &test_path {
+                TestPath::Directory(path) | TestPath::File(path) => path.starts_with(directory),
+                TestPath::Function(function) => function.path.starts_with(directory),
+            },
+            TestPath::File(_) | TestPath::Function(_) => false,
+        }) {
+            continue;
+        }
+        paths.push(test_path);
+    }
+
+    if paths.is_empty() {
+        vec![literal]
+    } else {
+        paths.into_iter().map(Ok).collect()
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Error)]
 /// Reason a user-provided test path could not become a valid selection.
 pub enum TestPathError {
@@ -162,6 +232,15 @@ pub enum TestPathError {
     MissingFunctionName(Utf8PathBuf),
     #[error("function selector `{0}` has a malformed parametrize index")]
     MalformedCaseIndex(String),
+    #[error("glob `{pattern}` is invalid: {error}")]
+    InvalidGlob { pattern: String, error: String },
+    #[error("glob matched a non-UTF-8 path: `{0:?}`")]
+    NonUtf8GlobMatch(std::path::PathBuf),
+    #[error("could not read glob match `{path:?}`: {error}")]
+    GlobWalk {
+        path: std::path::PathBuf,
+        error: String,
+    },
 }
 
 #[cfg(test)]

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -681,14 +681,16 @@ Controls test-path discovery and whether filesystem ignore rules are honored.
 
 #### `include`
 
-A list of files and directories to check.
+A list of files, directories, and shell-style glob patterns to check.
 Including a file or directory will make it so that it (and its contents)
-are tested.
+are tested. Glob patterns are relative to the project root and support
+`*`, `?`, `[]`, and recursive `**` matching.
 When unset, Karva checks the `tests` directory if it exists, otherwise
 it checks the project root.
 
 - `tests` matches a directory named `tests`
 - `tests/test.py` matches a file named `test.py` in the `tests` directory
+- `tests/**/test_*.py` matches test files below the `tests` directory
 
 **Default value**: `null`
 

--- a/karva.schema.json
+++ b/karva.schema.json
@@ -627,7 +627,7 @@
       "type": "object",
       "properties": {
         "include": {
-          "description": "A list of files and directories to check.\nIncluding a file or directory will make it so that it (and its contents)\nare tested.\nWhen unset, Karva checks the `tests` directory if it exists, otherwise\nit checks the project root.\n\n- `tests` matches a directory named `tests`\n- `tests/test.py` matches a file named `test.py` in the `tests` directory",
+          "description": "A list of files, directories, and shell-style glob patterns to check.\nIncluding a file or directory will make it so that it (and its contents)\nare tested. Glob patterns are relative to the project root and support\n`*`, `?`, `[]`, and recursive `**` matching.\nWhen unset, Karva checks the `tests` directory if it exists, otherwise\nit checks the project root.\n\n- `tests` matches a directory named `tests`\n- `tests/test.py` matches a file named `test.py` in the `tests` directory\n- `tests/**/test_*.py` matches test files below the `tests` directory",
           "type": [
             "array",
             "null"


### PR DESCRIPTION
## Summary

Support shell-style glob patterns in `src.include` for test execution and language-server indexing while preserving literal file and directory includes. Document supported syntax and close #1347.

## Test Plan

`cargo test -p karva_project`; `just test -p karva test_src_include_globs`; `cargo nextest run -p karva_language_server resolves_glob_include_from_project_root`; `uvx prek run -a`