### PR TITLE
Serialize test cache keys directly

### DIFF
--- a/crates/karva_python_semantic/src/name.rs
+++ b/crates/karva_python_semantic/src/name.rs
@@ -119,7 +119,7 @@ impl Serialize for TestCacheKey {
     where
         S: Serializer,
     {
-        serializer.collect_str(self)
+        serializer.serialize_str(&self.0)
     }
 }
 


### PR DESCRIPTION
## Summary

Serializes each test cache key from its stored string instead of formatting it into a temporary allocation, preserving the wire representation. Closes #1388.

## Test plan

Python semantic and IPC tests, Clippy, and pre-commit.