### PR TITLE
Reuse single-module partition buffer

### DIFF
--- a/crates/karva_runner/src/partition/balancing.rs
+++ b/crates/karva_runner/src/partition/balancing.rs
@@ -88,20 +88,35 @@ pub fn partition_collected_tests(
         return partition_shuffled_tests(test_infos, num_workers, seed);
     }
 
-    let mut module_groups: Vec<ModuleGroup> = Vec::new();
-    let mut module_indices: HashMap<Arc<str>, usize> = HashMap::new();
-    for test_info in test_infos {
-        let weight = test_weight(test_info.duration);
-        if let Some(&index) = module_indices.get(&test_info.identity.module_name) {
-            module_groups[index].add_test(test_info, weight);
-        } else {
-            module_indices.insert(
-                Arc::clone(&test_info.identity.module_name),
-                module_groups.len(),
-            );
-            module_groups.push(ModuleGroup::new(vec![test_info], weight));
+    let single_module = test_infos.first().is_some_and(|first| {
+        let module_name = first.identity.module_name.as_ref();
+        test_infos
+            .iter()
+            .all(|test| test.identity.module_name.as_ref() == module_name)
+    });
+    let module_groups: Vec<ModuleGroup> = if single_module {
+        let total_weight = test_infos
+            .iter()
+            .map(|test| test_weight(test.duration))
+            .sum();
+        vec![ModuleGroup::new(test_infos, total_weight)]
+    } else {
+        let mut module_groups: Vec<ModuleGroup> = Vec::new();
+        let mut module_indices: HashMap<Arc<str>, usize> = HashMap::new();
+        for test_info in test_infos {
+            let weight = test_weight(test_info.duration);
+            if let Some(&index) = module_indices.get(&test_info.identity.module_name) {
+                module_groups[index].add_test(test_info, weight);
+            } else {
+                module_indices.insert(
+                    Arc::clone(&test_info.identity.module_name),
+                    module_groups.len(),
+                );
+                module_groups.push(ModuleGroup::new(vec![test_info], weight));
+            }
         }
-    }
+        module_groups
+    };
 
     let total_weight: u128 = module_groups.iter().map(ModuleGroup::weight).sum();
     let target_partition_weight = total_weight / num_workers.max(1) as u128;

--- a/crates/karva_runner/src/partition/tests/balancing.rs
+++ b/crates/karva_runner/src/partition/tests/balancing.rs
@@ -72,6 +72,36 @@ fn literal_parametrize_cases_split_across_workers() {
 }
 
 #[test]
+fn single_module_fast_path_preserves_case_assignments() {
+    let (_temp_dir, test_path, package) = collected_package(
+        "@karva.tags.parametrize('value', [0, 1])\n\
+         def test_value(value): pass\n\
+         def test_plain(): pass\n",
+    );
+
+    let partitions = partition_collected_tests(
+        &package,
+        2,
+        &HashMap::new(),
+        &HashSet::new(),
+        None,
+        TestOrdering::Stable,
+    );
+
+    assert_eq!(
+        partitions[0].test_paths().collect::<Vec<_>>(),
+        [
+            format!("{test_path}::test_plain"),
+            format!("{test_path}::test_value[1]"),
+        ]
+    );
+    assert_eq!(
+        partitions[1].test_paths().collect::<Vec<_>>(),
+        [format!("{test_path}::test_value[0]")]
+    );
+}
+
+#[test]
 fn dynamic_parametrize_cases_remain_one_unit() {
     let (_temp_dir, test_path, package) = collected_package(
         "@karva.tags.parametrize('value', range(6))\n\


### PR DESCRIPTION
## Summary

Moves the collected TestInfo vector directly into its module group for single-module suites instead of allocating and filling a second vector. The parametrized matrix workload avoids about 2 MiB of overlapping vector capacity and 16,807 hash lookups. Closes #1401.

## Test plan

Focused partition tests, Clippy, and pre-commit.