### PR TITLE
Skip unused fixture owner paths

### DIFF
--- a/crates/karva_test_semantic/src/extensions/fixtures/normalized_fixture.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/normalized_fixture.rs
@@ -52,7 +52,7 @@ pub struct NormalizedFixture {
     /// The scope at which this fixture's value is cached.
     pub(crate) scope: FixtureScope,
 
-    /// Package whose lifetime owns package-scoped values and finalizers.
+    /// Package whose lifetime owns package-scoped values and finalizers; empty for other scopes.
     pub(crate) package_owner: Utf8PathBuf,
 
     /// Whether this fixture uses yield for teardown logic.

--- a/crates/karva_test_semantic/src/runner/fixture_resolver.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_resolver.rs
@@ -3,7 +3,7 @@
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
-use camino::Utf8Path;
+use camino::{Utf8Path, Utf8PathBuf};
 use pyo3::prelude::*;
 
 use crate::discovery::models::definition::{
@@ -223,7 +223,12 @@ impl<'a> FixturePlanCompiler<'a> {
             identity: fixture.identity().clone(),
             dependencies: dependent_fixtures,
             scope: fixture.scope(),
-            package_owner: self.package_owner(fixture).to_path_buf(),
+            package_owner: match fixture.scope() {
+                FixtureScope::Package => self.package_owner(fixture).to_path_buf(),
+                FixtureScope::Function | FixtureScope::Module | FixtureScope::Session => {
+                    Utf8PathBuf::new()
+                }
+            },
             is_generator: fixture.is_generator(),
             py_function: fixture.function().clone_ref(py),
         };


### PR DESCRIPTION
## Summary

Retain package-owner paths only for package-scoped normalized fixtures. Function, module, and session scope keys never inspect this path, so they now use an allocation-free empty value instead of cloning it during every fixture-plan compilation. Closes #1373.

## Test Plan

`cargo nextest run -p karva_test_semantic`, focused Clippy, and `uvx prek run -a`.