### PR TITLE
Pre-size fixture argument maps

### DIFF
--- a/crates/karva_test_semantic/src/runner/fixture_arguments.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_arguments.rs
@@ -14,6 +14,13 @@ pub struct FixtureArguments {
 }
 
 impl FixtureArguments {
+    /// Creates an argument map sized for the known fixture and parameter count.
+    pub(super) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            inner: HashMap::with_capacity(capacity),
+        }
+    }
+
     /// Inserts one named Python argument.
     pub fn insert(&mut self, name: String, value: Py<PyAny>) -> Option<Py<PyAny>> {
         self.inner.insert(name, value)

--- a/crates/karva_test_semantic/src/runner/fixture_arguments.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_arguments.rs
@@ -15,9 +15,16 @@ pub struct FixtureArguments {
 
 impl FixtureArguments {
     /// Creates an argument map sized for the known fixture and parameter count.
+    ///
+    /// Zero- and one-entry maps stay lazy because they cannot grow after their
+    /// first insertion, while eager tables accumulate down nested fixture calls.
     pub(super) fn with_capacity(capacity: usize) -> Self {
         Self {
-            inner: HashMap::with_capacity(capacity),
+            inner: if capacity > 1 {
+                HashMap::with_capacity(capacity)
+            } else {
+                HashMap::new()
+            },
         }
     }
 

--- a/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
@@ -120,7 +120,8 @@ impl PackageRunner<'_, '_> {
             use_fixture_dependencies,
             FixtureUsage::UseFixtures,
         );
-        let mut function_arguments = FixtureArguments::default();
+        let mut function_arguments =
+            FixtureArguments::with_capacity(fixture_dependencies.len() + params.len());
 
         for fixture_id in fixture_dependencies {
             let fixture = fixture_plan.fixture(*fixture_id);
@@ -176,7 +177,7 @@ impl PackageRunner<'_, '_> {
             return Ok((cached, None));
         }
 
-        let mut function_arguments = FixtureArguments::default();
+        let mut function_arguments = FixtureArguments::with_capacity(fixture.dependencies().len());
 
         for dependency_id in fixture.dependencies() {
             let dependency = fixture_plan.fixture(*dependency_id);


### PR DESCRIPTION
## Summary

Pre-sizes multi-entry test and fixture keyword-argument maps from their already-known fixture and parameter counts, avoiding repeated hash-table growth on dense fixture graphs while leaving nested single-entry maps lazy. Closes #1382.

## Test plan

Semantic crate tests, Clippy, and pre-commit.