### PR TITLE
Share fixture plans within modules

### DIFF
--- a/crates/karva/tests/it/extensions/fixtures/invalid.rs
+++ b/crates/karva/tests/it/extensions/fixtures/invalid.rs
@@ -331,6 +331,55 @@ fn test_missing_fixture() {
 }
 
 #[test]
+fn test_fixture_resolution_error_does_not_block_other_tests() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+
+@karva.fixture
+def valid_fixture():
+    return 42
+
+@karva.fixture
+def broken_fixture(missing_fixture):
+    return missing_fixture
+
+def test_broken(broken_fixture):
+    pass
+
+def test_valid(valid_fixture):
+    assert valid_fixture == 42
+"#,
+    );
+
+    assert_cmd_snapshot!(context.command_no_parallel(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+           ERROR [TIME] test::test_broken
+            PASS [TIME] test::test_valid(valid_fixture=42)
+
+    failures:
+
+    test::test_broken:
+
+    error[missing-fixtures]: Fixture `broken_fixture` has missing fixtures
+     --> test.py:9:5
+      |
+    9 | def broken_fixture(missing_fixture):
+      |     ^^^^^^^^^^^^^^
+    info: Missing fixtures: `missing_fixture`
+
+    ────────────
+         Summary [TIME] 2 tests run: 1 passed, 1 error, 0 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_fixture_fails_to_run() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva/tests/it/extensions/fixtures/invalid.rs
+++ b/crates/karva/tests/it/extensions/fixtures/invalid.rs
@@ -334,7 +334,7 @@ fn test_missing_fixture() {
 fn test_fixture_resolution_error_does_not_block_other_tests() {
     let context = TestContext::with_file(
         "test.py",
-        r#"
+        r"
 import karva
 
 @karva.fixture
@@ -350,7 +350,7 @@ def test_broken(broken_fixture):
 
 def test_valid(valid_fixture):
     assert valid_fixture == 42
-"#,
+",
     );
 
     assert_cmd_snapshot!(context.command_no_parallel(), @"

--- a/crates/karva_test_semantic/src/runner/package_runner/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/mod.rs
@@ -1,6 +1,7 @@
 //! Package-tree orchestration and run-wide execution state.
 
 use std::collections::HashMap;
+use std::rc::Rc;
 
 use karva_coverage::CoverageSession;
 use karva_python_semantic::QualifiedTestName;
@@ -11,7 +12,7 @@ use crate::discovery::{DiscoveredModule, DiscoveredPackage, DiscoveredTestFuncti
 use crate::extensions::fixtures::FixtureScope;
 use crate::runner::fixture_resolver::{FixturePlanCompiler, FixtureResolutionError};
 use crate::runner::scoped_storage::ScopeKey;
-use crate::runner::test_iterator::{CompiledTestPlan, TestVariantIterator};
+use crate::runner::test_iterator::{CompiledTestPlan, PendingTestPlan, TestVariantIterator};
 use crate::runner::{FinalizerCache, FixtureCache};
 use crate::{Context, RunState};
 
@@ -164,10 +165,19 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
         child_parents.push(package);
 
         for module in package.modules().values() {
+            let mut compiler = FixturePlanCompiler::new(&child_parents, module, package.path());
+            let mut module_plans = Vec::with_capacity(module.test_functions().len());
+
             for test in module.test_functions() {
-                let compiler = FixturePlanCompiler::new(&child_parents, module, package.path());
-                let plan = CompiledTestPlan::compile(py, test, compiler);
-                plans.insert(test.name().to_string(), plan);
+                module_plans.push((
+                    test.name().to_string(),
+                    PendingTestPlan::compile(py, test, &mut compiler),
+                ));
+            }
+
+            let fixture_plan = Rc::new(compiler.finish());
+            for (name, plan) in module_plans {
+                plans.insert(name, plan.map(|plan| plan.finish(Rc::clone(&fixture_plan))));
             }
         }
 

--- a/crates/karva_test_semantic/src/runner/test_iterator.rs
+++ b/crates/karva_test_semantic/src/runner/test_iterator.rs
@@ -103,12 +103,21 @@ pub(super) struct CompiledTestPlan {
     runtime_tags: RuntimeTags,
 }
 
-impl CompiledTestPlan {
-    /// Resolves all fixture roots for one test without executing fixture code.
+/// Per-test roots and parameter cases compiled against a module fixture arena.
+pub(super) struct PendingTestPlan {
+    fixture_dependencies: Rc<[FixtureId]>,
+    use_fixture_dependencies: Rc<[FixtureId]>,
+    auto_use_fixtures: Rc<[FixtureId]>,
+    parameters: ParameterPlan,
+    runtime_tags: RuntimeTags,
+}
+
+impl PendingTestPlan {
+    /// Resolves one test's fixture roots without executing fixture code.
     pub(super) fn compile(
         py: Python,
         test: &DiscoveredTestFunction,
-        mut compiler: FixturePlanCompiler<'_>,
+        compiler: &mut FixturePlanCompiler<'_>,
     ) -> FixtureResolutionResult<Self> {
         let tags = CompiledTags::new(&test.tags);
         let parametrize_param_names = tags.parameter_names();
@@ -126,13 +135,24 @@ impl CompiledTestPlan {
         let (parameters, runtime_tags) = tags.into_runtime();
 
         Ok(Self {
-            fixture_plan: Rc::new(compiler.finish()),
             fixture_dependencies: Rc::from(fixture_dependencies),
             use_fixture_dependencies: Rc::from(use_fixture_dependencies),
             auto_use_fixtures: Rc::from(auto_use_fixtures),
             parameters,
             runtime_tags,
         })
+    }
+
+    /// Attaches the immutable arena shared by every test in the module.
+    pub(super) fn finish(self, fixture_plan: Rc<FixturePlan>) -> CompiledTestPlan {
+        CompiledTestPlan {
+            fixture_plan,
+            fixture_dependencies: self.fixture_dependencies,
+            use_fixture_dependencies: self.use_fixture_dependencies,
+            auto_use_fixtures: self.auto_use_fixtures,
+            parameters: self.parameters,
+            runtime_tags: self.runtime_tags,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Compiles every test’s fixture roots into one module-local immutable arena instead of rebuilding and retaining the same fixture graph per test. Per-test roots and resolution errors remain isolated. Closes #1380.

## Test plan

Focused semantic and fixture integration tests, Clippy, and pre-commit.