### PR TITLE
Reduce controller collection memory

### DIFF
--- a/crates/karva_collector/src/lib.rs
+++ b/crates/karva_collector/src/lib.rs
@@ -78,6 +78,81 @@ pub fn collect_file(
     ))
 }
 
+/// Collects only metadata needed by controller-side test scheduling.
+///
+/// Source text and the complete syntax tree are discarded before returning.
+/// Test function definitions are moved from the syntax tree instead of cloned.
+pub fn collect_file_for_scheduling(
+    path: &Utf8PathBuf,
+    cwd: &Utf8Path,
+    settings: &CollectionSettings,
+    function_names: &[String],
+) -> Result<Option<CollectedModule>, CollectionError> {
+    if ModulePath::new(path, cwd).is_none() {
+        return Ok(None);
+    }
+
+    let source_text = fs::read_to_string(path).map_err(|source| CollectionError::ReadSource {
+        path: path.clone(),
+        source,
+    })?;
+
+    Ok(collect_source_for_scheduling(
+        path,
+        cwd,
+        &source_text,
+        settings,
+        function_names,
+    ))
+}
+
+fn collect_source_for_scheduling(
+    path: &Utf8PathBuf,
+    cwd: &Utf8Path,
+    source_text: &str,
+    settings: &CollectionSettings,
+    function_names: &[String],
+) -> Option<CollectedModule> {
+    let module_path = ModulePath::new(path, cwd)?;
+    let module_type: ModuleType = path.into();
+    let parse_options =
+        ParseOptions::from(Mode::Module).with_target_version(settings.python_version);
+    let parsed = parse_unchecked(source_text, parse_options).try_into_module()?;
+    let module_body = parsed.into_suite();
+    let doctests = if settings.collect_doctests && module_type == ModuleType::Test {
+        collect_doctests(&module_body, source_text)
+    } else {
+        Vec::new()
+    };
+    let mut collected_module =
+        CollectedModule::new(module_path, module_type, Box::default(), String::new());
+
+    for doctest in doctests {
+        if function_names.is_empty() || function_names.iter().any(|name| name == &doctest.name) {
+            collected_module.add_doctest(doctest);
+        }
+    }
+
+    for statement in module_body {
+        let Stmt::FunctionDef(function_def) = statement else {
+            continue;
+        };
+        if settings.collect_fixtures && is_fixture_function(&function_def) {
+            collected_module.add_fixture_function_def(function_def);
+            continue;
+        }
+        if is_test_function_to_collect(
+            &function_def.name,
+            function_names,
+            settings.test_function_prefix,
+        ) {
+            collected_module.add_test_function_def(function_def);
+        }
+    }
+
+    Some(collected_module)
+}
+
 /// Collects tests and fixtures from supplied Python source.
 ///
 /// This is the source-first collection boundary used for unsaved editor buffers.

--- a/crates/karva_runner/src/collection.rs
+++ b/crates/karva_runner/src/collection.rs
@@ -1,5 +1,5 @@
 use karva_collector::{
-    CollectedModule, CollectedPackage, CollectionSettings, ModuleType, collect_file,
+    CollectedModule, CollectedPackage, CollectionSettings, ModuleType, collect_file_for_scheduling,
 };
 
 use std::thread;
@@ -98,7 +98,7 @@ impl<'a> ParallelCollector<'a> {
                     return WalkState::Continue;
                 };
 
-                match collect_file(&file_path, self.cwd, &self.settings, &[]) {
+                match collect_file_for_scheduling(&file_path, self.cwd, &self.settings, &[]) {
                     Ok(Some(module)) => {
                         if let Err(err) = tx.send(CollectionMessage::Module(module)) {
                             tracing::warn!(
@@ -147,14 +147,19 @@ impl<'a> ParallelCollector<'a> {
                     function_name,
                     parametrize_index: _,
                 }) => {
-                    if let Some(module) =
-                        collect_file(&file_path, self.cwd, &self.settings, &[function_name])?
-                    {
+                    if let Some(module) = collect_file_for_scheduling(
+                        &file_path,
+                        self.cwd,
+                        &self.settings,
+                        &[function_name],
+                    )? {
                         session_package.add_module(module);
                     }
                 }
                 TestPath::File(file_path) => {
-                    if let Some(module) = collect_file(&file_path, self.cwd, &self.settings, &[])? {
+                    if let Some(module) =
+                        collect_file_for_scheduling(&file_path, self.cwd, &self.settings, &[])?
+                    {
                         session_package.add_module(module);
                     }
                 }
@@ -214,6 +219,29 @@ mod tests {
             collect_fixtures: false,
             collect_doctests: false,
         }
+    }
+
+    #[test]
+    fn scheduling_collection_discards_module_context() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let root = temp_path(&temp_dir);
+        let test_path = root.join("test_sample.py");
+        std::fs::write(
+            &test_path,
+            "\"\"\"Example.\n\n>>> 1 + 1\n2\n\"\"\"\nvalue = 1\ndef test_sample(): assert value == 1\n",
+        )
+        .expect("write test file");
+        let mut settings = collection_settings();
+        settings.collect_doctests = true;
+
+        let module = collect_file_for_scheduling(&test_path, root, &settings, &[])
+            .expect("collect file")
+            .expect("module should collect");
+
+        assert_eq!(module.test_function_defs[0].name.as_str(), "test_sample");
+        assert_eq!(module.doctests[0].name, "doctest:@module");
+        assert!(module.source_text.is_empty());
+        assert!(module.module_body.is_empty());
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

Collect controller scheduling metadata without retaining source text or complete syntax trees, moving extracted test definitions instead of cloning them. Worker and IDE collection stay unchanged. Closes #1354.

## Test Plan

`cargo nextest run -p karva_collector -p karva_runner`, focused Clippy, wheel-backed doctest integration coverage, and `uvx prek run -a`.