### PR TITLE
Compact no-cache completion tracking

### DIFF
--- a/crates/karva/src/commands/test/mod.rs
+++ b/crates/karva/src/commands/test/mod.rs
@@ -146,6 +146,11 @@ pub fn test(args: TestCommand) -> Result<ExitStatus> {
         } else {
             karva_runner::TestResultRetention::FailuresAndRetries
         },
+        duration_retention: if !no_cache || durations.is_some_and(|count| count > 0) {
+            karva_runner::DurationRetention::Retain
+        } else {
+            karva_runner::DurationRetention::Compact
+        },
     };
 
     if watch {

--- a/crates/karva/tests/it/durations.rs
+++ b/crates/karva/tests/it/durations.rs
@@ -20,7 +20,7 @@ def test_slow():
 ",
     );
 
-    assert_cmd_snapshot!(context.command_no_parallel().args(["--durations", "2"]), @"
+    assert_cmd_snapshot!(context.command_no_parallel().args(["--durations", "2", "--no-cache"]), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -84,7 +84,7 @@ def test_a():
 ",
     );
 
-    assert_cmd_snapshot!(context.command_no_parallel().args(["--durations", "0"]), @"
+    assert_cmd_snapshot!(context.command_no_parallel().args(["--durations", "0", "--no-cache"]), @"
     success: true
     exit_code: 0
     ----- stdout -----

--- a/crates/karva/tests/it/worker_crash/recovery/active.rs
+++ b/crates/karva/tests/it/worker_crash/recovery/active.rs
@@ -80,7 +80,7 @@ def test_worker_crash(value, worker_fixture):
     assert_cmd_snapshot!(
         context
             .command()
-            .args(["--num-workers=2", "--status-level=none"]),
+            .args(["--num-workers=2", "--status-level=none", "--no-cache"]),
         @r###"
     success: false
     exit_code: 1

--- a/crates/karva_benchmark/src/lib.rs
+++ b/crates/karva_benchmark/src/lib.rs
@@ -436,6 +436,7 @@ pub fn try_run_project(project: &Project) -> Result<RunOutput> {
         partition: None,
         test_ordering: karva_runner::TestOrdering::Stable,
         result_retention: karva_runner::TestResultRetention::FailuresAndRetries,
+        duration_retention: karva_runner::DurationRetention::Compact,
     };
 
     let args = SubTestCommand {

--- a/crates/karva_diagnostic/src/result/mod.rs
+++ b/crates/karva_diagnostic/src/result/mod.rs
@@ -81,6 +81,7 @@ impl<D> RunResults<D> {
         cache_key: TestCacheKey,
         test_case: TestCaseResult<D>,
         retain_case: bool,
+        retain_duration: bool,
     ) {
         let result = test_case.outcome().result_kind();
         self.stats.add(result.clone().into());
@@ -103,11 +104,13 @@ impl<D> RunResults<D> {
             ));
         }
 
-        let duration = test_case.duration();
-        self.durations
-            .entry(cache_key)
-            .and_modify(|existing_duration| *existing_duration += duration)
-            .or_insert(duration);
+        if retain_duration {
+            let duration = test_case.duration();
+            self.durations
+                .entry(cache_key)
+                .and_modify(|existing_duration| *existing_duration += duration)
+                .or_insert(duration);
+        }
         if retain_case {
             self.test_cases.push(test_case);
         }
@@ -141,11 +144,12 @@ impl RunResults<RenderedDiagnostic> {
         cache_key: TestCacheKey,
         test_case: TestCaseResult,
         retain_all_test_results: bool,
+        retain_duration: bool,
     ) {
         let retain_case = retain_all_test_results
             || test_case.outcome().is_non_success()
             || test_case.retry().is_some();
-        self.register_case(cache_key, test_case, retain_case);
+        self.register_case(cache_key, test_case, retain_case, retain_duration);
     }
 
     /// Records one worker-reported slow test.
@@ -178,7 +182,12 @@ impl RunResults<RenderedDiagnostic> {
     }
 
     /// Records a test interrupted by controller shutdown as a failed result.
-    pub fn register_interrupted_test(&mut self, name: &str, duration: std::time::Duration) {
+    pub fn register_interrupted_test(
+        &mut self,
+        name: &str,
+        duration: std::time::Duration,
+        retain_duration: bool,
+    ) {
         let cache_key = interrupted_test_cache_key(name);
         self.register_case(
             cache_key,
@@ -189,6 +198,7 @@ impl RunResults<RenderedDiagnostic> {
                 None,
             ),
             true,
+            retain_duration,
         );
     }
 
@@ -200,6 +210,7 @@ impl RunResults<RenderedDiagnostic> {
         duration: std::time::Duration,
         termination: &str,
         stderr: &str,
+        retain_duration: bool,
     ) {
         self.register_case(
             cache_key,
@@ -214,6 +225,7 @@ impl RunResults<RenderedDiagnostic> {
                 None,
             ),
             true,
+            retain_duration,
         );
     }
 
@@ -259,7 +271,7 @@ mod tests {
         );
         let mut aggregated = AggregatedResults::default();
 
-        aggregated.register_rendered_test_case(cache_key.clone(), result, false);
+        aggregated.register_rendered_test_case(cache_key.clone(), result, false, true);
 
         assert_eq!(aggregated.stats.failed(), 1);
         assert_eq!(aggregated.failed_tests, BTreeSet::from([cache_key.clone()]));
@@ -277,7 +289,7 @@ mod tests {
         );
         let mut aggregated = AggregatedResults::default();
 
-        aggregated.register_rendered_test_case(cache_key, result, false);
+        aggregated.register_rendered_test_case(cache_key, result, false, true);
 
         assert_eq!(aggregated.stats.passed(), 1);
         assert!(aggregated.test_cases.is_empty());
@@ -294,7 +306,7 @@ mod tests {
         );
         let mut aggregated = AggregatedResults::default();
 
-        aggregated.register_rendered_test_case(cache_key, result, true);
+        aggregated.register_rendered_test_case(cache_key, result, true, true);
 
         assert_eq!(aggregated.test_cases.len(), 1);
     }
@@ -303,10 +315,31 @@ mod tests {
     fn interrupted_parameters_use_base_name_for_history() {
         let mut aggregated = AggregatedResults::default();
 
-        aggregated.register_interrupted_test("mod::test_slow(value=1)", Duration::from_millis(24));
+        aggregated.register_interrupted_test(
+            "mod::test_slow(value=1)",
+            Duration::from_millis(24),
+            true,
+        );
 
         let cache_key = TestCacheKey::function_name("mod::test_slow");
         assert_eq!(aggregated.failed_tests, BTreeSet::from([cache_key.clone()]));
         assert!(aggregated.durations.contains_key(&cache_key));
+    }
+
+    #[test]
+    fn skips_duration_storage_when_not_needed() {
+        let cache_key = TestCacheKey::function_name("mod::test_success");
+        let result = TestCaseResult::from_display_name(
+            "mod::test_success",
+            TestCaseOutcome::Passed,
+            Duration::from_millis(10),
+            None,
+        );
+        let mut aggregated = AggregatedResults::default();
+
+        aggregated.register_rendered_test_case(cache_key, result, false, false);
+
+        assert_eq!(aggregated.stats().passed(), 1);
+        assert!(aggregated.durations.is_empty());
     }
 }

--- a/crates/karva_python_semantic/src/name.rs
+++ b/crates/karva_python_semantic/src/name.rs
@@ -75,6 +75,21 @@ impl TestCacheKey {
         Self(format!("{function}[{index}]"))
     }
 
+    /// Returns the serialized cache key without allocating.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Returns the canonical terminal parameter-case index used by generated keys.
+    pub fn parameter_case_index(&self) -> Option<usize> {
+        let (_, suffix) = self.0.rsplit_once('[')?;
+        let index = suffix.strip_suffix(']')?;
+        if !is_canonical_parameter_index(index) {
+            return None;
+        }
+        index.parse().ok()
+    }
+
     /// Returns the qualified function portion without a case index.
     pub fn test_function_name(&self) -> &str {
         let Some((function, suffix)) = self.0.rsplit_once('[') else {
@@ -83,7 +98,7 @@ impl TestCacheKey {
         let Some(index) = suffix.strip_suffix(']') else {
             return &self.0;
         };
-        if !index.is_empty() && index.bytes().all(|byte| byte.is_ascii_digit()) {
+        if is_parameter_index(index) {
             function
         } else {
             &self.0
@@ -94,6 +109,14 @@ impl TestCacheKey {
     pub fn is_parameter_case(&self) -> bool {
         self.test_function_name().len() != self.0.len()
     }
+}
+
+fn is_canonical_parameter_index(index: &str) -> bool {
+    (index == "0" || !index.starts_with('0')) && is_parameter_index(index)
+}
+
+fn is_parameter_index(index: &str) -> bool {
+    !index.is_empty() && index.bytes().all(|byte| byte.is_ascii_digit())
 }
 
 impl std::borrow::Borrow<str> for TestCacheKey {
@@ -285,6 +308,8 @@ mod tests {
             TestCacheKey::function_name("tests/[generated]/test.py::test_case");
         let named_brackets = TestCacheKey::function_name("tests::test_case[name]");
         let indexed = TestCacheKey::function_name("tests/[generated]/test.py::test_case[12]");
+        let signed_index = TestCacheKey::function_name("tests::test_case[+1]");
+        let leading_zero_index = TestCacheKey::function_name("tests::test_case[01]");
 
         assert_eq!(
             path_with_brackets.test_function_name(),
@@ -301,5 +326,12 @@ mod tests {
             "tests/[generated]/test.py::test_case"
         );
         assert!(indexed.is_parameter_case());
+        assert_eq!(indexed.parameter_case_index(), Some(12));
+        assert_eq!(path_with_brackets.parameter_case_index(), None);
+        assert_eq!(named_brackets.parameter_case_index(), None);
+        assert_eq!(signed_index.parameter_case_index(), None);
+        assert!(!signed_index.is_parameter_case());
+        assert_eq!(leading_zero_index.parameter_case_index(), None);
+        assert!(leading_zero_index.is_parameter_case());
     }
 }

--- a/crates/karva_runner/src/lib.rs
+++ b/crates/karva_runner/src/lib.rs
@@ -7,7 +7,9 @@ mod partition;
 mod shutdown;
 mod worker_args;
 
-pub use orchestration::{ParallelTestConfig, RunOutput, TestResultRetention, run_parallel_tests};
+pub use orchestration::{
+    DurationRetention, ParallelTestConfig, RunOutput, TestResultRetention, run_parallel_tests,
+};
 pub use partition::TestOrdering;
 pub use shutdown::shutdown_receiver;
 

--- a/crates/karva_runner/src/orchestration.rs
+++ b/crates/karva_runner/src/orchestration.rs
@@ -15,7 +15,7 @@ mod supervision;
 mod termination;
 mod worker;
 
-pub use config::{ParallelTestConfig, RunOutput, TestResultRetention};
+pub use config::{DurationRetention, ParallelTestConfig, RunOutput, TestResultRetention};
 pub use run::run_parallel_tests;
 
 // Receipt: worker writes and controller reads each advance every 10 ms. With

--- a/crates/karva_runner/src/orchestration/config.rs
+++ b/crates/karva_runner/src/orchestration/config.rs
@@ -36,6 +36,19 @@ pub struct ParallelTestConfig {
 
     /// Which completed test case bodies the controller retains.
     pub result_retention: TestResultRetention,
+
+    /// How completed test durations are retained.
+    pub duration_retention: DurationRetention,
+}
+
+/// Controls controller storage for completed test durations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DurationRetention {
+    /// Keep only compact completion identities for crash recovery.
+    Compact,
+
+    /// Keep every duration for cache writes or slowest-test output.
+    Retain,
 }
 
 /// Controls whether successful non-retried case bodies remain in memory.

--- a/crates/karva_runner/src/orchestration/dispatcher.rs
+++ b/crates/karva_runner/src/orchestration/dispatcher.rs
@@ -4,7 +4,7 @@
 //! frames serially so result aggregation and active-test attribution have one
 //! owner.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::process::ExitStatus;
 use std::time::Duration;
 
@@ -28,12 +28,75 @@ pub(super) struct EventDispatcher {
     /// Results and diagnostics aggregated across every worker generation.
     results: AggregatedResults,
 
-    /// Synthetic crash results deferred until recovery no longer needs the
-    /// duration map as exact `TestFinished` membership.
+    /// Completed test membership retained in its smallest useful form when
+    /// durations are not needed by cache or terminal output.
+    completed_test_tracking: CompletedTestTracking,
+
+    /// Synthetic crash results deferred until recovery no longer needs exact
+    /// `TestFinished` membership.
     crashed_tests: Vec<CrashedTest>,
 
     /// Completed case bodies retained for final report formats.
     result_retention: TestResultRetention,
+}
+
+/// Selects the representation needed for crash-recovery membership checks.
+#[derive(Default)]
+enum CompletedTestTracking {
+    /// Use the retained duration-map keys as exact completion membership.
+    #[default]
+    Durations,
+
+    /// Retain completion identities without per-case durations.
+    Compact(CompactCompletedKeys),
+}
+
+/// Stores exact completed keys without retaining a duration per case.
+#[derive(Default)]
+struct CompactCompletedKeys {
+    /// Complete keys that cannot be represented as a canonical case index.
+    plain: HashSet<Box<str>>,
+
+    /// Canonical case indices grouped under one allocated function key.
+    parameterized: HashMap<Box<str>, HashSet<usize>>,
+}
+
+impl CompactCompletedKeys {
+    /// Records one completed function or indexed parameter case.
+    fn insert(&mut self, cache_key: &TestCacheKey) {
+        let Some(index) = cache_key.parameter_case_index() else {
+            self.plain.insert(cache_key.as_str().into());
+            return;
+        };
+
+        let function = cache_key.test_function_name();
+        if let Some(indices) = self.parameterized.get_mut(function) {
+            indices.insert(index);
+            return;
+        }
+
+        self.parameterized
+            .insert(function.into(), HashSet::from([index]));
+    }
+
+    /// Rebuilds full cache keys only when a replacement worker needs them.
+    fn materialize(&self) -> HashSet<TestCacheKey> {
+        let parameterized_count = self.parameterized.values().map(HashSet::len).sum::<usize>();
+        let mut keys = HashSet::with_capacity(self.plain.len() + parameterized_count);
+        keys.extend(
+            self.plain
+                .iter()
+                .map(|key| TestCacheKey::function_name(key)),
+        );
+        for (function, indices) in &self.parameterized {
+            keys.extend(
+                indices
+                    .iter()
+                    .map(|index| TestCacheKey::parameter_case_name(function, *index)),
+            );
+        }
+        keys
+    }
 }
 
 /// Unexpected test termination retained until crash recovery completes.
@@ -94,6 +157,7 @@ impl EventDispatcher {
     pub(super) fn with_test_capacity(
         test_capacity: usize,
         result_retention: TestResultRetention,
+        retain_durations: bool,
     ) -> Self {
         let test_case_capacity = match result_retention {
             TestResultRetention::FailuresAndRetries => 0,
@@ -102,7 +166,15 @@ impl EventDispatcher {
         Self {
             expected_workers: HashSet::new(),
             completed_workers: HashSet::new(),
-            results: AggregatedResults::with_capacities(test_capacity, test_case_capacity),
+            results: AggregatedResults::with_capacities(
+                if retain_durations { test_capacity } else { 0 },
+                test_case_capacity,
+            ),
+            completed_test_tracking: if retain_durations {
+                CompletedTestTracking::Durations
+            } else {
+                CompletedTestTracking::Compact(CompactCompletedKeys::default())
+            },
             crashed_tests: Vec::new(),
             result_retention,
         }
@@ -128,10 +200,19 @@ impl EventDispatcher {
             match *message.event {
                 WorkerEvent::TestSlow => self.results.register_slow_test(),
                 WorkerEvent::TestFinished { cache_key, result } => {
+                    if let CompletedTestTracking::Compact(completed) =
+                        &mut self.completed_test_tracking
+                    {
+                        completed.insert(&cache_key);
+                    }
                     self.results.register_rendered_test_case(
                         cache_key,
                         *result,
                         matches!(self.result_retention, TestResultRetention::All),
+                        matches!(
+                            &self.completed_test_tracking,
+                            CompletedTestTracking::Durations
+                        ),
                     );
                 }
                 WorkerEvent::RunDiagnostic(diagnostic) => {
@@ -164,7 +245,10 @@ impl EventDispatcher {
     ///
     /// Deferred synthetic crash results are intentionally absent.
     pub(super) fn completed_test_keys(&self) -> HashSet<TestCacheKey> {
-        self.results.durations.keys().cloned().collect()
+        match &self.completed_test_tracking {
+            CompletedTestTracking::Durations => self.results.durations.keys().cloned().collect(),
+            CompletedTestTracking::Compact(completed) => completed.materialize(),
+        }
     }
 
     /// Whether a worker delivered its terminal event exactly once.
@@ -227,6 +311,10 @@ impl EventDispatcher {
                 crashed.duration,
                 &crashed.termination,
                 &crashed.stderr,
+                matches!(
+                    &self.completed_test_tracking,
+                    CompletedTestTracking::Durations
+                ),
             );
         }
         results
@@ -235,11 +323,38 @@ impl EventDispatcher {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use std::time::Duration;
 
     use karva_python_semantic::TestCacheKey;
 
-    use super::EventDispatcher;
+    use super::{CompactCompletedKeys, EventDispatcher};
+
+    #[test]
+    fn compact_completed_keys_materialize_exact_cases() {
+        let mut completed = CompactCompletedKeys::default();
+        for key in [
+            "module::test_case[0]",
+            "module::test_case[2]",
+            "module::test_case[2]",
+            "module::test_case[01]",
+            "module::test_plain",
+            "module::test[not-an-index]",
+        ] {
+            completed.insert(&TestCacheKey::function_name(key));
+        }
+
+        assert_eq!(
+            completed.materialize(),
+            HashSet::from([
+                TestCacheKey::function_name("module::test_case[0]"),
+                TestCacheKey::function_name("module::test_case[2]"),
+                TestCacheKey::function_name("module::test_case[01]"),
+                TestCacheKey::function_name("module::test_plain"),
+                TestCacheKey::function_name("module::test[not-an-index]"),
+            ])
+        );
+    }
 
     #[test]
     fn crashed_test_is_not_committed_until_recovery_finishes() {

--- a/crates/karva_runner/src/orchestration/run.rs
+++ b/crates/karva_runner/src/orchestration/run.rs
@@ -12,7 +12,7 @@ use karva_ipc::ControllerServer;
 use karva_logging::Printer;
 use karva_project::Project;
 
-use super::config::{ParallelTestConfig, RunOutput};
+use super::config::{DurationRetention, ParallelTestConfig, RunOutput};
 use super::planning::{collect_tests, last_failed_set, previous_durations, write_last_failed};
 use super::recovery::recover_crashed_workers;
 use super::spawn::{spawn_worker, spawn_workers};
@@ -29,6 +29,7 @@ pub fn run_parallel_tests(
     args: &SubTestCommand,
     printer: Printer,
 ) -> Result<RunOutput> {
+    let retain_durations = matches!(config.duration_retention, DurationRetention::Retain);
     // Install the Ctrl+C handler before any potentially long-running work
     // (collection, partitioning, worker spawn). Otherwise an early SIGINT
     // hits the default disposition and the run terminates silently with no
@@ -151,6 +152,7 @@ pub fn run_parallel_tests(
         forward_stdout,
         scheduled_cases,
         config.result_retention,
+        retain_durations,
     )?;
 
     let max_fail = project.settings().max_fail();
@@ -208,7 +210,7 @@ pub fn run_parallel_tests(
     worker_manager.finish_events(&mut controller)?;
     let mut results = worker_manager.take_results();
     for test in interrupted_tests {
-        results.register_interrupted_test(&test.name, test.duration);
+        results.register_interrupted_test(&test.name, test.duration, retain_durations);
     }
     let results = results.into_sorted();
 

--- a/crates/karva_runner/src/orchestration/spawn.rs
+++ b/crates/karva_runner/src/orchestration/spawn.rs
@@ -23,8 +23,10 @@ pub(super) fn spawn_workers(
     forward_stdout: bool,
     test_capacity: usize,
     result_retention: TestResultRetention,
+    retain_durations: bool,
 ) -> Result<WorkerSupervisor> {
-    let mut supervisor = WorkerSupervisor::with_test_capacity(test_capacity, result_retention);
+    let mut supervisor =
+        WorkerSupervisor::with_test_capacity(test_capacity, result_retention, retain_durations);
 
     for (worker_id, partition) in partitions.into_iter().enumerate() {
         if partition.is_empty() {

--- a/crates/karva_runner/src/orchestration/supervision.rs
+++ b/crates/karva_runner/src/orchestration/supervision.rs
@@ -105,10 +105,15 @@ impl WorkerSupervisor {
     pub(super) fn with_test_capacity(
         test_capacity: usize,
         result_retention: TestResultRetention,
+        retain_durations: bool,
     ) -> Self {
         Self {
             workers: Vec::new(),
-            dispatcher: EventDispatcher::with_test_capacity(test_capacity, result_retention),
+            dispatcher: EventDispatcher::with_test_capacity(
+                test_capacity,
+                result_retention,
+                retain_durations,
+            ),
         }
     }
 }


### PR DESCRIPTION
## Summary

Stops retaining the full per-case duration map during no-cache runs that do not request slowest-test output. Completed parameter cases are stored as one function identity plus exact indices and materialized into full keys only if crash recovery needs them. Closes #1394.

## Test plan

Focused result, duration, and two-worker crash-recovery tests; Clippy, Hawk, and pre-commit.