### PR TITLE
Release collection before worker execution

### DIFF
--- a/crates/karva_runner/src/orchestration/run.rs
+++ b/crates/karva_runner/src/orchestration/run.rs
@@ -99,6 +99,7 @@ pub fn run_parallel_tests(
         .iter()
         .filter(|partition| !partition.is_empty())
         .count();
+    drop(collected);
 
     if scheduled_cases > 0 {
         let mut stdout = printer.stream_for_test_result().lock();


### PR DESCRIPTION
## Summary

Drops the collected package after partitioning and scheduled-count derivation, before workers start and controller results accumulate. The many-modules workload otherwise retains 8,192 collected module and test definitions throughout execution. Closes #1418.

## Test plan

Runner tests, affected-crate Clippy, and pre-commit.