### PR TITLE
Strengthen runtime fixture semantics

### DIFF
--- a/crates/karva/tests/it/extensions/fixtures/basic.rs
+++ b/crates/karva/tests/it/extensions/fixtures/basic.rs
@@ -608,6 +608,45 @@ def test_value(value):
     ");
 }
 
+#[test]
+fn test_defaulted_parameters_are_not_fixture_requests() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+
+@karva.fixture
+def positional():
+    return "injected positional"
+
+@karva.fixture
+def dependency():
+    return "injected dependency"
+
+@karva.fixture
+def configured(positional="fixture positional", /, dependency="fixture default"):
+    return positional, dependency
+
+def test_defaults(positional="test positional", /, *, configured, dependency="test default"):
+    assert configured == ("fixture positional", "fixture default")
+    assert positional == "test positional"
+    assert dependency == "test default"
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 1 test across 1 worker
+            PASS [TIME] test::test_defaults(configured=('fixture positional', 'fix...)
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
 #[rstest]
 fn test_fixture_initialization_order(#[values("pytest", "karva")] framework: &str) {
     let context = TestContext::with_file(

--- a/crates/karva/tests/it/extensions/fixtures/basic.rs
+++ b/crates/karva/tests/it/extensions/fixtures/basic.rs
@@ -563,6 +563,51 @@ def test_database(database):
     ");
 }
 
+#[test]
+fn test_same_named_session_fixtures_do_not_share_values() {
+    let context = TestContext::with_files([
+        (
+            "test_alpha.py",
+            r#"
+import karva
+
+@karva.fixture(scope="session")
+def value():
+    return "alpha"
+
+def test_value(value):
+    assert value == "alpha"
+"#,
+        ),
+        (
+            "test_beta.py",
+            r#"
+import karva
+
+@karva.fixture(scope="session")
+def value():
+    return "beta"
+
+def test_value(value):
+    assert value == "beta"
+"#,
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+            PASS [TIME] test_alpha::test_value(value='alpha')
+            PASS [TIME] test_beta::test_value(value='beta')
+    ────────────
+         Summary [TIME] 2 tests run: 2 passed, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
 #[rstest]
 fn test_fixture_initialization_order(#[values("pytest", "karva")] framework: &str) {
     let context = TestContext::with_file(

--- a/crates/karva/tests/it/extensions/fixtures/invalid.rs
+++ b/crates/karva/tests/it/extensions/fixtures/invalid.rs
@@ -242,8 +242,8 @@ fn test_rejected_conftest_fixture_blocks_framework_fixture() {
             r#"
 import karva
 
-@karva.fixture(scope="invalid")
-def tmp_path():
+@karva.fixture(name="tmp_path", scope="invalid")
+def invalid_tmp_path():
     return None
 "#,
         ),
@@ -278,11 +278,11 @@ def test_tmp_path(tmp_path):
 
     diagnostics:
 
-    error[invalid-fixture]: Discovered an invalid fixture `tmp_path`
+    error[invalid-fixture]: Discovered an invalid fixture `invalid_tmp_path`
      --> conftest.py:5:5
       |
-    5 | def tmp_path():
-      |     ^^^^^^^^
+    5 | def invalid_tmp_path():
+      |     ^^^^^^^^^^^^^^^^
     info: Invalid fixture scope `invalid`
 
     ────────────

--- a/crates/karva/tests/it/extensions/fixtures/invalid.rs
+++ b/crates/karva/tests/it/extensions/fixtures/invalid.rs
@@ -235,6 +235,65 @@ def second():
 }
 
 #[test]
+fn test_rejected_conftest_fixture_blocks_framework_fixture() {
+    let context = TestContext::with_files([
+        (
+            "conftest.py",
+            r#"
+import karva
+
+@karva.fixture(scope="invalid")
+def tmp_path():
+    return None
+"#,
+        ),
+        (
+            "test_example.py",
+            r#"
+from pathlib import Path
+
+def test_tmp_path(tmp_path):
+    Path("test-ran").touch()
+"#,
+        ),
+    ]);
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 1 test across 1 worker
+           ERROR [TIME] test_example::test_tmp_path
+
+    failures:
+
+    test_example::test_tmp_path:
+
+    error[missing-fixtures]: Test `test_tmp_path` has missing fixtures
+     --> test_example.py:4:5
+      |
+    4 | def test_tmp_path(tmp_path):
+      |     ^^^^^^^^^^^^^
+    info: Missing fixtures: `tmp_path`
+
+    diagnostics:
+
+    error[invalid-fixture]: Discovered an invalid fixture `tmp_path`
+     --> conftest.py:5:5
+      |
+    5 | def tmp_path():
+      |     ^^^^^^^^
+    info: Invalid fixture scope `invalid`
+
+    ────────────
+         Summary [TIME] 1 test run: 0 passed, 1 error, 0 skipped
+
+    ----- stderr -----
+    ");
+    assert!(!context.root().join("test-ran").exists());
+}
+
+#[test]
 fn test_missing_fixture() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva_test_semantic/src/diagnostic.rs
+++ b/crates/karva_test_semantic/src/diagnostic.rs
@@ -590,7 +590,7 @@ fn fixture_missing_fixtures_diagnostic(
             Severity::Info,
             format!(
                 "Fixture `{}` was rejected during discovery: {}",
-                rejected_fixture.name(),
+                rejected_fixture.exposure_name(),
                 rejected_fixture.reason()
             ),
         );

--- a/crates/karva_test_semantic/src/discovery/models/definition.rs
+++ b/crates/karva_test_semantic/src/discovery/models/definition.rs
@@ -5,6 +5,17 @@ use ruff_python_ast::{Parameters, StmtFunctionDef};
 use ruff_source_file::SourceFile;
 use ruff_text_size::TextRange;
 
+/// Returns names Python requires and Karva can supply by keyword.
+pub fn required_keyword_parameter_names(parameters: &Parameters) -> Vec<String> {
+    parameters
+        .args
+        .iter()
+        .chain(&parameters.kwonlyargs)
+        .filter(|parameter| parameter.default().is_none())
+        .map(|parameter| parameter.name().to_string())
+        .collect()
+}
+
 /// Immutable source identity shared by fixtures and fixture diagnostics.
 #[derive(Debug)]
 pub struct FunctionDefinition {
@@ -130,11 +141,7 @@ impl TestDefinition {
     }
 
     pub(super) fn required_fixtures(&self) -> Vec<String> {
-        self.parameters().map_or_else(Vec::new, |parameters| {
-            parameters
-                .iter_non_variadic_params()
-                .map(|parameter| parameter.parameter.name.to_string())
-                .collect()
-        })
+        self.parameters()
+            .map_or_else(Vec::new, required_keyword_parameter_names)
     }
 }

--- a/crates/karva_test_semantic/src/discovery/models/module.rs
+++ b/crates/karva_test_semantic/src/discovery/models/module.rs
@@ -70,7 +70,7 @@ impl DiscoveredModule {
     pub(crate) fn rejected_fixture(&self, name: &str) -> Option<&RejectedFixture> {
         self.rejected_fixtures
             .iter()
-            .find(|fixture| fixture.name() == name)
+            .find(|fixture| fixture.exposure_name() == name)
     }
 
     /// Finds a rejected fixture by its defining Python symbol rather than its public name.

--- a/crates/karva_test_semantic/src/discovery/visitor.rs
+++ b/crates/karva_test_semantic/src/discovery/visitor.rs
@@ -122,8 +122,10 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
             Ok(fixture_def) => Some(fixture_def),
             Err(error) => {
                 let source_file = self.module.source_file();
+                let exposure_name =
+                    DiscoveredFixture::exposure_name_from_function(&stmt_function_def, py_module);
                 self.module.add_rejected_fixture(RejectedFixture::new(
-                    stmt_function_def.name.to_string(),
+                    exposure_name,
                     error.value(self.py).to_string(),
                     Rc::clone(&stmt_function_def),
                     source_file,
@@ -414,6 +416,7 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
         ) {
             Ok(fixture_def) => self.module.add_fixture(fixture_def),
             Err(error) => {
+                // Imported fixtures are exposed under their conftest binding.
                 self.module.add_rejected_fixture(RejectedFixture::new(
                     name.to_string(),
                     error.value(self.py).to_string(),

--- a/crates/karva_test_semantic/src/extensions/fixtures/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/mod.rs
@@ -18,7 +18,7 @@ mod utils;
 pub use finalizer::Finalizer;
 pub use normalized_fixture::{FixtureId, FixturePlan, NormalizedFixture};
 pub use scope::FixtureScope;
-pub use traits::{FixtureLookup, HasFixtures, RequiresFixtures};
+pub use traits::{FixtureLookup, HasFixtures};
 pub use utils::missing_arguments_from_error;
 
 use crate::discovery::DiscoveredPackage;
@@ -54,8 +54,8 @@ pub struct DiscoveredFixture {
 /// Fixture definition rejected during discovery.
 #[derive(Clone, Debug)]
 pub struct RejectedFixture {
-    /// Unqualified fixture name used for later lookup failures.
-    name: String,
+    /// Public fixture name used for lookup and diagnostics.
+    exposure_name: String,
 
     /// Discovery error retained for dependency diagnostics.
     reason: String,
@@ -66,7 +66,7 @@ pub struct RejectedFixture {
 
 impl RejectedFixture {
     pub(crate) fn new(
-        name: String,
+        exposure_name: String,
         reason: String,
         stmt_function_def: Rc<StmtFunctionDef>,
         source_file: SourceFile,
@@ -75,7 +75,7 @@ impl RejectedFixture {
         let qualified_name =
             QualifiedFunctionName::new(stmt_function_def.name.to_string(), module_path);
         Self {
-            name,
+            exposure_name,
             reason,
             definition: Rc::new(FunctionDefinition::new(
                 qualified_name,
@@ -85,8 +85,8 @@ impl RejectedFixture {
         }
     }
 
-    pub(crate) fn name(&self) -> &str {
-        &self.name
+    pub(crate) fn exposure_name(&self) -> &str {
+        &self.exposure_name
     }
 
     pub(crate) fn reason(&self) -> &str {
@@ -153,6 +153,31 @@ impl DiscoveredFixture {
         self.definition.statement_rc()
     }
 
+    /// Reads the fixture name exposed at runtime, falling back to its source symbol.
+    pub(crate) fn exposure_name_from_function(
+        stmt_function_def: &StmtFunctionDef,
+        py_module: &Bound<'_, PyModule>,
+    ) -> String {
+        let fallback = stmt_function_def.name.as_str();
+        let Ok(function) = py_module.getattr(fallback) else {
+            return fallback.to_string();
+        };
+
+        if let Ok(marker) = get_fixture_function_marker(&function)
+            && let Ok(name) = pytest_fixture_name(&marker, fallback)
+        {
+            return name;
+        }
+
+        if let Ok(function) = function.cast::<python::FixtureFunctionDefinition>()
+            && let Ok(function) = function.try_borrow()
+        {
+            return function.name.clone();
+        }
+
+        fallback.to_string()
+    }
+
     pub(crate) fn try_from_function(
         py: Python<'_>,
         stmt_function_def: Rc<StmtFunctionDef>,
@@ -196,19 +221,13 @@ impl DiscoveredFixture {
     ) -> PyResult<Self> {
         let fixture_function_marker = get_fixture_function_marker(function)?;
 
-        let found_name = fixture_function_marker.getattr("name")?;
-
         let scope = fixture_function_marker.getattr("scope")?;
 
         let auto_use = fixture_function_marker.getattr("autouse")?;
 
         let fixture_function = get_fixture_function(function)?;
 
-        let name = if found_name.is_none() {
-            stmt_function_def.name.to_string()
-        } else {
-            found_name.to_string()
-        };
+        let name = pytest_fixture_name(&fixture_function_marker, stmt_function_def.name.as_str())?;
 
         let fixture_scope =
             fixture_scope(py, &scope, &name).map_err(InvalidFixtureError::new_err)?;
@@ -254,6 +273,15 @@ impl DiscoveredFixture {
             py_function.into(),
             is_generator_function,
         ))
+    }
+}
+
+fn pytest_fixture_name(marker: &Bound<'_, PyAny>, fallback: &str) -> PyResult<String> {
+    let name = marker.getattr("name")?;
+    if name.is_none() {
+        Ok(fallback.to_string())
+    } else {
+        name.extract()
     }
 }
 

--- a/crates/karva_test_semantic/src/extensions/fixtures/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/mod.rs
@@ -53,11 +53,11 @@ impl FixtureIdentity {
         }
     }
 
-    pub(crate) fn definition(&self) -> &Rc<FunctionDefinition> {
+    fn definition(&self) -> &Rc<FunctionDefinition> {
         &self.definition
     }
 
-    pub(crate) fn name(&self) -> &QualifiedFunctionName {
+    fn name(&self) -> &QualifiedFunctionName {
         self.definition.name()
     }
 }

--- a/crates/karva_test_semantic/src/extensions/fixtures/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/mod.rs
@@ -1,5 +1,7 @@
 //! Fixture definitions, dependency resolution, caching, and teardown semantics.
 
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::rc::Rc;
 
 use karva_python_semantic::{ModulePath, QualifiedFunctionName};
@@ -26,6 +28,54 @@ use crate::discovery::models::definition::FunctionDefinition;
 use crate::extensions::fixtures::python::InvalidFixtureError;
 use crate::extensions::fixtures::scope::fixture_scope;
 
+/// Cheap run-local key for one qualified fixture definition.
+///
+/// The qualified name is hashed once during discovery. Equality still compares
+/// the full name, so independently discovered imports share scoped values and
+/// hash collisions cannot merge distinct fixtures.
+#[derive(Clone, Debug)]
+pub struct FixtureIdentity {
+    /// Source definition retained for diagnostics and execution.
+    definition: Rc<FunctionDefinition>,
+
+    /// Precomputed qualified-name hash used by fixture hot paths.
+    hash: u64,
+}
+
+impl FixtureIdentity {
+    fn new(definition: FunctionDefinition) -> Self {
+        let definition = Rc::new(definition);
+        let mut hasher = DefaultHasher::new();
+        definition.name().hash(&mut hasher);
+        Self {
+            definition,
+            hash: hasher.finish(),
+        }
+    }
+
+    pub(crate) fn definition(&self) -> &Rc<FunctionDefinition> {
+        &self.definition
+    }
+
+    pub(crate) fn name(&self) -> &QualifiedFunctionName {
+        self.definition.name()
+    }
+}
+
+impl PartialEq for FixtureIdentity {
+    fn eq(&self, other: &Self) -> bool {
+        self.name() == other.name()
+    }
+}
+
+impl Eq for FixtureIdentity {}
+
+impl Hash for FixtureIdentity {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_u64(self.hash);
+    }
+}
+
 /// Represents a pytest-style fixture discovered from Python source code.
 ///
 /// Fixtures provide reusable setup and teardown logic for tests. They can be
@@ -33,8 +83,8 @@ use crate::extensions::fixtures::scope::fixture_scope;
 /// be auto-used without explicit declaration.
 #[derive(Clone, Debug)]
 pub struct DiscoveredFixture {
-    /// Immutable source identity and syntax.
-    definition: Rc<FunctionDefinition>,
+    /// Qualified identity and immutable source definition.
+    identity: FixtureIdentity,
 
     /// The scope at which this fixture's value is cached.
     scope: FixtureScope,
@@ -113,7 +163,7 @@ impl DiscoveredFixture {
         is_generator: bool,
     ) -> Self {
         Self {
-            definition: Rc::new(FunctionDefinition::new(
+            identity: FixtureIdentity::new(FunctionDefinition::new(
                 name,
                 stmt_function_def,
                 source_file,
@@ -126,11 +176,15 @@ impl DiscoveredFixture {
     }
 
     pub(crate) fn name(&self) -> &QualifiedFunctionName {
-        self.definition.name()
+        self.identity.name()
+    }
+
+    pub(crate) fn identity(&self) -> &FixtureIdentity {
+        &self.identity
     }
 
     pub(crate) fn definition(&self) -> &Rc<FunctionDefinition> {
-        &self.definition
+        self.identity.definition()
     }
 
     pub(crate) fn scope(&self) -> FixtureScope {
@@ -150,7 +204,7 @@ impl DiscoveredFixture {
     }
 
     pub(crate) fn stmt_function_def(&self) -> &Rc<StmtFunctionDef> {
-        self.definition.statement_rc()
+        self.identity.definition().statement_rc()
     }
 
     /// Reads the fixture name exposed at runtime, falling back to its source symbol.

--- a/crates/karva_test_semantic/src/extensions/fixtures/mod.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/mod.rs
@@ -18,7 +18,7 @@ mod utils;
 pub use finalizer::Finalizer;
 pub use normalized_fixture::{FixtureId, FixturePlan, NormalizedFixture};
 pub use scope::FixtureScope;
-pub use traits::{HasFixtures, RequiresFixtures};
+pub use traits::{FixtureLookup, HasFixtures, RequiresFixtures};
 pub use utils::missing_arguments_from_error;
 
 use crate::discovery::DiscoveredPackage;

--- a/crates/karva_test_semantic/src/extensions/fixtures/normalized_fixture.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/normalized_fixture.rs
@@ -6,7 +6,7 @@ use pyo3::prelude::*;
 use ruff_python_ast::StmtFunctionDef;
 
 use crate::discovery::models::definition::FunctionDefinition;
-use crate::extensions::fixtures::FixtureScope;
+use crate::extensions::fixtures::{FixtureIdentity, FixtureScope};
 use crate::runner::FixtureArguments;
 use crate::utils::run_coroutine;
 
@@ -43,8 +43,8 @@ impl FixturePlan {
 /// and normalized the same way as user-defined ones.
 #[derive(Debug)]
 pub struct NormalizedFixture {
-    /// Immutable fixture identity, syntax, and source.
-    pub(crate) definition: Rc<FunctionDefinition>,
+    /// Qualified identity and immutable source definition.
+    pub(crate) identity: FixtureIdentity,
 
     /// Resolved fixture dependencies this fixture requires.
     pub(crate) dependencies: Vec<FixtureId>,
@@ -65,16 +65,24 @@ pub struct NormalizedFixture {
 impl NormalizedFixture {
     /// Returns the fixture's unqualified function name.
     pub(crate) fn function_name(&self) -> &str {
-        self.definition.name().function_name()
+        self.identity.name().function_name()
     }
 
     /// Returns the stable qualified fixture identity.
     pub(crate) fn name(&self) -> &QualifiedFunctionName {
-        self.definition.name()
+        self.identity.name()
+    }
+
+    pub(crate) fn identity(&self) -> &FixtureIdentity {
+        &self.identity
+    }
+
+    pub(crate) fn definition(&self) -> &Rc<FunctionDefinition> {
+        self.identity.definition()
     }
 
     pub(crate) fn statement(&self) -> &StmtFunctionDef {
-        self.definition.statement()
+        self.identity.definition().statement()
     }
 
     /// Returns the fixture dependencies.

--- a/crates/karva_test_semantic/src/extensions/fixtures/normalized_fixture.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/normalized_fixture.rs
@@ -68,6 +68,7 @@ impl NormalizedFixture {
         self.definition.name().function_name()
     }
 
+    /// Returns the stable qualified fixture identity.
     pub(crate) fn name(&self) -> &QualifiedFunctionName {
         self.definition.name()
     }

--- a/crates/karva_test_semantic/src/extensions/fixtures/traits.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/traits.rs
@@ -1,8 +1,5 @@
 use std::fmt::Debug;
 
-use pyo3::Python;
-use ruff_python_ast::StmtFunctionDef;
-
 use crate::discovery::{DiscoveredModule, DiscoveredPackage};
 use crate::extensions::fixtures::{DiscoveredFixture, FixtureScope, RejectedFixture};
 
@@ -18,6 +15,13 @@ pub enum FixtureLookup<'a> {
 
     /// The provider does not define the name.
     Missing,
+}
+
+impl FixtureLookup<'_> {
+    /// Returns whether lookup found an accepted fixture.
+    pub(crate) const fn is_found(self) -> bool {
+        matches!(self, Self::Found(_))
+    }
 }
 
 /// Supplies fixtures from one position in the runtime provider chain.
@@ -102,28 +106,5 @@ impl<'a> HasFixtures<'a> for &'a DiscoveredPackage {
 
     fn auto_use_fixtures(&'a self, scopes: &[FixtureScope]) -> Vec<&'a DiscoveredFixture> {
         (*self).auto_use_fixtures(scopes)
-    }
-}
-
-/// This trait is used to represent an object that may require fixtures to be called before it is run.
-pub trait RequiresFixtures {
-    fn required_fixtures(&self, py: Python<'_>) -> Vec<String>;
-}
-
-impl RequiresFixtures for StmtFunctionDef {
-    fn required_fixtures(&self, _py: Python<'_>) -> Vec<String> {
-        let mut required_fixtures = Vec::new();
-
-        for parameter in self.parameters.iter_non_variadic_params() {
-            required_fixtures.push(parameter.parameter.name.as_str().to_string());
-        }
-
-        required_fixtures
-    }
-}
-
-impl RequiresFixtures for DiscoveredFixture {
-    fn required_fixtures(&self, py: Python<'_>) -> Vec<String> {
-        self.stmt_function_def().required_fixtures(py)
     }
 }

--- a/crates/karva_test_semantic/src/extensions/fixtures/traits.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/traits.rs
@@ -6,16 +6,24 @@ use ruff_python_ast::StmtFunctionDef;
 use crate::discovery::{DiscoveredModule, DiscoveredPackage};
 use crate::extensions::fixtures::{DiscoveredFixture, FixtureScope, RejectedFixture};
 
-/// This trait is used to get all fixtures (from a module or package) that have a given scope.
-///
-/// For example, if we are in a test module, we want to get all fixtures used in the test module.
-/// If we are in a package, we want to get all fixtures used in the package from the configuration module.
-pub trait HasFixtures<'a>: Debug {
-    /// Get a fixture with the given name
-    fn get_fixture(&'a self, fixture_name: &str) -> Option<&'a DiscoveredFixture>;
+/// Result of looking up one public fixture name in a provider.
+#[must_use]
+#[derive(Clone, Copy, Debug)]
+pub enum FixtureLookup<'a> {
+    /// The provider exposes an accepted fixture.
+    Found(&'a DiscoveredFixture),
 
-    /// Get a fixture definition rejected during discovery.
-    fn get_rejected_fixture(&'a self, fixture_name: &str) -> Option<&'a RejectedFixture>;
+    /// The provider defines the name, but discovery rejected the fixture.
+    Rejected(&'a RejectedFixture),
+
+    /// The provider does not define the name.
+    Missing,
+}
+
+/// Supplies fixtures from one position in the runtime provider chain.
+pub trait HasFixtures<'a>: Debug {
+    /// Resolves one public name while preserving rejected definitions as shadowing results.
+    fn lookup_fixture(&'a self, fixture_name: &str) -> FixtureLookup<'a>;
 
     /// Get all autouse fixtures
     ///
@@ -24,14 +32,17 @@ pub trait HasFixtures<'a>: Debug {
 }
 
 impl<'a> HasFixtures<'a> for DiscoveredModule {
-    fn get_fixture(&'a self, fixture_name: &str) -> Option<&'a DiscoveredFixture> {
-        self.fixtures()
+    fn lookup_fixture(&'a self, fixture_name: &str) -> FixtureLookup<'a> {
+        if let Some(fixture) = self
+            .fixtures()
             .iter()
             .find(|f| f.name().function_name() == fixture_name)
-    }
+        {
+            return FixtureLookup::Found(fixture);
+        }
 
-    fn get_rejected_fixture(&'a self, fixture_name: &str) -> Option<&'a RejectedFixture> {
         self.rejected_fixture(fixture_name)
+            .map_or(FixtureLookup::Missing, FixtureLookup::Rejected)
     }
 
     fn auto_use_fixtures(&'a self, scopes: &[FixtureScope]) -> Vec<&'a DiscoveredFixture> {
@@ -43,21 +54,17 @@ impl<'a> HasFixtures<'a> for DiscoveredModule {
 }
 
 impl<'a> HasFixtures<'a> for DiscoveredPackage {
-    fn get_fixture(&'a self, fixture_name: &str) -> Option<&'a DiscoveredFixture> {
-        self.configuration_module_impl()
-            .and_then(|module| module.get_fixture(fixture_name))
-            .or_else(|| {
-                self.framework_module_impl()
-                    .and_then(|module| module.get_fixture(fixture_name))
-            })
-    }
+    fn lookup_fixture(&'a self, fixture_name: &str) -> FixtureLookup<'a> {
+        if let Some(module) = self.configuration_module_impl() {
+            match module.lookup_fixture(fixture_name) {
+                FixtureLookup::Missing => {}
+                lookup => return lookup,
+            }
+        }
 
-    fn get_rejected_fixture(&'a self, fixture_name: &str) -> Option<&'a RejectedFixture> {
-        self.configuration_module_impl()
-            .and_then(|module| module.get_rejected_fixture(fixture_name))
-            .or_else(|| {
-                self.framework_module_impl()
-                    .and_then(|module| module.get_rejected_fixture(fixture_name))
+        self.framework_module_impl()
+            .map_or(FixtureLookup::Missing, |module| {
+                module.lookup_fixture(fixture_name)
             })
     }
 
@@ -89,12 +96,8 @@ impl<'a> HasFixtures<'a> for DiscoveredPackage {
 }
 
 impl<'a> HasFixtures<'a> for &'a DiscoveredPackage {
-    fn get_fixture(&'a self, fixture_name: &str) -> Option<&'a DiscoveredFixture> {
-        (*self).get_fixture(fixture_name)
-    }
-
-    fn get_rejected_fixture(&'a self, fixture_name: &str) -> Option<&'a RejectedFixture> {
-        (*self).get_rejected_fixture(fixture_name)
+    fn lookup_fixture(&'a self, fixture_name: &str) -> FixtureLookup<'a> {
+        (*self).lookup_fixture(fixture_name)
     }
 
     fn auto_use_fixtures(&'a self, scopes: &[FixtureScope]) -> Vec<&'a DiscoveredFixture> {

--- a/crates/karva_test_semantic/src/runner/fixture_cache.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_cache.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 
+use karva_python_semantic::QualifiedFunctionName;
 use pyo3::prelude::*;
 
 use crate::runner::scoped_storage::{ScopeKey, ScopedStorage};
@@ -13,23 +14,33 @@ use crate::runner::scoped_storage::{ScopeKey, ScopedStorage};
 #[derive(Debug, Default)]
 pub(super) struct FixtureCache {
     /// Fixture values isolated by their declared lifetime scope.
-    storage: ScopedStorage<HashMap<String, Py<PyAny>>>,
+    storage: ScopedStorage<HashMap<QualifiedFunctionName, Py<PyAny>>>,
 }
 
 impl FixtureCache {
     /// Returns a new Python reference to a cached fixture value.
-    pub(super) fn get(&self, py: Python<'_>, name: &str, scope: ScopeKey<'_>) -> Option<Py<PyAny>> {
+    pub(super) fn get(
+        &self,
+        py: Python<'_>,
+        identity: &QualifiedFunctionName,
+        scope: ScopeKey<'_>,
+    ) -> Option<Py<PyAny>> {
         self.storage
             .with(scope, |values| {
-                values.get(name).map(|value| value.clone_ref(py))
+                values.get(identity).map(|value| value.clone_ref(py))
             })
             .flatten()
     }
 
     /// Caches a fixture value until its declared scope completes.
-    pub(super) fn insert(&mut self, name: String, value: Py<PyAny>, scope: ScopeKey<'_>) {
+    pub(super) fn insert(
+        &mut self,
+        identity: QualifiedFunctionName,
+        value: Py<PyAny>,
+        scope: ScopeKey<'_>,
+    ) {
         self.storage.with_mut(scope, |values| {
-            values.insert(name, value);
+            values.insert(identity, value);
         });
     }
 

--- a/crates/karva_test_semantic/src/runner/fixture_cache.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_cache.rs
@@ -2,9 +2,9 @@
 
 use std::collections::HashMap;
 
-use karva_python_semantic::QualifiedFunctionName;
 use pyo3::prelude::*;
 
+use crate::extensions::fixtures::FixtureIdentity;
 use crate::runner::scoped_storage::{ScopeKey, ScopedStorage};
 
 /// Caches fixture values at different scope levels.
@@ -14,7 +14,7 @@ use crate::runner::scoped_storage::{ScopeKey, ScopedStorage};
 #[derive(Debug, Default)]
 pub(super) struct FixtureCache {
     /// Fixture values isolated by their declared lifetime scope.
-    storage: ScopedStorage<HashMap<QualifiedFunctionName, Py<PyAny>>>,
+    storage: ScopedStorage<HashMap<FixtureIdentity, Py<PyAny>>>,
 }
 
 impl FixtureCache {
@@ -22,7 +22,7 @@ impl FixtureCache {
     pub(super) fn get(
         &self,
         py: Python<'_>,
-        identity: &QualifiedFunctionName,
+        identity: &FixtureIdentity,
         scope: ScopeKey<'_>,
     ) -> Option<Py<PyAny>> {
         self.storage
@@ -35,7 +35,7 @@ impl FixtureCache {
     /// Caches a fixture value until its declared scope completes.
     pub(super) fn insert(
         &mut self,
-        identity: QualifiedFunctionName,
+        identity: FixtureIdentity,
         value: Py<PyAny>,
         scope: ScopeKey<'_>,
     ) {

--- a/crates/karva_test_semantic/src/runner/fixture_resolver.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_resolver.rs
@@ -9,8 +9,8 @@ use pyo3::prelude::*;
 use crate::discovery::models::definition::{FunctionDefinition, TestDefinition};
 use crate::discovery::{DiscoveredPackage, DiscoveredTestFunction};
 use crate::extensions::fixtures::{
-    DiscoveredFixture, FixtureId, FixturePlan, FixtureScope, HasFixtures, NormalizedFixture,
-    RejectedFixture, RequiresFixtures, get_auto_use_fixtures,
+    DiscoveredFixture, FixtureId, FixtureLookup, FixturePlan, FixtureScope, HasFixtures,
+    NormalizedFixture, RejectedFixture, RequiresFixtures, get_auto_use_fixtures,
 };
 
 /// Compiles fixture lookup results into an arena for one request context.
@@ -173,11 +173,10 @@ impl<'a> FixturePlanCompiler<'a> {
     /// Finds the package whose provider contributed `fixture`.
     fn package_owner(&self, fixture: &DiscoveredFixture) -> &Utf8Path {
         let name = fixture.name().function_name();
-        if self
-            .current
-            .get_fixture(name)
-            .is_some_and(|candidate| std::ptr::eq(candidate, fixture))
-        {
+        if matches!(
+            self.current.lookup_fixture(name),
+            FixtureLookup::Found(candidate) if std::ptr::eq(candidate, fixture)
+        ) {
             return self.current_package;
         }
 
@@ -185,9 +184,10 @@ impl<'a> FixturePlanCompiler<'a> {
             .iter()
             .rev()
             .find(|package| {
-                package
-                    .get_fixture(name)
-                    .is_some_and(|candidate| std::ptr::eq(candidate, fixture))
+                matches!(
+                    package.lookup_fixture(name),
+                    FixtureLookup::Found(candidate) if std::ptr::eq(candidate, fixture)
+                )
             })
             .map_or(self.current_package, |package| package.path())
     }
@@ -271,7 +271,12 @@ impl<'a> FixturePlanCompiler<'a> {
         } else {
             regular_fixture_names
                 .iter()
-                .filter(|name| find_fixture(None, name, self.parents, self.current).is_none())
+                .filter(|name| {
+                    !matches!(
+                        lookup_fixture(None, name, self.parents, self.current),
+                        FixtureLookup::Found(_)
+                    )
+                })
                 .cloned()
                 .collect::<Vec<_>>()
         };
@@ -310,35 +315,44 @@ impl<'a> FixturePlanCompiler<'a> {
         let mut rejected_fixtures = Vec::new();
 
         for dep_name in fixture_names {
-            if let Some(fixture) =
-                find_fixture(current_fixture, dep_name, self.parents, self.current)
+            let lookup = lookup_fixture(current_fixture, dep_name, self.parents, self.current);
+            if let Some(fixture) = current_fixture
+                && fixture.name().function_name() == dep_name
+                && !matches!(lookup, FixtureLookup::Found(_))
             {
-                if let Some(current_fixture) = current_fixture
-                    && !current_fixture.scope().can_use(fixture.scope())
-                {
-                    let dependency_path = path
-                        .fixtures
-                        .split_last()
-                        .map_or(&[][..], |(_, dependency_path)| dependency_path);
-                    return Err(FixtureResolutionError::scope_mismatch(
-                        dependency_path,
-                        current_fixture,
-                        fixture,
-                    ));
-                }
                 let normalized = self.normalize_fixture(py, fixture, path)?;
                 normalized_fixtures.push(normalized);
-            } else if let Some(fixture) = current_fixture {
-                if fixture.name().function_name() == dep_name {
+                continue;
+            }
+
+            match lookup {
+                FixtureLookup::Found(fixture) => {
+                    if let Some(current_fixture) = current_fixture
+                        && !current_fixture.scope().can_use(fixture.scope())
+                    {
+                        let dependency_path = path
+                            .fixtures
+                            .split_last()
+                            .map_or(&[][..], |(_, dependency_path)| dependency_path);
+                        return Err(FixtureResolutionError::scope_mismatch(
+                            dependency_path,
+                            current_fixture,
+                            fixture,
+                        ));
+                    }
                     let normalized = self.normalize_fixture(py, fixture, path)?;
                     normalized_fixtures.push(normalized);
-                } else {
-                    if let Some(rejected_fixture) =
-                        find_rejected_fixture(dep_name, self.parents, self.current)
-                    {
+                }
+                FixtureLookup::Rejected(rejected_fixture) => {
+                    if current_fixture.is_some() {
                         rejected_fixtures.push(rejected_fixture.clone());
+                        missing_fixtures.push(dep_name.clone());
                     }
-                    missing_fixtures.push(dep_name.clone());
+                }
+                FixtureLookup::Missing => {
+                    if current_fixture.is_some() {
+                        missing_fixtures.push(dep_name.clone());
+                    }
                 }
             }
         }
@@ -357,52 +371,31 @@ impl<'a> FixturePlanCompiler<'a> {
     }
 }
 
-/// Finds a fixture by name, searching in the current node and parent packages.
+/// Looks up a fixture by name in the current node and parent packages.
 /// The current definition is skipped so a fixture can override and depend on a
 /// same-name fixture from a parent scope. If no override exists, the resolver
 /// handles the dependency as a direct cycle.
-fn find_fixture<'a>(
+fn lookup_fixture<'a>(
     current_fixture: Option<&DiscoveredFixture>,
     name: &str,
     parents: &'a [&'a DiscoveredPackage],
     current: &'a (dyn HasFixtures<'a> + 'a),
-) -> Option<&'a DiscoveredFixture> {
-    if let Some(fixture) = current.get_fixture(name)
-        && current_fixture.is_none_or(|current_fixture| current_fixture.name() != fixture.name())
-    {
-        return Some(fixture);
-    }
-    if current.get_rejected_fixture(name).is_some() {
-        return None;
+) -> FixtureLookup<'a> {
+    match current.lookup_fixture(name) {
+        FixtureLookup::Found(fixture)
+            if current_fixture.is_some_and(|current| std::ptr::eq(current, fixture)) => {}
+        FixtureLookup::Missing => {}
+        lookup => return lookup,
     }
 
     for parent in parents.iter().rev() {
-        if let Some(fixture) = parent.get_fixture(name)
-            && current_fixture
-                .is_none_or(|current_fixture| current_fixture.name() != fixture.name())
-        {
-            return Some(fixture);
-        }
-        if parent.get_rejected_fixture(name).is_some() {
-            return None;
+        match parent.lookup_fixture(name) {
+            FixtureLookup::Found(fixture)
+                if current_fixture.is_some_and(|current| std::ptr::eq(current, fixture)) => {}
+            FixtureLookup::Missing => {}
+            lookup => return lookup,
         }
     }
 
-    None
-}
-
-/// Finds rejected fixture metadata using the same provider precedence as fixture lookup.
-fn find_rejected_fixture<'a>(
-    name: &str,
-    parents: &'a [&'a DiscoveredPackage],
-    current: &'a (dyn HasFixtures<'a> + 'a),
-) -> Option<&'a RejectedFixture> {
-    if let Some(fixture) = current.get_rejected_fixture(name) {
-        return Some(fixture);
-    }
-
-    parents
-        .iter()
-        .rev()
-        .find_map(|parent| parent.get_rejected_fixture(name))
+    FixtureLookup::Missing
 }

--- a/crates/karva_test_semantic/src/runner/fixture_resolver.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_resolver.rs
@@ -4,6 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use camino::Utf8Path;
+use karva_python_semantic::QualifiedFunctionName;
 use pyo3::prelude::*;
 
 use crate::discovery::models::definition::{FunctionDefinition, TestDefinition};
@@ -29,7 +30,7 @@ pub(super) struct FixturePlanCompiler<'a> {
     /// Package owning fixtures provided by `current`.
     current_package: &'a Utf8Path,
     /// Definition IDs reused within this compilation pass.
-    fixture_ids: HashMap<String, FixtureId>,
+    fixture_ids: HashMap<QualifiedFunctionName, FixtureId>,
 
     /// Arena under construction.
     fixtures: Vec<NormalizedFixture>,
@@ -207,9 +208,7 @@ impl<'a> FixturePlanCompiler<'a> {
         fixture: &'a DiscoveredFixture,
         path: &mut FixturePath<'a>,
     ) -> FixtureResolutionResult<FixtureId> {
-        let cache_key = fixture.name().to_string();
-
-        if let Some(cached) = self.fixture_ids.get(&cache_key) {
+        if let Some(cached) = self.fixture_ids.get(fixture.name()) {
             return Ok(*cached);
         }
 
@@ -229,7 +228,7 @@ impl<'a> FixturePlanCompiler<'a> {
 
         let fixture_id = FixtureId::new(self.fixtures.len());
         self.fixtures.push(result);
-        self.fixture_ids.insert(cache_key, fixture_id);
+        self.fixture_ids.insert(fixture.name().clone(), fixture_id);
 
         Ok(fixture_id)
     }
@@ -383,7 +382,7 @@ fn lookup_fixture<'a>(
 ) -> FixtureLookup<'a> {
     match current.lookup_fixture(name) {
         FixtureLookup::Found(fixture)
-            if current_fixture.is_some_and(|current| std::ptr::eq(current, fixture)) => {}
+            if current_fixture.is_some_and(|current| current.name() == fixture.name()) => {}
         FixtureLookup::Missing => {}
         lookup => return lookup,
     }
@@ -391,7 +390,7 @@ fn lookup_fixture<'a>(
     for parent in parents.iter().rev() {
         match parent.lookup_fixture(name) {
             FixtureLookup::Found(fixture)
-                if current_fixture.is_some_and(|current| std::ptr::eq(current, fixture)) => {}
+                if current_fixture.is_some_and(|current| current.name() == fixture.name()) => {}
             FixtureLookup::Missing => {}
             lookup => return lookup,
         }

--- a/crates/karva_test_semantic/src/runner/fixture_resolver.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_resolver.rs
@@ -4,7 +4,6 @@ use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use camino::Utf8Path;
-use karva_python_semantic::QualifiedFunctionName;
 use pyo3::prelude::*;
 
 use crate::discovery::models::definition::{
@@ -12,8 +11,8 @@ use crate::discovery::models::definition::{
 };
 use crate::discovery::{DiscoveredPackage, DiscoveredTestFunction};
 use crate::extensions::fixtures::{
-    DiscoveredFixture, FixtureId, FixtureLookup, FixturePlan, FixtureScope, HasFixtures,
-    NormalizedFixture, RejectedFixture, get_auto_use_fixtures,
+    DiscoveredFixture, FixtureId, FixtureIdentity, FixtureLookup, FixturePlan, FixtureScope,
+    HasFixtures, NormalizedFixture, RejectedFixture, get_auto_use_fixtures,
 };
 
 /// Compiles fixture lookup results into an arena for one request context.
@@ -32,7 +31,7 @@ pub(super) struct FixturePlanCompiler<'a> {
     /// Package owning fixtures provided by `current`.
     current_package: &'a Utf8Path,
     /// Definition IDs reused within this compilation pass.
-    fixture_ids: HashMap<QualifiedFunctionName, FixtureId>,
+    fixture_ids: HashMap<FixtureIdentity, FixtureId>,
 
     /// Arena under construction.
     fixtures: Vec<NormalizedFixture>,
@@ -210,7 +209,7 @@ impl<'a> FixturePlanCompiler<'a> {
         fixture: &'a DiscoveredFixture,
         path: &mut FixturePath<'a>,
     ) -> FixtureResolutionResult<FixtureId> {
-        if let Some(cached) = self.fixture_ids.get(fixture.name()) {
+        if let Some(cached) = self.fixture_ids.get(fixture.identity()) {
             return Ok(*cached);
         }
 
@@ -221,7 +220,7 @@ impl<'a> FixturePlanCompiler<'a> {
         })?;
 
         let result = NormalizedFixture {
-            definition: Rc::clone(fixture.definition()),
+            identity: fixture.identity().clone(),
             dependencies: dependent_fixtures,
             scope: fixture.scope(),
             package_owner: self.package_owner(fixture).to_path_buf(),
@@ -231,7 +230,8 @@ impl<'a> FixturePlanCompiler<'a> {
 
         let fixture_id = FixtureId::new(self.fixtures.len());
         self.fixtures.push(result);
-        self.fixture_ids.insert(fixture.name().clone(), fixture_id);
+        self.fixture_ids
+            .insert(fixture.identity().clone(), fixture_id);
 
         Ok(fixture_id)
     }

--- a/crates/karva_test_semantic/src/runner/fixture_resolver.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_resolver.rs
@@ -7,11 +7,13 @@ use camino::Utf8Path;
 use karva_python_semantic::QualifiedFunctionName;
 use pyo3::prelude::*;
 
-use crate::discovery::models::definition::{FunctionDefinition, TestDefinition};
+use crate::discovery::models::definition::{
+    FunctionDefinition, TestDefinition, required_keyword_parameter_names,
+};
 use crate::discovery::{DiscoveredPackage, DiscoveredTestFunction};
 use crate::extensions::fixtures::{
     DiscoveredFixture, FixtureId, FixtureLookup, FixturePlan, FixtureScope, HasFixtures,
-    NormalizedFixture, RejectedFixture, RequiresFixtures, get_auto_use_fixtures,
+    NormalizedFixture, RejectedFixture, get_auto_use_fixtures,
 };
 
 /// Compiles fixture lookup results into an arena for one request context.
@@ -213,7 +215,8 @@ impl<'a> FixturePlanCompiler<'a> {
         }
 
         let dependent_fixtures = path.enter(fixture, |path| {
-            let required_fixtures: Vec<String> = fixture.required_fixtures(py);
+            let required_fixtures =
+                required_keyword_parameter_names(fixture.stmt_function_def().parameters.as_ref());
             self.get_dependent_fixtures(py, Some(fixture), &required_fixtures, path)
         })?;
 
@@ -270,12 +273,7 @@ impl<'a> FixturePlanCompiler<'a> {
         } else {
             regular_fixture_names
                 .iter()
-                .filter(|name| {
-                    !matches!(
-                        lookup_fixture(None, name, self.parents, self.current),
-                        FixtureLookup::Found(_)
-                    )
-                })
+                .filter(|name| !lookup_fixture(None, name, self.parents, self.current).is_found())
                 .cloned()
                 .collect::<Vec<_>>()
         };
@@ -317,7 +315,7 @@ impl<'a> FixturePlanCompiler<'a> {
             let lookup = lookup_fixture(current_fixture, dep_name, self.parents, self.current);
             if let Some(fixture) = current_fixture
                 && fixture.name().function_name() == dep_name
-                && !matches!(lookup, FixtureLookup::Found(_))
+                && !lookup.is_found()
             {
                 let normalized = self.normalize_fixture(py, fixture, path)?;
                 normalized_fixtures.push(normalized);

--- a/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
@@ -159,7 +159,7 @@ impl PackageRunner<'_, '_> {
     ) -> Result<(Py<PyAny>, Option<Finalizer>), FixtureCallError> {
         let fixture = fixture_plan.fixture(fixture_id);
         let scope = scope_key(fixture.scope(), fixture.package_owner());
-        if let Some(cached) = self.fixture_cache.get(py, fixture.function_name(), scope) {
+        if let Some(cached) = self.fixture_cache.get(py, fixture.name(), scope) {
             return Ok((cached, None));
         }
 
@@ -188,11 +188,8 @@ impl PackageRunner<'_, '_> {
         let (value, finalizer) = get_value_and_finalizer(py, fixture, fixture_call_result)
             .map_err(|error| FixtureCallError::new(fixture, error, function_arguments))?;
 
-        self.fixture_cache.insert(
-            fixture.function_name().to_string(),
-            value.clone_ref(py),
-            scope,
-        );
+        self.fixture_cache
+            .insert(fixture.name().clone(), value.clone_ref(py), scope);
 
         let function_finalizer = finalizer.and_then(|finalizer| {
             if finalizer.scope == FixtureScope::Function {

--- a/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
@@ -159,7 +159,7 @@ impl PackageRunner<'_, '_> {
     ) -> Result<(Py<PyAny>, Option<Finalizer>), FixtureCallError> {
         let fixture = fixture_plan.fixture(fixture_id);
         let scope = scope_key(fixture.scope(), fixture.package_owner());
-        if let Some(cached) = self.fixture_cache.get(py, fixture.name(), scope) {
+        if let Some(cached) = self.fixture_cache.get(py, fixture.identity(), scope) {
             return Ok((cached, None));
         }
 
@@ -189,7 +189,7 @@ impl PackageRunner<'_, '_> {
             .map_err(|error| FixtureCallError::new(fixture, error, function_arguments))?;
 
         self.fixture_cache
-            .insert(fixture.name().clone(), value.clone_ref(py), scope);
+            .insert(fixture.identity().clone(), value.clone_ref(py), scope);
 
         let function_finalizer = finalizer.and_then(|finalizer| {
             if finalizer.scope == FixtureScope::Function {
@@ -360,7 +360,7 @@ impl FixtureCallError {
         Self {
             fixture_name: fixture.function_name().to_string(),
             error,
-            definition: Rc::clone(&fixture.definition),
+            definition: Rc::clone(fixture.definition()),
             arguments,
             dependency_chain: Vec::new(),
         }
@@ -370,7 +370,7 @@ impl FixtureCallError {
     fn with_dependent(mut self, fixture: &NormalizedFixture) -> Self {
         self.dependency_chain.push(FixtureChainEntry {
             name: fixture.function_name().to_string(),
-            definition: Rc::clone(&fixture.definition),
+            definition: Rc::clone(fixture.definition()),
         });
         self
     }
@@ -392,7 +392,7 @@ fn get_value_and_finalizer(
             is_async: true,
             scope: fixture.scope(),
             package_owner: fixture.package_owner().to_path_buf(),
-            definition: Rc::clone(&fixture.definition),
+            definition: Rc::clone(fixture.definition()),
         };
 
         Ok((value, Some(finalizer)))
@@ -413,7 +413,7 @@ fn get_value_and_finalizer(
                     is_async: false,
                     scope: fixture.scope(),
                     package_owner: fixture.package_owner().to_path_buf(),
-                    definition: Rc::clone(&fixture.definition),
+                    definition: Rc::clone(fixture.definition()),
                 };
 
                 Ok((value.unbind(), Some(finalizer)))


### PR DESCRIPTION
## Summary

Model runtime fixture lookup as explicit accepted, rejected, or missing outcomes and carry qualified identities through plan and runtime caches. Prehash qualified fixture identities once so cache correctness does not add repeated path hashing or key allocations. Preserve rejected fixture exposure names, keep provider precedence intact, and classify only required keyword-bindable parameters as fixture requests.

## Test Plan

Focused fixture lookup, alias, request, and session-cache regressions; karva_test_semantic tests; Clippy; hooks; optimized main/head fixture benchmarks.