### PR TITLE
Cache module-level pytest marks

### DIFF
--- a/crates/karva/tests/it/extensions/tags/parametrize.rs
+++ b/crates/karva/tests/it/extensions/tags/parametrize.rs
@@ -1292,6 +1292,35 @@ def test_value(value):
 }
 
 #[test]
+fn test_module_level_pytestmark_applies_to_multiple_tests() {
+    let test_context = TestContext::with_file(
+        "test.py",
+        r#"import pytest
+
+pytestmark = pytest.mark.skip(reason="module mark")
+
+def test_first():
+    assert False
+
+@pytest.mark.parametrize("value", [1, 2])
+def test_second(value):
+    assert False
+"#,
+    );
+
+    assert_cmd_snapshot!(test_context.command(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+        Starting 2 tests across 1 worker
+    ────────────
+         Summary [TIME] 3 tests run: 0 passed, 3 skipped
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn test_multiple_module_level_pytest_parametrize_marks() {
     let test_context = TestContext::with_file(
         "test.py",

--- a/crates/karva_test_semantic/src/discovery/models/function.rs
+++ b/crates/karva_test_semantic/src/discovery/models/function.rs
@@ -11,6 +11,33 @@ use crate::discovery::DiscoveredModule;
 use crate::discovery::models::definition::TestDefinition;
 use crate::extensions::tags::Tags;
 
+/// Cached module-level pytest marks for one discovery visitor.
+#[derive(Default)]
+pub struct ModuleTagsCache(Option<PyResult<Option<Rc<Tags>>>>);
+
+impl ModuleTagsCache {
+    fn get(
+        &mut self,
+        py: Python<'_>,
+        py_module: &Bound<'_, PyModule>,
+    ) -> PyResult<Option<Rc<Tags>>> {
+        if self.0.is_none() {
+            let result = match py_module.getattr("pytestmark") {
+                Ok(marks) => Tags::from_pytest_marks(py, &marks.unbind(), Some(&py_module.dict()))
+                    .map(|tags| tags.map(Rc::new)),
+                Err(_) => Ok(None),
+            };
+            self.0 = Some(result);
+        }
+
+        match self.0.as_ref() {
+            Some(Ok(tags)) => Ok(tags.clone()),
+            Some(Err(error)) => Err(error.clone_ref(py)),
+            None => Ok(None),
+        }
+    }
+}
+
 /// Represents a single executable test discovered from Python source code.
 ///
 /// Contains all the information needed to execute a test, including the
@@ -40,6 +67,7 @@ impl DiscoveredTestFunction {
         stmt_function_def: Rc<StmtFunctionDef>,
         py_function: Py<PyAny>,
         case_filter: Option<Vec<usize>>,
+        module_tags: &mut ModuleTagsCache,
     ) -> PyResult<Self> {
         let name = QualifiedFunctionName::new(
             stmt_function_def.name.to_string(),
@@ -47,11 +75,8 @@ impl DiscoveredTestFunction {
         );
 
         let mut tags = Tags::from_py_any(py, &py_function, Some(&stmt_function_def))?;
-        if let Ok(marks) = py_module.getattr("pytestmark") {
-            tags.extend(
-                &Tags::from_pytest_marks(py, &marks.unbind(), Some(&py_module.dict()))?
-                    .unwrap_or_default(),
-            );
+        if let Some(module_tags) = module_tags.get(py, py_module)? {
+            tags.extend(&module_tags);
         }
 
         Ok(Self {
@@ -73,14 +98,12 @@ impl DiscoveredTestFunction {
         name: String,
         range: TextRange,
         py_function: Py<PyAny>,
+        module_tags: &mut ModuleTagsCache,
     ) -> PyResult<Self> {
         let name = QualifiedFunctionName::new(name, module.module_path().clone());
-        let tags = if let Ok(marks) = py_module.getattr("pytestmark") {
-            Tags::from_pytest_marks(py, &marks.unbind(), Some(&py_module.dict()))?
-                .unwrap_or_default()
-        } else {
-            Tags::default()
-        };
+        let tags = module_tags
+            .get(py, py_module)?
+            .map_or_else(Tags::default, |tags| (*tags).clone());
 
         Ok(Self {
             definition: Rc::new(TestDefinition::doctest(name, range, module.source_file())),

--- a/crates/karva_test_semantic/src/discovery/visitor.rs
+++ b/crates/karva_test_semantic/src/discovery/visitor.rs
@@ -15,6 +15,7 @@ use ruff_source_file::SourceFileBuilder;
 use ruff_text_size::TextRange;
 
 use crate::Context;
+use crate::discovery::models::function::ModuleTagsCache;
 use crate::discovery::{DiscoveredModule, DiscoveredTestFunction, DiscoveryError, DiscoveryIssue};
 use crate::extensions::fixtures::python::FixtureFunctionDefinition;
 use crate::extensions::fixtures::{DiscoveredFixture, RejectedFixture};
@@ -43,6 +44,9 @@ struct FunctionDefinitionVisitor<'ctx, 'py, 'a, 'b> {
     /// Flag to prevent multiple import attempts for the same module.
     tried_to_import_module: bool,
 
+    /// Module-level pytest marks loaded once and cloned into each test's tags.
+    module_tags: ModuleTagsCache,
+
     /// Issues produced while discovering this module, in source order.
     issues: Vec<DiscoveryIssue>,
 }
@@ -61,6 +65,7 @@ impl<'ctx, 'py, 'a, 'b> FunctionDefinitionVisitor<'ctx, 'py, 'a, 'b> {
             py_module: None,
             py,
             tried_to_import_module: false,
+            module_tags: ModuleTagsCache::default(),
             issues: Vec::new(),
         }
     }
@@ -161,6 +166,7 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
                 Rc::new(stmt_function_def),
                 py_function.unbind(),
                 case_filter,
+                &mut self.module_tags,
             ) {
                 Ok(test_function) => {
                     if self.context.settings().test().strict_tags {
@@ -259,6 +265,7 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
                 doctest.name,
                 doctest.range,
                 function.unbind(),
+                &mut self.module_tags,
             ) {
                 Ok(mut test_function) => {
                     test_function.tags.remove_parametrize();

--- a/crates/karva_test_semantic/src/discovery/visitor.rs
+++ b/crates/karva_test_semantic/src/discovery/visitor.rs
@@ -158,7 +158,7 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
             return;
         };
 
-        if let Ok(py_function) = py_module.getattr(stmt_function_def.name.to_string()) {
+        if let Ok(py_function) = py_module.getattr(stmt_function_def.name.as_str()) {
             match DiscoveredTestFunction::new_function(
                 self.py,
                 self.module,


### PR DESCRIPTION
## Summary

Loads and parses module-level pytest marks once per discovered module instead of once per test, preserving function-mark precedence and cached parse errors. Discovery also borrows parsed function names for Python lookup instead of allocating one String per function. Closes #1403.

## Test plan

Focused module-mark integration test, affected-crate Clippy, and pre-commit.