### PR TITLE
Skip unassigned parametrize combinations

### DIFF
--- a/crates/karva_test_semantic/src/discovery/discoverer.rs
+++ b/crates/karva_test_semantic/src/discovery/discoverer.rs
@@ -251,6 +251,11 @@ fn build_case_filter(test_paths: &[TestPathFunction]) -> CaseFilterMap {
         }
     }
 
+    for indices in filter.values_mut().flatten() {
+        indices.sort_unstable();
+        indices.dedup();
+    }
+
     filter
 }
 

--- a/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
+++ b/crates/karva_test_semantic/src/extensions/tags/parametrize.rs
@@ -481,9 +481,51 @@ impl Iterator for ParameterPlanIterator {
         self.advance();
         Some(combination)
     }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        if !self.skip(n) {
+            return None;
+        }
+        self.next()
+    }
 }
 
 impl ParameterPlanIterator {
+    /// Advances mixed-radix indices without materializing skipped combinations.
+    fn skip(&mut self, mut count: usize) -> bool {
+        if self.complete {
+            return false;
+        }
+        if self.dimensions.is_empty() {
+            if count == 0 {
+                return true;
+            }
+            self.complete = true;
+            return false;
+        }
+
+        for dimension_index in (0..self.indices.len()).rev() {
+            let radix = self.dimensions[dimension_index].len();
+            let quotient = count / radix;
+            let remainder = count % radix;
+            let (sum, overflow) = self.indices[dimension_index].overflowing_add(remainder);
+            if overflow || sum >= radix {
+                self.indices[dimension_index] = sum.wrapping_sub(radix);
+                count = quotient + 1;
+            } else {
+                self.indices[dimension_index] = sum;
+                count = quotient;
+            }
+        }
+
+        if count == 0 {
+            true
+        } else {
+            self.complete = true;
+            false
+        }
+    }
+
     fn advance(&mut self) {
         for dimension_index in (0..self.indices.len()).rev() {
             self.indices[dimension_index] += 1;
@@ -952,5 +994,24 @@ mod tests {
 
         assert_eq!(combinations.len(), 1);
         assert_eq!(combinations[0].id(), None);
+    }
+
+    #[test]
+    fn parameter_plan_jumps_to_requested_combination() {
+        let mut combinations = ParameterPlan::new(vec![
+            vec![args("a0"), args("a1")],
+            vec![args("b0"), args("b1"), args("b2")],
+        ])
+        .into_iter();
+
+        assert_eq!(
+            combinations.nth(4).map(|args| args.id),
+            Some("a1-b1".to_string())
+        );
+        assert_eq!(
+            combinations.next().map(|args| args.id),
+            Some("a1-b2".to_string())
+        );
+        assert!(combinations.nth(usize::MAX).is_none());
     }
 }

--- a/crates/karva_test_semantic/src/runner/test_iterator.rs
+++ b/crates/karva_test_semantic/src/runner/test_iterator.rs
@@ -76,6 +76,8 @@ pub(super) struct TestVariantIterator<'a> {
     /// Restricts execution to the selected indices while retaining their
     /// positions in the full parametrize expansion.
     case_filter: Option<&'a [usize]>,
+    /// Position of the next selected case in the sorted filter.
+    next_filtered_case: usize,
     /// Index of the next item in the full parametrize expansion.
     next_case_index: usize,
     /// Whether emitted variants need a stable parametrize index.
@@ -141,6 +143,7 @@ impl<'a> TestVariantIterator<'a> {
             test,
             param_args: plan.parameters.into_iter(),
             case_filter: test.case_filter.as_deref(),
+            next_filtered_case: 0,
             next_case_index: 0,
             parametrized: test.tags.has_parametrize(),
             runtime_tags: plan.runtime_tags,
@@ -156,20 +159,19 @@ impl<'a> Iterator for TestVariantIterator<'a> {
     type Item = TestVariant<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (case_index, param_args) = loop {
-            let param_args = self.param_args.next()?;
-            if !self.parametrized {
-                break (None, param_args);
-            }
-
+        let (case_index, param_args) = if !self.parametrized {
+            (None, self.param_args.next()?)
+        } else if let Some(indices) = self.case_filter {
+            let case_index = *indices.get(self.next_filtered_case)?;
+            let skipped = case_index.checked_sub(self.next_case_index)?;
+            let param_args = self.param_args.nth(skipped)?;
+            self.next_case_index = case_index + 1;
+            self.next_filtered_case += 1;
+            (Some(case_index), param_args)
+        } else {
             let case_index = self.next_case_index;
             self.next_case_index += 1;
-            if self
-                .case_filter
-                .is_none_or(|indices| indices.contains(&case_index))
-            {
-                break (Some(case_index), param_args);
-            }
+            (Some(case_index), self.param_args.next()?)
         };
 
         let mut tags = self.runtime_tags.clone();


### PR DESCRIPTION
## Summary

Sort each worker’s selected parametrize cases once, then jump directly through the mixed-radix parameter plan. This removes quadratic case-filter scans and avoids materializing combinations assigned to other workers.

## Test Plan

`cargo nextest run -p karva_test_semantic`, focused wheel-backed cached parametrize partition coverage, and `uvx prek run -a`.