### PR TITLE
Call eligible tests with positional arguments

### DIFF
--- a/crates/karva_test_semantic/src/runner/fixture_arguments.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_arguments.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
+use pyo3::types::{PyDict, PyTuple};
 use ruff_python_ast::Parameters;
 
 /// Keyword arguments resolved for a test or fixture call.
@@ -68,6 +68,32 @@ impl FixtureArguments {
             kwargs.set_item(key, value)?;
         }
         Ok(kwargs)
+    }
+
+    /// Builds positional arguments when every value fills the signature prefix.
+    pub(crate) fn to_positional<'py>(
+        &self,
+        py: Python<'py>,
+        parameters: &Parameters,
+    ) -> PyResult<Option<Bound<'py, PyTuple>>> {
+        if !parameters.posonlyargs.is_empty() || self.inner.len() > parameters.args.len() {
+            return Ok(None);
+        }
+
+        let Some(values) = parameters
+            .args
+            .iter()
+            .take(self.inner.len())
+            .map(|parameter| self.inner.get(parameter.name().as_str()))
+            .collect::<Option<Vec<_>>>()
+        else {
+            return Ok(None);
+        };
+
+        Ok(Some(PyTuple::new(
+            py,
+            values.into_iter().map(|value| value.bind(py)),
+        )?))
     }
 }
 

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/attempt.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/attempt.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, Instant};
 use karva_coverage::CoveragePhase;
 use karva_diagnostic::{CapturedTestOutput, TestExecutionAttempt, TestExecutionOutcome};
 use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyTuple};
 
 use crate::extensions::functions::snapshot::set_snapshot_context;
 use crate::utils::{run_coroutine, run_test_with_timeout};
@@ -115,13 +116,21 @@ impl VariantRunner<'_, '_, '_, '_, '_> {
                 return Err(error.clone_ref(self.py));
             }
             if function_arguments.is_empty() || settings.execution.timeout_seconds.is_some() {
-                Ok(None)
+                Ok(PreparedCall::Empty)
+            } else if let Some(statement) = self.input.test.function_statement()
+                && statement.decorator_list.is_empty()
+                && let Some(parameters) = self.input.test.parameters()
+                && let Some(arguments) = function_arguments.to_positional(self.py, parameters)?
+            {
+                Ok(PreparedCall::Positional(arguments))
             } else {
-                function_arguments.to_kwargs(self.py).map(Some)
+                function_arguments
+                    .to_kwargs(self.py)
+                    .map(PreparedCall::Keyword)
             }
         });
         let (test_result, call_duration) = match prepared_call {
-            Ok(keyword_arguments) => {
+            Ok(call) => {
                 let call_start = Instant::now();
                 let result = if let Some(seconds) = settings.execution.timeout_seconds {
                     run_test_with_timeout(
@@ -133,10 +142,14 @@ impl VariantRunner<'_, '_, '_, '_, '_> {
                         &settings.identity.snapshot_context,
                     )
                 } else {
-                    let result = if let Some(keyword_arguments) = keyword_arguments {
-                        function.call(self.py, (), Some(&keyword_arguments))
-                    } else {
-                        function.call0(self.py)
+                    let result = match call {
+                        PreparedCall::Empty => function.call0(self.py),
+                        PreparedCall::Positional(arguments) => {
+                            function.call(self.py, &arguments, None)
+                        }
+                        PreparedCall::Keyword(arguments) => {
+                            function.call(self.py, (), Some(&arguments))
+                        }
                     };
                     if settings.execution.is_async {
                         result.and_then(|coroutine| run_coroutine(self.py, coroutine))
@@ -168,6 +181,12 @@ impl VariantRunner<'_, '_, '_, '_, '_> {
             retryable: result.retryable,
         }
     }
+}
+
+enum PreparedCall<'py> {
+    Empty,
+    Positional(Bound<'py, PyTuple>),
+    Keyword(Bound<'py, PyDict>),
 }
 
 /// Test-body result before common teardown and duration policy are applied.


### PR DESCRIPTION
## Summary

Calls undecorated tests positionally when resolved arguments exactly fill the source signature prefix, avoiding Python keyword-dictionary construction. Ambiguous signatures, decorators, doctests, and timeouts retain the existing keyword path. Closes #1437.

## Test plan

Semantic tests plus real-wheel coverage for defaulted, decorated, and async fixture calls.