### PR TITLE
Render fixture-only snapshot names directly

### DIFF
--- a/crates/karva/tests/it/extensions/snapshot/json.rs
+++ b/crates/karva/tests/it/extensions/snapshot/json.rs
@@ -112,6 +112,54 @@ def test_response(machine_path, tmp_path: Path, monkeypatch: karva.MockEnv, ok):
 }
 
 #[test]
+fn test_json_snapshot_fixture_names_use_signature_order_and_truncation() {
+    let context = TestContext::with_file(
+        "test.py",
+        r#"
+import karva
+
+@karva.fixture
+def first_fixture():
+    return 1
+
+@karva.fixture
+def fixture_very_very_very_very_very_long_name():
+    return 2
+
+def test_fixture_only(fixture_very_very_very_very_very_long_name, first_fixture):
+    karva.assert_json_snapshot({"ok": True})
+        "#,
+    );
+
+    assert_cmd_snapshot!(
+        context
+            .command_no_parallel()
+            .args(["--snapshot-update", "--status-level=none"]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ────────────
+         Summary [TIME] 1 test run: 1 passed, 0 skipped
+
+    ----- stderr -----
+    "
+    );
+
+    let content = context.read_file(
+        "snapshots/test__test_fixture_only(fixture_very_very_very_very..., first_fixture).snap",
+    );
+    insta::assert_snapshot!(content, @r#"
+    ---
+    source: test.py:13::test_fixture_only(fixture_very_very_very_very..., first_fixture)
+    ---
+    {
+      "ok": true
+    }
+    "#);
+}
+
+#[test]
 fn test_json_snapshot_nested_data() {
     let context = TestContext::with_file(
         "test.py",

--- a/crates/karva_test_semantic/src/runner/fixture_arguments.rs
+++ b/crates/karva_test_semantic/src/runner/fixture_arguments.rs
@@ -34,6 +34,16 @@ impl FixtureArguments {
         self.inner.is_empty()
     }
 
+    /// Returns the number of prepared arguments.
+    pub(crate) fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns whether an argument with the given name is prepared.
+    pub(crate) fn contains(&self, name: &str) -> bool {
+        self.inner.contains_key(name)
+    }
+
     /// Iterates arguments in unspecified hash-map order.
     pub fn iter(&self) -> std::collections::hash_map::Iter<'_, String, Py<PyAny>> {
         self.inner.iter()

--- a/crates/karva_test_semantic/src/runner/package_runner/variant/settings.rs
+++ b/crates/karva_test_semantic/src/runner/package_runner/variant/settings.rs
@@ -13,7 +13,7 @@ use crate::extensions::tags::expect_fail::ExpectFailTag;
 use crate::extensions::tags::fail_slow::FailSlowTag;
 use crate::extensions::tags::timeout::TimeoutTag;
 use crate::runner::fixture_arguments::FixtureArguments;
-use crate::utils::test_parameters;
+use crate::utils::{test_parameters, truncate_string};
 
 use super::VariantRunner;
 
@@ -176,15 +176,34 @@ impl VariantRunner<'_, '_, '_, '_, '_> {
                 snapshot_test_name.push_str(parameters);
                 snapshot_test_name.push(')');
             }
-        } else if let Some(parameters) = test_parameters(
-            self.py,
-            function_arguments,
-            self.input.test.parameters(),
-            &fixture_names,
-        ) {
-            snapshot_test_name.push('(');
-            snapshot_test_name.push_str(&parameters);
-            snapshot_test_name.push(')');
+        } else {
+            let parameters = if !fixture_names.is_empty()
+                && function_arguments.len() == fixture_names.len()
+                && fixture_names
+                    .iter()
+                    .all(|name| function_arguments.contains(name))
+            {
+                let mut rendered = String::new();
+                for (index, name) in fixture_names.iter().enumerate() {
+                    if index > 0 {
+                        rendered.push_str(", ");
+                    }
+                    rendered.push_str(&truncate_string(name));
+                }
+                Some(rendered)
+            } else {
+                test_parameters(
+                    self.py,
+                    function_arguments,
+                    self.input.test.parameters(),
+                    &fixture_names,
+                )
+            };
+            if let Some(parameters) = parameters {
+                snapshot_test_name.push('(');
+                snapshot_test_name.push_str(&parameters);
+                snapshot_test_name.push(')');
+            }
         }
         let snapshot_context =
             SnapshotContext::new(self.input.module_path.to_string(), snapshot_test_name);


### PR DESCRIPTION
## Summary

Renders fixture-only snapshot identities directly from ordered dependency names when every fixture succeeded, avoiding a second argument collection and sort. Parametrized and incomplete fixture cases retain the existing renderer. Closes #1436.

## Test plan

Semantic checks and a real-wheel snapshot filename test covering fixture order and truncation.