### PR TITLE
Defer worker selector formatting

### DIFF
--- a/crates/karva_ipc/src/controller/tests.rs
+++ b/crates/karva_ipc/src/controller/tests.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 use karva_python_semantic::{ModulePath, QualifiedFunctionName, QualifiedTestName, TestCacheKey};
 use rstest::rstest;
 
-use crate::protocol::{WireMessage, WorkerEvent, WorkerSelection};
+use crate::protocol::{WireMessage, WorkerEvent, WorkerPath, WorkerSelection};
 use crate::transport::ControllerStream;
 use crate::worker::WorkerClient;
 
@@ -20,7 +20,7 @@ const BUFFERED_EVENT_TIMEOUT: Duration = Duration::from_secs(2);
 
 fn selection(test_paths: Vec<String>) -> WorkerSelection {
     WorkerSelection {
-        test_paths: test_paths.into_iter().map(Into::into).collect(),
+        test_paths: test_paths.into_iter().map(WorkerPath::owned).collect(),
         resume_skip: Vec::new(),
     }
 }
@@ -36,7 +36,13 @@ fn accept_connections(server: &mut ControllerServer, count: usize) {
 fn retains_attributed_worker_checkpoint_after_disconnect() {
     let mut server = ControllerServer::bind("run-id").expect("bind controller");
     server
-        .register_worker_selection(7, selection(vec!["mod::test".to_string()]))
+        .register_worker_selection(
+            7,
+            WorkerSelection {
+                test_paths: vec![WorkerPath::indexed("mod::test".into(), 3)],
+                resume_skip: Vec::new(),
+            },
+        )
         .expect("register worker selection");
     let address = server.endpoint();
     let worker = thread::spawn(move || {
@@ -46,9 +52,9 @@ fn retains_attributed_worker_checkpoint_after_disconnect() {
             selection
                 .test_paths
                 .iter()
-                .map(AsRef::as_ref)
+                .map(|path| path.as_cow().into_owned())
                 .collect::<Vec<_>>(),
-            ["mod::test"]
+            ["mod::test[3]".to_string()]
         );
         let test_name = QualifiedTestName::new(QualifiedFunctionName::new(
             "test".to_string(),
@@ -123,7 +129,7 @@ fn closing_worker_connection_interrupts_a_blocked_selection_write() {
         .register_worker_selection(
             7,
             WorkerSelection {
-                test_paths: vec![path; 1_000_000],
+                test_paths: vec![WorkerPath::owned(path); 1_000_000],
                 resume_skip: Vec::new(),
             },
         )
@@ -308,7 +314,13 @@ fn worker_can_disconnect_before_handshake() {
 fn retired_startup_selection_rejects_a_late_handshake_cleanly() {
     let mut server = ControllerServer::bind("run-id").expect("bind controller");
     server
-        .register_worker_selection(7, selection(vec!["mod::test".to_string()]))
+        .register_worker_selection(
+            7,
+            WorkerSelection {
+                test_paths: vec![WorkerPath::indexed("mod::test".into(), 3)],
+                resume_skip: Vec::new(),
+            },
+        )
         .expect("register worker selection");
     server
         .retire_worker_startup(7)
@@ -416,7 +428,7 @@ fn transfers_resume_skip_cases() {
         .register_worker_selection(
             7,
             WorkerSelection {
-                test_paths: vec!["mod::test".into()],
+                test_paths: vec![WorkerPath::owned("mod::test")],
                 resume_skip: vec![TestCacheKey::function_name("mod::test[1]")],
             },
         )
@@ -499,13 +511,13 @@ fn transfers_large_worker_selection(#[values(50_000, 1_000_000)] path_count: usi
         let test_paths = selection.test_paths;
         assert_eq!(test_paths.len(), path_count);
         assert_eq!(
-            test_paths.first().map(AsRef::as_ref),
-            Some("tests/test_0.py::test_case")
+            test_paths.first().map(|path| path.as_cow().into_owned()),
+            Some("tests/test_0.py::test_case".to_string())
         );
         let last_path = format!("tests/test_{}.py::test_case", path_count - 1);
         assert_eq!(
-            test_paths.last().map(AsRef::as_ref),
-            Some(last_path.as_str())
+            test_paths.last().map(|path| path.as_cow().into_owned()),
+            Some(last_path)
         );
         client.complete().expect("complete worker");
     });

--- a/crates/karva_ipc/src/lib.rs
+++ b/crates/karva_ipc/src/lib.rs
@@ -11,6 +11,6 @@ mod transport;
 mod worker;
 
 pub use controller::{ControllerEvent, ControllerServer, WorkerCheckpoint, WorkerConnectionClose};
-pub use protocol::{WorkerEvent, WorkerSelection};
+pub use protocol::{WorkerEvent, WorkerPath, WorkerSelection};
 pub use transport::ControllerEndpoint;
 pub use worker::WorkerClient;

--- a/crates/karva_ipc/src/protocol.rs
+++ b/crates/karva_ipc/src/protocol.rs
@@ -1,10 +1,12 @@
 //! Wire protocol shared by the Karva controller and worker processes.
 
+use std::borrow::Cow;
+use std::fmt;
 use std::sync::Arc;
 
 use karva_diagnostic::{RenderedDiagnostic, TestCaseResult};
 use karva_python_semantic::TestCacheKey;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// One runtime state change sent from a worker to the controller.
 #[derive(Serialize, Deserialize)]
@@ -71,9 +73,109 @@ pub enum WireMessage {
 /// Work owned by one worker generation.
 #[derive(Serialize, Deserialize)]
 pub struct WorkerSelection {
-    /// Exact test selectors in execution order, shared with controller recovery state.
-    pub test_paths: Vec<Arc<str>>,
+    /// Compact test selectors in execution order, serialized as exact wire paths.
+    pub test_paths: Vec<WorkerPath>,
 
     /// Runtime-expanded cases already completed by an earlier generation.
     pub resume_skip: Vec<TestCacheKey>,
+}
+
+/// Test selector retained compactly until the worker-selection frame is written.
+#[derive(Clone, Debug)]
+pub struct WorkerPath {
+    /// Base selector shared by every static case from one test function.
+    selector: Arc<str>,
+
+    /// Static parameter case index, absent for an unindexed selector.
+    index: Option<usize>,
+}
+
+impl WorkerPath {
+    /// Retains a complete selector received from, or ready for, the wire.
+    pub fn owned(path: impl Into<Arc<str>>) -> Self {
+        Self {
+            selector: path.into(),
+            index: None,
+        }
+    }
+
+    /// Retains a base selector and case index without formatting the suffix.
+    pub fn indexed(selector: Arc<str>, index: usize) -> Self {
+        Self {
+            selector,
+            index: Some(index),
+        }
+    }
+
+    /// Borrows an owned selector or formats an indexed selector for a worker API.
+    pub fn as_cow(&self) -> Cow<'_, str> {
+        match self.index {
+            Some(index) => Cow::Owned(format!("{}[{index}]", self.selector)),
+            None => Cow::Borrowed(&self.selector),
+        }
+    }
+}
+
+impl fmt::Display for WorkerPath {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.index {
+            Some(index) => write!(formatter, "{}[{index}]", self.selector),
+            None => formatter.write_str(&self.selector),
+        }
+    }
+}
+
+impl Serialize for WorkerPath {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self.index {
+            Some(_) => serializer.collect_str(self),
+            None => serializer.serialize_str(self.selector.as_ref()),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for WorkerPath {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Self::owned(String::deserialize(deserializer)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{WireMessage, WorkerPath, WorkerSelection};
+
+    #[test]
+    fn indexed_paths_keep_exact_wire_shape() {
+        let compact = WireMessage::TestSelection(WorkerSelection {
+            test_paths: vec![WorkerPath::indexed("mod::test".into(), 3)],
+            resume_skip: Vec::new(),
+        });
+        let materialized = WireMessage::TestSelection(WorkerSelection {
+            test_paths: vec![WorkerPath::owned("mod::test[3]")],
+            resume_skip: Vec::new(),
+        });
+
+        let compact_json = serde_json::to_string(&compact).expect("serialize compact selection");
+        let materialized_json =
+            serde_json::to_string(&materialized).expect("serialize materialized selection");
+        assert_eq!(
+            compact_json,
+            r#"{"TestSelection":{"test_paths":["mod::test[3]"],"resume_skip":[]}}"#
+        );
+        assert_eq!(compact_json, materialized_json);
+
+        let decoded: WireMessage =
+            serde_json::from_str(&compact_json).expect("deserialize selection");
+        assert!(matches!(decoded, WireMessage::TestSelection(_)));
+
+        let decoded: WorkerPath =
+            serde_json::from_str(r#""mod::test[3]""#).expect("deserialize worker path");
+        assert_eq!(decoded.as_cow(), "mod::test[3]");
+    }
 }

--- a/crates/karva_runner/src/partition.rs
+++ b/crates/karva_runner/src/partition.rs
@@ -11,6 +11,7 @@ pub use balancing::partition_collected_tests;
 #[cfg(test)]
 use balancing::partition_shuffled_tests;
 use collection::{TestIdentity, TestInfo};
+use karva_ipc::WorkerPath;
 use karva_python_semantic::TestCacheKey;
 #[cfg(test)]
 use ordering::order_tests_for_partitioning;
@@ -56,11 +57,11 @@ struct ScheduledTest {
 }
 
 impl ScheduledTest {
-    /// Materializes the exact worker selector for the outbound IPC selection.
-    fn worker_path(&self) -> Arc<str> {
+    /// Retains exact worker selector without formatting static case suffix.
+    fn worker_path(&self) -> WorkerPath {
         self.case_index.map_or_else(
-            || Arc::clone(&self.identity.selector),
-            |index| format!("{}[{index}]", self.identity.selector).into(),
+            || WorkerPath::owned(Arc::clone(&self.identity.selector)),
+            |index| WorkerPath::indexed(Arc::clone(&self.identity.selector), index),
         )
     }
 
@@ -107,8 +108,8 @@ impl Partition {
         self.tests.iter().map(ScheduledTest::cache_key)
     }
 
-    /// Materializes worker selectors for the outbound IPC handshake.
-    pub(super) fn worker_test_paths(&self) -> Vec<Arc<str>> {
+    /// Retains worker selectors compactly for the outbound IPC handshake.
+    pub(super) fn worker_test_paths(&self) -> Vec<WorkerPath> {
         self.tests.iter().map(ScheduledTest::worker_path).collect()
     }
 

--- a/crates/karva_worker/src/cli.rs
+++ b/crates/karva_worker/src/cli.rs
@@ -150,7 +150,7 @@ fn run(f: impl FnOnce(Vec<OsString>) -> Vec<OsString>) -> anyhow::Result<ExitSta
     let test_paths: Vec<Result<TestPath, TestPathError>> = selection
         .test_paths
         .into_iter()
-        .map(|path| TestPath::new(path.as_ref()))
+        .map(|path| TestPath::new(path.as_cow().as_ref()))
         .collect();
     let reporter = WorkerReporter::new(
         TestCaseReporter::new(printer),


### PR DESCRIPTION
## Summary

Keeps each static parameter case as a shared base selector plus index until the worker handshake is serialized. The wire format stays identical while the controller avoids allocating one complete selector string per scheduled case. Closes #1407.

## Test plan

Focused IPC, runner, and worker tests; affected-crate Clippy; and pre-commit.