### PR TITLE
Share module names across test identities

### DIFF
--- a/crates/karva_runner/src/partition/collection.rs
+++ b/crates/karva_runner/src/partition/collection.rs
@@ -42,13 +42,17 @@ pub(super) fn collect_test_paths_recursive(
     previous_durations: &HashMap<TestCacheKey, Duration>,
 ) {
     for module in package.modules.values() {
+        if module.test_function_defs.is_empty() && module.doctests.is_empty() {
+            continue;
+        }
+
+        let module_name: Arc<str> = module.path.module_name().into();
+        let module_path = module.path.path();
         for test_fn_def in &module.test_function_defs {
-            let module_name: Arc<str> = module.path.module_name().into();
-            let module_path = module.path.path();
             let function_name = test_fn_def.name.as_str();
             let qualified_function: Arc<str> = format!("{module_name}::{function_name}").into();
             let identity = Arc::new(TestIdentity {
-                module_name,
+                module_name: Arc::clone(&module_name),
                 selector: format!("{module_path}::{function_name}").into(),
                 function_root: qualified_function,
             });
@@ -90,12 +94,10 @@ pub(super) fn collect_test_paths_recursive(
         }
 
         for doctest in &module.doctests {
-            let module_name: Arc<str> = module.path.module_name().into();
-            let module_path = module.path.path();
             let function_name = doctest.name.as_str();
             let qualified_function: Arc<str> = format!("{module_name}::{function_name}").into();
             let identity = Arc::new(TestIdentity {
-                module_name,
+                module_name: Arc::clone(&module_name),
                 selector: format!("{module_path}::{function_name}").into(),
                 function_root: qualified_function,
             });


### PR DESCRIPTION
## Summary

Allocate each non-empty module name once during partition collection and share its `Arc<str>` across test and doctest identities. This removes one heap allocation per additional identity in a module. Closes #1363.

## Test Plan

`cargo nextest run -p karva_runner`, focused Clippy, and `uvx prek run -a`.