### PR TITLE
Move fixture values into call arguments

### DIFF
--- a/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
@@ -126,8 +126,7 @@ impl PackageRunner<'_, '_> {
             let fixture = fixture_plan.fixture(*fixture_id);
             match self.run_fixture(py, fixture_plan, *fixture_id) {
                 Ok((value, finalizer)) => {
-                    function_arguments
-                        .insert(fixture.function_name().to_string(), value.clone_ref(py));
+                    function_arguments.insert(fixture.function_name().to_string(), value);
 
                     if let Some(finalizer) = finalizer {
                         test_finalizers.push(finalizer);
@@ -182,8 +181,7 @@ impl PackageRunner<'_, '_> {
             let dependency = fixture_plan.fixture(*dependency_id);
             match self.run_fixture(py, fixture_plan, *dependency_id) {
                 Ok((value, finalizer)) => {
-                    function_arguments
-                        .insert(dependency.function_name().to_string(), value.clone_ref(py));
+                    function_arguments.insert(dependency.function_name().to_string(), value);
 
                     if let Some(finalizer) = finalizer {
                         self.finalizer_cache.add_finalizer(finalizer);


### PR DESCRIPTION
## Summary

Moves already-owned resolved fixture values directly into call argument storage. This removes redundant Python refcount increment/decrement pairs from fixture-heavy execution and closes #1375.

## Test plan

Focused semantic and fixture integration tests, Clippy, and pre-commit.