### PR TITLE
Borrow fixture call arguments

### DIFF
--- a/crates/karva_test_semantic/src/extensions/fixtures/normalized_fixture.rs
+++ b/crates/karva_test_semantic/src/extensions/fixtures/normalized_fixture.rs
@@ -3,11 +3,11 @@ use std::rc::Rc;
 use camino::{Utf8Path, Utf8PathBuf};
 use karva_python_semantic::QualifiedFunctionName;
 use pyo3::prelude::*;
+use pyo3::types::PyDict;
 use ruff_python_ast::StmtFunctionDef;
 
 use crate::discovery::models::definition::FunctionDefinition;
 use crate::extensions::fixtures::{FixtureIdentity, FixtureScope};
-use crate::runner::FixtureArguments;
 use crate::utils::run_coroutine;
 
 /// Stable index into one compiled [`FixturePlan`].
@@ -104,12 +104,15 @@ impl NormalizedFixture {
     pub(crate) fn call(
         &self,
         py: Python,
-        fixture_arguments: &FixtureArguments,
+        fixture_arguments: &[(&str, Py<PyAny>)],
     ) -> PyResult<Py<PyAny>> {
         let result = if fixture_arguments.is_empty() {
             self.py_function.call0(py)
         } else {
-            let kwargs_dict = fixture_arguments.to_kwargs(py)?;
+            let kwargs_dict = PyDict::new(py);
+            for (name, value) in fixture_arguments {
+                kwargs_dict.set_item(*name, value)?;
+            }
             self.py_function.call(py, (), Some(&kwargs_dict))
         };
 

--- a/crates/karva_test_semantic/src/runner/fixture_arguments.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_arguments.rs
@@ -14,6 +14,16 @@ pub struct FixtureArguments {
 }
 
 impl FixtureArguments {
+    /// Owns borrowed fixture names only when a call needs diagnostics.
+    pub(super) fn from_fixture_values(arguments: Vec<(&str, Py<PyAny>)>) -> Self {
+        Self {
+            inner: arguments
+                .into_iter()
+                .map(|(name, value)| (name.to_string(), value))
+                .collect(),
+        }
+    }
+
     /// Inserts one named Python argument.
     pub fn insert(&mut self, name: String, value: Py<PyAny>) -> Option<Py<PyAny>> {
         self.inner.insert(name, value)

--- a/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/fixture.rs
@@ -176,14 +176,18 @@ impl PackageRunner<'_, '_> {
             return Ok((cached, None));
         }
 
-        let mut function_arguments = FixtureArguments::default();
+        let mut function_arguments = Vec::new();
 
         for dependency_id in fixture.dependencies() {
             let dependency = fixture_plan.fixture(*dependency_id);
             match self.run_fixture(py, fixture_plan, *dependency_id) {
                 Ok((value, finalizer)) => {
-                    function_arguments
-                        .insert(dependency.function_name().to_string(), value.clone_ref(py));
+                    if function_arguments.is_empty() {
+                        // Delay allocation until recursion unwinds so deep chains do not
+                        // retain empty argument buffers for every active fixture call.
+                        function_arguments.reserve_exact(fixture.dependencies().len());
+                    }
+                    function_arguments.push((dependency.function_name(), value));
 
                     if let Some(finalizer) = finalizer {
                         self.finalizer_cache.add_finalizer(finalizer);
@@ -195,11 +199,23 @@ impl PackageRunner<'_, '_> {
 
         let fixture_call_result = match fixture.call(py, &function_arguments) {
             Ok(result) => result,
-            Err(error) => return Err(FixtureCallError::new(fixture, error, function_arguments)),
+            Err(error) => {
+                return Err(FixtureCallError::new(
+                    fixture,
+                    error,
+                    FixtureArguments::from_fixture_values(function_arguments),
+                ));
+            }
         };
 
         let (value, finalizer) = get_value_and_finalizer(py, fixture, fixture_call_result)
-            .map_err(|error| FixtureCallError::new(fixture, error, function_arguments))?;
+            .map_err(|error| {
+                FixtureCallError::new(
+                    fixture,
+                    error,
+                    FixtureArguments::from_fixture_values(function_arguments),
+                )
+            })?;
 
         self.fixture_cache
             .insert(fixture.identity().clone(), value.clone_ref(py), scope);


### PR DESCRIPTION
## Summary

Builds successful fixture calls from borrowed dependency names and owned Python values, avoiding a temporary Rust hash map, copied names, and cloned Python references for every invocation. Owned diagnostic arguments are materialized only when a call fails. Closes #1390.

## Test plan

Semantic crate tests, focused successful and failing fixture integration coverage, Clippy, and pre-commit.