### PR TITLE
Share partition qualified names

### DIFF
--- a/crates/karva_runner/src/partition/balancing.rs
+++ b/crates/karva_runner/src/partition/balancing.rs
@@ -64,19 +64,19 @@ pub fn partition_collected_tests(
             .map(TestCacheKey::test_function_name)
             .collect::<HashSet<_>>();
         test_infos.retain(|info| {
-            last_failed.contains(info.qualified_name.as_str())
+            last_failed.contains(info.qualified_name())
                 || last_failed.contains(info.identity.function_root.as_ref())
-                || (info.qualified_name == info.identity.function_root.as_ref()
+                || (info.qualified_name() == info.identity.function_root.as_ref()
                     && failed_function_roots.contains(info.identity.function_root.as_ref()))
         });
     }
 
     // Explicit partitioning uses deterministic ordering of post-filter tests.
     if let Some(selection) = partition_selection {
-        test_infos.sort_by(|a, b| a.qualified_name.cmp(&b.qualified_name));
+        test_infos.sort_by(|a, b| a.qualified_name().cmp(b.qualified_name()));
         let mut position = 0usize;
         test_infos.retain(|info| {
-            let keep = selection.contains_test(position, &info.qualified_name);
+            let keep = selection.contains_test(position, info.qualified_name());
             position += 1;
             keep
         });
@@ -145,7 +145,7 @@ pub(super) fn partition_shuffled_tests(
     }
 
     for test_info in test_infos {
-        let key = seeded_order_key(seed, &test_info.qualified_name);
+        let key = seeded_order_key(seed, test_info.qualified_name());
         let partition_index = seeded_partition_index(key, partitions.len());
         partitions[partition_index].add_test(test_info, 1);
     }

--- a/crates/karva_runner/src/partition/collection.rs
+++ b/crates/karva_runner/src/partition/collection.rs
@@ -12,14 +12,23 @@ pub(super) struct TestInfo {
     /// Function-level metadata shared by cases collected from one function.
     pub(super) identity: Arc<TestIdentity>,
 
-    /// Qualified name of test, used for last-failed filtering.
-    pub(super) qualified_name: String,
+    /// Case-qualified name, when distinct from the shared function root.
+    pub(super) qualified_case_name: Option<String>,
 
     /// Wall-clock runtime from previous run, when cached.
     pub(super) duration: Option<Duration>,
 
     /// Stable expansion index for a statically countable parameter case.
     pub(super) case_index: Option<usize>,
+}
+
+impl TestInfo {
+    /// Qualified name used for filtering and deterministic ordering.
+    pub(super) fn qualified_name(&self) -> &str {
+        self.qualified_case_name
+            .as_deref()
+            .unwrap_or(&self.identity.function_root)
+    }
 }
 
 /// Scheduling identity shared by every case collected from one function.
@@ -71,7 +80,7 @@ pub(super) fn collect_test_paths_recursive(
                         });
                     test_infos.push(TestInfo {
                         identity: Arc::clone(&identity),
-                        qualified_name,
+                        qualified_case_name: Some(qualified_name),
                         duration,
                         case_index: Some(idx),
                     });
@@ -81,7 +90,7 @@ pub(super) fn collect_test_paths_recursive(
                     .get(identity.function_root.as_ref())
                     .copied();
                 test_infos.push(TestInfo {
-                    qualified_name: identity.function_root.to_string(),
+                    qualified_case_name: None,
                     identity,
                     duration,
                     case_index: None,
@@ -103,7 +112,7 @@ pub(super) fn collect_test_paths_recursive(
                 duration: previous_durations
                     .get(identity.function_root.as_ref())
                     .copied(),
-                qualified_name: identity.function_root.to_string(),
+                qualified_case_name: None,
                 identity,
                 case_index: None,
             });

--- a/crates/karva_runner/src/partition/ordering.rs
+++ b/crates/karva_runner/src/partition/ordering.rs
@@ -10,12 +10,12 @@ use super::TestOrdering;
 use super::collection::TestInfo;
 
 pub(super) fn order_tests_for_partitioning(test_infos: &mut Vec<TestInfo>, ordering: TestOrdering) {
-    test_infos.sort_by(|a, b| a.qualified_name.cmp(&b.qualified_name));
+    test_infos.sort_by(|a, b| a.qualified_name().cmp(b.qualified_name()));
 
     match ordering {
         TestOrdering::RandomizeUnmeasured => shuffle_tests_without_durations(test_infos),
         TestOrdering::SeededShuffle(seed) => {
-            test_infos.sort_by_cached_key(|test| seeded_order_key(seed, &test.qualified_name));
+            test_infos.sort_by_cached_key(|test| seeded_order_key(seed, test.qualified_name()));
         }
         TestOrdering::Stable => {}
     }

--- a/crates/karva_runner/src/partition/tests/helpers.rs
+++ b/crates/karva_runner/src/partition/tests/helpers.rs
@@ -31,7 +31,7 @@ pub(super) fn test_info_with_duration(
             selector: function_root.into(),
             function_root: Arc::from(function_root),
         }),
-        qualified_name: qualified_name.to_string(),
+        qualified_case_name: case_index.map(|_| qualified_name.to_string()),
         duration,
         case_index,
     }

--- a/crates/karva_runner/src/partition/tests/ordering.rs
+++ b/crates/karva_runner/src/partition/tests/ordering.rs
@@ -12,10 +12,7 @@ fn deterministic_partitioning_sorts_by_qualified_name() {
 
     order_tests_for_partitioning(&mut tests, TestOrdering::Stable);
 
-    let ordered_names: Vec<_> = tests
-        .iter()
-        .map(|test| test.qualified_name.as_str())
-        .collect();
+    let ordered_names: Vec<_> = tests.iter().map(TestInfo::qualified_name).collect();
     assert_eq!(
         ordered_names,
         [
@@ -37,10 +34,7 @@ fn duration_backed_partitioning_starts_from_qualified_name_order() {
 
     order_tests_for_partitioning(&mut tests, TestOrdering::RandomizeUnmeasured);
 
-    let ordered_names: Vec<_> = tests
-        .iter()
-        .map(|test| test.qualified_name.as_str())
-        .collect();
+    let ordered_names: Vec<_> = tests.iter().map(TestInfo::qualified_name).collect();
     assert_eq!(
         ordered_names,
         [
@@ -70,7 +64,7 @@ fn seeded_ordering_is_reproducible() {
     let names = |tests: &[TestInfo]| {
         tests
             .iter()
-            .map(|test| test.qualified_name.clone())
+            .map(|test| test.qualified_name().to_string())
             .collect::<Vec<_>>()
     };
     assert_eq!(names(&first), names(&repeated));


### PR DESCRIPTION
## Summary

Reuse each ordinary test or doctest function-root allocation as its partitioning qualified name. Parameter cases keep their distinct owned names. Closes #1358.

## Test Plan

`cargo nextest run -p karva_runner`, focused Clippy, and `uvx prek run -a`.