### PR TITLE
Drop non-strict discovery module AST

### DIFF
--- a/crates/karva_test_semantic/src/discovery/discoverer.rs
+++ b/crates/karva_test_semantic/src/discovery/discoverer.rs
@@ -203,6 +203,14 @@ impl<'ctx, 'a> StandardDiscoverer<'ctx, 'a> {
                 .collect()
         };
 
+        // Runtime tag validation is the only discovery step that reads the complete AST.
+        // Release it before visiting functions in non-strict mode.
+        let module_body = if self.context.settings().test().strict_tags {
+            module_body
+        } else {
+            Box::default()
+        };
+
         self.issues.extend(discover(
             self.context,
             py,

--- a/crates/karva_test_semantic/src/discovery/visitor.rs
+++ b/crates/karva_test_semantic/src/discovery/visitor.rs
@@ -31,7 +31,8 @@ struct FunctionDefinitionVisitor<'ctx, 'py, 'a, 'b> {
     /// The module being populated with discovered test functions and fixtures.
     module: &'b mut DiscoveredModule,
 
-    /// Complete module statements used to locate runtime-discovered module marks.
+    /// Complete module statements used to locate runtime-discovered module marks during strict
+    /// tag validation. Empty when strict tags are disabled.
     module_body: Box<[Stmt]>,
 
     /// Lazily-loaded Python module, imported only when needed to avoid side effects.
@@ -440,8 +441,8 @@ impl FunctionDefinitionVisitor<'_, '_, '_, '_> {
 /// Binds collected AST definitions to imported Python callables.
 ///
 /// Duplicate or invalid definitions emit diagnostics and are excluded. Imported fixtures
-/// are scanned only for `conftest.py` or when `try_import_fixtures` is enabled. The complete
-/// module body provides source ranges for marks inherited by each test at runtime.
+/// are scanned only for `conftest.py` or when `try_import_fixtures` is enabled. In strict-tag mode,
+/// the complete module body provides source ranges for marks inherited by each test at runtime.
 pub fn discover(
     context: &Context,
     py: Python,


### PR DESCRIPTION
## Summary

Releases the complete module AST before function discovery when strict tag validation is disabled, while retaining it unchanged for strict mode. The wide workload otherwise keeps a second AST containing 524,288 fixture-name occurrences through discovery. Closes #1417.

## Test plan

Strict and non-strict tag integration tests, affected-crate Clippy, and pre-commit.