### PR TITLE
Skip redundant test variant allocations

### DIFF
--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -1852,6 +1852,34 @@ retries = 0
     }
 
     #[test]
+    fn retry_possible_requires_positive_configured_retry() {
+        let no_retry = Config::from_toml_str(
+            r"
+[profile.default.test]
+retry = 0
+",
+        )
+        .expect("parse")
+        .resolve_profile(None)
+        .expect("resolves")
+        .to_settings();
+        assert!(!no_retry.retry_possible());
+
+        let positive_override = Config::from_toml_str(
+            r#"
+[[profile.default.overrides]]
+filter = "tag(network)"
+retries = 1
+"#,
+        )
+        .expect("parse")
+        .resolve_profile(None)
+        .expect("resolves")
+        .to_settings();
+        assert!(positive_override.retry_possible());
+    }
+
+    #[test]
     fn timeout_for_picks_first_matching_override() {
         let toml = r#"
 [profile.default.test]

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -558,6 +558,14 @@ impl ProjectSettings {
         &self.overrides
     }
 
+    /// Returns whether any test in this run can receive a positive retry budget.
+    pub fn retry_possible(&self) -> bool {
+        self.test.retry > 0
+            || self.overrides.iter().any(|override_settings| {
+                override_settings.retries.is_some_and(|retries| retries > 0)
+            })
+    }
+
     /// Find the first matching override that sets a value for `field`.
     fn first_matching_override<T>(
         &self,

--- a/crates/karva_test_semantic/src/runner/package_runner/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/mod.rs
@@ -44,6 +44,8 @@ pub struct PackageRunner<'context, 'settings> {
     coverage: Option<&'context CoverageSession>,
     /// Failed variants observed so far, used to enforce `max-fail`.
     failed_count: u32,
+    /// Whether any test in this run can receive a positive retry budget.
+    retry_possible: bool,
 }
 
 impl<'context, 'settings> PackageRunner<'context, 'settings> {
@@ -60,6 +62,7 @@ impl<'context, 'settings> PackageRunner<'context, 'settings> {
             finalizer_cache: FinalizerCache::default(),
             coverage,
             failed_count: 0,
+            retry_possible: context.settings().retry_possible(),
         }
     }
 

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
@@ -88,7 +88,11 @@ impl<'runner, 'context, 'settings, 'test, 'py>
         self.package_runner
             .context
             .report_test_started(&initial_test_name);
-        let retry_params = self.input.params.clone();
+        let retry_params = if self.package_runner.retry_possible {
+            self.input.params.clone()
+        } else {
+            HashMap::new()
+        };
         let first_params = std::mem::take(&mut self.input.params);
         self.begin_pending_coverage_setup();
         let first_attempt = self.prepare_attempt(first_params, self.start_output_capture());
@@ -108,8 +112,7 @@ impl<'runner, 'context, 'settings, 'test, 'py>
         };
         self.resolve_pending_coverage_setup(&settings.identity.qualified_name);
         let function = self.input.test.py_function.clone_ref(self.py);
-        let test_name_env_result =
-            set_test_name_env(self.py, &settings.identity.qualified_test_name.to_string());
+        let test_name_env_result = set_test_name_env(self.py, &settings.identity.qualified_name);
 
         tracing::debug!("Running test `{}`", settings.identity.qualified_test_name);
         let mut attempt_number = 1;


### PR DESCRIPTION
## Summary

Skips cloning parameter maps when profile and override settings make retries impossible, and reuses the qualified test name already stored for each variant. The matrix workload avoids roughly 100,000 short-lived allocations. Closes #1395.

## Test plan

Focused metadata and semantic tests, Clippy, and pre-commit.