### PR TITLE
Borrow fixture names during plan compilation

### DIFF
--- a/crates/karva_test_semantic/src/discovery/models/definition.rs
+++ b/crates/karva_test_semantic/src/discovery/models/definition.rs
@@ -6,13 +6,13 @@ use ruff_source_file::SourceFile;
 use ruff_text_size::TextRange;
 
 /// Returns names Python requires and Karva can supply by keyword.
-pub fn required_keyword_parameter_names(parameters: &Parameters) -> Vec<String> {
+pub fn required_keyword_parameter_names(parameters: &Parameters) -> Vec<&str> {
     parameters
         .args
         .iter()
         .chain(&parameters.kwonlyargs)
         .filter(|parameter| parameter.default().is_none())
-        .map(|parameter| parameter.name().to_string())
+        .map(|parameter| parameter.name().as_str())
         .collect()
 }
 
@@ -140,7 +140,7 @@ impl TestDefinition {
             .is_some_and(|statement| statement.is_async)
     }
 
-    pub(super) fn required_fixtures(&self) -> Vec<String> {
+    pub(super) fn required_fixtures(&self) -> Vec<&str> {
         self.parameters()
             .map_or_else(Vec::new, required_keyword_parameter_names)
     }

--- a/crates/karva_test_semantic/src/discovery/models/function.rs
+++ b/crates/karva_test_semantic/src/discovery/models/function.rs
@@ -118,7 +118,7 @@ impl DiscoveredTestFunction {
         self.definition.is_async()
     }
 
-    pub(crate) fn required_fixtures(&self) -> Vec<String> {
+    pub(crate) fn required_fixtures(&self) -> Vec<&str> {
         self.definition.required_fixtures()
     }
 

--- a/crates/karva_test_semantic/src/runner/fixture_resolver.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_resolver.rs
@@ -259,10 +259,10 @@ impl<'a> FixturePlanCompiler<'a> {
         parametrize_param_names: &HashSet<&str>,
     ) -> FixtureResolutionResult<Vec<FixtureId>> {
         let fixture_names = test.required_fixtures();
-        let regular_fixture_names: Vec<String> = fixture_names
+        let regular_fixture_names: Vec<&str> = fixture_names
             .iter()
-            .filter(|name| !parametrize_param_names.contains(name.as_str()))
-            .cloned()
+            .filter(|name| !parametrize_param_names.contains(*name))
+            .copied()
             .collect();
 
         // Wrapped and Hypothesis decorators can supply arguments declared in source.
@@ -274,7 +274,7 @@ impl<'a> FixturePlanCompiler<'a> {
             regular_fixture_names
                 .iter()
                 .filter(|name| !lookup_fixture(None, name, self.parents, self.current).is_found())
-                .cloned()
+                .map(|name| (*name).to_owned())
                 .collect::<Vec<_>>()
         };
 
@@ -300,11 +300,11 @@ impl<'a> FixturePlanCompiler<'a> {
     }
 
     /// Resolves a list of names and validates every dependency scope edge.
-    fn get_dependent_fixtures(
+    fn get_dependent_fixtures<N: AsRef<str>>(
         &mut self,
         py: Python,
         current_fixture: Option<&'a DiscoveredFixture>,
-        fixture_names: &[String],
+        fixture_names: &[N],
         path: &mut FixturePath<'a>,
     ) -> FixtureResolutionResult<Vec<FixtureId>> {
         let mut normalized_fixtures = Vec::with_capacity(fixture_names.len());
@@ -312,6 +312,7 @@ impl<'a> FixturePlanCompiler<'a> {
         let mut rejected_fixtures = Vec::new();
 
         for dep_name in fixture_names {
+            let dep_name = dep_name.as_ref();
             let lookup = lookup_fixture(current_fixture, dep_name, self.parents, self.current);
             if let Some(fixture) = current_fixture
                 && fixture.name().function_name() == dep_name
@@ -343,12 +344,12 @@ impl<'a> FixturePlanCompiler<'a> {
                 FixtureLookup::Rejected(rejected_fixture) => {
                     if current_fixture.is_some() {
                         rejected_fixtures.push(rejected_fixture.clone());
-                        missing_fixtures.push(dep_name.clone());
+                        missing_fixtures.push(dep_name.to_owned());
                     }
                 }
                 FixtureLookup::Missing => {
                     if current_fixture.is_some() {
-                        missing_fixtures.push(dep_name.clone());
+                        missing_fixtures.push(dep_name.to_owned());
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Borrow required parameter names from retained function syntax while compiling fixture plans. Resolution now allocates owned names only when building missing-fixture diagnostics, removing repeated short-lived string copies from successful fixture-heavy runs. Closes #1367.

## Test Plan

`cargo nextest run -p karva_test_semantic`, focused Clippy, and `uvx prek run -a`.