### PR TITLE
Skip parameter clones without retries

### DIFF
--- a/crates/karva_metadata/src/options/mod.rs
+++ b/crates/karva_metadata/src/options/mod.rs
@@ -1852,6 +1852,40 @@ retries = 0
     }
 
     #[test]
+    fn may_retry_covers_profile_and_positive_overrides() {
+        let no_retry = Config::default()
+            .resolve_profile(None)
+            .expect("default profile resolves")
+            .to_settings();
+        assert!(!no_retry.may_retry());
+
+        let profile_retry = Config::from_toml_str("[profile.default.test]\nretry = 1\n")
+            .expect("profile retry parses")
+            .resolve_profile(None)
+            .expect("default profile resolves")
+            .to_settings();
+        assert!(profile_retry.may_retry());
+
+        let override_retry = Config::from_toml_str(
+            "[[profile.default.overrides]]\nfilter = \"tag(retry)\"\nretries = 1\n",
+        )
+        .expect("override retry parses")
+        .resolve_profile(None)
+        .expect("default profile resolves")
+        .to_settings();
+        assert!(override_retry.may_retry());
+
+        let disabled_override = Config::from_toml_str(
+            "[[profile.default.overrides]]\nfilter = \"tag(retry)\"\nretries = 0\n",
+        )
+        .expect("disabled override parses")
+        .resolve_profile(None)
+        .expect("default profile resolves")
+        .to_settings();
+        assert!(!disabled_override.may_retry());
+    }
+
+    #[test]
     fn timeout_for_picks_first_matching_override() {
         let toml = r#"
 [profile.default.test]

--- a/crates/karva_metadata/src/settings.rs
+++ b/crates/karva_metadata/src/settings.rs
@@ -558,6 +558,17 @@ impl ProjectSettings {
         &self.overrides
     }
 
+    /// Returns whether any test may have a retry attempt.
+    ///
+    /// This is intentionally conservative because matching overrides are
+    /// resolved only after a test's final identity is known.
+    pub fn may_retry(&self) -> bool {
+        self.test.retry > 0
+            || self.overrides.iter().any(|override_settings| {
+                override_settings.retries.is_some_and(|retries| retries > 0)
+            })
+    }
+
     /// Find the first matching override that sets a value for `field`.
     fn first_matching_override<T>(
         &self,

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/mod.rs
@@ -88,7 +88,12 @@ impl<'runner, 'context, 'settings, 'test, 'py>
         self.package_runner
             .context
             .report_test_started(&initial_test_name);
-        let retry_params = self.input.params.clone();
+        let retry_params = self
+            .package_runner
+            .context
+            .settings()
+            .may_retry()
+            .then(|| self.input.params.clone());
         let first_params = std::mem::take(&mut self.input.params);
         self.begin_pending_coverage_setup();
         let first_attempt = self.prepare_attempt(first_params, self.start_output_capture());
@@ -112,6 +117,20 @@ impl<'runner, 'context, 'settings, 'test, 'py>
             set_test_name_env(self.py, &settings.identity.qualified_test_name.to_string());
 
         tracing::debug!("Running test `{}`", settings.identity.qualified_test_name);
+        let Some(retry_params) = retry_params else {
+            let attempt_env_result = set_attempt_env(self.py, 1, settings.retry.max_attempts);
+            self.set_coverage_context(&settings.identity.qualified_name, CoveragePhase::Run);
+            let final_attempt = self.execute_attempt(
+                &settings,
+                &function,
+                &test_name_env_result,
+                attempt_env_result,
+                first_attempt,
+                1,
+            );
+            return self.finish(&settings, Vec::new(), final_attempt.lifecycle);
+        };
+
         let mut attempt_number = 1;
         let mut prepared_attempt = Some(first_attempt);
         let mut prior_attempts = Vec::new();


### PR DESCRIPTION
## Summary

Skips retaining a second parameter map when the active profile and every override disable retries, while preserving the existing retry path conservatively whenever any test can retry. The parametrized matrix avoids 16,807 HashMap clones, 84,035 String-key allocations, and 84,035 Python-value Arc increments. Closes #1408.

## Test plan

Focused metadata and semantic tests, Clippy, and pre-commit.