### PR TITLE
Pin uv in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ env:
   HAWK_VERSION: 0.1.12
   # Keep this exact version preinstalled before nextest starts.
   PYTHON_VERSION: "3.14.4"
+  # Pin uv so CI does not depend on the mutable latest release manifest.
+  UV_VERSION: "0.12.5"
   RUSTUP_MAX_RETRIES: 10
   NEXTEST_PROFILE: ci
 
@@ -99,6 +101,8 @@ jobs:
           persist-credentials: false
 
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: ${{ env.UV_VERSION }}
 
       - uses: j178/prek-action@5337cb91e0fa35a7ff31b9ca345126d8bbbcdf16 # v2.0.6
 
@@ -251,6 +255,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
+          version: ${{ env.UV_VERSION }}
           python-version: "3.10"
 
       - name: "Install integration test Python"
@@ -293,6 +298,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
+          version: ${{ env.UV_VERSION }}
           python-version: "3.10"
 
       - name: Build wheel
@@ -376,6 +382,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
+          version: ${{ env.UV_VERSION }}
           python-version: "3.10"
 
       - name: Setup Python
@@ -415,6 +422,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
+          version: ${{ env.UV_VERSION }}
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Build docs


### PR DESCRIPTION
## Summary

Pins every CI setup-uv step to uv 0.12.5, the version installed by the prior successful main run. Main run 32315421998 failed before tests when one Windows shard could not fetch the mutable latest-version manifest; the pin removes that lookup. Closes #1429.

## Test plan

pinact, workflow validation, and pre-commit.