### PR TITLE
Refactor fixture source analysis model

### DIFF
--- a/crates/karva_ide/src/completion.rs
+++ b/crates/karva_ide/src/completion.rs
@@ -32,8 +32,8 @@ pub fn complete_fixtures(
     let prefix = source.get(replacement.start().to_usize()..replacement.end().to_usize())?;
 
     let mut completions = Vec::new();
-    let mut names = analysis.fixture_completion_blocked_names.clone();
-    for fixture in &analysis.visible_fixtures {
+    let mut names = analysis.fixture_model.blocked_names().clone();
+    for fixture in analysis.fixture_model.visible() {
         if names.insert(fixture.name.clone()) && fixture.name.starts_with(prefix) {
             completions.push(completion(
                 fixture.name.clone(),
@@ -44,7 +44,7 @@ pub fn complete_fixtures(
             ));
         }
     }
-    if analysis.fixture_completion_builtins_visible {
+    if analysis.fixture_model.builtins_visible() {
         for (name, scope) in crate::fixture::builtin_fixtures() {
             if names.insert(name.to_owned()) && name.starts_with(prefix) {
                 completions.push(completion(
@@ -138,7 +138,7 @@ fn use_fixtures_context(analysis: &SourceAnalysis, offset: TextSize) -> Option<T
             let Expr::Call(call) = &decorator.expression else {
                 continue;
             };
-            if !crate::fixture::is_use_fixtures_reference(&analysis.module, &call.func) {
+            if !analysis.fixture_model.is_use_fixtures_reference(&call.func) {
                 continue;
             }
             for argument in &call.arguments.args {

--- a/crates/karva_ide/src/definition.rs
+++ b/crates/karva_ide/src/definition.rs
@@ -24,10 +24,7 @@ pub fn fixture_definition(
 ) -> Option<FixtureDefinitionTarget> {
     let hover = hover_fixture(analysis, offset)?;
     let provider = hover.provider?;
-    let definition = analysis
-        .visible_fixtures
-        .iter()
-        .find(|definition| definition.id == provider)?;
+    let definition = analysis.fixture_model.definition(&provider)?;
     Some(FixtureDefinitionTarget {
         path: definition.id.path.clone(),
         range: definition.name_range,

--- a/crates/karva_ide/src/fixture.rs
+++ b/crates/karva_ide/src/fixture.rs
@@ -1,3 +1,12 @@
+//! Models fixture declarations, references, and their static runtime resolution.
+//!
+//! Fixture parameters are ordinary Python definitions, but Karva resolves them
+//! by public fixture name across the current module and ancestor `conftest.py`
+//! providers. This module overlays that relationship on collected syntax. One
+//! [`FixtureModel`] owns the resolved declarations and visibility barriers used
+//! by every editor feature, so provider discovery and precedence stay
+//! consistent across diagnostics, completion, navigation, and rename.
+
 #![expect(
     clippy::redundant_pub_crate,
     reason = "the crate root re-exports fixture analysis across this private module"
@@ -170,8 +179,69 @@ struct FixtureProvider {
     definitions: Vec<FixtureDefinition>,
     by_name: HashMap<String, FixtureId>,
     rejected: HashMap<String, Vec<FixtureId>>,
+    bindings: FixtureBindings,
     unknown: bool,
     diagnostics: Vec<SourceDiagnostic>,
+}
+
+/// Resolved fixture declarations and visibility for one source document.
+#[derive(Debug)]
+pub(super) struct FixtureModel {
+    local: Vec<FixtureDefinition>,
+    visible: Vec<FixtureDefinition>,
+    blocked_names: HashSet<String>,
+    bindings: FixtureBindings,
+    builtins_visible: bool,
+}
+
+impl FixtureModel {
+    /// Returns declarations defined by the current source document.
+    pub(super) fn local(&self) -> &[FixtureDefinition] {
+        &self.local
+    }
+
+    /// Returns declarations selected before any dynamic provider barrier.
+    pub(super) fn visible(&self) -> &[FixtureDefinition] {
+        &self.visible
+    }
+
+    /// Returns the visible source declaration for `name`.
+    pub(super) fn resolve(&self, name: &str) -> Option<&FixtureDefinition> {
+        if self.blocked_names.contains(name) {
+            return None;
+        }
+        self.visible.iter().find(|fixture| fixture.name == name)
+    }
+
+    /// Returns the visible declaration with stable identity `id`.
+    pub(super) fn definition(&self, id: &FixtureId) -> Option<&FixtureDefinition> {
+        self.visible.iter().find(|fixture| &fixture.id == id)
+    }
+
+    /// Returns names whose rejected declarations prevent provider fallback.
+    pub(super) fn blocked_names(&self) -> &HashSet<String> {
+        &self.blocked_names
+    }
+
+    /// Returns whether `expression` is a recognized fixture-use decorator.
+    pub(super) fn is_use_fixtures_reference(&self, expression: &Expr) -> bool {
+        self.bindings.is_use_fixtures_reference(expression)
+    }
+
+    /// Returns whether a test parameter remains available for fixture injection.
+    pub(super) fn parameter_is_fixture(&self, function: &StmtFunctionDef, name: &str) -> bool {
+        parameter_is_fixture(self.bindings, function, name)
+    }
+
+    /// Returns whether parametrization may capture unknown parameter names.
+    pub(super) fn parametrization_is_dynamic(&self, function: &StmtFunctionDef) -> bool {
+        parametrization_is_dynamic(self.bindings, function)
+    }
+
+    /// Returns whether static lookup may fall back to Karva's built-ins.
+    pub(super) const fn builtins_visible(&self) -> bool {
+        self.builtins_visible
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -287,7 +357,7 @@ const BUILTIN_FIXTURES: &[BuiltinFixture] = &[
 pub(super) fn analyze(
     module: &CollectedModule,
     try_import_fixtures: bool,
-) -> (Vec<FixtureDefinition>, Vec<SourceDiagnostic>) {
+) -> (FixtureModel, Vec<SourceDiagnostic>) {
     analyze_modules(module, &[], try_import_fixtures)
 }
 
@@ -297,7 +367,7 @@ pub(super) fn analyze_modules(
     current: &CollectedModule,
     parents: &[&CollectedModule],
     try_import_fixtures: bool,
-) -> (Vec<FixtureDefinition>, Vec<SourceDiagnostic>) {
+) -> (FixtureModel, Vec<SourceDiagnostic>) {
     let mut providers = parents
         .iter()
         .rev()
@@ -305,17 +375,6 @@ pub(super) fn analyze_modules(
         .collect::<Vec<_>>();
     let current_provider = parse_provider(current, try_import_fixtures);
     providers.insert(0, current_provider);
-
-    let definition_order = providers
-        .iter()
-        .flat_map(|provider| provider.definitions.iter())
-        .map(|definition| definition.id.clone())
-        .collect::<Vec<_>>();
-    let mut definitions = providers
-        .iter()
-        .flat_map(|provider| provider.definitions.iter().cloned())
-        .map(|definition| (definition.id.clone(), definition))
-        .collect::<HashMap<_, _>>();
 
     let resolutions = providers
         .iter()
@@ -335,13 +394,15 @@ pub(super) fn analyze_modules(
         })
         .collect::<HashMap<_, _>>();
 
-    for definition in definitions.values_mut() {
-        if let Some(resolved) = resolutions.get(&definition.id) {
-            for reference in &mut definition.dependencies {
-                if let Some((_, resolution)) =
-                    resolved.iter().find(|(name, _)| name == &reference.name)
-                {
-                    reference.resolution = resolution.clone();
+    for provider in &mut providers {
+        for definition in &mut provider.definitions {
+            if let Some(resolved) = resolutions.get(&definition.id) {
+                for reference in &mut definition.dependencies {
+                    if let Some((_, resolution)) =
+                        resolved.iter().find(|(name, _)| name == &reference.name)
+                    {
+                        reference.resolution = resolution.clone();
+                    }
                 }
             }
         }
@@ -351,20 +412,15 @@ pub(super) fn analyze_modules(
         .iter()
         .flat_map(|provider| provider.diagnostics.iter().cloned())
         .collect::<Vec<_>>();
-    let all_definitions = definition_order
+    let all_definitions = providers
         .iter()
-        .filter_map(|id| definitions.get(id))
+        .flat_map(|provider| &provider.definitions)
         .collect::<Vec<_>>();
     diagnostics.extend(reference_diagnostics(&all_definitions));
     diagnostics.extend(scope_diagnostics(&all_definitions));
     diagnostics.extend(cycle_diagnostics(&all_definitions));
     diagnostics.extend(test_diagnostics(current, &providers));
 
-    let current_definitions = providers[0]
-        .definitions
-        .iter()
-        .filter_map(|definition| definitions.get(&definition.id).cloned())
-        .collect::<Vec<_>>();
     diagnostics.sort_by(|left, right| {
         (
             &left.location.path,
@@ -377,61 +433,44 @@ pub(super) fn analyze_modules(
                 right.code.as_str(),
             ))
     });
-    (current_definitions, diagnostics)
+    (FixtureModel::from_providers(&providers), diagnostics)
 }
 
-/// Visible fixture providers plus conservative completion barriers.
-pub(super) struct VisibleFixtures {
-    /// Definitions selected before any dynamic provider barrier.
-    pub(super) definitions: Vec<FixtureDefinition>,
-
-    /// Rejected names that prevent fallback to later providers.
-    pub(super) blocked_names: HashSet<String>,
-
-    /// Whether every provider was statically known, allowing built-in fallback.
-    pub(super) builtins_visible: bool,
-}
-
-/// Returns fixture definitions that can be selected from the current module.
-///
-/// Providers follow runtime lookup order. A rejected definition blocks the same
-/// name from every later provider, including Karva's built-ins.
-pub(super) fn visible_fixtures(
-    current: &CollectedModule,
-    parents: &[&CollectedModule],
-    try_import_fixtures: bool,
-) -> VisibleFixtures {
-    let mut providers = parents
-        .iter()
-        .rev()
-        .map(|module| parse_provider(module, try_import_fixtures))
-        .collect::<Vec<_>>();
-    providers.insert(0, parse_provider(current, try_import_fixtures));
-
-    let mut visible = Vec::new();
-    let mut names = HashSet::new();
-    let mut blocked_names = HashSet::new();
-    let mut builtins_visible = true;
-    for provider in providers {
-        for rejected in provider.rejected.keys() {
-            if names.insert(rejected.clone()) {
-                blocked_names.insert(rejected.clone());
+impl FixtureModel {
+    fn from_providers(providers: &[FixtureProvider]) -> Self {
+        let local = providers
+            .first()
+            .map_or_else(Vec::new, |provider| provider.definitions.clone());
+        let bindings = providers
+            .first()
+            .map_or_else(FixtureBindings::default, |provider| provider.bindings);
+        let mut visible = Vec::new();
+        let mut names = HashSet::new();
+        let mut blocked_names = HashSet::new();
+        let mut builtins_visible = true;
+        for provider in providers {
+            for rejected in provider.rejected.keys() {
+                if names.insert(rejected.clone()) {
+                    blocked_names.insert(rejected.clone());
+                }
+            }
+            for definition in &provider.definitions {
+                if names.insert(definition.name.clone()) {
+                    visible.push(definition.clone());
+                }
+            }
+            if provider.unknown {
+                builtins_visible = false;
+                break;
             }
         }
-        for definition in provider.definitions {
-            if names.insert(definition.name.clone()) {
-                visible.push(definition);
-            }
+        Self {
+            local,
+            visible,
+            blocked_names,
+            bindings,
+            builtins_visible,
         }
-        if provider.unknown {
-            builtins_visible = false;
-            break;
-        }
-    }
-    VisibleFixtures {
-        definitions: visible,
-        blocked_names,
-        builtins_visible,
     }
 }
 
@@ -451,6 +490,7 @@ impl FixtureProvider {
     fn from_parsed(
         parsed: &[ParsedFixture],
         path: &Utf8PathBuf,
+        bindings: FixtureBindings,
         imported_fixtures_unknown: bool,
     ) -> Self {
         let mut diagnostics = Vec::new();
@@ -492,6 +532,7 @@ impl FixtureProvider {
             definitions,
             by_name,
             rejected,
+            bindings,
             unknown: imported_fixtures_unknown
                 || parsed.iter().any(|fixture| !fixture.public_name_known),
             diagnostics,
@@ -510,7 +551,7 @@ fn parse_provider(module: &CollectedModule, try_import_fixtures: bool) -> Fixtur
     let imported_fixtures_unknown = (try_import_fixtures
         || module.module_type == ModuleType::Configuration)
         && has_external_imports(&module.module_body);
-    FixtureProvider::from_parsed(&parsed, &path, imported_fixtures_unknown)
+    FixtureProvider::from_parsed(&parsed, &path, bindings, imported_fixtures_unknown)
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -600,10 +641,6 @@ impl FixtureBindings {
             _ => false,
         }
     }
-}
-
-pub(super) fn is_use_fixtures_reference(module: &CollectedModule, expression: &Expr) -> bool {
-    FixtureBindings::from_statements(&module.module_body).is_use_fixtures_reference(expression)
 }
 
 /// Returns the replaceable contents of a non-concatenated string literal.
@@ -1142,10 +1179,13 @@ fn test_diagnostics(
     module: &CollectedModule,
     providers: &[FixtureProvider],
 ) -> Vec<SourceDiagnostic> {
+    let bindings = providers
+        .first()
+        .map_or_else(FixtureBindings::default, |provider| provider.bindings);
     let path = module.path.path();
     let mut diagnostics = Vec::new();
     for test in &module.test_function_defs {
-        let Some(parametrized) = parametrized_names(module, test) else {
+        let Some(parametrized) = parametrized_names(bindings, test) else {
             continue;
         };
         diagnostics.extend(
@@ -1191,12 +1231,7 @@ fn test_diagnostics(
     diagnostics
 }
 
-pub(super) fn test_parameter_is_fixture(
-    module: &CollectedModule,
-    function: &StmtFunctionDef,
-    name: &str,
-) -> bool {
-    let bindings = FixtureBindings::from_statements(&module.module_body);
+fn parameter_is_fixture(bindings: FixtureBindings, function: &StmtFunctionDef, name: &str) -> bool {
     for decorator in &function.decorator_list {
         let Expr::Call(call) = &decorator.expression else {
             continue;
@@ -1228,12 +1263,7 @@ pub(super) fn test_parameter_is_fixture(
     true
 }
 
-/// Returns whether recognized parametrization may capture unknown parameter names.
-pub(super) fn test_parametrization_is_dynamic(
-    module: &CollectedModule,
-    function: &StmtFunctionDef,
-) -> bool {
-    let bindings = FixtureBindings::from_statements(&module.module_body);
+fn parametrization_is_dynamic(bindings: FixtureBindings, function: &StmtFunctionDef) -> bool {
     function.decorator_list.iter().any(|decorator| {
         let Expr::Call(call) = &decorator.expression else {
             return false;
@@ -1259,10 +1289,9 @@ pub(super) fn test_parametrization_is_dynamic(
 
 /// Returns `None` when a decorator may supply arguments dynamically.
 fn parametrized_names(
-    module: &CollectedModule,
+    bindings: FixtureBindings,
     function: &StmtFunctionDef,
 ) -> Option<HashSet<String>> {
-    let bindings = FixtureBindings::from_statements(&module.module_body);
     let mut names = HashSet::new();
     for decorator in &function.decorator_list {
         let Expr::Call(call) = &decorator.expression else {
@@ -1496,7 +1525,7 @@ mod tests {
         let analysis = analyze_sources(current, &[parent], &settings());
 
         assert!(analysis.diagnostics.is_empty());
-        let dependency = &analysis.fixtures[0].dependencies[0].resolution;
+        let dependency = &analysis.fixture_model.local()[0].dependencies[0].resolution;
         assert!(
             matches!(dependency, FixtureResolution::Resolved(id) if id.path == "/project/conftest.py")
         );
@@ -1519,7 +1548,7 @@ mod tests {
         let analysis = analyze_sources(current, &[root, nearest], &settings());
 
         assert!(analysis.diagnostics.is_empty());
-        let dependency = &analysis.fixtures[0].dependencies[0].resolution;
+        let dependency = &analysis.fixture_model.local()[0].dependencies[0].resolution;
         assert!(
             matches!(dependency, FixtureResolution::Resolved(id) if id.path == "/project/pkg/conftest.py")
         );
@@ -1611,7 +1640,7 @@ mod tests {
             "from custom import fixture\n\n@fixture\ndef database(): pass\n\ndef test_example(database): pass\n",
         );
 
-        assert!(analysis.fixtures.is_empty());
+        assert!(analysis.fixture_model.local().is_empty());
         assert!(analysis.diagnostics.is_empty());
     }
 
@@ -1621,7 +1650,7 @@ mod tests {
             "from karva import fixture\n\n@fixture\ndef database(): pass\n\ndef test_example(database): pass\n",
         );
 
-        assert_eq!(analysis.fixtures[0].name, "database");
+        assert_eq!(analysis.fixture_model.local()[0].name, "database");
         assert!(analysis.diagnostics.is_empty());
     }
 

--- a/crates/karva_ide/src/hover.rs
+++ b/crates/karva_ide/src/hover.rs
@@ -1,7 +1,8 @@
 use ruff_python_ast::{Expr, StmtFunctionDef};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
-use crate::{FixtureDefinition, FixtureId, FixtureResolution, FixtureScope, SourceAnalysis};
+use crate::fixture::FixtureDefinition;
+use crate::{FixtureId, FixtureResolution, FixtureScope, SourceAnalysis};
 
 /// Source-only hover information for one fixture reference.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -37,7 +38,7 @@ pub struct FixtureHover {
 /// missing, and dynamic providers remain silent rather than showing a target
 /// that runtime lookup cannot guarantee.
 pub fn hover_fixture(analysis: &SourceAnalysis, offset: TextSize) -> Option<FixtureHover> {
-    if let Some(reference) = analysis.fixtures.iter().find_map(|fixture| {
+    if let Some(reference) = analysis.fixture_model.local().iter().find_map(|fixture| {
         fixture
             .dependencies
             .iter()
@@ -77,17 +78,10 @@ fn hover_from_name(
     name: String,
     range: TextRange,
 ) -> Option<FixtureHover> {
-    let definition = analysis
-        .visible_fixtures
-        .iter()
-        .find(|fixture| fixture.name == name);
-    if analysis.fixture_completion_blocked_names.contains(&name) {
-        return None;
-    }
-    if let Some(definition) = definition {
+    if let Some(definition) = analysis.fixture_model.resolve(&name) {
         return Some(hover_from_definition(name, range, definition));
     }
-    if !analysis.fixture_completion_builtins_visible {
+    if !analysis.fixture_model.builtins_visible() {
         return None;
     }
     let builtin = crate::fixture::builtin_info(&name)?;
@@ -111,10 +105,7 @@ fn hover_from_resolution(
 ) -> Option<FixtureHover> {
     match resolution {
         FixtureResolution::Resolved(id) => {
-            let definition = analysis
-                .visible_fixtures
-                .iter()
-                .find(|fixture| fixture.id == *id)?;
+            let definition = analysis.fixture_model.definition(id)?;
             Some(hover_from_definition(name, range, definition))
         }
         FixtureResolution::Builtin => hover_from_name(analysis, name, range),
@@ -154,15 +145,14 @@ fn test_parameter_reference(
         .parameters
         .iter_non_variadic_params()
         .find(|parameter| parameter.parameter.name.range.contains_inclusive(offset))?;
-    if !crate::fixture::test_parameter_is_fixture(
-        &analysis.module,
-        function,
-        parameter.parameter.name.as_str(),
-    ) {
+    if !analysis
+        .fixture_model
+        .parameter_is_fixture(function, parameter.parameter.name.as_str())
+    {
         return None;
     }
     let name = parameter.parameter.name.to_string();
-    if analysis.fixture_completion_blocked_names.contains(&name) {
+    if analysis.fixture_model.blocked_names().contains(&name) {
         return None;
     }
     Some((name, parameter.parameter.name.range))
@@ -180,7 +170,7 @@ fn use_fixtures_reference(
         let Expr::Call(call) = &decorator.expression else {
             continue;
         };
-        if !crate::fixture::is_use_fixtures_reference(&analysis.module, &call.func) {
+        if !analysis.fixture_model.is_use_fixtures_reference(&call.func) {
             continue;
         }
         for argument in &call.arguments.args {

--- a/crates/karva_ide/src/implementation.rs
+++ b/crates/karva_ide/src/implementation.rs
@@ -25,10 +25,7 @@ pub fn fixture_implementation(
     offset: TextSize,
 ) -> Option<FixtureImplementationTarget> {
     let fixture = fixture_target(analysis, offset)?;
-    let definition = analysis
-        .visible_fixtures
-        .iter()
-        .find(|definition| definition.id == fixture)?;
+    let definition = analysis.fixture_model.definition(&fixture)?;
     Some(FixtureImplementationTarget {
         path: definition.id.path.clone(),
         range: definition.implementation_range,

--- a/crates/karva_ide/src/lib.rs
+++ b/crates/karva_ide/src/lib.rs
@@ -18,8 +18,8 @@ use ruff_text_size::TextRange;
 
 pub use completion::{FixtureCompletion, complete_fixtures};
 pub use definition::{FixtureDefinitionTarget, fixture_definition};
-use fixture::{FixtureDefinition, FixtureResolution};
 pub use fixture::{FixtureId, FixtureScope};
+use fixture::{FixtureModel, FixtureResolution};
 pub use hover::{FixtureHover, hover_fixture};
 pub use implementation::{FixtureImplementationTarget, fixture_implementation};
 pub(crate) use occurrences::fixture_occurrences;
@@ -142,15 +142,8 @@ pub struct SourceAnalysis {
     /// Collector output retained for later editor features.
     module: CollectedModule,
 
-    /// Statically understood fixture declarations.
-    fixtures: Vec<FixtureDefinition>,
-
-    /// Fixture declarations visible to the current module, including parents.
-    visible_fixtures: Vec<FixtureDefinition>,
-
-    fixture_completion_blocked_names: std::collections::HashSet<String>,
-
-    fixture_completion_builtins_visible: bool,
+    /// Resolved fixture declarations and provider visibility.
+    fixture_model: FixtureModel,
 
     /// Definite diagnostics. Unknown dynamic behavior remains silent.
     pub diagnostics: Vec<SourceDiagnostic>,
@@ -178,14 +171,10 @@ pub(crate) fn analyze_source(
         collect_doctests: false,
     };
     let module = collect_source(path, project_root, source_text, &collection_settings, &[])?;
-    let (fixtures, diagnostics) = fixture::analyze(&module, settings.try_import_fixtures);
-    let visible_fixtures = fixture::visible_fixtures(&module, &[], settings.try_import_fixtures);
+    let (fixture_model, diagnostics) = fixture::analyze(&module, settings.try_import_fixtures);
     Some(SourceAnalysis {
         module,
-        fixtures,
-        visible_fixtures: visible_fixtures.definitions,
-        fixture_completion_blocked_names: visible_fixtures.blocked_names,
-        fixture_completion_builtins_visible: visible_fixtures.builtins_visible,
+        fixture_model,
         diagnostics,
     })
 }
@@ -230,16 +219,11 @@ pub(crate) fn analyze_source_with_parents(
         })
         .collect::<Vec<_>>();
     let parent_modules = parent_modules.iter().collect::<Vec<_>>();
-    let (fixtures, diagnostics) =
+    let (fixture_model, diagnostics) =
         fixture::analyze_modules(&current, &parent_modules, settings.try_import_fixtures);
-    let visible_fixtures =
-        fixture::visible_fixtures(&current, &parent_modules, settings.try_import_fixtures);
     Some(SourceAnalysis {
         module: current,
-        fixtures,
-        visible_fixtures: visible_fixtures.definitions,
-        fixture_completion_blocked_names: visible_fixtures.blocked_names,
-        fixture_completion_builtins_visible: visible_fixtures.builtins_visible,
+        fixture_model,
         diagnostics,
     })
 }
@@ -269,16 +253,11 @@ pub(crate) fn analyze_collected_source(
     parents: &[&CollectedModule],
     settings: &SourceAnalysisSettings,
 ) -> SourceAnalysis {
-    let (fixtures, diagnostics) =
+    let (fixture_model, diagnostics) =
         fixture::analyze_modules(&current, parents, settings.try_import_fixtures);
-    let visible_fixtures =
-        fixture::visible_fixtures(&current, parents, settings.try_import_fixtures);
     SourceAnalysis {
         module: current,
-        fixtures,
-        visible_fixtures: visible_fixtures.definitions,
-        fixture_completion_blocked_names: visible_fixtures.blocked_names,
-        fixture_completion_builtins_visible: visible_fixtures.builtins_visible,
+        fixture_model,
         diagnostics,
     }
 }

--- a/crates/karva_ide/src/occurrences.rs
+++ b/crates/karva_ide/src/occurrences.rs
@@ -59,7 +59,8 @@ pub(crate) fn fixture_occurrences(analysis: &SourceAnalysis) -> Vec<FixtureOccur
 
     occurrences.extend(
         analysis
-            .fixtures
+            .fixture_model
+            .local()
             .iter()
             .map(|definition| FixtureOccurrence {
                 range: definition.public_name_range,
@@ -69,25 +70,31 @@ pub(crate) fn fixture_occurrences(analysis: &SourceAnalysis) -> Vec<FixtureOccur
             }),
     );
 
-    occurrences.extend(analysis.fixtures.iter().flat_map(|definition| {
-        definition.dependencies.iter().filter_map(|reference| {
-            let FixtureResolution::Resolved(fixture) = &reference.resolution else {
-                return None;
-            };
-            Some(FixtureOccurrence {
-                range: reference.range,
-                edit_range: Some(reference.range),
-                kind: FixtureOccurrenceKind::Dependency,
-                fixture: fixture.clone(),
-            })
-        })
-    }));
+    occurrences.extend(
+        analysis
+            .fixture_model
+            .local()
+            .iter()
+            .flat_map(|definition| {
+                definition.dependencies.iter().filter_map(|reference| {
+                    let FixtureResolution::Resolved(fixture) = &reference.resolution else {
+                        return None;
+                    };
+                    Some(FixtureOccurrence {
+                        range: reference.range,
+                        edit_range: Some(reference.range),
+                        kind: FixtureOccurrenceKind::Dependency,
+                        fixture: fixture.clone(),
+                    })
+                })
+            }),
+    );
 
     for function in &analysis.module.test_function_defs {
         occurrences.extend(function.parameters.iter_non_variadic_params().filter_map(
             |parameter| {
                 let name = parameter.parameter.name.as_str();
-                if !crate::fixture::test_parameter_is_fixture(&analysis.module, function, name) {
+                if !analysis.fixture_model.parameter_is_fixture(function, name) {
                     return None;
                 }
                 Some(FixtureOccurrence {
@@ -124,7 +131,8 @@ pub fn fixture_target(analysis: &SourceAnalysis, offset: TextSize) -> Option<Fix
         .map(|occurrence| occurrence.fixture)
         .or_else(|| {
             analysis
-                .fixtures
+                .fixture_model
+                .local()
                 .iter()
                 .find(|definition| definition.name_range.contains_inclusive(offset))
                 .map(|definition| definition.id.clone())
@@ -146,7 +154,8 @@ pub fn fixture_document_highlights(
         .collect();
 
     if let Some(definition) = analysis
-        .fixtures
+        .fixture_model
+        .local()
         .iter()
         .find(|definition| definition.id == fixture)
         && definition.name_range != definition.public_name_range
@@ -180,7 +189,8 @@ pub fn fixture_rename_target(
     }
 
     let definition = analysis
-        .fixtures
+        .fixture_model
+        .local()
         .iter()
         .find(|definition| definition.name_range.contains_inclusive(offset))?;
     Some(FixtureRenameTarget {
@@ -196,27 +206,16 @@ pub fn fixture_rename_target(
 
 fn fixture_name(analysis: &SourceAnalysis, fixture: &FixtureId) -> Option<String> {
     analysis
-        .fixtures
-        .iter()
-        .chain(&analysis.visible_fixtures)
-        .find(|definition| &definition.id == fixture)
+        .fixture_model
+        .definition(fixture)
         .map(|definition| definition.name.clone())
 }
 
 fn resolve_source_fixture(analysis: &SourceAnalysis, name: &str) -> Option<FixtureId> {
-    if analysis
-        .visible_fixtures
-        .iter()
-        .any(|fixture| fixture.name == name)
-        && !analysis.fixture_completion_blocked_names.contains(name)
-    {
-        return analysis
-            .visible_fixtures
-            .iter()
-            .find(|fixture| fixture.name == name)
-            .map(|fixture| fixture.id.clone());
-    }
-    None
+    analysis
+        .fixture_model
+        .resolve(name)
+        .map(|fixture| fixture.id.clone())
 }
 
 fn use_fixtures_occurrences(
@@ -230,7 +229,10 @@ fn use_fixtures_occurrences(
             let Expr::Call(call) = &decorator.expression else {
                 return None;
             };
-            crate::fixture::is_use_fixtures_reference(&analysis.module, &call.func).then_some(call)
+            analysis
+                .fixture_model
+                .is_use_fixtures_reference(&call.func)
+                .then_some(call)
         })
         .flat_map(move |call| {
             call.arguments.args.iter().filter_map(move |argument| {

--- a/crates/karva_ide/src/rename.rs
+++ b/crates/karva_ide/src/rename.rs
@@ -85,28 +85,28 @@ fn fixture_name_conflicts(
     new_name: &str,
 ) -> bool {
     let target_name = analysis
-        .fixtures
-        .iter()
-        .chain(&analysis.visible_fixtures)
-        .find(|definition| &definition.id == target)
+        .fixture_model
+        .definition(target)
         .map(|definition| definition.name.as_str());
     if target_name == Some(new_name) {
         return false;
     }
 
-    analysis.fixture_completion_blocked_names.contains(new_name)
+    analysis.fixture_model.blocked_names().contains(new_name)
         || analysis
-            .visible_fixtures
+            .fixture_model
+            .visible()
             .iter()
             .any(|definition| definition.name == new_name && &definition.id != target)
         || crate::fixture::builtin_info(new_name).is_some()
         || target_name.is_some_and(|target_name| {
             analysis
-                .visible_fixtures
+                .fixture_model
+                .visible()
                 .iter()
                 .any(|definition| &definition.id == target && definition.name == target_name)
                 && analysis.module.test_function_defs.iter().any(|function| {
-                    crate::fixture::test_parametrization_is_dynamic(&analysis.module, function)
+                    analysis.fixture_model.parametrization_is_dynamic(function)
                         && function
                             .parameters
                             .iter_non_variadic_params()
@@ -151,11 +151,9 @@ fn fixture_name_conflicts(
                                 })
                         })
                         || is_test
-                            && !crate::fixture::test_parameter_is_fixture(
-                                &analysis.module,
-                                function,
-                                new_name,
-                            ))
+                            && !analysis
+                                .fixture_model
+                                .parameter_is_fixture(function, new_name))
             })
 }
 

--- a/crates/karva_ide/src/source_index.rs
+++ b/crates/karva_ide/src/source_index.rs
@@ -212,7 +212,7 @@ mod tests {
             .analyze(Utf8Path::new("/project/pkg/test_example.py"))
             .expect("indexed source should analyze");
         assert!(matches!(
-            &analysis.fixtures[0].dependencies[0].resolution,
+            &analysis.fixture_model.local()[0].dependencies[0].resolution,
             FixtureResolution::Resolved(id) if id.path == "/project/pkg/conftest.py"
         ));
     }
@@ -261,6 +261,6 @@ mod tests {
 
         assert!(index.parent_modules(path).is_empty());
         assert!(analysis.diagnostics.is_empty());
-        assert_eq!(analysis.visible_fixtures.len(), 1);
+        assert_eq!(analysis.fixture_model.visible().len(), 1);
     }
 }

--- a/crates/karva_ide/src/symbols.rs
+++ b/crates/karva_ide/src/symbols.rs
@@ -57,7 +57,7 @@ pub fn source_symbols(analysis: &SourceAnalysis) -> Vec<SourceSymbol> {
                 .fixture_function_defs
                 .iter()
                 .filter_map(|function| {
-                    let definition = analysis.fixtures.iter().find(|definition| {
+                    let definition = analysis.fixture_model.local().iter().find(|definition| {
                         definition.id.path.as_path() == analysis.module.path.path().as_path()
                             && definition.id.range == function.name.range
                     })?;


### PR DESCRIPTION
## Summary

Model fixture editor analysis as one resolved `FixtureModel`, so each source and ancestor provider is discovered once and completion, diagnostics, navigation, references, and rename consume the same lookup state.

## Test Plan

`cargo nextest run -p karva_ide`, `cargo clippy -p karva_ide --all-targets`, and `uvx prek run -a`