### PR TITLE
Compact test result identities

### DIFF
--- a/crates/karva_diagnostic/src/result/case.rs
+++ b/crates/karva_diagnostic/src/result/case.rs
@@ -30,13 +30,7 @@ pub struct TestCaseResult<D = RenderedDiagnostic> {
 /// Display identity attached to a final test result.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct TestCaseIdentity {
-    /// Dotted Python module containing the test.
-    module_name: String,
-
-    /// Module-relative test name, including rendered parameters.
-    name: String,
-
-    /// Fully qualified user-visible test name.
+    /// Canonical `module::name` identity; component accessors borrow slices.
     full_name: String,
 }
 
@@ -103,12 +97,18 @@ impl<D> TestCaseResult<D> {
 
     /// Returns the dotted Python module containing the test.
     pub fn module_name(&self) -> &str {
-        &self.identity.module_name
+        self.identity
+            .full_name
+            .split_once("::")
+            .map_or("unknown", |(module_name, _)| module_name)
     }
 
     /// Returns the module-relative name, including rendered parameters.
     pub fn name(&self) -> &str {
-        &self.identity.name
+        self.identity
+            .full_name
+            .split_once("::")
+            .map_or(self.identity.full_name.as_str(), |(_, name)| name)
     }
 
     /// Returns the fully qualified user-visible test name.
@@ -169,26 +169,14 @@ impl<D> TestCaseResult<D> {
 impl TestCaseIdentity {
     /// Builds identity directly from semantic worker-side names.
     fn from_test_name(test_case_name: &QualifiedTestName) -> Self {
-        let function_name = test_case_name.function_name();
-        let name = test_case_name.parameters().map_or_else(
-            || function_name.function_name().to_string(),
-            |parameters| format!("{}({parameters})", function_name.function_name()),
-        );
         Self {
-            module_name: function_name.module_path().module_name().to_string(),
-            name,
             full_name: test_case_name.to_string(),
         }
     }
 
     /// Splits the canonical `module::test` display form.
     fn from_display_name(full_name: &str) -> Self {
-        let (module_name, name) = full_name
-            .split_once("::")
-            .map_or(("unknown", full_name), |identity| identity);
         Self {
-            module_name: module_name.to_string(),
-            name: name.to_string(),
             full_name: full_name.to_string(),
         }
     }

--- a/crates/karva_diagnostic/src/result/case/serialization.rs
+++ b/crates/karva_diagnostic/src/result/case/serialization.rs
@@ -17,12 +17,6 @@ use super::{
 #[derive(Deserialize)]
 #[serde(bound(deserialize = "D: Deserialize<'de>"))]
 struct SerializedTestCaseResult<D> {
-    /// Dotted Python module containing the test.
-    module_name: String,
-
-    /// Module-relative test name, including rendered parameters.
-    name: String,
-
     /// Fully qualified user-visible test name.
     full_name: String,
 
@@ -54,8 +48,8 @@ impl<D: Serialize> Serialize for TestCaseResult<D> {
             + usize::from(self.payload.captured_output.is_some())
             + usize::from(!self.payload.attempts.is_empty());
         let mut result = serializer.serialize_struct("TestCaseResult", 5 + optional_fields)?;
-        result.serialize_field("module_name", &self.identity.module_name)?;
-        result.serialize_field("name", &self.identity.name)?;
+        result.serialize_field("module_name", self.module_name())?;
+        result.serialize_field("name", self.name())?;
         result.serialize_field("full_name", &self.identity.full_name)?;
         result.serialize_field("outcome", &self.payload.outcome)?;
         result.serialize_field("duration", &self.payload.duration)?;
@@ -80,8 +74,6 @@ impl<'de, D: Deserialize<'de>> Deserialize<'de> for TestCaseResult<D> {
         let result = SerializedTestCaseResult::deserialize(deserializer)?;
         Ok(Self {
             identity: TestCaseIdentity {
-                module_name: result.module_name,
-                name: result.name,
                 full_name: result.full_name,
             },
             payload: TestCaseResultPayload {

--- a/crates/karva_diagnostic/src/result/case/tests.rs
+++ b/crates/karva_diagnostic/src/result/case/tests.rs
@@ -50,6 +50,29 @@ fn test_case_result_keeps_its_flat_serialized_shape() {
 }
 
 #[test]
+fn test_case_result_deserializes_without_derived_identity_fields() {
+    let name = QualifiedTestName::new(QualifiedFunctionName::new(
+        "test_example".to_string(),
+        ModulePath::new_with_name("test.py", "tests.test".to_string()),
+    ));
+    let result = TestCaseResult::<()>::new(
+        &name,
+        TestCaseOutcome::Passed,
+        Duration::from_millis(2),
+        None,
+    );
+    let mut value = serde_json::to_value(&result).expect("serialize result");
+    let object = value.as_object_mut().expect("result should be an object");
+    object.remove("module_name");
+    object.remove("name");
+
+    assert_eq!(
+        serde_json::from_value::<TestCaseResult<()>>(value).expect("deserialize result"),
+        result
+    );
+}
+
+#[test]
 fn test_case_result_round_trips_retry_payload() {
     let name = QualifiedTestName::new(QualifiedFunctionName::new(
         "test_example".to_string(),

--- a/crates/karva_ipc/src/worker/frames.rs
+++ b/crates/karva_ipc/src/worker/frames.rs
@@ -1,8 +1,12 @@
 //! Borrowed hot-path frames matching the owned worker protocol.
 
 use std::fmt;
+use std::time::Duration;
 
-use karva_diagnostic::TestCaseResult;
+use karva_diagnostic::{
+    CapturedTestOutput, RenderedDiagnostic, TestCaseAttempt, TestCaseOutcome, TestCaseResult,
+    TestCaseRetry,
+};
 use karva_python_semantic::{QualifiedFunctionName, QualifiedTestName, TestCacheKey};
 use serde::{Serialize, Serializer};
 
@@ -22,7 +26,10 @@ pub(super) fn completion<'a>(
     cache_key: &'a TestCacheKey,
     result: &'a TestCaseResult,
 ) -> impl Serialize + 'a {
-    BorrowedEventFrame::Event(BorrowedWorkerEvent::TestFinished { cache_key, result })
+    BorrowedEventFrame::Event(BorrowedWorkerEvent::TestFinished {
+        cache_key,
+        result: BorrowedTestCaseResult::from_result(result),
+    })
 }
 
 /// Allocation-free checkpoint frame matching the owned protocol variant.
@@ -57,8 +64,50 @@ enum BorrowedWorkerEvent<'a> {
         cache_key: &'a TestCacheKey,
 
         /// Transport-safe completed test result.
-        result: &'a TestCaseResult,
+        result: BorrowedTestCaseResult<'a>,
     },
+}
+
+/// Compact completed result frame omitting identities derivable from `full_name`.
+#[derive(Serialize)]
+struct BorrowedTestCaseResult<'a> {
+    /// Fully qualified user-visible test name.
+    full_name: &'a str,
+
+    /// Final semantic outcome after retry policy has completed.
+    outcome: &'a TestCaseOutcome<RenderedDiagnostic>,
+
+    /// Total duration represented by this final result.
+    duration: Duration,
+
+    /// Retry policy and attempt count, when the test was retried.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    retry: Option<&'a TestCaseRetry>,
+
+    /// Output captured during the final attempt, when non-empty.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    captured_output: Option<&'a CapturedTestOutput>,
+
+    /// Earlier attempts retained when retry policy reran the test.
+    #[serde(skip_serializing_if = "slice_is_empty")]
+    attempts: &'a [TestCaseAttempt],
+}
+
+impl<'a> BorrowedTestCaseResult<'a> {
+    fn from_result(result: &'a TestCaseResult) -> Self {
+        Self {
+            full_name: result.full_name(),
+            outcome: result.outcome(),
+            duration: result.duration(),
+            retry: result.retry(),
+            captured_output: result.captured_output(),
+            attempts: result.attempts(),
+        }
+    }
+}
+
+fn slice_is_empty<T>(value: &[T]) -> bool {
+    value.is_empty()
 }
 
 /// Stable cache identity serialized without constructing an owned string.
@@ -121,7 +170,7 @@ mod tests {
     }
 
     #[test]
-    fn borrowed_completion_matches_owned_wire_format() {
+    fn borrowed_completion_omits_derived_identities_and_round_trips() {
         let test_name = QualifiedTestName::new(QualifiedFunctionName::new(
             "test_example".to_string(),
             ModulePath::new_with_name("test.py", "tests.test".to_string()),
@@ -135,14 +184,31 @@ mod tests {
         );
         let borrowed = serde_json::to_value(completion(&cache_key, &result))
             .expect("serialize borrowed completion");
-        let owned = WireMessage::Event(Box::new(WorkerEvent::TestFinished {
-            cache_key,
-            result: Box::new(result),
-        }));
-
-        assert_eq!(
-            borrowed,
-            serde_json::to_value(owned).expect("serialize owned completion")
+        assert!(
+            borrowed["Event"]["TestFinished"]["result"]
+                .get("module_name")
+                .is_none()
         );
+        assert!(
+            borrowed["Event"]["TestFinished"]["result"]
+                .get("name")
+                .is_none()
+        );
+
+        let decoded: WireMessage =
+            serde_json::from_value(borrowed).expect("deserialize compact completion");
+        let (decoded_cache_key, decoded_result) = (if let WireMessage::Event(event) = decoded
+            && let WorkerEvent::TestFinished {
+                cache_key: decoded_cache_key,
+                result: decoded_result,
+            } = *event
+        {
+            Some((decoded_cache_key, decoded_result))
+        } else {
+            None
+        })
+        .expect("compact completion should decode as test result");
+        assert_eq!(decoded_cache_key, cache_key);
+        assert_eq!(*decoded_result, result);
     }
 }


### PR DESCRIPTION
## Summary

Store each completed test identity once and derive its module and local name as borrowed slices. Worker completion frames omit those derived identity fields while the public result JSON shape remains unchanged. Closes #1371.

## Test Plan

`cargo nextest run -p karva_diagnostic -p karva_ipc`, focused Clippy, and `uvx prek run -a`.